### PR TITLE
Added "VMGeneration" to Teletemetry DB

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -542,6 +542,7 @@ Function Get-AllDeploymentData($ResourceGroups)
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name URLv6 -Value $URL -Force
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name Status -Value $Status -Force
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name InstanceSize -Value $InstanceSize -Force
+        Add-Member -InputObject $objNode -MemberType NoteProperty -Name VMGeneration -Value 1 -Force
         return $objNode
     }
 

--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -26,7 +26,7 @@
 ###############################################################################################
 
 Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,$TestArea,$TestName,$CurrentTestResult, `
-									$ExecutionTag,$GuestDistro,$KernelVersion,$LISVersion,$HostVersion,$VMSize, `
+									$ExecutionTag,$GuestDistro,$KernelVersion,$LISVersion,$HostVersion,$VMSize, $VMGeneration, `
 									$Networking,$ARMImageName,$OsVHD,$LogFile,$BuildURL)
 {
 	try
@@ -50,15 +50,15 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,
 			$BuildURL = ""
 		}
 		$dataTableName = "LISAv2Results"
-		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,LISVersion,HostVersion,VMSize,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
-		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
+		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,LISVersion,HostVersion,VMSize,VMGeneration,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
+		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
 		if ($TestSummary) {
 			foreach ($tempResult in $TestSummary.Split('>')) {
 				if ($tempResult) {
 					$tempResult = $tempResult.Trim().Replace("<br /","").Trim()
 					$subTestResult = $tempResult.Split(":")[$tempResult.Split(":").Count -1 ].Trim()
 					$subTestName = $tempResult.Replace("$subTestResult","").Trim().TrimEnd(":").Trim()
-					$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','$subTestName','$subTestResult','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
+					$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','$subTestName','$subTestResult','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
 				}
 			}
 		}

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -501,6 +501,7 @@ function Get-AllHyperVDeployementData($HyperVGroupNames,$GlobalConfig,$RetryCoun
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name PublicIP -Value $null -Force
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name InternalIP -Value $null -Force
         Add-Member -InputObject $objNode -MemberType NoteProperty -Name RoleName -Value $null -Force
+        Add-Member -InputObject $objNode -MemberType NoteProperty -Name VMGeneration -Value $null -Force
         if ($global:IsWindowsImage) {
             Add-Member -InputObject $objNode -MemberType NoteProperty -Name RDPPort -Value 3389 -Force
         } else {
@@ -546,6 +547,7 @@ function Get-AllHyperVDeployementData($HyperVGroupNames,$GlobalConfig,$RetryCoun
 
             $QuickVMNode.InternalIP = $QuickVMNode.PublicIP
             $QuickVMNode.HyperVHost = $ComputerName
+            $QuickVMNode.VMGeneration = $VM.Generation
             if ($QuickVMNode.PublicIP -notmatch "\b(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}\b") {
                 Write-LogInfo ("Cannot collect public IP for VM {0}" -f @($VM.Name))
             } else {

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -196,12 +196,13 @@ Function Get-SystemBasicLogs($AllVMData, $User, $Password, $currentTestData, $Cu
 		{
 			$VMSize = $HyperVInstanceSize
 		}
+		$VMGeneration = $vmData.VMGeneration
 		#endregion
 		if ($enableTelemetry) {
 			$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
 			-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
 			-ExecutionTag $global:GlobalConfig.$TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
-			-LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -Networking $Networking `
+			-LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -VMGeneration $VMGeneration -Networking $Networking `
 			-ARMImageName $global:ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL
 
 			Upload-TestResultToDatabase -SQLQuery $SQLQuery


### PR DESCRIPTION
This PR adds a column to Telemetry Database - "VMGenaration".
This gives us more flexibility to create PowerBI reports / Charts / Sheets in automated way.

- [x] Verified on Azure
- [x] Verified on HyperV
- [x] Verified database push
- [ ] Update the Telemetry Database after the PR is merged