### PR TITLE
Fix LSVMBUS test case for big VM sizes

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -90,7 +90,7 @@ done
 # SECOND TEST CASE
 $lsvmbus_path -vvv > lsvmbus.log
 
-#Check number of NICs on VM
+# Check number of NICs on VM
 nics=$( grep -o "Synthetic network adapter" lsvmbus.log | wc -l)
 if [ "$nics" -gt 1 ]; then
   LogMsg "Counting the cores spread only for the first NIC.."
@@ -99,7 +99,7 @@ if [ "$nics" -gt 1 ]; then
   sed -i '/ignored adapter/,$d' lsvmbus.log
 fi
 
-#Check number of SCSI Controllers on VM
+# Check number of SCSI Controllers on VM
 scsiAdapters=$( grep -o "Synthetic SCSI Controller" lsvmbus.log | wc -l)
 if [ "$scsiAdapters" -gt 1 ]; then
   LogMsg "Counting the cores spread only for the first SCSI Adapter.."


### PR DESCRIPTION
**Behavior**: 
```
Wed Apr 10 14:29:43 2019 : Error: values are wrong. Expected for network adapter: 64 and actual: 8;
    expected for scsi controller: 16, actual: 32.

```
**Changes**: 
* Count cores only for 1 NIC
* CPU Count for NIC is MIN(the number of vCPUs, 8).
* Count cores only for 1 SCSI Controller
* CPU Count for SCSI is MIN(the number of vCPUs/4, 64).

