### PR TITLE
Ubuntu: fix BVT-CORE-TIMESYNC-NTP install dependencies

### DIFF
--- a/Testscripts/Linux/BVT-CORE-TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/BVT-CORE-TIMESYNC-NTP.sh
@@ -90,9 +90,8 @@ elif is_ubuntu ; then
     if ! service ntp restart
     then
         LogMsg "NTP is not installed. Trying to install..."
-        apt-get update
-        if ! apt-get install ntp -y
-        then
+        update_repos
+        if ! install_package ntp; then
             LogErr "Unable to install ntp. Aborting"
             SetTestStateAborted
             exit 0

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2099,6 +2099,7 @@ function check_exit_status ()
 		$cmd "$message: Success"
 		UpdateSummary "$message: Success"
 	fi
+	return $exit_status
 }
 
 # Detect the version of Linux distribution, it gets the version only


### PR DESCRIPTION
* ntp is not found after custom kernel install because dpkg needs reconfigure, this is an automation issue since the package can be installed.

**Issue logs:**

---

**TestExecution.log**

```
Wed Mar 27 16:54:51 2019 : Testscript running on ubuntu_x
Wed Mar 27 16:54:51 2019 : Successfully initialized testscript!
Wed Mar 27 16:54:52 2019 : NTP is not installed. Trying to install...
Wed Mar 27 16:54:56 2019 : Unable to install ntp. Aborting
```

---

**LISAv2-Test-CM33.log**

```
Test Run On           : 03/27/2019 14:51:25
VHD Under Test        : Ubuntu-18.04-gen2.vhdx
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 BVT-CORE-TIMESYNC-NTP                                                          ABORTED                 1.02 

```