### PR TITLE
Revert "To use -scp option for pscp in Download-RemoteFile"

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -163,7 +163,7 @@ function Download-RemoteFile($downloadFrom, $downloadTo, $port, $file, $username
 				$downloadStatusRandomFile=$args[7];
 				Set-Location $curDir;
 				Set-Content -Value "1" -Path $args[6];
-				Write-Output "yes" | .\Tools\pscp -scp -i .\ssh\$sshKey -q -P $port $username@${downloadFrom}:$testFile $downloadTo;
+				Write-Output "yes" | .\Tools\pscp -i .\ssh\$sshKey -q -P $port $username@${downloadFrom}:$testFile $downloadTo;
 				Set-Content -Value $LASTEXITCODE -Path $downloadStatusRandomFile;
 			} -ArgumentList $curDir,$sshKey,$port,$file,$username,${downloadFrom},$downloadTo,$downloadStatusRandomFile
 		} else {
@@ -177,7 +177,7 @@ function Download-RemoteFile($downloadFrom, $downloadTo, $port, $file, $username
 				$downloadTo=$args[6];
 				$downloadStatusRandomFile=$args[7];
 				Set-Location $curDir;
-				Write-Output "yes" | .\Tools\pscp.exe -scp -2 -unsafe -pw $password -q -P $port $username@${downloadFrom}:$testFile $downloadTo 2> $downloadStatusRandomFile;
+				Write-Output "yes" | .\Tools\pscp.exe -2 -unsafe -pw $password -q -P $port $username@${downloadFrom}:$testFile $downloadTo 2> $downloadStatusRandomFile;
 				Add-Content -Value "DownloadExitCode_$LASTEXITCODE" -Path $downloadStatusRandomFile;
 			} -ArgumentList $curDir,$password,$port,$file,$username,${downloadFrom},$downloadTo,$downloadStatusRandomFile
 		}


### PR DESCRIPTION
Reverts LIS/LISAv2#3

**Reason :** 
Observing file transfer errors.
```
03/11/2019 12:09:44 : [INFO ] Upload successful after 1 attempt
03/11/2019 12:09:44 : [INFO ] .\Tools\plink.exe -t -pw ****** -P 22 lisa@10.128.72.92 "echo ****** | sudo -S dmesg > /home/lisa/InitialBootLogs.txt"
03/11/2019 12:09:45 : [INFO ] dmesg > /home/lisa/InitialBootLogs.txt executed successfully in 1.23 seconds.
03/11/2019 12:09:45 : [INFO ] Downloading /home/lisa/InitialBootLogs.txt from lisa : 10.128.72.92,port 22 to C:\GitHub\LISAv2-2\TestResults\2019-11-03-05-07-59-7792\BVT-VERIFY-DEPLOYMENT-PROVISION\LISAv2-OneVM-SS-HB73-636878776876-role-0 using Password authentication
03/11/2019 12:09:46 : [INFO ] Download command returned exit code 1
03/11/2019 12:09:46 : [INFO ] .\Tools\pscp.exe : Fatal: Received unexpected end-of-file from server At line:11 char:26 + ... put "yes" | .\Tools\pscp.exe -scp -2 -unsafe -pw $password -q -P $por ... +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (Fatal: Received...ile from server:String) [], RemoteException     + FullyQualifiedErrorId : NativeCommandError   DownloadExitCode_1
03/11/2019 12:09:46 : [WARN ] Download error, attempt 1. Retrying for download
03/11/2019 12:09:46 : [INFO ] Downloading /home/lisa/InitialBootLogs.txt from lisa : 10.128.72.92,port 22 to C:\GitHub\LISAv2-2\TestResults\2019-11-03-05-07-59-7792\BVT-VERIFY-DEPLOYMENT-PROVISION\LISAv2-OneVM-SS-HB73-636878776876-role-0 using Password authentication
03/11/2019 12:09:48 : [INFO ] Download command returned exit code 1
03/11/2019 12:09:48 : [INFO ] .\Tools\pscp.exe : Fatal: Received unexpected end-of-file from server At line:11 char:26 + ... put "yes" | .\Tools\pscp.exe -scp -2 -unsafe -pw $password -q -P $por ... +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (Fatal: Received...ile from server:String) [], RemoteException     + FullyQualifiedErrorId : NativeCommandError   DownloadExitCode_1
03/11/2019 12:09:48 : [WARN ] Download error, attempt 2. Retrying for download
```

**Reverting the changes resolves this.**