### PR TITLE
SR-IOV: Add Mlnx CX4 support for HyperV; SLES: Firewall check fix

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -213,7 +213,7 @@ InstallDependencies()
     case "$DISTRO" in
         suse*)
             # Disable firewall
-            rcSuSEfirewall2 stop
+            service SuSEfirewall2 stop
         ;;
 
         ubuntu*|debian*)

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -60,16 +60,14 @@ VerifyVF()
     # Using lsmod command, verify if driver is loaded
     lsmod | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
-        LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
-        # note v-stlups: log the error but don't fail the test, mlx5_core doens't show up in lsmod
-        # SetTestStateFailed
-        # exit 1
+		# driver can be built-in, continuing to lspci
+		LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
     fi
 
     # Using the lspci command, verify if NIC has SR-IOV support
     lspci -vvv | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
-        LogMsg "No NIC with SR-IOV support found!"
+        LogMsg "No Mellanox or Intel NIC with SR-IOV support found!"
         SetTestStateFailed
         exit 1
     fi
@@ -83,7 +81,7 @@ VerifyVF()
 
     ip addr show "$vf_interface"
     if [ $? -ne 0 ]; then
-        LogErr "VF device, $vf_interface , was not found!"
+        LogErr "VF device $vf_interface was not found!"
         SetTestStateFailed
         exit 1
     fi
@@ -140,7 +138,6 @@ ConfigureVF()
     __iterator=1
     __ipIterator=$1
     LogMsg "Iterator: $__iterator"
-    # LogMsg "vfCount: $vfCount"
 
     # Set static IPs for each vf created
     while [ $__iterator -le "$vfCount" ]; do
@@ -213,20 +210,14 @@ InstallDependencies()
     GetDistro
     case "$DISTRO" in
         suse*)
-            # Disable firewall
             service SuSEfirewall2 stop
         ;;
-
         ubuntu*|debian*)
-            # Disable firewall
             ufw disable
         ;;
-
         redhat*|centos*)
-            # Disable firewall
             service firewalld stop
         ;;
-
         *)
             LogErr "OS Version not supported in InstallDependencies!"
             SetTestStateFailed
@@ -244,6 +235,7 @@ InstallDependencies()
             exit 1
         fi  
     fi
+
     # Check if iPerf3 is already installed
     iperf3 -v > /dev/null 2>&1
     if [ $? -ne 0 ]; then

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -61,8 +61,9 @@ VerifyVF()
     lsmod | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
         LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
-        SetTestStateFailed
-        exit 1
+        # note v-stlups: log the error but don't fail the test, mlx5_core doens't show up in lsmod
+        # SetTestStateFailed
+        # exit 1
     fi
 
     # Using the lspci command, verify if NIC has SR-IOV support

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -58,15 +58,15 @@ VerifyVF()
     fi
 
     # Using lsmod command, verify if driver is loaded
-    lsmod | grep 'mlx4_core\|mlx4_en\|ixgbevf'
+    lsmod | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
-        LogErr "Neither mlx4_core\mlx4_en or ixgbevf drivers are in use!"
+        LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
         SetTestStateFailed
         exit 1
     fi
 
     # Using the lspci command, verify if NIC has SR-IOV support
-    lspci -vvv | grep 'mlx4_core\|mlx4_en\|ixgbevf'
+    lspci -vvv | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
         LogMsg "No NIC with SR-IOV support found!"
         SetTestStateFailed

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3221,9 +3221,9 @@ function stop_firewall() {
     GetDistro
     case "$DISTRO" in
         suse*)
-            status=$(systemctl is-active rcSuSEfirewall2)
+            status=$(systemctl is-active SuSEfirewall2)
             if [ "$status" = "active" ]; then
-               /sbin/rcSuSEfirewall2 stop
+                service SuSEfirewall2 stop
                 if [ $? -ne 0 ]; then    
                     return 1
                 fi

--- a/Testscripts/Windows/SRIOV-CHANGE-RSS.ps1
+++ b/Testscripts/Windows/SRIOV-CHANGE-RSS.ps1
@@ -20,7 +20,7 @@ function Main {
         $VMPassword,
         $TestParams
     )
-    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx4_core\|mlx4_en\|ixgbevf'"
+    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'"
     $vfCheckCMD = "find /sys/devices -name net -a -ipath '*vmbus*' | grep -c pci"
 
     # Get IP

--- a/Testscripts/Windows/SRIOV-DETACH-NIC.ps1
+++ b/Testscripts/Windows/SRIOV-DETACH-NIC.ps1
@@ -16,7 +16,7 @@ function Main {
         $VMPort,
         $VMPassword
     )
-    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx4_core\|mlx4_en\|ixgbevf'"
+    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'"
     $vfCheckCMD = "find /sys/devices -name net -a -ipath '*vmbus*' | grep -c pci"
 
     # Get IP

--- a/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
@@ -23,7 +23,7 @@ function Main {
         $VMPort,
         $VMPassword
     )
-    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx4_core\|mlx4_en\|ixgbevf'"
+    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'"
     $vfCheckCMD = "find /sys/devices -name net -a -ipath '*vmbus*' | grep -c pci"
 
     # Get IP

--- a/Testscripts/Windows/SRIOV-DISABLE-VMQ.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLE-VMQ.ps1
@@ -50,7 +50,7 @@ function Main {
 
     # Check if the SR-IOV module is still loaded
     $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "lspci -vvv | grep -c 'mlx4_core\|mlx4_en\|ixgbevf'" `
+        $VMPassword -command "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'" `
         -ignoreLinuxExitCode:$true
     if ($moduleCount -lt 1) {
         Write-LogErr "Module is not loaded"


### PR DESCRIPTION
Fixes #94 
* Add match pattern to verify in `lspci` for Mellanox driver `mlx5_core`, must remove test case failure if driver is not listed by `lsmod`, connection works, but mlx5_core isn't listed in `lsmod`
* use `SuSEfirewall2` service for consistency across framework, and `systemctl` does not correctly report for rcSuSEfirewall2. - verified on SLES 15 and SLES 12sp4 on Azure

tested with Mellanox CX4 card (mlx5_core driver) on HyperV
SRIOV-PCI-RESCIND also covers verify basic vf conenction.
```
04/25/2019 14:38:14 : [INFO ] TEST SCRIPT SUMMARY ~~~~~~~~~~~~~~~
Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!
Expected VF count: 1. Actual VF count: 1
Successfully sent file from VM1 to VM2 through eth1
04/25/2019 14:38:14 : [INFO ] END OF TEST SCRIPT SUMMARY ~~~~~~~~~~~~~~~
[...]
[LISAv2 Test Results Summary]
Test Run On           : 04/25/2019 14:32:39
VHD Under Test        : ubuntu_18.04.1_gen1_gen2-vstlups.vhdx
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-PCI-RESCIND                                                                 PASS                 4.43
```