### PR TITLE
SetupRDMA.sh: Fix for wrong function name

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -55,12 +55,14 @@ function Main() {
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
 
+	# Install common packages
+	install_package "gcc zip"
 	case $DISTRO in
 		redhat_7|centos_7)
 			# install required packages regardless VM types.
 			LogMsg "Starting RHEL/CentOS setup"
 			LogMsg "Installing required packages ..."
-			Install_package "kernel-devel-3.10.0-862.9.1.el7.x86_64 python-devel valgrind-devel redhat-rpm-config rpm-build gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel gcc elfutils-devel libtool libnl3-devel git java libstdc++.i686 dapl python-setuptools gtk2 atk cairo tcl tk createrepo libibverbs-devel libibmad-devel byacc.x86_64 kernel-devel-3.10.0-862.11.6.el7.x86_64 zip net-tools"
+			install_package "kernel-devel-3.10.0-862.9.1.el7.x86_64 python-devel valgrind-devel redhat-rpm-config rpm-build gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel elfutils-devel libtool libnl3-devel git java libstdc++.i686 dapl python-setuptools gtk2 atk cairo tcl tk createrepo libibverbs-devel libibmad-devel byacc.x86_64 kernel-devel-3.10.0-862.11.6.el7.x86_64 net-tools"
 
 			yum -y groupinstall "InfiniBand Support"
 			Verify_Result
@@ -125,7 +127,7 @@ function Main() {
 			# install required packages
 			LogMsg "This is SUSE"
 			LogMsg "Installing required packages ..."
-			install_package "expect glibc-32bit glibc-devel libgcc_s1 libgcc_s1-32bit make gcc gcc-c++ gcc-fortran rdma-core libibverbs-devel librdmacm1 libibverbs-utils bison flex zip net-tools-deprecated"
+			install_package "expect glibc-32bit glibc-devel libgcc_s1 libgcc_s1-32bit make gcc-c++ gcc-fortran rdma-core libibverbs-devel librdmacm1 libibverbs-utils bison flex net-tools-deprecated"
 			# force install package that is known to have broken dependencies
 			zypper --non-interactive in libibmad-devel
 			# Enable mlx5_ib module on boot
@@ -143,7 +145,7 @@ function Main() {
 				exit 0
 			fi
 			LogMsg "Installing required packages ..."
-			install_package "gcc build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils zip net-tools"
+			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools"
 			;;
 		*)
 			LogErr "MPI type $mpi_type does not support on '$DISTRO' or not implement"


### PR DESCRIPTION
typo fix: Install_package was called instead of install_package. Also added common install for zip and gcc for all distros