### PR TITLE
RDMA IB: Intel fix

### DIFF
--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -580,6 +580,11 @@ function Main() {
 			mpi_run_path=$(find / -name mpirun | head -n 1)
 		;;
 		intel)
+			vars=$(find / -name mpivars.sh | grep intel)
+			source $vars
+			imb_mpi1_path=$(find / -name IMB-MPI1 | grep intel)
+			imb_rma_path=$(find / -name IMB-RMA | grep intel)
+			imb_nbc_path=$(find / -name IMB-NBC | grep intel)
 			mpi_run_path=$(find / -name mpirun | grep intel64)
 		;;
 		mvapich)


### PR DESCRIPTION
This commit is consolidating INTEL MPI run by making sure the right variables and binaries are used when running the Intel TCs.