### PR TITLE
BVT-CORE-RELOAD-MODULES-SMP: Fix issue against CentOS

### DIFF
--- a/Testscripts/Linux/BVT-CORE-RELOAD-MODULES.sh
+++ b/Testscripts/Linux/BVT-CORE-RELOAD-MODULES.sh
@@ -164,7 +164,7 @@ LogMsg "Info: Finished testing, bringing up eth0"
 ip link set eth0 down
 ip link set eth0 up
 
-if ! dhclient
+if ! (dhclient -r && dhclient)
 then
     msg="Error: dhclient exited with an error"
     LogMsg "${msg}"


### PR DESCRIPTION
In Ubuntu, the eth0 will be back when remove/reload network driver. During testing, VM is accessible. 
```
[  770.559509] hv_vmbus: unregistering driver hv_netvsc
[  771.616893] hv_vmbus: registering driver hv_netvsc
[  771.682080] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[  771.682121] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  774.686442] hv_vmbus: unregistering driver hid_hyperv
[  775.779801] hv_vmbus: registering driver hid_hyperv
```
In CentOS, the eth0 will not be bring back till run ip link set eth0 down and ip link set eth0 up, at this point, it doesn't have IP, so change dhclient command. During testing, we can't access this test VM.

```
[13739.676089] hv_vmbus: unregistering driver hv_netvsc
[13740.702424] hv_vmbus: registering driver hv_netvsc
[13743.748328] hv_vmbus: unregistering driver hid_hyperv
[13744.787897] hv_vmbus: registering driver hid_hyperv
```

Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 04/03/2019 09:53:50
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 BVT-CORE-RELOAD-MODULES-SMP                                                       PASS                13.19 

[LISAv2 Test Results Summary]
Test Run On           : 04/03/2019 10:07:07
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 BVT-CORE-RELOAD-MODULES-SMP                                                       PASS                13.41 

[LISAv2 Test Results Summary]
Test Run On           : 04/03/2019 10:22:29
VHD Under Test        : E:\lili\vhd\L1_ubuntu _18_04_azure.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 BVT-CORE-RELOAD-MODULES-SMP                                                       PASS                12.13 
```


