### PR TITLE
Verfiy LIS modules load and version after LIS installation

### DIFF
--- a/Testscripts/Linux/azuremodules.py
+++ b/Testscripts/Linux/azuremodules.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-import argparse
 import logging
 import os
 import os.path
@@ -109,7 +108,10 @@ def DetectDistro():
         if (re.match(r'^ID=(.*)', line, re.M|re.I) ):
             matchObj = re.match( r'^ID=(.*)', line, re.M|re.I)
             distribution  = matchObj.group(1)
-        elif (re.match(r'^VERSION_ID=(.*)', line, re.M|re.I) ):
+        elif (re.match(r'.*release (.*) .*', line, re.M|re.I) ):
+            matchObj = re.match( r'.*release (.*) \(.*', line, re.M|re.I)
+            version = matchObj.group(1)
+        elif (version is None and re.match(r'^VERSION_ID=(.*)', line, re.M|re.I) ):
             matchObj = re.match( r'^VERSION_ID=(.*)', line, re.M|re.I)
             version = matchObj.group(1)
 
@@ -885,3 +887,9 @@ def GetOSDisk():
         return 'sdb'
     else :
         return 'sda'
+
+try:
+   import argparse
+except ImportError:
+   InstallPackage("python-argparse")
+   import argparse

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -429,4 +429,9 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>WALAAgent_REPO</ReplaceThis>
 		<ReplaceWith>https://github.com/Azure/WALinuxAgent</ReplaceWith>
 	</Parameter>
+	<Parameter>
+        <!-- mlnxofed version which is installed from LIS for 7.3 and 7.4 -->
+		<ReplaceThis>EXPECTED_MLNX_VERSION</ReplaceThis>
+		<ReplaceWith>4.5-0.0.8</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -46,7 +46,7 @@
         <testScript>LIS-MODULES-CHECK.py</testScript>
         <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
-        <Platform>Azure</Platform>
+        <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>
         <Tags>hv_module</Tags>
@@ -59,6 +59,7 @@
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/LIS-Tests.xml
+++ b/XML/TestCases/LIS-Tests.xml
@@ -13,12 +13,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-1</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-1</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -30,12 +32,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-2</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-2</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -47,12 +51,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-3</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-3</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -64,12 +70,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-4</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-4</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -81,12 +89,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-5</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-5</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -98,12 +108,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-6</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-6</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -115,12 +127,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-7</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-7</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>
@@ -132,12 +146,14 @@
     <test>
         <testName>LIS-DEPLOY-SCENARIO-8</testName>
         <testScript>LIS-INSTALL-SCENARIOS.ps1</testScript>
-        <files>.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\TestScripts\Linux\VERIFY-LIS-MODULES-VERSION.sh,.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>Install-LIS-Scenario-8</param>
             <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
             <param>LIS_TARBALL_URL_OLD=LIS_OLD_URL</param>
+            <param>MLNX_VERSION=EXPECTED_MLNX_VERSION</param>
+            <param>HYPERV_MODULES=(hv_vmbus hyperv_keyboard hv_netvsc hid_hyperv hv_utils hv_storvsc hv_balloon)</param>
         </TestParameters>
         <Timeout>2400</Timeout>
         <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
This PR meets below requirements

1) Current LIS deploy tests are verifying only module "vmbus", So enhanced to check version for all other modules
2) MLNX driver is installed with latest LIS, So handled a check in the code to verify installed MLNX version matches with  expected MLNX version
3) Fixed the issue where argparse is throwing ImportError for few distros
4) Improved VERIFY-LIS-MODULES-VERSION.sh , so that it generates only required logs