### PR TITLE
Fixed VM size calculation

### DIFF
--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -68,7 +68,7 @@ function Main {
 			Write-LogInfo "Waiting 5 minutes to finish RDMA update for NC series VMs."
 			Start-Sleep -Seconds 300
 		}
-		$VM_Size = $ServerVMData.InstanceSize -replace "[^0-9]",''
+		$VM_Size = ($ServerVMData.InstanceSize -split "_")[1] -replace "[^0-9]",''
 		Write-LogInfo "Getting VM instance size: $VM_Size"
 		#region CONFIGURE VMs for TEST
 


### PR DESCRIPTION
Change: extract the number before '_' character. Some of VM size have '_v2' or '_v3'. Here is fixed results

<Case 1>
.\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "westeurope" -ARMImageName "RedHat RHEL 7.5 latest" -RGIdentifier "juhlee" -TestNames "INFINIBAND-INTEL-MPI-2VM" -XMLSecretFile <secret file> -ResourceCleanup Keep -OverrideVMSize "Standard_NC24rs_v2"

03/26/2019 01:32:23 : [INFO ] Waiting 5 minutes to finish RDMA update for NC series VMs.
03/26/2019 01:37:23 : [INFO ] Getting VM instance size: 24
03/26/2019 01:37:23 : [INFO ] SERVER VM details :
03/26/2019 01:37:23 : [INFO ]   RoleName : controller-vm
03/26/2019 01:37:23 : [INFO ]   Public IP : 104.45.0.120
03/26/2019 01:37:23 : [INFO ]   SSH Port : 1110
03/26/2019 01:37:23 : [INFO ] CLIENT VM #1 details :
03/26/2019 01:37:23 : [INFO ]   RoleName : dependency-vm
03/26/2019 01:37:23 : [INFO ]   Public IP : 104.45.0.120
03/26/2019 01:37:23 : [INFO ]   SSH Port : 1111



.\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "westus2" -ARMImageName "RedHat RHEL 7.5 latest" -RGIdentifier "juhlee" -TestNames "INFINIBAND-INTEL-MPI-2VM" -XMLSecretFile <secret file> -ResourceCleanup Keep -OverrideVMSize "Standard_HC44rs"

03/26/2019 06:53:37 : [INFO ] Getting VM instance size: 44
03/26/2019 06:53:37 : [INFO ] SERVER VM details :
03/26/2019 06:53:37 : [INFO ]   RoleName : controller-vm
03/26/2019 06:53:37 : [INFO ]   Public IP : 52.175.245.121
03/26/2019 06:53:37 : [INFO ]   SSH Port : 1110
03/26/2019 06:53:38 : [INFO ] CLIENT VM #1 details :
03/26/2019 06:53:38 : [INFO ]   RoleName : dependency-vm
03/26/2019 06:53:38 : [INFO ]   Public IP : 52.175.245.121
03/26/2019 06:53:38 : [INFO ]   SSH Port : 1111
03/26/2019 06:53:38 : [INFO ] Configuring controller-vm for LISA test...
03/26/2019 06:53:38 : [INFO ] dos2unix: converting file .\Tests