### PR TITLE
dpdk: fail if negative perf variation is greater than 20%

### DIFF
--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -91,6 +91,29 @@ function Set-Phase() {
 	Run-LinuxCmd -ip $masterVM.PublicIP -port $masterVM.SSHPort -username $superUser -password $password -command "echo $phase_msg > phase.txt"
 }
 
+function Confirm-WithinPercentage() {
+	param (
+		[double]$num0,
+		[double]$num1,
+		$percent = 20
+	)
+
+	$variation = ($num0 - $num1) / $num1 * 100
+	if ($variation -gt 0) {
+		Write-LogInfo "Positive variation ${variation} for the performance."
+		return $true
+	} else {
+		$variation = [math]::abs($variation)
+		if ($variation -gt $percent) {
+			Write-LogErr "Negative variation ${variation} for the performance greater than the threshold ${percent}."
+			return $false
+		} else {
+			Write-LogWarn "Negative variation ${variation} for the performance smaller than the threshold ${percent}."
+			return $true
+		}
+	}
+}
+
 function Main {
 	Write-LogInfo "DPDK-TESTCASE-DRIVER starting..."
 

--- a/Testscripts/Windows/dpdk-testFWD.ps1
+++ b/Testscripts/Windows/dpdk-testFWD.ps1
@@ -38,25 +38,25 @@ function Confirm-Performance() {
 		$coreData = Select-Xml -Xml $sizeData -XPath "core$($testRun.core)" | Select-Object -ExpandProperty Node
 		Write-LogInfo "Comparing $($testRun.core) core(s) data"
 		Write-LogInfo "  compare tx pps $($testRun.tx_pps_avg) with lowerbound $($coreData.tx)"
-		if ([int]$testRun.tx_pps_avg -lt [int]$coreData.tx) {
+		if (!(Confirm-WithinPercentage $testRun.tx_pps_avg $coreData.tx)) {
 			Write-LogErr "  Perf Failure; $($testRun.tx_pps_avg) must be > $($coreData.tx)"
 			$tempResult = "FAIL"
 		}
 
 		Write-LogInfo "  compare fwdrx pps $($testRun.fwdrx_pps_avg) with lowerbound $($coreData.fwdrx)"
-		if ([int]$testRun.fwdrx_pps_avg -lt [int]$coreData.fwdrx) {
+		if (!(Confirm-WithinPercentage $testRun.fwdrx_pps_avg $coreData.fwdrx)) {
 			Write-LogErr "  Perf Failure; $($testRun.fwdrx_pps_avg) must be > $($coreData.fwdrx)"
 			$tempResult = "FAIL"
 		}
 
 		Write-LogInfo "  compare fwdtx pps $($testRun.fwdtx_pps_avg) with lowerbound $($coreData.fwdtx)"
-		if ([int]$testRun.fwdtx_pps_avg -lt [int]$coreData.fwdtx) {
+		if (!(Confirm-WithinPercentage $testRun.fwdtx_pps_avg $coreData.fwdtx)) {
 			Write-LogErr "  Perf Failure; $($testRun.fwdtx_pps_avg) must be > $($coreData.fwdtx)"
 			$tempResult = "FAIL"
 		}
 
 		Write-LogInfo "  compare rx pps $($testRun.rx_pps_avg) with lowerbound $($coreData.rx)"
-		if ([int]$testRun.rx_pps_avg -lt [int]$coreData.rx) {
+		if (!(Confirm-WithinPercentage $testRun.rx_pps_avg $coreData.rx)) {
 			Write-LogErr "  Perf Failure; $($testRun.rx_pps_avg) must be > $($coreData.rx)"
 			$tempResult = "FAIL"
 		}
@@ -64,3 +64,4 @@ function Confirm-Performance() {
 
 	return $tempResult
 }
+

--- a/Testscripts/Windows/dpdk-testFailsafe.ps1
+++ b/Testscripts/Windows/dpdk-testFailsafe.ps1
@@ -28,29 +28,6 @@ function Set-Runtime() {
 	}
 }
 
-function Confirm-WithinPercentage() {
-	param (
-		[double]$num0,
-		[double]$num1,
-		[double]$percent
-	)
-
-	$larger = $num0
-	$smaller = $num1
-	if ($smaller -gt $larger) {
-		$larger = $num1
-		$smaller = $num0
-	}
-
-	$difference = ($larger - $smaller) / $smaller * 100
-
-	if ($difference -gt $percent) {
-		return $false
-	}
-
-	return $true
-}
-
 function Confirm-Performance() {
 	# count is non header lines
 	$isEmpty = ($testDataCsv.Count -eq 0)

--- a/Testscripts/Windows/dpdk-testPMD.ps1
+++ b/Testscripts/Windows/dpdk-testPMD.ps1
@@ -29,26 +29,26 @@ function Confirm-Performance() {
 		$coreData = Select-Xml -Xml $sizeData -XPath "core$($testRun.core)" | Select-Object -ExpandProperty Node
 		Write-LogInfo "Comparing $($testRun.core) core(s) data"
 		Write-LogInfo "  compare tx pps $($testRun.tx_pps_avg) with lowerbound $($coreData.tx)"
-		if ([int]$testRun.tx_pps_avg -lt [int]$coreData.tx) {
+		if (!(Confirm-WithinPercentage $testRun.tx_pps_avg $coreData.tx)) {
 			Write-LogErr "  Perf Failure in $($testRun.test_mode) mode; $($testRun.tx_pps_avg) must be > $($coreData.tx)"
 			$tempResult = "FAIL"
 		}
 
 		if ($testRun.test_mode -eq "rxonly") {
 			Write-LogInfo "  compare rx pps $($testRun.rx_pps_avg) with lowerbound $($coreData.rx)"
-			if ([int]$testRun.rx_pps_avg -lt [int]$coreData.rx) {
+			if (!(Confirm-WithinPercentage $testRun.rx_pps_avg $coreData.rx)) {
 				Write-LogErr "  Perf Failure in $($testRun.test_mode) mode; $($testRun.rx_pps_avg) must be > $($coreData.rx)"
 				$tempResult = "FAIL"
 			}
 		} elseif ($testRun.test_mode -eq "io") {
 			Write-LogInfo "  compare rx pps $($testRun.rx_pps_avg) with lowerbound $($coreData.fwdrx)"
 			Write-LogInfo "  compare fwdtx pps $($testRun.fwdtx_pps_avg) with lowerbound $($coreData.fwdtx)"
-			if ([int]$testRun.rx_pps_avg -lt [int]$coreData.fwdrx) {
+			if (!(Confirm-WithinPercentage $testRun.rx_pps_avg $coreData.fwdrx)) {
 				Write-LogErr "  Perf Failure in $($testRun.test_mode) mode; $($testRun.rx_pps_avg) must be > $($coreData.fwdrx)"
 				$tempResult = "FAIL"
 			}
 
-			if ([int]$testRun.fwdtx_pps_avg -lt [int]$coreData.fwdtx) {
+			if (!(Confirm-WithinPercentage $testRun.fwdtx_pps_avg $coreData.fwdtx)) {
 				Write-LogErr "  Perf Failure in $($testRun.test_mode) mode; $($testRun.fwdtx_pps_avg) must be > $($coreData.fwdtx)"
 				$tempResult = "FAIL"
 			}


### PR DESCRIPTION
Also, allow the dpdk package to be installed from a ppa or from the native debian repo.