### PR TITLE
Use -scp option if default pscp upload/download is failed

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -91,6 +91,9 @@ function Upload-RemoteFile($uploadTo, $port, $file, $username, $password, $usePr
 							$username = $args[4];
 							$uploadTo = $args[5];
 							Write-Output "yes" | .\Tools\pscp -v -pw $args[1] -q -P $args[2] $args[3] $username@${uploadTo}: ;
+							if ( $LASTEXITCODE -ne 0 ) {
+								Write-Output "yes" | .\Tools\pscp -v -scp -pw $args[1] -q -P $args[2] $args[3] $username@${uploadTo}: ;
+							}
 							Set-Content -Value $LASTEXITCODE -Path $args[6];
 						} -ArgumentList $curDir,$password,$port,$file,$username,${uploadTo},$uploadStatusRandomFile
 			Start-Sleep -Milliseconds 100
@@ -178,6 +181,9 @@ function Download-RemoteFile($downloadFrom, $downloadTo, $port, $file, $username
 				$downloadStatusRandomFile=$args[7];
 				Set-Location $curDir;
 				Write-Output "yes" | .\Tools\pscp.exe -2 -unsafe -pw $password -q -P $port $username@${downloadFrom}:$testFile $downloadTo 2> $downloadStatusRandomFile;
+				if ( $LASTEXITCODE -ne 0 ) {
+					Write-Output "yes" | .\Tools\pscp.exe -2 -v -scp -unsafe -pw $password -q -P $port $username@${downloadFrom}:$testFile $downloadTo 2> $downloadStatusRandomFile;
+				}
 				Add-Content -Value "DownloadExitCode_$LASTEXITCODE" -Path $downloadStatusRandomFile;
 			} -ArgumentList $curDir,$password,$port,$file,$username,${downloadFrom},$downloadTo,$downloadStatusRandomFile
 		}


### PR DESCRIPTION
Verified the upload and download functionality on distros: CentOS 7.5, CentOS 6.8 and Ubuntu 18.04 with running BVT-VERIFY-BASH-HISTORY test.

[LISAv2 Test Results Summary]
Test Run On           : 03/12/2019 05:34:09
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 BVT-VERIFY-BASH-HISTORY                                                           PASS                 0.54 

