### PR TITLE
Remove offset for crashkernel parameter.

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -636,7 +636,7 @@
         <TestParameters>
             <param>vmCpuNumber=2</param>
             <param>vmMemory=2GB</param>
-            <param>crashkernel=256M@128M</param>
+            <param>crashkernel=256M</param>
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Sometimes hit issue 'crashkernel reservation failed - memory is in use', reboot can resolve this issue.
Guru suggests that 'Please try not to use the offset for the crashkernel memory location. Kernel will determine the appropriate location to load the crash kernel..'