### PR TITLE
CPU: Azure L3 cache spread

### DIFF
--- a/Testscripts/Linux/L3Cache-Verify.sh
+++ b/Testscripts/Linux/L3Cache-Verify.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+# Description:
+# This script was created to automate the testing of L3 Cache spread.
+# The L3 cache must be mapped to the socket for each of the NUMA nodes.
+# An incorrect mapping would be for the L3 cache to be assigned on per VM core.
+
+. utils.sh || {
+    echo "unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 1
+}
+
+UtilsInit
+
+if ! which lscpu; then
+    install_package util-linux
+fi
+
+lscpu --extended=cpu,node,socket,cache > lscpu.log
+# change cache column separator
+sed -i 's/:/ /g' lscpu.log
+
+# we don't need the table header
+sed -i 's/^CPU.*//g' lscpu.log
+sed -i '/^$/d' lscpu.log
+
+# table header should now look like this:
+# CPU NODE SOCKET L1d L1i L2 L3
+
+while read line;
+do
+    # Test case L3 CACHE Spread on NUMA nodes
+    # Each line in the file details the mapping of one CPU core.
+    # The L3 cache of each core must be mapped to the
+    # NUMA node that core belongs to instead of the core itself.
+
+    # Corect mapping:
+    # CPU NODE SOCKET L1d L1i L2 L3
+    # 8   0    0      8   8   8  0
+    # 9   1    1      9   9   9  1
+
+    # Inorect mapping:
+    # CPU NODE SOCKET L1d L1i L2 L3
+    # 8   0    0      8   8   8  8
+    # 9   1    1      9   9   9  9
+
+    # Current core number
+    core=$(echo "$line" | awk '{ print $1 }')
+    # NUMA Node the current core is assigned to.
+    node=$(echo "$line" | awk '{ print $2 }')
+    # L3 Cache mapping for the current core.
+    l3Cache=$(echo "$line" | awk '{ print $7 }')
+    if [ "$l3Cache" -ne "$node" ]; then
+        LogErr "Core $core L3 Cache should be mapped to NUMA node $node, actual: $l3Cache"
+        SetTestStateFailed
+        exit 0
+    fi
+done < lscpu.log
+
+LogMsg "Test completed successfully"
+SetTestStateCompleted
+exit 0

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -924,4 +924,16 @@
         <Tags>hot_resize,memory</Tags>
         <Priority>1</Priority>
     </test>
+    <test>
+        <testName>L3-CACHE-CHECK</testName>
+        <testScript>L3Cache-Verify.sh</testScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\L3Cache-Verify.sh</files>
+        <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_D32s_v3</OverrideVMSize>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>CORE</Area>
+        <Tags>cpu</Tags>
+        <Priority>1</Priority>
+    </test>
 </TestCases>


### PR DESCRIPTION
Create lisav2 test case to verify the L3 cache spread on all VM cores.

The L3 cache must be mapped to the socket for each of the NUMA nodes.
An incorrect mapping would be for the L3 cache to be assigned on per VM core.

**Expected Pass:**

---
```
04/12/2019 18:03:37 : [INFO ] Setting parameter: TestPlatform = Azure
04/12/2019 18:03:37 : [INFO ] Setting parameter: TestLocation = westus2
04/12/2019 18:03:37 : [INFO ] Setting parameter: ARMImageName = Canonical UbuntuServer 18.04-LTS latest
[...]
[LISAv2 Test Results Summary]
Test Run On           : 04/12/2019 18:03:39
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 L3-CACHE-CHECK                                                                    PASS                  0.8 
```
**Expected Fail**

---
```
04/12/2019 18:03:29 : [INFO ] Setting parameter: TestPlatform = Azure
04/12/2019 18:03:29 : [INFO ] Setting parameter: TestLocation = eastus2
04/12/2019 18:03:29 : [INFO ] Setting parameter: ARMImageName = Canonical UbuntuServer 18.04-LTS latest
[...]
[LISAv2 Test Results Summary]
Test Run On           : 04/12/2019 18:03:32
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 L3-CACHE-CHECK                                                                    FAIL                 1.62 
```
TestExecutionError
`Fri Apr 12 18:06:22 2019 : Core 0 L3 Cache should be mapped to NUMA node 0, actual: 1`
