### PR TITLE
Azure: don't remove availability set on cleanup when using existing resource group

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -366,10 +366,12 @@ Function Delete-ResourceGroup([string]$RGName, [switch]$KeepDisks, [bool]$UseExi
             # "Microsoft.Authorization/locks" is the standard ResourceType for RG locks
             $rgLock = (Get-AzureRmResourceLock -ResourceGroupName $RGName).ResourceType -eq "Microsoft.Authorization/locks"
             if (-not $rgLock) {
-                $CurrentResources = Get-AzureRmResource -ResourceGroupName $RGName
+                $CurrentResources = Get-AzureRmResource -ResourceGroupName $RGName | `
+                   Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( !($_.ResourceType -imatch "availabilitySets" )))}
                 $attempts = 0
                 while (($CurrentResources) -and ($attempts -le 10)) {
-                    $CurrentResources = Get-AzureRmResource -ResourceGroupName $RGName
+                    $CurrentResources = Get-AzureRmResource -ResourceGroupName $RGName | `
+                        Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( !($_.ResourceType -imatch "availabilitySets" )))}
                     $unlockedResources = @()
                     # Get the lock for each resource and compute a list of "unlocked" resources
                     foreach ($resource in $CurrentResources) {
@@ -778,8 +780,16 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     $PublicIPv6Name = "PublicIPv6"
     $sshPath = '/home/' + $user + '/.ssh/authorized_keys'
     $sshKeyData = ""
+    $createAvailabilitySet = !$UseExistingRG
+
     if ($UseExistingRG) {
-        $availabilitySetName = (Get-AzureRmResource | Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( $_.ResourceType -imatch "availabilitySets" ))}).ResourceName
+        $existentAvailabilitySet = Get-AzureRmResource | Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( $_.ResourceType -imatch "availabilitySets" ))} | `
+            Select-Object -First 1
+        if ($existentAvailabilitySet) {
+            $availabilitySetName = $existentAvailabilitySet.Name
+        } else {
+            $createAvailabilitySet = $true
+        }
     }
     if ( $CurrentTestData.ProvisionTimeExtensions ) {
         $extensionString = (Get-Content .\XML\Extensions.xml)
@@ -887,10 +897,9 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     #region Common Resources for all deployments..
 
     #region availabilitySets
-    if ($UseExistingRG) {
+    if (!$createAvailabilitySet) {
         Write-LogInfo "Using existing Availability Set: $availabilitySetName"
-    }
-    else {
+    } else {
         Add-Content -Value "$($indents[2]){" -Path $jsonFile
         Add-Content -Value "$($indents[3])^apiVersion^: ^$apiVersion^," -Path $jsonFile
         Add-Content -Value "$($indents[3])^type^: ^Microsoft.Compute/availabilitySets^," -Path $jsonFile
@@ -1542,10 +1551,8 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         Add-Content -Value "$($indents[3])^tags^: {^TestID^: ^$TestID^}," -Path $jsonFile
         Add-Content -Value "$($indents[3])^dependsOn^: " -Path $jsonFile
         Add-Content -Value "$($indents[3])[" -Path $jsonFile
-        if ($ExistingRG) {
-            #Add-Content -Value "$($indents[4])^[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]^," -Path $jsonFile
-        }
-        else {
+
+        if ($createAvailabilitySet) {
             Add-Content -Value "$($indents[4])^[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]^," -Path $jsonFile
         }
         if ( $NewARMStorageAccountType) {


### PR DESCRIPTION
This commit is a bug fix/feature completion on the UseExistingRG implementation:

if $UseExistingRG is set to True:
1. if the RG does not exist, it will fallback to the normal workflow
2. If the RG exists:
  2.1 If at least one vm exists in the RG, no deployment is made
  2.2 If no VM exists:
           2.3. if one AvailabilitySet already exists in the region, does not create a new one with the name AvailabilitySet and it uses the one that exists. If multiple exist, the first one will be used.
          2.4 If no AvailabilitySet exists, it will create it and proceed with the deployment
