### PR TITLE
Added support to send VM Hardware Platform to Telemetry DB

### DIFF
--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -26,7 +26,7 @@
 ###############################################################################################
 
 Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,$TestArea,$TestName,$CurrentTestResult, `
-									$ExecutionTag,$GuestDistro,$KernelVersion,$LISVersion,$HostVersion,$VMSize, $VMGeneration, `
+									$ExecutionTag,$GuestDistro,$KernelVersion,$HardwarePlatform,$LISVersion,$HostVersion,$VMSize, $VMGeneration, `
 									$Networking,$ARMImageName,$OsVHD,$LogFile,$BuildURL)
 {
 	try
@@ -50,15 +50,15 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform,$TestLocation,$TestCategory,
 			$BuildURL = ""
 		}
 		$dataTableName = "LISAv2Results"
-		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,LISVersion,HostVersion,VMSize,VMGeneration,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
-		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
+		$SQLQuery = "INSERT INTO $dataTableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,HardwarePlatform,LISVersion,HostVersion,VMSize,VMGeneration,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES "
+		$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','','','$ExecutionTag','$GuestDistro','$KernelVersion','$HardwarePlatform','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
 		if ($TestSummary) {
 			foreach ($tempResult in $TestSummary.Split('>')) {
 				if ($tempResult) {
 					$tempResult = $tempResult.Trim().Replace("<br /","").Trim()
 					$subTestResult = $tempResult.Split(":")[$tempResult.Split(":").Count -1 ].Trim()
 					$subTestName = $tempResult.Replace("$subTestResult","").Trim().TrimEnd(":").Trim()
-					$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','$subTestName','$subTestResult','$ExecutionTag','$GuestDistro','$KernelVersion','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
+					$SQLQuery += "('$DateTimeUTC','$TestPlatform','$TestLocation','$TestCategory','$TestArea','$TestName','$testResult','$subTestName','$subTestResult','$ExecutionTag','$GuestDistro','$KernelVersion','$HardwarePlatform','$LISVersion','$HostVersion','$VMSize','$VMGeneration','$Networking','$ARMImageName','$OsVHD','$UploadedURL', '$BuildURL'),"
 				}
 			}
 		}

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -164,6 +164,7 @@ Function Get-SystemBasicLogs($AllVMData, $User, $Password, $currentTestData, $Cu
 		$Null = Copy-RemoteFiles -downloadFrom $vmData.PublicIP -port $vmData.SSHPort `
 			-username $user -password $password -files "$FilesToDownload" -downloadTo "$LogDir" -download
 		$KernelVersion = Get-Content "$LogDir\$($vmData.RoleName)-kernelVersion.txt"
+		$HardwarePlatform = Get-Content "$LogDir\$($vmData.RoleName)-hardwarePlatform.txt"
 		$GuestDistro = Get-Content "$LogDir\$($vmData.RoleName)-distroVersion.txt"
 		$LISMatch = (Select-String -Path "$LogDir\$($vmData.RoleName)-lis.txt" -Pattern "^version:").Line
 		if ($LISMatch)
@@ -207,7 +208,7 @@ Function Get-SystemBasicLogs($AllVMData, $User, $Password, $currentTestData, $Cu
 			$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
 			-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
 			-ExecutionTag $global:GlobalConfig.Global.$global:TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
-			-LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -VMGeneration $VMGeneration -Networking $Networking `
+			-HardwarePlatform $HardwarePlatform -LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -VMGeneration $VMGeneration -Networking $Networking `
 			-ARMImageName $global:ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL
 
 			Upload-TestResultToDatabase -SQLQuery $SQLQuery

--- a/Testscripts/Linux/CollectLogFile.sh
+++ b/Testscripts/Linux/CollectLogFile.sh
@@ -15,6 +15,7 @@ export PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 dmesg > ${hostname}-dmesg.txt
 cp /var/log/waagent.log ${hostname}-waagent.log.txt
 uname -r > ${hostname}-kernelVersion.txt
+uname -i > ${hostname}-hardwarePlatform.txt
 uptime -s > ${hostname}-uptime.txt || echo "UPTIME_COMMAND_ERROR" > ${hostname}-uptime.txt
 modinfo hv_netvsc > ${hostname}-lis.txt
 release=$(cat /etc/*release*)


### PR DESCRIPTION
Many of our HyperV Tests are running on 32bit VMs. This will help us separating / presenting correct data in our PowerBI / Excel reports.