### PR TITLE
CustomKernel: Get VM ip if dhcp changed it after reboot

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -348,6 +348,10 @@ function Is-VmAlive {
                     Write-LogErr "Linux VM $($vm.RoleName) failed to boot because of a kernel panic."
                     return "False"
                 }
+                if ($TestPlatform -eq "HyperV") {
+                    Write-LogWarn "Checking if HyperV VM changed IP at boot."
+                    $AllVMDataObject = Check-IP -VMData $AllVMDataObject
+                }
             } else {
                 Write-LogInfo "Connecting to $($vm.PublicIP):$port succeeded."
             }


### PR DESCRIPTION
After kernel install the VM is restarted and it is possible the VM gets a new IP via dhcp and the Is-VmAlive function does not check for it and LISAv2 can't reach it