### PR TITLE
Update KVP-TestRescind.ps1 to fix Get-VMFeatureSupport function

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1028,7 +1028,7 @@ function Get-VMFeatureSupportStatus {
 
 	Write-Output "yes" | .\Tools\plink.exe -C -pw $Password -P $SSHPort $Username@$Ipv4 'exit 0'
 	$currentKernel = Write-Output "yes" | .\Tools\plink.exe -C -pw $Password -P $SSHPort $Username@$Ipv4  "uname -r"
-	if ( $LASTEXITCODE -eq $false) {
+	if ( $LASTEXITCODE -ne 0 ) {
 		Write-LogInfo "Warning: Could not get kernel version".
 	}
 	$sKernel = $SupportKernel.split(".-")

--- a/Testscripts/Windows/KVP-TestRescind.ps1
+++ b/Testscripts/Windows/KVP-TestRescind.ps1
@@ -68,7 +68,7 @@ function Main {
     $supportkernel = "3.10.0.514" #kernel version for RHEL 7.3
     $null = .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$ipv4 "yum --version 2> /dev/null"
     if ($? -eq "True") {
-        $kernelSupport = Get-VMFeatureSupportStatus -VmIp $ipv4 -VmPort $VMPort -UserName $VMUserName `
+        $kernelSupport = Get-VMFeatureSupportStatus -Ipv4 $ipv4 -SSHPort $VMPort -UserName $VMUserName `
                             -Password $VMPassword -SupportKernel $supportkernel
         if ($kernelSupport -ne "True") {
             Write-LogInfo "Info: Kernels older than 3.10.0-514 require LIS-4.x drivers."


### PR DESCRIPTION
This commit includes two minor changes:
1) $LASTEXITCODE -eq $false -> should be -ne 0 since $LASTEXITCODE value is number.
2) Get-VMFeatureSupportStatus -Ipv4 $ipv4 -SSHPort $VMPort -UserName $VMUserName, in the commonFunction.ps1, Get-VMFeatureSupportStatus parameter is IPV4 and SSHPort. If using the parameter style to transfer parameter, it needs keeping same name, but not "-VmIp and -VmPort".
Thank you so much.

[LISAv2 Test Results Summary]
Test Run On           : 04/08/2019 08:19:05
VHD Under Test        : C:\RHEL-8.0.0-20190213.0-x86_64-GEN1-A.vhdx
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDu
ration(in minutes)
------------------------------------------------------------------------------------------------------------------------
-------------------
    1 KVP                  KVP-TEST-RESCIND                                                                  PASS
