### PR TITLE
Add OSType as Custom Parameter

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -194,7 +194,7 @@ Function Collect-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Tes
 }
 
 # This function set the AdditionalHWConfig of the test case data
-# Called when DiskType=Managed/Unmanaged or Networking=SRIOV/Synthetic or ImageType=Specialized/Generalized set in -CustomParameters
+# Called when DiskType=Managed/Unmanaged or Networking=SRIOV/Synthetic or ImageType=Specialized/Generalized or OSType=Windows/Linux set in -CustomParameters
 function Set-AdditionalHWConfigInTestCaseData ($CurrentTestData, $ConfigName, $ConfigValue) {
 	Write-LogInfo "The AdditionalHWConfig $ConfigName of case $($CurrentTestData.testName) is set to $ConfigValue"
 	if (!$CurrentTestData.AdditionalHWConfig) {

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Please follow the steps mentioned at [here](https://docs.microsoft.com/en-us/azu
         Example:
         .\Run-LisaV2.ps1 -TestPlatform WSL -TestLocation "localhost" -RGIdentifier 'ubuntuwsl' -TestNames "BVT-VERIFY-BOOT-ERROR-WARNINGS" -OsVHD 'https://aka.ms/wsl-ubuntu-1804' -DestinationOsVHDPath "D:\test"
 
+	.\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "<Region location>" -RGIdentifier "<Identifier of the resource group>" [-ARMImageName "<publisher offer SKU version>" | -OsVHD "<VHD from storage account>" ] [[-TestCategory "<Test Catogry from Jenkins pipeline>" | -TestArea "<Test Area from Jenkins pipeline>"]* | -TestTag "<A Tag from Jenkins pipeline>" | -TestNames "<Test cases separated by comma>"] -CustomParameters "TiPCluster=<cluster name> | TipSessionId=<Test in Production ID> |  DiskType=Managed/Unmanaged | Networking=SRIOV/Synthetic | ImageType=Specialized/Generalized | OSType=Windows/Linux" 
+	Example:
+        .\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "westus" -RGIdentifier "deployment" -ARMImageName "MicrosoftWindowsServer WindowsServer 2016-Datacenter latest" -TestNames "NESTED-HYPERV-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE" -CustomeParameters "OSType=Windows"
+
    b. Provide parameters in .\XML\TestParameters.xml.
 
         .\Run-LisaV2.ps1 -TestParameters .\XML\TestParameters.xml

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -88,7 +88,7 @@ Param(
 	[switch] $EnableTelemetry,
 	[switch] $UseExistingRG,
 
-	# [Optional] Parameters for setting TiPCluster, TipSessionId, DiskType=Managed/Unmanaged, Networking=SRIOV/Synthetic, ImageType=Specialized/Generalized.
+	# [Optional] Parameters for setting TiPCluster, TipSessionId, DiskType=Managed/Unmanaged, Networking=SRIOV/Synthetic, ImageType=Specialized/Generalized, OSType=Windows/Linux.
 	[string] $CustomParameters = "",
 
 	# [Optional] Parameters for Overriding VM Configuration.

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -271,6 +271,9 @@ Class TestController
 			if ( $this.CustomParams["ImageType"] -eq "Specialized" -or $this.CustomParams["ImageType"] -eq "Generalized") {
 				Set-AdditionalHWConfigInTestCaseData -CurrentTestData $test -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"]
 			}
+			if ( $this.CustomParams["OSType"] -eq "Windows" -or $this.CustomParams["OSType"] -eq "Linux") {
+				Set-AdditionalHWConfigInTestCaseData -CurrentTestData $test -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"]
+			}
 			if ($this.OverrideVMSize) {
 				Write-LogInfo "The OverrideVMSize of case $($test.testName) is set to $($this.OverrideVMSize)"
 				if ($test.OverrideVMSize) {
@@ -283,7 +286,8 @@ Class TestController
 			# Put test case to hashtable, per setupType,OverrideVMSize,networking,diskType,osDiskType,switchName
 			if ($test.setupType) {
 				$key = "$($test.setupType),$($test.OverrideVMSize),$($test.AdditionalHWConfig.Networking),$($test.AdditionalHWConfig.DiskType)," +
-					"$($test.AdditionalHWConfig.OSDiskType),$($test.AdditionalHWConfig.SwitchName),$($test.AdditionalHWConfig.ImageType)"
+					"$($test.AdditionalHWConfig.OSDiskType),$($test.AdditionalHWConfig.SwitchName),$($test.AdditionalHWConfig.ImageType)," +
+					"$($test.AdditionalHWConfig.OSType)"
 				if ($this.SetupTypeToTestCases.ContainsKey($key)) {
 					$this.SetupTypeToTestCases[$key] += $test
 				} else {
@@ -293,7 +297,7 @@ Class TestController
 
 			# Check whether the case if for Windows images
 			$IsWindowsImage = $false
-			if($test.Tags -and $test.Tags.ToString().Contains("nested-hyperv")) {
+			if(($test.AdditionalHWConfig.OSType -contains "Windows")) {
 				$IsWindowsImage = $true
 			}
 			Set-Variable -Name IsWindowsImage -Value $IsWindowsImage -Scope Global

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -207,6 +207,7 @@
         <OverrideVMSize>Standard_F16</OverrideVMSize>
         <AdditionalHWConfig>
             <SwitchName>NonSRIOV</SwitchName>
+            <OSType>Windows</OSType>
         </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be vhd format, and accessible from a public URL-->
@@ -313,6 +314,9 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM1Disk</setupType>
         <OverrideVMSize>Standard_F16</OverrideVMSize>
+        <AdditionalHWConfig>
+            <OSType>Windows</OSType>
+        </AdditionalHWConfig>
         <TestParameters>
             <!-- The nested image should be vhd format, it's a local path, a SMB path, or a public URL  -->
             <param>NestedImageUrl=NESTED_VHD_PATH</param>
@@ -344,6 +348,9 @@
         <setupScript>.\Testscripts\Windows\SETUP-Enable-NestedVirtualization.ps1</setupScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM4Disk</setupType>
+        <AdditionalHWConfig>
+            <OSType>Windows</OSType>
+        </AdditionalHWConfig>
         <TestParameters>
             <!-- The nested image should be vhd format, it's a local path, a SMB path, or a public URL  -->
             <param>NestedImageUrl=NESTED_VHD_PATH</param>
@@ -378,6 +385,7 @@
         <setupType>OneVM1DiskNested</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
+            <OSType>Windows</OSType>
         </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be vhd format, and accessible from a public URL-->
@@ -411,6 +419,7 @@
         <setupType>OneVM6DiskNested</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
+            <OSType>Windows</OSType>
         </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be vhd format, and accessible from a public URL-->
@@ -498,6 +507,9 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_hyperv_ntttcp_different_l1_nat.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\perf_ntttcp.sh</files>
         <setupType>TwoVM2Host</setupType>
         <OverrideVMSize>Standard_F16</OverrideVMSize>
+        <AdditionalHWConfig>
+            <OSType>Windows</OSType>
+        </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be vhd format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_VHD_URL</param>
@@ -522,6 +534,9 @@
         <testScript>NESTED-HYPERV-NTTTCP-DIFFERENT-L1-NAT.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_hyperv_ntttcp_different_l1_nat.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\perf_ntttcp.sh</files>
         <setupType>TwoVMNested</setupType>
+        <AdditionalHWConfig>
+            <OSType>Windows</OSType>
+        </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be vhd format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_VHD_URL</param>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -17,6 +17,30 @@
             </VirtualMachine>
         </ResourceGroup>
     </OneVM>
+    <OneVMWin>
+        <isDeployed>NO</isDeployed>
+        <ResourceGroup>
+            <VirtualMachine>
+                <state></state>
+                <InstanceSize>Standard_DS1_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS1_v2</ARMInstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>RDP</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>3389</LocalPort>
+                    <PublicPort>3389</PublicPort>
+                </EndPoints>
+                <EndPoints>
+                    <Name>Session</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>5985</LocalPort>
+                    <PublicPort>5985</PublicPort>
+                </EndPoints>
+	        <DataDisk></DataDisk>
+            </VirtualMachine>
+        </ResourceGroup>
+    </OneVMWin> 
     <OneVMCluster>
         <isDeployed>NO</isDeployed>
         <ClusteredVM>True</ClusteredVM>


### PR DESCRIPTION
In Lisav2 framework the Windows VM deployment is supported for nested-VM tests. This change adds the OSType as custom parameter which supports to deploy the windows VM. 

Below is the log snippet which shows Windows VM is deployed successfully:
03/19/2019 05:52:18 : [INFO ] Adding Virtual Machine LISAv2-OneVMW-0
03/19/2019 05:52:18 : [INFO ] >>> Using ARMImage : MicrosoftWindowsServer : WindowsServer : 2016-Datacenter : latest
03/19/2019 05:52:18 : [INFO ] Added Unmanaged-Persistent OS disk : LISAv2-OneVMW-0-OSDisk
03/19/2019 05:52:18 : [INFO ] Added Virtual Machine LISAv2-OneVMW-0
03/19/2019 05:52:18 : [INFO ] Template generated successfully.
03/19/2019 05:52:18 : [INFO ] Creating Deployment using C:\Users\v-prmhet\AppData\Local\Temp\LISAv2-OneVMWin-PRstaginglisav2-BO24-20190318225205.json ...
03/19/2019 05:55:20 : [INFO ] Resource Group Deployment created.
03/19/2019 05:55:20 : [INFO ] Collecting LISAv2-OneVMWin-PRstaginglisav2-BO24-20190318225205 data..
03/19/2019 05:55:20 : [INFO ] 	Microsoft.Network/publicIPAddresses data collection in progress..
03/19/2019 05:55:21 : [INFO ] 	Microsoft.Compute/virtualMachines data collection in progress..
03/19/2019 05:55:21 : [INFO ] 	Microsoft.Network/networkInterfaces data collection in progress..
03/19/2019 05:55:22 : [INFO ] 	Microsoft.Network/loadBalancers data collection in progress..
03/19/2019 05:55:23 : [INFO ] Collected LISAv2-OneVMWin-PRstaginglisav2-BO24-20190318225205 data!
03/19/2019 05:55:23 : [INFO ] Trying to connect to deployed VMs.
03/19/2019 05:55:23 : [INFO ] Connecting to 52.246.251.131:3389 succeeded.
03/19/2019 05:55:23 : [INFO ] All VM ports are open.
