### PR TITLE
dpdk: added perf data to TC summary + centos fixes

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -108,7 +108,7 @@ function Install_Dpdk_Dependencies() {
 	elif [[ "${distro}" == rhel7* || "${distro}" == centos7* ]]; then
 		ssh ${install_ip} "yum -y groupinstall 'Infiniband Support'"
 		ssh ${install_ip} "dracut --add-drivers 'mlx4_en mlx4_ib mlx5_ib' -f"
-		ssh ${install_ip} "yum install -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel"
+		ssh ${install_ip} "yum install --setopt=skip_missing_names_on_install=False -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel"
 
 	elif [[ "${distro}" == "sles15" ]]; then
 		local kernel=$(uname -r)

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -108,7 +108,15 @@ function Install_Dpdk_Dependencies() {
 	elif [[ "${distro}" == rhel7* || "${distro}" == centos7* ]]; then
 		ssh ${install_ip} "yum -y groupinstall 'Infiniband Support'"
 		ssh ${install_ip} "dracut --add-drivers 'mlx4_en mlx4_ib mlx5_ib' -f"
-		ssh ${install_ip} "yum install --setopt=skip_missing_names_on_install=False -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel"
+		yum_flags=""
+		if [[ "${distro}" == centos7* ]]; then
+			# for all releases that are moved into vault.centos.org
+			# we have to update the repositories first
+			ssh ${install_ip} "yum -y install centos-release"
+			ssh ${install_ip} "yum clean all"
+			yum_flags="--enablerepo=C*-base --enablerepo=C*-updates"
+		fi
+		ssh ${install_ip} "yum install ${yum_flags} --setopt=skip_missing_names_on_install=False -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel"
 
 	elif [[ "${distro}" == "sles15" ]]; then
 		local kernel=$(uname -r)

--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -323,8 +323,8 @@ collect_VM_properties
 		$perfData = $testDataCsv | Format-Table | Out-String
 		Write-LogInfo $perfData
 		if ($perfData) {
-			$currentTestResult.TestSummary +=  New-ResultSummary -testResult "Performance report" `
-				-metaData $perfData -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+			$currentTestResult.TestSummary +=  New-ResultSummary -testResult $perfData `
+				-metaData "Performance report" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
 		}
 	}
 	catch {
@@ -336,8 +336,6 @@ collect_VM_properties
 			$testResult = "Aborted"
 		}
 		$resultArr += $testResult
-		$currentTestResult.TestSummary +=  New-ResultSummary -testResult $testResult `
-			-metaData "DPDK-TEST" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
 	}
 
 	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr

--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -316,7 +316,12 @@ collect_VM_properties
 			}
 		}
 		Write-LogInfo "Test result : $testResult"
-		Write-LogInfo ($testDataCsv | Format-Table | Out-String)
+		$perfData = $testDataCsv | Format-Table | Out-String
+		Write-LogInfo $perfData
+		if ($perfData) {
+			$currentTestResult.TestSummary +=  New-ResultSummary -testResult "Performance report" `
+				-metaData $perfData -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+		}
 	}
 	catch {
 		$ErrorMessage =  $_.Exception.Message
@@ -327,7 +332,8 @@ collect_VM_properties
 			$testResult = "Aborted"
 		}
 		$resultArr += $testResult
-		$currentTestResult.TestSummary +=  New-ResultSummary -testResult $testResult -metaData "DPDK-TEST" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+		$currentTestResult.TestSummary +=  New-ResultSummary -testResult $testResult `
+			-metaData "DPDK-TEST" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
 	}
 
 	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr

--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -249,6 +249,10 @@ collect_VM_properties
 		Copy-RemoteFiles -downloadFrom $masterVM.PublicIP -port $masterVM.SSHPort -username $superUser -password $password -download -downloadTo $LogDir -files "*.csv, *.txt, *.log"
 
 		$testDataCsv = Import-Csv -Path "${LogDir}\dpdk_test.csv"
+		if (!$testDataCsv) {
+			Write-LogErr "Could not get performance data. Failing the test."
+			$finalState = "TestFailed"
+		}
 
 		if ($finalState -imatch "TestFailed") {
 			Write-LogErr "Test failed. Last known output: $currentOutput."


### PR DESCRIPTION
dpdk: added perf data to TC summary
dpdk: Fail the test is not perf data is present
dpdk: fail in rhel based distro if a package is missing
dpdk: make sure old CentOS packages are installable even they are put to Vault
