### PR TITLE
LISAv2: fix multiple overridevmsize on multiple TC

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -558,6 +558,7 @@ Class TestController
 					}
 					if ($multiplexedTestConfig["TestVmSize"]) {
 						$case.OverrideVMSize = $multiplexedTestConfig["TestVmSize"]
+						$this.SetupTypeToTestCases[$key][0].OverrideVMSize = $multiplexedTestConfig["TestVmSize"]
 					}
 
 					Write-LogInfo "$($case.testName) started running."


### PR DESCRIPTION
The override vm size was not applied to the second test case.

This PR fixes that problem by setting the correct override vm size property to the test case object.