### PR TITLE
Azure : Increase retry count and time for restarting resources

### DIFF
--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -143,14 +143,14 @@ Class AzureProvider : TestProvider
 			$restartJobs += Start-Job -ScriptBlock {
 				$vmData = $args[0]
 				$retries = 0
-				$maxRetryCount = 3
+				$maxRetryCount = 10
 				$vmRestarted = $false
 
 				# Note(v-advlad): Azure API can sometimes fail on burst requests, we have to retry
 				while (!$vmRestarted -and $retries -lt $maxRetryCount) {
 					$null = Restart-AzureRmVM -ResourceGroupName $vmData.ResourceGroupName -Name $vmData.RoleName -Verbose
 					if (!$?) {
-						Start-Sleep -Seconds 0.5
+						Start-Sleep -Seconds 3
 						$retries++
 					} else {
 						$vmRestarted = $true


### PR DESCRIPTION

Logs :
03/13/2019 16:43:59 : [ERROR] Restart-receiver failed with error: Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorCode: ResourceGroupNotFound
ErrorMessage: Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorTarget: 
StatusCode: 404
ReasonPhrase: Not Found
OperationID : b898d1d3-e5bb-4680-a6e0-2f569296a0d7 Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorCode: ResourceGroupNotFound
ErrorMessage: Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorTarget: 
StatusCode: 404
ReasonPhrase: Not Found
OperationID : b7870849-1cfe-42de-b824-b6adbc0518c8 Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorCode: ResourceGroupNotFound
ErrorMessage: Resource group 'LISAv2-TwoVM2NIC-XXXXX' could not be found.
ErrorTarget: 
StatusCode: 404
ReasonPhrase: Not Found
OperationID : 6f907ffa-46ab-4857-8ea1-ca934471124e Failed to restart Azure VM receiver

Fix : 
Increased retry count in case API responds after more time has passed 
