### PR TITLE
Update for refer undefined parameter

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -415,9 +415,9 @@ Function Delete-ResourceGroup([string]$RGName, [switch]$KeepDisks, [bool]$UseExi
 					Write-LogInfo "Successfully triggered delete operation for Resource Group ${RGName}"
 					$isRGDeleting = $true
 				} else {
-					Write-LogWarn "RG ${RGName} status is $($ProvisioningState)"
+					Write-LogWarn "RG ${RGName} status is $($rgStatus.ProvisioningState)"
 					$maxRgDeletingRetries++
-					Start-Sleep 1
+					Start-Sleep 5
 				}
 			}
             $retValue = $isRgDeleting


### PR DESCRIPTION
Before fix:
```
04/25/2019 01:23:33 : [INFO ] Triggering delete operation for Resource Group LISAv2-OneVM-lilimsft-NH96-20190424181620
04/25/2019 01:23:34 : [WARN ] RG LISAv2-OneVM-lilimsft-NH96-20190424181620 status is 
04/25/2019 01:23:36 : [WARN ] RG LISAv2-OneVM-lilimsft-NH96-20190424181620 status is 
04/25/2019 01:23:38 : [INFO ] Successfully triggered delete operation for Resource Group LISAv2-OneVM-lilimsft-NH96-20190424181620
```
After fix:
```
04/25/2019 05:34:18 : [INFO ] Checking if LISAv2-OneVM-lilimsft-TZ64-20190424222734 exists...
04/25/2019 05:34:19 : [INFO ] Triggering delete operation for Resource Group LISAv2-OneVM-lilimsft-TZ64-20190424222734
04/25/2019 05:34:20 : [WARN ] RG LISAv2-OneVM-lilimsft-TZ64-20190424222734 status is Succeeded
04/25/2019 05:34:26 : [INFO ] Successfully triggered delete operation for Resource Group LISAv2-OneVM-lilimsft-TZ64-20190424222734
04/25/2019 05:34:26 : [INFO ] Successfully cleaned up RG LISAv2-OneVM-lilimsft-TZ64-20190424222734..
```






