### PR TITLE
GPU: Added rescind for PCI device

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3424,18 +3424,18 @@ function RescindPCI ()
 
     LogMsg "Attempting to disable and enable the VF $vf_pci_type device."
     # Get the VF address
-    vf_pci_address=$(lspci | grep -i $vf_pci_type | awk '{ print $1 }')
+    vf_pci_address=$(lspci | grep -i "$vf_pci_type" | awk '{ print $1 }')
     vf_pci_remove_path="/sys/bus/pci/devices/${vf_pci_address}/remove"
-    if [ ! -f $vf_pci_remove_path ]; then
+    if [ ! -f "$vf_pci_remove_path" ]; then
         LogErr "Unable to disable the VF, because the $vf_pci_remove_path doesn't exist."
         return 1
     fi
     # Remove the VF
-    echo 1 > $vf_pci_remove_path
+    echo 1 > "$vf_pci_remove_path"
     sleep 5
 
     # Check if the VF has been disabled.
-    if lspci -vvv | grep $vf_pci_check_removed; then
+    if lspci -vvv | grep "$vf_pci_check_removed"; then
         LogErr "Disable the VF $vf_pci_type device failed."
         return 1
     fi
@@ -3454,4 +3454,3 @@ function RescindPCI ()
     done
     return 0
 }
-

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -188,7 +188,7 @@ function Main {
         [int]$expectedGPUCount = $($vmCPUCount/6)
 
         Write-LogInfo "Azure VM Size: $($allVMData.InstanceSize), expected GPU Adapters total: $expectedGPUCount"
-        
+
         # rescind the PCI device first if the parameter is given
         if ($TestParams.rescind_pci -eq "yes") {
             Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP -port $allVMData.SSHPort `
@@ -200,9 +200,7 @@ function Main {
                 $metaData = "Successfully rescinded the PCI device."
                 Write-LogInfo "$metaData"
             }
-            $resultArr += $currentResult
-            $CurrentTestResult.TestSummary += New-ResultSummary -testResult $currentResult -metaData $metaData `
-                -checkValues "PASS,FAIL,ABORTED" -testName $CurrentTestData.testName
+            $CurrentTestResult.TestSummary += New-ResultSummary -metaData "$metaData" -testName $CurrentTestData.testName
         }
 
         # run the tools

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -14,12 +14,15 @@
     4. Check if the nVidia driver is loaded
     5. Compare number of expected GPU adapters with the actual count.
     6. The following tools are used for validation: lsvmbus, lspci, lshw and nvidia-smi
+    7. If test parameter "rescind_pci=yes" is provided, the 3D controller PCI device
+    will be rescinded first.
 
 #>
 
 param([object] $AllVmData,
       [object] $CurrentTestData,
-      [object] $TestProvider
+      [object] $TestProvider,
+      [object] $TestParams
     )
 
 function Start-Validation {
@@ -96,7 +99,8 @@ function Main {
     param (
         [object] $AllVmData,
         [object] $CurrentTestData,
-        [object] $TestProvider
+        [object] $TestProvider,
+        [object] $TestParams
     )
     # Create test result
     $currentTestResult = Create-TestResultObject
@@ -184,6 +188,22 @@ function Main {
         [int]$expectedGPUCount = $($vmCPUCount/6)
 
         Write-LogInfo "Azure VM Size: $($allVMData.InstanceSize), expected GPU Adapters total: $expectedGPUCount"
+        
+        # rescind the PCI device first if the parameter is given
+        if ($TestParams.rescind_pci -eq "yes") {
+            Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP -port $allVMData.SSHPort `
+                -command ". utils.sh && RescindPCI GPU" -RunAsSudo -ignoreLinuxExitCode | Out-Null
+            if (-not $?) {
+                $metaData = "Could not rescind PCI device."
+                Write-LogErr "$metaData"
+            } else {
+                $metaData = "Successfully rescinded the PCI device."
+                Write-LogInfo "$metaData"
+            }
+            $resultArr += $currentResult
+            $CurrentTestResult.TestSummary += New-ResultSummary -testResult $currentResult -metaData $metaData `
+                -checkValues "PASS,FAIL,ABORTED" -testName $CurrentTestData.testName
+        }
 
         # run the tools
         Start-Validation
@@ -223,4 +243,5 @@ function Main {
     return $currentTestResult
 }
 
-Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData -TestProvider $TestProvider
+Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData -TestProvider $TestProvider `
+    -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n"))

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -74,6 +74,7 @@
         <files>.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\utils.sh</files>
         <TestParameters>
             <param>CUDADriverVersion="CUDA_DRIVER"</param>
+            <param>rescind_pci=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -66,4 +66,19 @@
         <Tags>gpu,benchmark</Tags>
         <Priority>1</Priority>
     </test>
+    <test>
+        <testName>GPU-PCI-RESCIND</testName>
+        <testScript>GPU-DRIVER-INSTALL.ps1</testScript>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_NC6</OverrideVMSize>
+        <files>.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\utils.sh</files>
+        <TestParameters>
+            <param>CUDADriverVersion="CUDA_DRIVER"</param>
+        </TestParameters>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>GPU</Area>
+        <Tags>gpu,pci_hyperv</Tags>
+        <Priority>1</Priority>
+    </test>
 </TestCases>


### PR DESCRIPTION
This new test case will rescind the 3D Controller GPU device, then do the GPU validation.

```
[Azure GPU-PCI-RESCIND westus] [LISAv2 Test Results Summary]
[Azure GPU-PCI-RESCIND westus] Test Run On           : 04/12/2019 18:09:24
[Azure GPU-PCI-RESCIND westus] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
[Azure GPU-PCI-RESCIND westus] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Azure GPU-PCI-RESCIND westus] Total Time (dd:hh:mm) : 0:0:11
[Azure GPU-PCI-RESCIND westus] 
[Azure GPU-PCI-RESCIND westus]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Azure GPU-PCI-RESCIND westus] -------------------------------------------------------------------------------------------------------------------------------------------
[Azure GPU-PCI-RESCIND westus]     1 GPU                  GPU-PCI-RESCIND                                                                   PASS                 6.08 
[Azure GPU-PCI-RESCIND westus] 	Using nVidia driver: GRID :  
[Azure GPU-PCI-RESCIND westus] 	Successfully rescinded the PCI device. :  
[Azure GPU-PCI-RESCIND westus] 	lsvmbus: Expected "PCI Express pass-through" count: 4, count inside the VM: 4 : PASS 
[Azure GPU-PCI-RESCIND westus] 	lspci: Expected "3D controller: NVIDIA Corporation" count: 4, found inside the VM: 4 : PASS 
[Azure GPU-PCI-RESCIND westus] 	lshw: Expected Display adapters: 4, total adapters found in VM: 4 : PASS 
[Azure GPU-PCI-RESCIND westus] 	nvidia-smi: Expected GPU count: 4, found inside the VM: 4 : PASS 
```