### PR TITLE
AzurePlatform: fix typo in availability name and use existing one

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -768,8 +768,7 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     #$virtualNetworkName = $($RGName.ToUpper() -replace '[^a-z]') + "VNET"
     $virtualNetworkName = "VirtualNetwork"
     $defaultSubnetName = "SubnetForPrimaryNIC"
-    #$availabilitySetName = $($RGName.ToUpper() -replace '[^a-z]') + "AvSet"
-    $availibilitySetName = "AvailibilitySet"
+    $availabilitySetName = "AvailabilitySet"
     #$LoadBalancerName =  $($RGName.ToUpper() -replace '[^a-z]') + "LoadBalancer"
     $LoadBalancerName = "LoadBalancer"
     $apiVersion = "2018-04-01"
@@ -779,12 +778,8 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     $PublicIPv6Name = "PublicIPv6"
     $sshPath = '/home/' + $user + '/.ssh/authorized_keys'
     $sshKeyData = ""
-    if ($ExistingRG) {
-        $customAVSetName = (Get-AzureRmResource | Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( $_.ResourceType -imatch "availabilitySets" ))}).ResourceName
-    }
-    else {
-        $availibilitySetName = "AvailibilitySet"
-        $customAVSetName = $availibilitySetName
+    if ($UseExistingRG) {
+        $availabilitySetName = (Get-AzureRmResource | Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( $_.ResourceType -imatch "availabilitySets" ))}).ResourceName
     }
     if ( $CurrentTestData.ProvisionTimeExtensions ) {
         $extensionString = (Get-Content .\XML\Extensions.xml)
@@ -871,12 +866,7 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         Add-Content -Value "$($indents[2])^defaultSubnetID^: ^[concat(variables('vnetID'),'/subnets/', variables('defaultSubnet'))]^," -Path $jsonFile
         Add-Content -Value "$($indents[2])^vnetID^: ^[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]^," -Path $jsonFile
     }
-    if ($ExistingRG) {
-        Add-Content -Value "$($indents[2])^availabilitySetName^: ^$customAVSetName^," -Path $jsonFile
-    }
-    else {
-        Add-Content -Value "$($indents[2])^availabilitySetName^: ^$availibilitySetName^," -Path $jsonFile
-    }
+    Add-Content -Value "$($indents[2])^availabilitySetName^: ^$availabilitySetName^," -Path $jsonFile
     Add-Content -Value "$($indents[2])^lbName^: ^$LoadBalancerName^," -Path $jsonFile
     Add-Content -Value "$($indents[2])^lbID^: ^[resourceId('Microsoft.Network/loadBalancers',variables('lbName'))]^," -Path $jsonFile
     Add-Content -Value "$($indents[2])^frontEndIPv4ConfigID^: ^[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEndIPv4')]^," -Path $jsonFile
@@ -897,8 +887,8 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     #region Common Resources for all deployments..
 
     #region availabilitySets
-    if ($ExistingRG) {
-        Write-LogInfo "Using existing Availibility Set: $customAVSetName"
+    if ($UseExistingRG) {
+        Write-LogInfo "Using existing Availability Set: $availabilitySetName"
     }
     else {
         Add-Content -Value "$($indents[2]){" -Path $jsonFile
@@ -931,7 +921,7 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         }
         Add-Content -Value "$($indents[3])}" -Path $jsonFile
         Add-Content -Value "$($indents[2])}," -Path $jsonFile
-        Write-LogInfo "Added availabilitySet $availibilitySetName.."
+        Write-LogInfo "Added availabilitySet $availabilitySetName.."
     }
     #endregion
 
@@ -1579,7 +1569,7 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         #region availabilitySet
         Add-Content -Value "$($indents[4])^availabilitySet^: " -Path $jsonFile
         Add-Content -Value "$($indents[4]){" -Path $jsonFile
-        Add-Content -Value "$($indents[5])^id^: ^[resourceId('Microsoft.Compute/availabilitySets','$customAVSetName')]^" -Path $jsonFile
+        Add-Content -Value "$($indents[5])^id^: ^[resourceId('Microsoft.Compute/availabilitySets','$availabilitySetName')]^" -Path $jsonFile
         Add-Content -Value "$($indents[4])}," -Path $jsonFile
         #endregion
 


### PR DESCRIPTION
This change fixes the Availability Set typo: Availibil**i**tySet -> AvailabilitySet (see the wrong i)

Also fixes the reuse of the existing Availability set, if there is one. It seems during the refactors, someone forgot to rename the $ExistingRGto $UseExistingRG.