### PR TITLE
Fix VERIFY-VHD-PREREQUISITES and CollectLogFile.sh

### DIFF
--- a/Testscripts/Linux/CollectLogFile.sh
+++ b/Testscripts/Linux/CollectLogFile.sh
@@ -29,7 +29,8 @@ if [ -f /etc/redhat-release ] ; then
 elif [ -f /etc/SuSE-release ] ; then
         echo "/etc/SuSE-release detected"
         cat /etc/os-release | grep ^PRETTY_NAME | sed 's/"//g' | sed 's/PRETTY_NAME=//g' > ${hostname}-distroVersion.txt
-elif [[ "$release" =~ "UBUNTU" ]] || [[ "$release" =~ "Ubuntu" ]] || [[ "$release" =~ "Debian" ]] || [[ "$release" =~ "SUSE Linux Enterprise Server 15" ]]; then
+elif [[ "$release" =~ "UBUNTU" ]] || [[ "$release" =~ "Ubuntu" ]] || [[ "$release" =~ "Debian" ]] || \
+            [[ "$release" =~ "SUSE Linux Enterprise Server 15" ]] || [[ "$release" =~ "CoreOS" ]]; then
         NAME=$(cat /etc/os-release | grep ^NAME= | sed 's/"//g' | sed 's/NAME=//g')
         VERSION=$(cat /etc/os-release | grep ^VERSION= | sed 's/"//g' | sed 's/VERSION=//g')
         echo "$NAME $VERSION" > ${hostname}-distroVersion.txt

--- a/Testscripts/Linux/VERIFY-VHD-PREREQUISITES.py
+++ b/Testscripts/Linux/VERIFY-VHD-PREREQUISITES.py
@@ -35,7 +35,7 @@ def verify_grub(distro):
     import os.path
     RunLog.info("Checking console=ttyS0 rootdelay=300..")
     if distro == "UBUNTU":
-        grub_out = Run("cat /etc/default/grub")
+        grub_out = Run("cat /boot/grub/grub.cfg")
     if distro == "SUSE":
         if os.path.exists("/boot/grub2/grub.cfg"):
             grub_out = Run("cat /boot/grub2/grub.cfg")


### PR DESCRIPTION
1 CoreOS not detected by CollectLogFile.sh, found by data inserted into database.
2 Case failed for kernel parameter not found in /etc/default/grub against ubuntu.

```
[LISAv2 Test Results Summary]
Test Run On           : 04/25/2019 09:04:52
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-VHD-PREREQUISITES                                                          PASS                 3.92 


[LISAv2 Test Results Summary]
Test Run On           : 04/25/2019 09:12:51
ARM Image Under Test  : CoreOS : CoreOS : Stable : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-VHD-PREREQUISITES                                                          PASS                 3.88 
'Container Linux by CoreOS 2079.3.0' in LISAv2-OneVM-lilimsft-BR77-20190425021300-role-0-distroVersion.txt
```