### PR TITLE
Adjust test case sequence.

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -42,6 +42,17 @@
         <Priority>0</Priority>
     </test>
     <test>
+        <testName>VERIFY-LINUX-CONFIGURATION</testName>
+        <testScript>VERIFY-LINUX-CONFIGURATION.py</testScript>
+        <files>.\Testscripts\Linux\VERIFY-LINUX-CONFIGURATION.py,.\Testscripts\Linux\azuremodules.py</files>
+        <setupType>OneVM</setupType>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>CORE</Area>
+        <Tags>linux_setting</Tags>
+        <Priority>0</Priority>
+    </test>
+    <test>
         <testName>LIS-MODULES-CHECK</testName>
         <testScript>LIS-MODULES-CHECK.py</testScript>
         <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\LIS-MODULES-CHECK.py</files>
@@ -1094,17 +1105,6 @@
         <Area>CORE</Area>
         <Tags>cpu</Tags>
         <Priority>1</Priority>
-    </test>
-    <test>
-        <testName>VERIFY-LINUX-CONFIGURATION</testName>
-        <testScript>VERIFY-LINUX-CONFIGURATION.py</testScript>
-        <files>.\Testscripts\Linux\VERIFY-LINUX-CONFIGURATION.py,.\Testscripts\Linux\azuremodules.py</files>
-        <setupType>OneVM</setupType>
-        <Platform>Azure</Platform>
-        <Category>Functional</Category>
-        <Area>CORE</Area>
-        <Tags>linux_setting</Tags>
-        <Priority>0</Priority>
     </test>
     <test>
         <testName>VERIFY-LINUX-DISK-SETUP</testName>


### PR DESCRIPTION
Before update, VERIFY-LINUX-CONFIGURATION will run after KDUMP cases, KDUMP cases will remove the console params, https://github.com/LIS/LISAv2/blob/master/Testscripts/Linux/KDUMP-Config.sh#L323
Case VERIFY-LINUX-CONFIGURATION is to verify console=ttys0, it failed if run after case KDUMP.

After
```
04/30/2019 01:10:55 : [INFO ] Collected Test : VERIFY-LINUX-CONFIGURATION
04/30/2019 01:10:55 : [INFO ] Collected Test : LIS-MODULES-CHECK
04/30/2019 01:10:55 : [INFO ] Collected Test : VERIFY-LIS-MODULES-VERSION
04/30/2019 01:10:55 : [INFO ] Collected Test : VERIFY-BOOT-ERROR-WARNINGS
04/30/2019 01:10:55 : [INFO ] Collected Test : VERIFY-VHD-PREREQUISITES
04/30/2019 01:10:55 : [INFO ] Collected Test : TIMESYNC-NTP
04/30/2019 01:10:55 : [INFO ] Collected Test : TIME-CLOCKSOURCE
04/30/2019 01:10:55 : [INFO ] Collected Test : TIME-CLOCKEVENT-UP
04/30/2019 01:10:55 : [INFO ] Collected Test : TIME-CLOCKEVENT-SMP
04/30/2019 01:10:55 : [INFO ] Collected Test : INITRD-MODULES-CHECK
04/30/2019 01:10:55 : [INFO ] Collected Test : CPU-VERIFY-ONLINE
04/30/2019 01:10:55 : [INFO ] Collected Test : RELOAD-MODULES-SMP
04/30/2019 01:10:55 : [INFO ] Collected Test : LSVMBUS
04/30/2019 01:10:55 : [INFO ] Collected Test : TIMESYNC-BASIC
04/30/2019 01:10:55 : [INFO ] Collected Test : VMBUS_VERIFY_INTERRUPTS
04/30/2019 01:10:55 : [INFO ] Collected Test : KDUMP-CRASH-SINGLE-CORE
04/30/2019 01:10:55 : [INFO ] Collected Test : KDUMP-CRASH-SMP
04/30/2019 01:10:55 : [INFO ] Collected Test : KDUMP-CRASH-AUTO-SIZE
04/30/2019 01:10:55 : [INFO ] Collected Test : KDUMP-CRASH-DIFFERENT-VCPU
04/30/2019 01:10:55 : [INFO ] Collected Test : KDUMP-CRASH-16-CORES
04/30/2019 01:10:55 : [INFO ] Collected Test : VM-HOT-RESIZE
04/30/2019 01:10:55 : [INFO ] Collected Test : L3-CACHE-CHECK
04/30/2019 01:10:55 : [INFO ] Collected Test : VERIFY-LINUX-DISK-SETUP
04/30/2019 01:10:55 : [INFO ] Collected Test : LIS-DRIVER-VERSION-CHECK
04/30/2019 01:10:55 : [INFO ] 58 Test Cases have been collected
```

