### PR TITLE
Fix null array member when waiting for IP on Hyper-V

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -709,8 +709,8 @@ function Check-IP {
                 if ($vmNic.Length -gt 1) {
                    $vmNic = $vmNic[0]
                 }
-                $vmIP = $vmNic.IPAddresses[0]
-                if ($vmIP) {
+                if ($vmNic.IPAddresses -and $vmNic.IPAddresses[0]) {
+                    $vmIP = $vmNic.IPAddresses[0]
                     $vmIP = $([ipaddress]$vmIP.trim()).IPAddressToString
                     if ($global:IsWindowsImage) {
                         $port = $($VM.RDPPort)


### PR DESCRIPTION
When running `-TestNames "NET-EXTERNAL,NET-INTERNAL"` in succession the IPAddresses member can be null on my machine for a while.
I suspect because of a timing issue with the member object's member may not be populated yet when it's called.
This aims to make a stronger check on the IP before using it. 

```
03-12-2019 12:44:08 : [INFO ] NET-INTERNAL started running.
WARNING: The virtual machine is already in the specified state.
03-12-2019 12:44:10 : [INFO ] VM:LISAv2-OneVM-Stef-ZA14-636879981908-role-0 restored to checkpoint: ICAbase
03-12-2019 12:44:10 : [INFO ] LISAv2-OneVM-Stef-ZA14-636879981908-role-0 : Waiting for IP address (Timeout in 300 seconds)...
03-12-2019 12:44:10 : [ERROR] EXCEPTION: Cannot index into a null array.
03-12-2019 12:44:10 : [ERROR] Source: Line 712 in script .\Libraries\HyperV.psm1.
```