### PR TITLE
Fix aria2 and sshpass package install issues; add testskipped for BVT-NET-IFUP-IFDOWN and LIS* tests

### DIFF
--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -39,7 +39,6 @@ Update_Test_State()
 Install_KVM_Dependencies()
 {
     update_repos
-    install_package aria2
     install_package qemu-kvm
     install_package bridge-utils
     lsmod | grep kvm_intel
@@ -63,6 +62,10 @@ Install_KVM_Dependencies()
         Update_Test_State $ICA_TESTFAILED
         exit 0
     fi
+    if [ $DISTRO_NAME == "sles" ]; then
+        add_sles_network_utilities_repo
+    fi
+    install_package aria2
 }
 
 Download_Image_Files()

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -63,9 +63,6 @@ declare -a LEGACY_NET_INTERFACES
 # Location that package blobs are stored
 declare PACKAGE_BLOB_LOCATION="https://eosgpackages.blob.core.windows.net/testpackages/tools"
 
-# Link of sshpass RPM for SLES 12
-declare SLES_12_SSHPASS_LINK="https://download.opensuse.org/repositories/network/SLE_12_SP3/x86_64/sshpass-1.06-7.1.x86_64.rpm"
-
 ######################################## Functions ########################################
 
 # Convenience function used to set-up most common variables
@@ -2294,11 +2291,20 @@ function install_sshpass () {
 	which sshpass
 	if [ $? -ne 0 ]; then
 		echo "sshpass not installed\n Installing now..."
-		if [ $DISTRO_NAME == "sles" ] && [[ $DISTRO_VERSION =~ 12 ]]; then
-			rpm -ivh $SLES_12_SSHPASS_LINK
-		else
-			install_package "sshpass"
+		install_package sshpass
+		which sshpass
+		if [ $? -ne 0 ]; then
+			echo "sshpass not installed\n Build it from source code now..."
+			package_name="sshpass-1.06"
+			source_url="https://sourceforge.net/projects/sshpass/files/sshpass/1.06/$package_name.tar.gz"
+			wget $source_url
+			tar -xvf "$package_name.tar.gz"
+			cd $package_name
+			install_package "gcc make"
+			./configure --prefix=/usr/ && make && make install
+			cd ..
 		fi
+		which sshpass
 		check_exit_status "install_sshpass"
 	fi
 }
@@ -2318,6 +2324,7 @@ function add_sles_benchmark_repo () {
 				return 1
 		esac
 		zypper addrepo $repo_url
+		zypper --no-gpg-checks refresh
 	else
 		echo "Unsupported distribution for add_sles_benchmark_repo"
 		return 1
@@ -2342,6 +2349,7 @@ function add_sles_network_utilities_repo () {
 				return 1
 		esac
 		zypper addrepo $repo_url
+		zypper --no-gpg-checks refresh
 	else
 		echo "Unsupported distribution for add_sles_network_utilities_repo"
 		return 1

--- a/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
+++ b/Testscripts/Windows/BVT-NET-IFUP-IFDOWN.ps1
@@ -37,15 +37,17 @@ function Main {
         Write-LogInfo "Current status:$state"
         Start-Sleep -Seconds 30
     } until (($state -eq "TestCompleted") -or ($state -eq "TestAborted") `
-     -or ($state -eq "TestFailed") -or ((Get-Date) -gt $expiration))
+     -or ($state -eq "TestFailed") -or ($state -eq "TestSkipped") -or ((Get-Date) -gt $expiration))
     Copy-RemoteFiles -download -downloadFrom $newIp -files "/home/${VMUserName}/BVT-NET-IFUP-IFDOWN.log" `
         -downloadTo $LogDir -port $VMPort -username $VMUserName -password $VMPassword
     if (($state -eq "TestAborted") -or ($state -eq "TestFailed") -or ((Get-Date) -gt $expiration)) {
         Write-LogErr "Running $remoteScript script failed on VM!"
         return "FAIL"
-    }
-    else {
-        Write-LogInfo "Test BVT-NET-IFUP-IFDOWN PASSED !"
+    } elseif ($state -eq "TestSkipped") {
+        Write-LogInfo "Test BVT-NET-IFUP-IFDOWN SKIPPED!"
+        return "SKIPPED"
+    } else {
+        Write-LogInfo "Test BVT-NET-IFUP-IFDOWN PASSED!"
         return "PASS"
     }
 }

--- a/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
+++ b/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
@@ -427,6 +427,10 @@ Function Main {
     $currentTestResult = Create-TestResultObject
     $resultArr = @()
     try {
+        if(! @("REDHAT", "ORACLELINUX", "CENTOS").contains($global:detectedDistro)) {
+                Write-LogInfo "Skip case for UNSUPPORTED distro - $global:detectedDistro"
+                return "SKIPPED"
+        }
         $PreviousTestResult="PASS"
         foreach ($param in $CurrentTestData.TestParameters.param) {
             if ($param -imatch "LIS_TARBALL_URL_CURRENT") {


### PR DESCRIPTION
Fix issue for install aria2 package.
Mark test skipped for test case BVT-NET-IFUP-IFDOWN when hv_netvsc module is built-in, before fix, the test result is abort
Mark test skipped for test area LIS if the distro is not REDHAT, CentOS or ORACLE which is compatible with REDHAT

```
[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 02:54:01
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 5.03 


[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 03:07:20
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 7.49 

[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 03:35:12
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 7.25 


[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 04:11:32
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 BVT-NET-IFUP-IFDOWN                                                               PASS                 7.33 

[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 04:38:16
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 BVT-NET-IFUP-IFDOWN                                                            SKIPPED                 2.79 


[LISAv2 Test Results Summary]
Test Run On           : 03/14/2019 04:58:33
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestCaseName                                                                TestResult TestDuration(in minutes) 
---------------------------------------------------------------------------------------------------------------------
    1 LIS-DEPLOY-SCENARIO-1                                                          SKIPPED                 1.66 
```
