### PR TITLE
Fixed bug where "ExecutionTag" was not pushed to Telemetry DB

### DIFF
--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -200,7 +200,7 @@ Function Get-SystemBasicLogs($AllVMData, $User, $Password, $currentTestData, $Cu
 		if ($enableTelemetry) {
 			$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
 			-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
-			-ExecutionTag $global:GlobalConfig.$TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
+			-ExecutionTag $global:GlobalConfig.Global.$global:TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
 			-LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -Networking $Networking `
 			-ARMImageName $global:ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL
 


### PR DESCRIPTION
Bug: Execution Tag was not pushed to teletetry database because, the XML path was wrong.

**Verified -**

- [x] Azure DB Push
- [x] HyperV DB push