### PR TITLE
add .editorconfig to set coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+# 4 tabs indentation
+indent_style = tab
+indent_size = 4
+# Set default charset
+charset = utf-8
+# remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+
+[*.{sh}]
+# ensure file ends with a newline when saving
+insert_final_newline = true


### PR DESCRIPTION
To maintain consistent code style between contributors and simplify merging, the solution should provide a .editorconfig to set some basic rules.
Text editors read this file when working on the repo and set the defaults.

- use UTF-8
- use Tab to indent (as defined in https://github.com/LIS/LISAv2/blob/master/Documents/How-to-use.md)
- trim trailing white-space
- add a new line at the end of files for bash scripts.

References:
- Microsoft/calculator#225
- https://editorconfig.org/