### PR TITLE
LTP: Use vhdx test disk instead of vhd

### DIFF
--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -38,23 +38,24 @@ GetDistro
 update_repos
 
 LogMsg "Installing dependencies"
-common_packages=(git m4 db48-utils bison flex make gcc psmisc autoconf automake)
+common_packages=(git m4 bison flex make gcc psmisc autoconf automake)
+update_repos
 install_package "${common_packages[@]}"
 
 case $DISTRO in
     "suse"*)
-        suse_packages=(libaio-devel libattr1 libcap-progs \
+        suse_packages=(db48-utils libaio-devel libattr1 libcap-progs \
             libdb-4_8 perl-BerkeleyDB git-core)
         install_package "${suse_packages[@]}"
         ;;
     "ubuntu"* | "debian"*)
-        deb_packages=(libaio-dev libattr1 libcap-dev keyutils \
+        deb_packages=(db-util libaio-dev libattr1 libcap-dev keyutils \
             libdb4.8 libberkeleydb-perl expect dh-autoreconf \
             libnuma-dev quota genisoimage gdb unzip exfat-utils)
         install_package "${deb_packages[@]}"
         ;;
     "redhat"* | "centos"* | "fedora"*)
-        rpm_packages=(libaio-devel libattr libcap-devel libdb)
+        rpm_packages=(db48-utils libaio-devel libattr libcap-devel libdb)
         install_package "${rpm_packages[@]}"
         ;;
     *)

--- a/XML/TestCases/CommunityTests.xml
+++ b/XML/TestCases/CommunityTests.xml
@@ -70,8 +70,8 @@
         <TestName>LINUX-TEST-PROJECT-TESTS</TestName>
         <TestScript>Linux-Test-Project-Tests.sh</TestScript>
         <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\Linux-Test-Project-Tests.sh</files>
-        <setupScript>.\TestScripts\Windows\AddHardDisk.ps1</setupScript>
-        <cleanupScript>.\TestScripts\Windows\RemoveHardDisk.ps1</cleanupScript>
+        <setupScript>.\TestScripts\Windows\AddVhdxHardDisk.ps1</setupScript>
+        <cleanupScript>.\TestScripts\Windows\RemoveVhdxHardDisk.ps1</cleanupScript>
         <setupType>OneVM1Disk5G</setupType>
         <OverrideVMSize>Standard_DS14_v2</OverrideVMSize>
         <TestParameters>
@@ -91,8 +91,8 @@
         <TestName>LINUX-TEST-PROJECT-TESTS-FULL-RUN</TestName>
         <TestScript>Linux-Test-Project-Tests.sh</TestScript>
         <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\Linux-Test-Project-Tests.sh</files>
-        <setupScript>.\TestScripts\Windows\AddHardDisk.ps1</setupScript>
-        <cleanupScript>.\TestScripts\Windows\RemoveHardDisk.ps1</cleanupScript>
+        <setupScript>.\TestScripts\Windows\AddVhdxHardDisk.ps1</setupScript>
+        <cleanupScript>.\TestScripts\Windows\RemoveVhdxHardDisk.ps1</cleanupScript>
         <setupType>OneVM1Disk5G</setupType>
         <OverrideVMSize>Standard_DS14_v2</OverrideVMSize>
         <TestParameters>

--- a/XML/TestCases/CommunityTests.xml
+++ b/XML/TestCases/CommunityTests.xml
@@ -77,7 +77,7 @@
         <TestParameters>
             <param>ltp_version_git_tag="LTP_TESTS_GIT_TAG"</param>
             <param>LTP_TEST_SUITE="LTP_SUITE"</param>
-            <param>SCSI=1,1,Fixed,5GB</param>
+            <param>SCSI=1,1,Fixed,512,5GB</param>
             <param>LTP_PACKAGE_URL="LTP_BUILD_URL"</param>
         </TestParameters>
         <Timeout>20000</Timeout>
@@ -98,7 +98,7 @@
         <TestParameters>
             <param>ltp_version_git_tag="LTP_TESTS_GIT_TAG"</param>
             <param>LTP_TEST_SUITE="full"</param>
-            <param>SCSI=1,1,Fixed,5GB</param>
+            <param>SCSI=1,1,Fixed,512,5GB</param>
             <param>LTP_PACKAGE_URL="LTP_BUILD_URL"</param>
         </TestParameters>
         <Timeout>20000</Timeout>


### PR DESCRIPTION
* `db48-utils` was common package but for Ubuntu it's `db-util`, fix prerequisites install.
* Fixes #47 