### PR TITLE
dpdk: add PERF-DPDK-MULTICORE-PPS-F32 TC for DPDK with 16 cores

### DIFF
--- a/XML/Other/testfwd_pps_lowerbound.xml
+++ b/XML/Other/testfwd_pps_lowerbound.xml
@@ -31,4 +31,36 @@
 			<rx>6500000</rx>
 		</core16>
 	</Standard_DS15_v2>
+	<Standard_F32s_v2>
+		<core1>
+			<tx>10000000</tx>
+			<fwdrx>9500000</fwdrx>
+			<fwdtx>8500000</fwdtx>
+			<rx>8200000</rx>
+		</core1>
+		<core2>
+			<tx>10000000</tx>
+			<fwdrx>9500000</fwdrx>
+			<fwdtx>8500000</fwdtx>
+			<rx>8200000</rx>
+		</core2>
+		<core4>
+			<tx>10000000</tx>
+			<fwdrx>9500000</fwdrx>
+			<fwdtx>8500000</fwdtx>
+			<rx>8200000</rx>
+		</core4>
+		<core8>
+			<tx>10000000</tx>
+			<fwdrx>10000000</fwdrx>
+			<fwdtx>8000000</fwdtx>
+			<rx>800000</rx>
+		</core8>
+		<core16>
+			<tx>6500000</tx>
+			<fwdrx>6500000</fwdrx>
+			<fwdtx>6500000</fwdtx>
+			<rx>6500000</rx>
+		</core16>
+	</Standard_F32s_v2>
 </testfwdpps>

--- a/XML/Other/testpmd_pps_lowerbound.xml
+++ b/XML/Other/testpmd_pps_lowerbound.xml
@@ -39,4 +39,36 @@
 			<fwdtx>6000000</fwdtx>
 		</core16>
 	</Standard_DS15_v2>
+	<Standard_F32s_v2>
+		<core1>
+			<tx>10000000</tx>
+			<rx>10000000</rx>
+			<fwdrx>6000000</fwdrx>
+			<fwdtx>6000000</fwdtx>
+		</core1>
+		<core2>
+			<tx>14000000</tx>
+			<rx>14000000</rx>
+			<fwdrx>6000000</fwdrx>
+			<fwdtx>6000000</fwdtx>
+		</core2>
+		<core4>
+			<tx>15000000</tx>
+			<rx>15000000</rx>
+			<fwdrx>6000000</fwdrx>
+			<fwdtx>6000000</fwdtx>
+		</core4>
+		<core8>
+			<tx>15000000</tx>
+			<rx>15000000</rx>
+			<fwdrx>6000000</fwdrx>
+			<fwdtx>6000000</fwdtx>
+		</core8>
+		<core16>
+			<tx>18000000</tx>
+			<rx>18000000</rx>
+			<fwdrx>6000000</fwdrx>
+			<fwdtx>6000000</fwdtx>
+		</core16>
+	</Standard_F32s_v2>
 </testpmdpps>

--- a/XML/TestCases/PerformanceTests-DPDK.xml
+++ b/XML/TestCases/PerformanceTests-DPDK.xml
@@ -10,7 +10,7 @@
         <TestParameters>
             <param>DPDK_LINK="DPDK_SOURCE_URL"</param>
             <param>TEST_DURATION=DPDK_TEST_DURATION_IN_SECONDS</param>
-            <param>CORES=DPDK_PERF_CORES</param>
+            <param>CORES=(2 4 8)</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
@@ -61,6 +61,27 @@
         <testName>PERF-DPDK-MULTICORE-PPS-DS15</testName>
         <testScript>DPDK-TESTCASE-DRIVER.ps1</testScript>
         <setupType>TwoVM2NIC</setupType>
+        <AdditionalHWConfig>
+            <Networking>SRIOV</Networking>
+        </AdditionalHWConfig>
+        <files>.\Testscripts\Linux\dpdk-testPMD.sh,.\Testscripts\Windows\dpdk-testPMD.ps1</files>
+        <TestParameters>
+            <param>DPDK_LINK="DPDK_SOURCE_URL"</param>
+            <param>TEST_DURATION=DPDK_TEST_DURATION_IN_SECONDS</param>
+            <param>MODES="rxonly io"</param>
+            <param>CORES=(2 4 8)</param>
+        </TestParameters>
+        <Platform>Azure</Platform>
+        <Category>Performance</Category>
+        <Area>DPDK</Area>
+        <Tags>dpdk,network,hv_netvsc,sriov</Tags>
+        <Priority>2</Priority>
+    </test>
+    <test>
+        <testName>PERF-DPDK-MULTICORE-PPS-F32</testName>
+        <testScript>DPDK-TESTCASE-DRIVER.ps1</testScript>
+        <setupType>TwoVM2NIC</setupType>
+        <OverrideVMSize>Standard_F32s_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>


### PR DESCRIPTION
PERF-DPDK-MULTICORE-PPS-DS15 test case on the 16 cores run
was always lower than the lowerbounds, as the Standard_DS15_v2
flavor has 2 NUMA nodes, first with 8 cores and the second
with 12 cores. The NUMA RAM access penalty was high enough
to downgrade the performance by more than 40-50% compared to
the lowerbounds.

Created another test "PERF-DPDK-MULTICORE-PPS-F32" with flavor
Standard_F32s_v2, which has 2 NUMA nodes - each with 16 cores.
Running DPDK perf tests on 16 cores will not suffer from NUMA
penalty, thus the tests should not have a performance downgrade.

Removed the 16 core run for the previous tests, as that run had
always a performance downgrade.