### PR TITLE
Fixed sh scripts exiting with passed when timed out

### DIFF
--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -120,7 +120,12 @@ function Collect-TestLogs {
 			 -files $filesTocopy
 		$summary = Get-Content (Join-Path $LogDir "summary.log")
 		$testState = Get-Content (Join-Path $LogDir "state.txt")
-		$currentTestResult.TestResult = $resultTranslation[$testState]
+		# If test has timed out state.txt will contain TestRunning
+		if ($testState -eq "TestRunning"){
+			$currentTestResult.TestResult = $global:ResultAborted
+		} else {
+			$currentTestResult.TestResult = $resultTranslation[$testState]
+		}
 	} elseif ($TestType -eq "py") {
 		$filesTocopy = "{0}/state.txt, {0}/Summary.log, {0}/${TestName}_summary.log" `
 			-f @("/home/${Username}")


### PR DESCRIPTION
Issue : 
When sh test script is timeout test resulted in pass , test should be aborted 
Verification Tests : 

Before fix : 
```
[ERROR] Timeout while executing command : bash Linux-Test-Project-Tests.sh > LINUX-TEST-PROJECT-TESTS_summary.log 2>&1
[LISAv2 Test Results Summary]
Test Run On           : 03/07/2019 20:10:25
VHD Under Test        : CentOS_7.5.vhdx
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 LINUX-TEST-PROJECT-TESTS                                                          PASS                 5.93 
```

After fix : 

```
[ERROR] Timeout while executing command : bash Linux-Test-Project-Tests.sh > LINUX-TEST-PROJECT-TESTS_summary.log 2>&1
[LISAv2 Test Results Summary]
Test Run On           : 03/07/2019 18:20:47
VHD Under Test        : CentOS_7.5.vhdx
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 LINUX-TEST-PROJECT-TESTS                                                       ABORTED                 6.45 
```

Note : In order to verify the issue timeout was set to 200sec in both test runs 