### PR TITLE
Change for collect total number of run cases

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -209,8 +209,6 @@ Class TestController
 
 		if( !$allTests ) {
 			Throw "Not able to collect any test cases from XML files"
-		} else {
-			$this.TotalCaseNum = @($allTests).Count
 		}
 		Write-LogInfo "$(@($allTests).Length) Test Cases have been collected"
 
@@ -275,6 +273,7 @@ Class TestController
 				Set-AdditionalHWConfigInTestCaseData -CurrentTestData $test -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"]
 			}
 			if ($this.OverrideVMSize) {
+				$this.OverrideVMSize = ($this.OverrideVMSize.Split(",") | select -Unique) -join ","
 				Write-LogInfo "The OverrideVMSize of case $($test.testName) is set to $($this.OverrideVMSize)"
 				if ($test.OverrideVMSize) {
 					$test.OverrideVMSize = $this.OverrideVMSize
@@ -301,7 +300,13 @@ Class TestController
 				$IsWindowsImage = $true
 			}
 			Set-Variable -Name IsWindowsImage -Value $IsWindowsImage -Scope Global
+			if ($test.OverrideVMSize) {
+				$this.TotalCaseNum += $test.OverrideVMSize.Split(",").Count
+			} else {
+				$this.TotalCaseNum++
+			}
 		}
+		$this.TotalCaseNum *= $this.TestIterations
 	}
 
 	[void] PrepareTestImage() {}


### PR DESCRIPTION
Let know if need count for iterations, for #139 

```
.\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lilitest' -TestPlatform 'Azure'  `
-ARMImageName "canonical ubuntuserver 18.04-lts Latest" `
 -XMLSecretFile E:\AzureSecrets_2_18.xml -TestNames "VERIFY-BOOT-ERROR-WARNINGS"

 [LISAv2 Test Results Summary]
Test Run On           : 04/29/2019 08:57:10
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 2.62 


 .\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lilitest' -TestPlatform 'Azure'  `
-ARMImageName "canonical ubuntuserver 18.04-lts Latest" `
 -XMLSecretFile E:\AzureSecrets_2_18.xml -TestNames "VERIFY-BOOT-ERROR-WARNINGS" -TestIterations 2

 [LISAv2 Test Results Summary]
Test Run On           : 04/29/2019 09:05:59
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS-1                                                      PASS                 3.33 
    2 CORE                 VERIFY-BOOT-ERROR-WARNINGS-2                                                      PASS                 3.14 


  .\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lilitest' -TestPlatform 'Azure'  `
-ARMImageName "canonical ubuntuserver 18.04-lts Latest" `
 -XMLSecretFile E:\AzureSecrets_2_18.xml -TestNames "VERIFY-BOOT-ERROR-WARNINGS,VERIFY-LINUX-DISK-SETUP" -OverrideVMSize "Standard_D14_v2,Standard_D13_v2"

 [LISAv2 Test Results Summary]
Test Run On           : 04/29/2019 09:18:52
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 4 (4 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D14_v2                                        PASS                 2.63 
    2 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D13_v2                                        PASS                 2.74 
    3 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D14_v2                                           PASS                 2.63 
    4 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D13_v2                                           PASS                 2.62 


  .\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lilitest' -TestPlatform 'Azure'  `
-ARMImageName "canonical ubuntuserver 18.04-lts Latest" `
 -XMLSecretFile E:\AzureSecrets_2_18.xml -TestNames "VERIFY-BOOT-ERROR-WARNINGS,VERIFY-LINUX-DISK-SETUP" -OverrideVMSize "Standard_D14_v2,Standard_D13_v2" -TestIterations 2

 [LISAv2 Test Results Summary]
Test Run On           : 04/29/2019 10:05:28
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 8 (8 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:29

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D14_v2-1                                      PASS                 2.54 
    2 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D14_v2-2                                      PASS                  2.6 
    3 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D13_v2-1                                      PASS                  2.5 
    4 CORE                 VERIFY-BOOT-ERROR-WARNINGS-Standard_D13_v2-2                                      PASS                 2.44 
    5 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D14_v2-1                                         PASS                 2.46 
    6 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D14_v2-2                                         PASS                 2.42 
    7 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D13_v2-1                                         PASS                 2.53 
    8 CORE                 VERIFY-LINUX-DISK-SETUP-Standard_D13_v2-2                                         PASS                  2.4 
```


