### PR TITLE
Fixed typo $false

### DIFF
--- a/Testscripts/Windows/PERF-STORAGE-OVER-NFS.ps1
+++ b/Testscripts/Windows/PERF-STORAGE-OVER-NFS.ps1
@@ -17,7 +17,7 @@ function Main {
                 $clientVMData = $vmData
                 $noClient = $false
             } elseif ($vmData.RoleName -imatch "server") {
-                $noServer = $fase
+                $noServer = $false
                 $serverVMData = $vmData
             }
         }

--- a/Testscripts/Windows/VERIFY-DPDK-BUILD-AND-TESTPMD-TEST.ps1
+++ b/Testscripts/Windows/VERIFY-DPDK-BUILD-AND-TESTPMD-TEST.ps1
@@ -18,7 +18,7 @@ function Main {
 				$noClient = $false
 			}
 			elseif ($vmData.RoleName -imatch "server") {
-				$noServer = $fase
+				$noServer = $false
 				$serverVMData = $vmData
 			}
 		}

--- a/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
+++ b/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
@@ -38,7 +38,7 @@ function Main {
 				$noClient = $false
 			}
 			elseif ($vmData.RoleName -imatch "receiver") {
-				$noServer = $fase
+				$noServer = $false
 				$serverVMData = $vmData
 			}
 		}

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -48,7 +48,7 @@ function Main {
 				$NoServer = $false
 			} elseif ($VmData.RoleName -imatch "Client" -or $VmData.RoleName -imatch "dependency") {
 				$ClientMachines += $VmData
-				$NoClient = $fase
+				$NoClient = $false
 				if ($SlaveInternalIPs) {
 					$SlaveInternalIPs += "," + $VmData.InternalIP
 				} else {


### PR DESCRIPTION
Simple fix the typo from $fase to $false

PR #81 showed one fix, and I re-scan the all code lines.