### PR TITLE
Revert set default priority, since using -TestPriority 1 will include unexpected cases

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -65,8 +65,7 @@ Function Match-TestPriority($currentTest, $TestPriority)
 
     $priorityInXml = $currentTest.Priority
     if (-not $priorityInXml) {
-        Write-LogWarn "Priority of $($currentTest.TestName) is not defined, set it to 1 (default)."
-        $priorityInXml = 1
+        Write-LogWarn "Priority of $($currentTest.TestName) is not defined."
     }
     foreach( $priority in $TestPriority.Split(",") ) {
         if ($priorityInXml -eq $priority) {


### PR DESCRIPTION
Before fix, run 54 cases for P1.
```
04/25/2019 14:54:36 : [WARN ] Priority of CAPTURE-VHD-BEFORE-TEST is not defined, set it to 1 (default).
04/25/2019 14:54:36 : [INFO ] Collected Test : CAPTURE-VHD-BEFORE-TEST
04/25/2019 14:54:36 : [WARN ] Priority of BUILD-GCOV-KERNEL is not defined, set it to 1 (default).
04/25/2019 14:54:36 : [INFO ] Collected Test : BUILD-GCOV-KERNEL
04/25/2019 14:54:36 : [WARN ] Priority of BUILD-GCOV-REPORT is not defined, set it to 1 (default).
04/25/2019 14:54:36 : [INFO ] Collected Test : BUILD-GCOV-REPORT
04/25/2019 14:54:36 : [WARN ] Priority of LONG-PERF-STRESS-TEST is not defined, set it to 1 (default).
04/25/2019 14:54:36 : [INFO ] Collected Test : LONG-PERF-STRESS-TEST
```
After fix, run 50 cases for P1.
```
04/28/2019 06:54:08 : [WARN ] Priority of CAPTURE-VHD-BEFORE-TEST is not defined.
04/28/2019 06:54:08 : [WARN ] Priority of BUILD-GCOV-KERNEL is not defined.
04/28/2019 06:54:08 : [WARN ] Priority of BUILD-GCOV-REPORT is not defined.
04/28/2019 06:54:08 : [WARN ] Priority of LONG-PERF-STRESS-TEST is not defined.
```