### PR TITLE
Fix nested perf storage test cases issues

### DIFF
--- a/Testscripts/Linux/nested_kvm_storage_perf.sh
+++ b/Testscripts/Linux/nested_kvm_storage_perf.sh
@@ -125,6 +125,9 @@ Run_Fio()
     remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./constants.sh -remote_path /root -cmd put
     remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./ParseFioTestLogs.sh -remote_path /root -cmd put
     remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./nested_kvm_perf_fio.sh -remote_path /root -cmd put
+    remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./fio_jason_parser.sh -remote_path /root -cmd put
+    remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./gawk -remote_path /root -cmd put
+    remote_copy -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort -filename ./JSON.awk -remote_path /root -cmd put
 
     Log_Msg "Start to run StartFioTest.sh on nested VM" $log_file
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port $HostFwdPort '/root/StartFioTest.sh'

--- a/Testscripts/Windows/NESTED-KVM-STORAGE-PERF.ps1
+++ b/Testscripts/Windows/NESTED-KVM-STORAGE-PERF.ps1
@@ -14,9 +14,6 @@ collect_VM_properties nested_properties.csv
 "@
 
 	$scriptContent2 = @"
-wget https://ciwestusv2.blob.core.windows.net/scriptfiles/JSON.awk
-wget https://ciwestusv2.blob.core.windows.net/scriptfiles/gawk
-wget https://ciwestusv2.blob.core.windows.net/scriptfiles/fio_jason_parser.sh
 chmod +x *.sh
 cp fio_jason_parser.sh gawk JSON.awk utils.sh /root/FIOLog/jsonLog/
 cd /root/FIOLog/jsonLog/

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -225,6 +225,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>NESTED-PERF-STORAGE-IO-MODES</ReplaceThis>
+		<ReplaceWith>(randread randwrite read write)</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>NETPERF_RUNTIME_IN_SECONDS</ReplaceThis>
 		<ReplaceWith>300</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -47,7 +47,7 @@
         <TestName>HYPERV-NESTED-KVM-STORAGE-SINGLE-DISK</TestName>
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
         <setupScript>.\Testscripts\Windows\SETUP-Enable-NestedVirtualization.ps1</setupScript>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM1Disk</setupType>
         <OverrideVMSize>Standard_F16</OverrideVMSize>
         <TestParameters>
@@ -59,7 +59,7 @@
             <param>NestedMemMB=8192</param>
             <param>HostFwdPort=60022</param>
             <param>RaidOption='No RAID'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -77,7 +77,7 @@
     <test>
         <TestName>AZURE-NESTED-KVM-STORAGE-SINGLE-DISK</TestName>
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM1DiskNested</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
@@ -91,7 +91,7 @@
             <param>NestedMemMB=8192</param>
             <param>HostFwdPort=60022</param>
             <param>RaidOption='No RAID'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -110,7 +110,7 @@
         <TestName>HYPERV-NESTED-KVM-STORAGE-MULTIDISK</TestName>
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
         <setupScript>.\Testscripts\Windows\SETUP-Enable-NestedVirtualization.ps1</setupScript>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM4Disk</setupType>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
@@ -122,7 +122,7 @@
             <param>HostFwdPort=60022</param>
             <!--The raid option allowed values: 'No RAID','RAID in L1','RAID in L2'-->
             <param>RaidOption='RAID_OPTION'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -140,7 +140,7 @@
     <test>
         <TestName>AZURE-NESTED-KVM-STORAGE-MULTIDISK</TestName>
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM6DiskNested</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
@@ -155,7 +155,7 @@
             <param>HostFwdPort=60022</param>
             <!--The raid option allowed values: 'No RAID','RAID in L1','RAID in L2'-->
             <param>RaidOption='RAID_OPTION'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -322,7 +322,7 @@
             <param>NestedMemMB=8192</param>
             <param>HostFwdPort=60022</param>
             <param>RaidOption='No RAID'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -354,7 +354,7 @@
             <param>HostFwdPort=60022</param>
             <!--The raid option allowed values: 'No RAID','RAID in L1','RAID in L2'-->
             <param>RaidOption='RAID in L1'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -388,7 +388,7 @@
             <param>NestedMemMB=8192</param>
             <param>HostFwdPort=60022</param>
             <param>RaidOption='No RAID'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>
@@ -422,7 +422,7 @@
             <param>HostFwdPort=60022</param>
             <!--The raid option allowed values: 'No RAID','RAID in L1','RAID in L2'-->
             <param>RaidOption='RAID in L1'</param>
-            <param>modes='randread randwrite read write'</param>
+            <param>modes=NESTED-PERF-STORAGE-IO-MODES</param>
             <param>startThread=1</param>
             <param>maxThread=1024</param>
             <param>startIO=4</param>


### PR DESCRIPTION
Update nested perf storage test cases.

[LISAv2 Test Results Summary]
Test Run On           : 03/19/2019 08:54:55
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:49

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               AZURE-NESTED-KVM-STORAGE-SINGLE-DISK                                              PASS                38.81 
[LISAv2 Test Results Summary]
Test Run On           : 03/19/2019 08:55:32
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:49

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               AZURE-NESTED-KVM-STORAGE-MULTIDISK                                                PASS                39.27 



