### PR TITLE
DPDK: replaceable DPDK_PERF_CORES and upload db results on failure

### DIFF
--- a/Testscripts/Linux/dpdk-testFWD.sh
+++ b/Testscripts/Linux/dpdk-testFWD.sh
@@ -146,7 +146,7 @@ function Testfwd_Parser() {
 
 function Run_Testcase() {
 	if [ -z "${CORES}" ]; then
-		CORES="1"
+		CORES=(1)
 		LogMsg "CORES not found in environment; doing default single core test"
 	fi
 
@@ -157,14 +157,14 @@ function Run_Testcase() {
 
 	LogMsg "Starting testfwd"
 	Create_Vm_Synthetic_Vf_Pair_Mappings
-	for core in ${CORES}; do
+	for core in "${CORES[@]}"; do
 		Run_Testfwd ${core} ${TEST_DURATION}
 	done
 
 	LogMsg "Starting testfwd parser"
 	local csv_file=$(Create_Csv)
 	echo "dpdk_version,core,tx_pps_avg,fwdrx_pps_avg,fwdtx_pps_avg,rx_pps_avg" > "${csv_file}"
-	for core in ${CORES}; do
+	for core in "${CORES[@]}"; do
 		Testfwd_Parser ${core} "${csv_file}"
 	done
 

--- a/Testscripts/Linux/dpdk-testPMD.sh
+++ b/Testscripts/Linux/dpdk-testPMD.sh
@@ -154,7 +154,7 @@ function Testpmd_Parser() {
 
 function Run_Testcase() {
 	if [ -z "${CORES}" ]; then
-		CORES="1"
+		CORES=(1)
 		LogMsg "CORES not found in environment; doing default single core test"
 	fi
 
@@ -170,14 +170,14 @@ function Run_Testcase() {
 
 	LogMsg "Starting testpmd"
 	Create_Vm_Synthetic_Vf_Pair_Mappings
-	for core in ${CORES}; do
+	for core in "${CORES[@]}"; do
 		Run_Testpmd ${core} "${MODES}" ${TEST_DURATION}
 	done
 
 	LogMsg "Starting testpmd parser"
 	local csv_file=$(Create_Csv)
 	echo "dpdk_version,test_mode,core,max_rx_pps,tx_pps_avg,rx_pps_avg,fwdtx_pps_avg,tx_bytes,rx_bytes,fwd_bytes,tx_packets,rx_packets,fwd_packets,tx_packet_size,rx_packet_size" > "${csv_file}"
-	for core in ${CORES}; do
+	for core in "${CORES[@]}"; do
 		for test_mode in ${MODES}; do
 			Testpmd_Parser ${core} "${test_mode}" "${csv_file}"
 		done

--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -248,7 +248,8 @@ collect_VM_properties
 		$finalState = Run-LinuxCmd -ip $masterVM.PublicIP -port $masterVM.SSHPort -username $superUser -password $password -command "cat /root/state.txt"
 		Copy-RemoteFiles -downloadFrom $masterVM.PublicIP -port $masterVM.SSHPort -username $superUser -password $password -download -downloadTo $LogDir -files "*.csv, *.txt, *.log"
 
-		$testDataCsv = Import-Csv -Path $LogDir\dpdk_test.csv
+		$testDataCsv = Import-Csv -Path "${LogDir}\dpdk_test.csv"
+
 		if ($finalState -imatch "TestFailed") {
 			Write-LogErr "Test failed. Last known output: $currentOutput."
 			$testResult = "FAIL"
@@ -269,8 +270,8 @@ collect_VM_properties
 			$testResult = "ABORTED"
 		}
 
-		if ($testResult -eq "PASS") {
-			Write-LogInfo "Generating the performance data for database insertion"
+		if ($testDataCsv -and @("PASS","FAIL").contains($testResult)) {
+			Write-LogInfo "Parsing the performance data for database insertion"
 			$properties = Get-VMProperties -PropertyFilePath "$LogDir\VM_properties.csv"
 			$testDate = $(Get-Date -Format yyyy-MM-dd)
 			foreach ($mode in $testDataCsv) {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -42,6 +42,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>https://fast.dpdk.org/rel/dpdk-18.08.tar.xz</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>DPDK_PERF_CORES</ReplaceThis>
+		<ReplaceWith>(2 4 8 16)</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>OVS_SOURCE_URL</ReplaceThis>
 		<ReplaceWith>https://github.com/openvswitch/ovs.git</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/PerformanceTests-DPDK.xml
+++ b/XML/TestCases/PerformanceTests-DPDK.xml
@@ -10,7 +10,7 @@
         <TestParameters>
             <param>DPDK_LINK="DPDK_SOURCE_URL"</param>
             <param>TEST_DURATION=DPDK_TEST_DURATION_IN_SECONDS</param>
-            <param>CORES="2 4 8 16"</param>
+            <param>CORES=DPDK_PERF_CORES</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
@@ -69,7 +69,7 @@
             <param>DPDK_LINK="DPDK_SOURCE_URL"</param>
             <param>TEST_DURATION=DPDK_TEST_DURATION_IN_SECONDS</param>
             <param>MODES="rxonly io"</param>
-            <param>CORES="2 4 8 16"</param>
+            <param>CORES=DPDK_PERF_CORES</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>


### PR DESCRIPTION
Added the option to parameterize the cores used for DPDK performance testing.
DPDK_PERF_CORES=(2,4,8,16)

If the test fails, the performance results are uploaded to the database, because it might have failed because of the performance variation.