### PR TITLE
Fix handling of starting vm after failed setup script

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -461,13 +461,15 @@ Class TestController
 		}
 
 		# Do log collecting and VM clean up
-		if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True") {
+		$isVmAlive = Is-VmAlive -AllVMDataObject $VMData -MaxRetryCount 10
+		# Check if VM is running before collecting logs
+		if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True" ) {
 			GetAndCheck-KernelLogs -allDeployedVMs $VmData -status "Final" -EnableCodeCoverage $this.EnableCodeCoverage | Out-Null
 			Get-SystemBasicLogs -AllVMData $VmData -User $global:user -Password $global:password -CurrentTestData $CurrentTestData `
 				-CurrentTestResult $currentTestResult -enableTelemetry $this.EnableTelemetry
 		}
 
-		$collectDetailLogs = !$this.TestCasePassStatus.contains($currentTestResult.TestResult) -and !$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True"
+		$collectDetailLogs = !$this.TestCasePassStatus.contains($currentTestResult.TestResult) -and !$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True"
 		$doRemoveFiles = $this.TestCasePassStatus.contains($currentTestResult.TestResult) -and !($this.ResourceCleanup -imatch "Keep") -and !$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True"
 		$this.TestProvider.RunTestCaseCleanup($vmData, $CurrentTestData, $currentTestResult, $collectDetailLogs, $doRemoveFiles, `
 			$global:user, $global:password, $SetupTypeData, $testParameters)

--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -116,7 +116,7 @@ Class HyperVProvider : TestProvider
 						$null = Run-SetupScript -Script $script -Parameters $TestParameters -VMData $VM -CurrentTestData $CurrentTestData
 					}
 					if (Get-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -EA SilentlyContinue) {
-						Start-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost
+						Start-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -EA Stop
 					}
 				}
 			}


### PR DESCRIPTION
Issue: 
If a setup script fails to start vm it takes to long for the test to get in failed state 

Before fix : 
```
[LISAv2 Test Results Summary]
Test Run On           : 03/11/2019 13:59:24
VHD Under Test        : CentOS_7.5.vhdx
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:25

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 MAX-VCPU                                                                          FAIL                23.43 
```
After fix : 
```
[LISAv2 Test Results Summary]
Test Run On           : 03/11/2019 14:00:01
VHD Under Test        : CentOS_7.5.vhdx
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 MAX-VCPU                                                                          FAIL                 4.05 
```