### PR TITLE
Change the restart way for try to work around when hit 404 issue on Azure.

### DIFF
--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -140,26 +140,7 @@ Class AzureProvider : TestProvider
 		$restartJobs = @()
 		foreach ( $vmData in $AllVMData ) {
 			Write-LogInfo "Triggering Restart-$($vmData.RoleName)..."
-			$restartJobs += Start-Job -ScriptBlock {
-				$vmData = $args[0]
-				$retries = 0
-				$maxRetryCount = 10
-				$vmRestarted = $false
-
-				# Note(v-advlad): Azure API can sometimes fail on burst requests, we have to retry
-				while (!$vmRestarted -and $retries -lt $maxRetryCount) {
-					$null = Restart-AzureRmVM -ResourceGroupName $vmData.ResourceGroupName -Name $vmData.RoleName -Verbose
-					if (!$?) {
-						Start-Sleep -Seconds 3
-						$retries++
-					} else {
-						$vmRestarted = $true
-					}
-				}
-				if (!$vmRestarted) {
-					throw "Failed to restart Azure VM $($vmData.RoleName)"
-				}
-			} -ArgumentList @($vmData) -Name "Restart-$($vmData.RoleName)"
+			$restartJobs += Restart-AzureRmVM -ResourceGroupName $vmData.ResourceGroupName -Name $vmData.RoleName -Verbose -AsJob
 		}
 		$recheckAgain = $true
 		Write-LogInfo "Waiting until VMs restart..."


### PR DESCRIPTION
I try 3 ways to work around when restart VM hit 404 issue -

1.  Extend wait time from 3 seconds to 30 seconds - **not working**, see upstream pipeline job 1286- 1289, this issue happen against in one job

2. Get the VM firstly, then restart vm using get vm's properties - **not working**, see job 1290 - 1293, one job has issue when restart VM

3. Add -asjob to make restart command run in parallel (included in current PR)
Job 1294 - 1297 - didn't hit issue
Job 1300 - 1304 - didn't hit issue