### PR TITLE
Add two columns NumberOfReceivers and NumberOfSenders in database to distinguish mode of ntttcp.

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
@@ -20,23 +20,24 @@ function Main {
         $noServer = $true
         $clientMachines = @()
         $clientIPs = ""
+        $numberOfReceivers = 0
+        $numberOfSenders = 0
         # role-0 vm is considered as the server-vm
-        # role-1 vm is considered as the client-vm-01
-        # role-2 vm is considered as the client-vm-02
-        # role-3 vm is considered as the client-vm-03
-        # role-4 vm is considered as the client-vm-04
+        # role-1 to role-8 vm is considered as the client-vm-01 to client-vm-08
         foreach ($vmData in $allVMData) {
             if ($vmData.RoleName -imatch "server" -or $vmData.RoleName -imatch "role-0") {
                 $serverVMData = $VmData
                 $noServer = $false
+                $numberOfReceivers++
             } elseif ($vmData.RoleName -imatch "client" -or $vmData.RoleName -imatch "role-1") {
                 $clientMachines += $VmData
-                $noClient = $fase
+                $noClient = $false
                 if ($clientIPs) {
                     $clientIPs += "," + $vmData.InternalIP
                 } else {
                     $clientIPs = $vmData.InternalIP
                 }
+                $numberOfSenders++
             }
         }
         if ($noClient -or $noServer) {
@@ -245,6 +246,10 @@ collect_VM_properties
                     $resultMap["TXpackets"] = $($Line[4])
                     $resultMap["RXpackets"] = $($Line[5])
                     $resultMap["PktsInterrupts"] = $($Line[6])
+                }
+                if ($TestPlatform -eq "Azure") {
+                    $resultMap["NumberOfReceivers"] = $numberOfReceivers
+                    $resultMap["NumberOfSenders"] = $numberOfSenders
                 }
                 $currentTestResult.TestResultData += $resultMap
             }


### PR DESCRIPTION
Test results - 
```
04/02/2019 03:38:43 : [INFO ] Generating the performance data for database insertion
04/02/2019 03:38:43 : [INFO ] Test result : PASS
04/02/2019 03:38:45 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','5576.858','Linux','Azure','0','15.26',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','8','14393-1
0.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:45 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','7885.675','Linux','Azure','0','21.24',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','16','14393-
10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:45 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','9436.820','Linux','Azure','0','21.39',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','32','14393-
10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:45 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','10109.558','Linux','Azure','0','22.74',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','64','14393
-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:46 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','12046.589','Linux','Azure','0','22.70',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','128','1439
3-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:46 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','12901.098','Linux','Azure','0','22.09',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','256','1439
3-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:46 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','14419.938','Linux','Azure','0','19.40',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','512','1439
3-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:46 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','15695.285','Linux','Azure','0','16.92',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','1024','143
93-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:47 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','14245.835','Linux','Azure','0','14.03',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','2048','143
93-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:47 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','16997.155','Linux','Azure','0','12.03',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','4096','143
93-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:47 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','17653.387','Linux','Azure','0','11.38',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','6144','143
93-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:47 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','16439.869','Linux','Azure','0','11.18',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','8192','143
93-10.0-0-0.274',8,'0','Synthetic','eastus2')
04/02/2019 03:38:48 : [INFO ] SQLQuery:  INSERT INTO Perf_Network_TCP_Azure_DefaultKernel (GuestSize,IPVersion,PktsInterrupts,TestCaseName,Latency_ms,GuestOSType,HostType,RXpacket
s,Throughput_Gbps,NumberOfReceivers,KernelVersion,GuestDistro,ProtocolType,TestDate,NumberOfConnections,HostOS,NumberOfSenders,TXpackets,DataPath,HostBy) VALUES ('Standard_D15_v2'
,'IPv4','0','PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic','17318.623','Linux','Azure','0','11.56',1,'4.18.0-1013-azure','ubuntu 18.04','TCP','2019-04-01','10240','14
393-10.0-0-0.274',8,'0','Synthetic','eastus2')

[LISAv2 Test Results Summary]
Test Run On           : 04/02/2019 01:33:05
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:2:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic                         PASS               126.75 
	Connections=8 : throughput=15.26Gbps cyclePerBytet=14.74 Avg_TCP_lat=5576.858 
	Connections=16 : throughput=21.24Gbps cyclePerBytet=13.74 Avg_TCP_lat=7885.675 
	Connections=32 : throughput=21.39Gbps cyclePerBytet=9.73 Avg_TCP_lat=9436.820 
	Connections=64 : throughput=22.74Gbps cyclePerBytet=9.86 Avg_TCP_lat=10109.558 
	Connections=128 : throughput=22.70Gbps cyclePerBytet=10.17 Avg_TCP_lat=12046.589 
	Connections=256 : throughput=22.09Gbps cyclePerBytet=17.62 Avg_TCP_lat=12901.098 
	Connections=512 : throughput=19.40Gbps cyclePerBytet=24.14 Avg_TCP_lat=14419.938 
	Connections=1024 : throughput=16.92Gbps cyclePerBytet=51.09 Avg_TCP_lat=15695.285 
	Connections=2048 : throughput=14.03Gbps cyclePerBytet=97.69 Avg_TCP_lat=14245.835 
	Connections=4096 : throughput=12.03Gbps cyclePerBytet=154.58 Avg_TCP_lat=16997.155 
	Connections=6144 : throughput=11.38Gbps cyclePerBytet=176.08 Avg_TCP_lat=17653.387 
	Connections=8192 : throughput=11.18Gbps cyclePerBytet=178.86 Avg_TCP_lat=16439.869 
	Connections=10240 : throughput=11.56Gbps cyclePerBytet=163.81 Avg_TCP_lat=17318.623 
```