### PR TITLE
Fix issue 'Test case script result does not match known ones: True True PASS'

### DIFF
--- a/Testscripts/Windows/KDUMP-TestScript.ps1
+++ b/Testscripts/Windows/KDUMP-TestScript.ps1
@@ -119,11 +119,13 @@ function Main {
     Start-Sleep 10 # Wait for kvp & ssh services stop
 
     # Wait for VM boot up and update ip address
-    Wait-ForVMToStartSSH -Ipv4addr $Ipv4 -StepTimeout 360
+    Wait-ForVMToStartSSH -Ipv4addr $Ipv4 -StepTimeout 360 | Out-Null
 
     # Prepare the kdump related
-    $state = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+    $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
                 -command "export HOME=``pwd``;chmod u+x KDUMP-Execute.sh && ./KDUMP-Execute.sh" -runAsSudo
+    $state = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+        -command "cat state.txt" -runAsSudo
     if (($state -eq "TestAborted") -or ($state -eq "TestFailed")) {
         Write-LogErr "Running KDUMP-Execute.sh script failed on VM!"
         return "ABORTED"
@@ -160,7 +162,7 @@ function Main {
     }
 
     # Wait for VM boot up and update ip address
-    Wait-ForVMToStartSSH -Ipv4addr $Ipv4 -StepTimeout 600
+    Wait-ForVMToStartSSH -Ipv4addr $Ipv4 -StepTimeout 600 | Out-Null
 
     # Verifying if the kernel panic process creates a vmcore file of size 10M+
     $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `


### PR DESCRIPTION
Run case KDUMP-CRASH-SMP
Before fix, though result is pass but have below line in log
03/13/2019 09:37:25 : [INFO ] Test case script result does not match known ones: True True PASS

After fix, no this line appear
```
[LISAv2 Test Results Summary]
Test Run On           : 03/13/2019 09:55:57
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 KDUMP-CRASH-SMP                                                                   PASS                12.37 
```