### PR TITLE
dpdk: fix dpdk version retrieval

### DIFF
--- a/Testscripts/Linux/dpdk-testFWD.sh
+++ b/Testscripts/Linux/dpdk-testFWD.sh
@@ -120,7 +120,7 @@ function Testfwd_Parser() {
 
 	local core=${1}
 	local testfwd_csv_file=${2}
-	local dpdk_version=$(grep "Version:" "${LIS_HOME}"/"${DPDK_DIR}"/pkg/dpdk.spec | awk '{print $2}')
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
 
 	local log_files=$(ls "${LOG_DIR}"/*.log | grep "dpdk-testfwd-.*-${core}-core")
 	LogMsg "Parsing test fwd ${core} core(s)"

--- a/Testscripts/Linux/dpdk-testFailsafe.sh
+++ b/Testscripts/Linux/dpdk-testFailsafe.sh
@@ -130,7 +130,7 @@ function Testfailsafe_Parser() {
 
 	local csv_file=$(Create_Csv)
 	echo "dpdk_version,phase,fwdrx_pps_avg,fwdtx_pps_avg" > "${csv_file}"
-	local dpdk_version=$(grep "Version:" "${LIS_HOME}"/"${DPDK_DIR}"/pkg/dpdk.spec | awk '{print $2}')
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
 
 	local trimmed_prefix="trimmed-forwarder"
 	local trimmed_log="${LOG_DIR}/${trimmed_prefix}.log"

--- a/Testscripts/Linux/dpdk-testPMD.sh
+++ b/Testscripts/Linux/dpdk-testPMD.sh
@@ -117,7 +117,7 @@ function Testpmd_Parser() {
 	local core=${1}
 	local test_mode=${2}
 	local testpmd_csv_file=${3}
-	local dpdk_version=$(grep "Version:" "${LIS_HOME}"/"${DPDK_DIR}"/pkg/dpdk.spec | awk '{print $2}')
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
 
 	local log_files=$(ls "${LOG_DIR}"/*.log | grep "dpdk-testpmd-${test_mode}-.*-${core}-core")
 	LogMsg "Parsing test run ${test_mode} mode ${core} core(s)"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -416,3 +416,9 @@ function Testpmd_Macfwd_To_Dest() {
 	sed -i "90i ${offload_code}" app/test-pmd/macfwd.c
 	sed -i "101i ${dst_addr_code}" app/test-pmd/macfwd.c
 }
+
+function Get_DPDK_Version() {
+	meson_config_path="${1}/meson.build"
+	dpdk_version=$(grep -m 1 "version:" $meson_config_path | awk '{print $2}' | tr -d "\`'\,")
+	echo $dpdk_version
+}


### PR DESCRIPTION
The dpdk version was retrieved from the file pkg/dpdk.spec, which was removed in the last stable version 19.02 by this commit:
DPDK/dpdk@36dd40a

This fixes the issue by using the meson.build file as a source for the version.

PR fixes issue: https://github.com/LIS/LISAv2/issues/20