### PR TITLE
LISAv2: implement supported vm size feature

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -205,7 +205,8 @@ Class TestController
 		$ReplaceableTestParameters = [xml](Get-Content -Path "$WorkingDirectory\XML\Other\ReplaceableTestParameters.xml")
 
 		$allTests = Collect-TestCases -TestXMLs $TestXMLs -TestCategory $this.TestCategory -TestArea $this.TestArea `
-			-TestNames $this.TestNames -TestTag $this.TestTag -TestPriority $this.TestPriority -ExcludeTests $this.ExcludeTests
+			-TestNames $this.TestNames -TestTag $this.TestTag -TestPriority $this.TestPriority -ExcludeTests $this.ExcludeTests `
+			-OverrideVMSize $this.OverrideVMSize -SupportedVmSize $this.CustomParams["SupportedVmSize"]
 
 		if( !$allTests ) {
 			Throw "Not able to collect any test cases from XML files"

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -79,6 +79,7 @@
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
+        <SupportedVmSize>Standard_D*</SupportedVmSize>
         <OverrideVMSize>Standard_D16_v3</OverrideVMSize>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\ovs_setup.sh</files>
         <TestParameters>


### PR DESCRIPTION
Implemented feature request: https://github.com/LIS/LISAv2/issues/108

Example run:

```
# This run will use 2 VM sizes and force the framework to accept those vm sizes, even if in the XML definition for the TC, there is a SupportedVMSize tag containing "one"
.\Run-LisaV2.ps1 -TestPlatform HyperV -RGIdentifier "ader1990" -OsVHD "test.vhdx" -TestNames 'BVT-IS-ROOT-PASSWORD-DELETED' -OverrideVMSize "one,two" -CustomParameters "SupportedVmSi
ze=one,two"
```