### PR TITLE
RDMA: Remove mpi-benchmark installation in Intel MPI

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -382,32 +382,35 @@ function Main() {
 	cd ~
 	LogMsg "Proceeding Intel MPI Benchmark test installation"
 
-	# install Intel MPI benchmark package
-	LogMsg "Cloning mpi-benchmarks repo, $intel_mpi_benchmark"
-	git clone $intel_mpi_benchmark
-	Verify_Result
-	LogMsg "Cloned Intel MPI Benchmark gitHub repo"
-	cd mpi-benchmarks/src_c
-	LogMsg "Building Intel MPI Benchmarks tests"
-	make -j $(nproc)
-	Verify_Result
+	# Intel MPI has its own IMB-MPI1, IMB-NBC and IMB-RMA binaries
+	if [ $mpi_type != "intel" ]; then
+		# install Intel MPI benchmark package
+		LogMsg "Cloning mpi-benchmarks repo, $intel_mpi_benchmark"
+		git clone $intel_mpi_benchmark
+		Verify_Result
+		LogMsg "Cloned Intel MPI Benchmark gitHub repo"
+		cd mpi-benchmarks/src_c
+		LogMsg "Building Intel MPI Benchmarks tests"
+		make -j $(nproc)
+		Verify_Result
 
-	# install P2P test
-	LogMsg "Change directory to P2P"
-	cd P2P
-	LogMsg "Renaming from mpiicc to mpicc in Makefile"
-	sed -i -e 's/CC=mpiicc/CC=mpicc/g' Makefile
-	LogMsg "Building P2P binary"
-	make -j $(nproc)
-	LogMsg "Completed P2P2 binary compilation"
-	Verify_Result
-	LogMsg "Intel MPI Benchmark test installation completed"
+		# install P2P test
+		LogMsg "Change directory to P2P"
+		cd P2P
+		LogMsg "Renaming from mpiicc to mpicc in Makefile"
+		sed -i -e 's/CC=mpiicc/CC=mpicc/g' Makefile
+		LogMsg "Building P2P binary"
+		make -j $(nproc)
+		LogMsg "Completed P2P2 binary compilation"
+		Verify_Result
+		LogMsg "Intel MPI Benchmark test installation completed"
 
-	# set string to verify Intel Benchmark binary
-	benchmark_bin=$HOMEDIR/mpi-benchmarks/src_c/IMB-MPI1
+		# set string to verify Intel Benchmark binary
+		benchmark_bin=$HOMEDIR/mpi-benchmarks/src_c/IMB-MPI1
 
-	# verify benchmark binary
-	Verify_File $benchmark_bin
+		# verify benchmark binary
+		Verify_File $benchmark_bin
+	fi
 
 	echo "setup_completed=0" >> /root/constants.sh
 

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -292,8 +292,8 @@ function Run_IMB_P2P() {
 					$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($p2p_ppn * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
-					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
-					$mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
+					# LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
+					# $mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				mvapich)
 					LogMsg "$mpi_run_path -n $(($p2p_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_p2p_path $extra_params"

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -230,7 +230,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_P2P_TEST_COUNT</ReplaceThis>
-		<ReplaceWith>1</ReplaceWith>
+		<ReplaceWith>0</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_P2P_TEST_COUNT</ReplaceThis>


### PR DESCRIPTION
Intel MPI package provides IMB-MPI1, IMB-NBC and IMB-RMA its own binaries. 
Removed P2P and other future tests enablement in Intel MPI section, and will use released 3 binaries in testing.

### Test Results
**Intel MPI case which does not call P2P.** 

[LISAv2 Test Results Summary]
Test Run On           : 04/24/2019 01:18:30
ARM Image Under Test  : RedHat : RHEL : 7.5 : 7.5.2018081519
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:40

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-2VM                                                          PASS                36.96
        InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
        InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS
        InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS
        InfiniBand-Verification-2-Reboot : eth0 IP : PASS
        InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS
        InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS
        InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
        InfiniBand-Verification-2-Reboot : IMB-RMA : PASS
        InfiniBand-Verification-2-Reboot : IMB-NBC : PASS


Logs can be found at C:\LISAv2\JY15\TestResults\2019-23-04-18-18-27-3994


04/24/2019 01:59:13 : [INFO ] Creating 'C:\LISAv2\JY15\Azure-JY15-TestLogs.zip' from 'C:\LISAv2\JY15\TestResults\2019-23-04-18-18-27-3994'
04/24/2019 01:59:13 : [INFO ] C:\LISAv2\JY15\Azure-JY15-TestLogs.zip created successfully.
04/24/2019 01:59:13 : [INFO ] Analyzing results..
04/24/2019 01:59:13 : [INFO ] Copying all files back to original working directory: C:\Users\juhlee\source\repo\LISAv2.
04/24/2019 01:59:15 : [INFO ] Cleaning up C:\LISAv2\JY15
04/24/2019 01:59:15 : [INFO ] Setting workspace back to original location: C:\Users\juhlee\source\repo\LISAv2
04/24/2019 01:59:15 : [INFO ] LISAv2 exit code: 0

---> Internally TestExecution.log shows those binaries are from Intel MPI installer like below.
Wed Apr 24 01:47:05 2019 : MPIRUN Path: /opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/intel64/bin/mpirun
Wed Apr 24 01:47:05 2019 : IMB-MPI1 Path: /usr/mpi/gcc/openmpi-4.0.0rc5/tests/imb/IMB-MPI1
Wed Apr 24 01:47:05 2019 : IMB-RMA Path: /usr/mpi/gcc/openmpi-4.0.0rc5/tests/imb/IMB-RMA
Wed Apr 24 01:47:05 2019 : IMB-NBC Path: /usr/mpi/gcc/openmpi-4.0.0rc5/tests/imb/IMB-NBC
Wed Apr 24 01:47:05 2019 : IMB-P2P Path: 
Wed Apr 24 01:47:05 2019 : Checking IMB-MPI1 IntraNode status in 10.0.0.4


**MVAPICH MPI case which does call P2P.** 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] [LISAv2 Test Results Summary]
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] Test Run On           : 04/23/2019 22:01:24
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] ARM Image Under Test  : RedHat : RHEL : 7.5 : 7.5.2018081519
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] Total Time (dd:hh:mm) : 0:1:9
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] -------------------------------------------------------------------------------------------------------------------------------------------
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus]     1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS                66.18 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : IMB-RMA : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] Logs can be found at C:\LISAv2\LW70\TestResults\2019-23-04-22-01-20-4526
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:22 : [INFO ] Creating 'C:\LISAv2\LW70\Azure-LW70-TestLogs.zip' from 'C:\LISAv2\LW70\TestResults\2019-23-04-22-01-20-4526'
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:22 : [INFO ] C:\LISAv2\LW70\Azure-LW70-TestLogs.zip created successfully.
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:22 : [INFO ] Analyzing results..
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:22 : [INFO ] Copying all files back to original working directory: C:\azure-executor-1\workspace\Microsoft-Test-Execution-Pipeline@3.
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:24 : [INFO ] Cleaning up C:\LISAv2\LW70
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:25 : [INFO ] Setting workspace back to original location: C:\azure-executor-1\workspace\Microsoft-Test-Execution-Pipeline@3
[Azure INFINIBAND-MVAPICH-MPI-2VM southcentralus] 04/23/2019 23:11:25 : [INFO ] LISAv2 exit code: 0

---> MVAPICH MPI like non-Intel MPI still uses binaries from Intel MPI Benchmark package.
Tue Apr 23 23:02:01 2019 : INFINIBAND_VERIFICATION_SUCCESS_IBV_PINGPONG
Tue Apr 23 23:02:08 2019 : MPIRUN Path: /usr/local/bin/mpirun_rsh
Tue Apr 23 23:02:08 2019 : IMB-MPI1 Path: /root/mpi-benchmarks/src_c/IMB-MPI1
Tue Apr 23 23:02:08 2019 : IMB-RMA Path: /root/mpi-benchmarks/src_c/IMB-RMA
Tue Apr 23 23:02:08 2019 : IMB-NBC Path: /root/mpi-benchmarks/src_c/IMB-NBC
Tue Apr 23 23:02:08 2019 : IMB-P2P Path: /root/mpi-benchmarks/src_c/P2P/IMB-P2P
Tue Apr 23 23:02:08 2019 : Checking IMB-MPI1 IntraNode status in 10.0.0.5