### PR TITLE
customLISInstall.sh: Multiple fixes

### DIFF
--- a/Testscripts/Linux/customLISInstall.sh
+++ b/Testscripts/Linux/customLISInstall.sh
@@ -4,18 +4,21 @@
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
+#
 # Description: It install the LIS using given LIS source file (.tar.gz or lis-next)
-# Usage: ./customLISInstall.sh -CustomLIS lisnext or tar file link -LISbranch a specific branch or default is master
+# Usage: ./customLISInstall.sh -CustomLIS lisnext or tar file link -LISbranch
+# a specific branch or default is master.
 #
 #######################################################################
 
-#HOW TO PARSE THE ARGUMENTS.. SOURCE - http://stackoverflow.com/questions/4882349/parsing-shell-script-arguments
-
+# HOW TO PARSE THE ARGUMENTS
+# SOURCE - http://stackoverflow.com/questions/4882349/parsing-shell-script-arguments
 while echo $1 | grep ^- > /dev/null; do
     eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
     shift
     shift
 done
+
 #
 # Constants/Globals
 #
@@ -27,28 +30,26 @@ ICA_TESTFAILED="TestFailed"        # Error occurred during the test
 # LogMsg()
 #
 #######################################################################
-LogMsg()
-{
-    echo $(date "+%b %d %Y %T") : "${1}"    # Add the time stamp to the log message
-    echo "${1}" >> ~/build-CustomLIS.txt
+LogMsg() {
+	echo $(date "+%b %d %Y %T") : "${1}"    # Add the time stamp to the log message
+	echo "${1}" >> ~/build-CustomLIS.txt
 }
 
-UpdateTestState()
-{
-    echo "${1}" > ~/state.txt
+UpdateTestState() {
+	echo "${1}" > ~/state.txt
 }
 
 if [ -z "$CustomLIS" ]; then
-	echo "Please mention -CustomLIS next"
+	echo "Please mention flag -CustomLIS lisnext or tar.gz/rpm name"
 	exit 1
 fi
 if [ -z "$LISbranch" ]; then
-	echo "Not mentioned LIS branch, Use Master branch"
+	echo "LIS branch not specified, using master branch"
 	LISbranch="master"
 fi
 touch ~/build-CustomLIS.txt
 
-#Detect Distro and it's version
+# Detect distro and version
 DistroName="Unknown"
 DistroVersion="Unknown"
 if [ -f /etc/redhat-release ] ; then
@@ -68,19 +69,18 @@ fi
 if [ -f /etc/UnitedLinux-release ] ; then
 	DistroName="${DistroName}[$(cat /etc/UnitedLinux-release | tr "\n" ' ' | sed s/VERSION.*//)]"
 fi
+
 LogMsg "*****OS Info*****"
 cat /etc/*-release >> ~/build-CustomLIS.txt 2>&1
-LogMsg "*****Kernen Info*****"
+LogMsg "*****Kernel Info*****"
 uname -r >> ~/build-CustomLIS.txt 2>&1
 LogMsg "*****LIS Info*****"
 modinfo hv_vmbus >> ~/build-CustomLIS.txt 2>&1
 kernel=$(uname -r)
+
 if [ "${CustomLIS}" == "lisnext" ]; then
 	LISSource="https://github.com/LIS/lis-next.git"
 	sourceDir="lis-next"
-elif [ "${CustomLIS}" == "netnext" ]; then
-	LISSource="https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git"
-	sourceDir="net-next"
 elif [[ $CustomLIS == *.rpm ]]; then
 	LogMsg "Custom LIS:$CustomLIS"
 	sed -i '/^exclude/c\#exclude' /etc/yum.conf
@@ -124,13 +124,12 @@ elif [[ $CustomLIS == *.tar.gz ]]; then
 fi
 LogMsg "Custom LIS:$CustomLIS"
 
-if [ $DistroName == "SLES" -o $DistroName == "SUSE" ]; then
-	zypper --non-interactive install git-core make tar gcc bc patch dos2unix wget xz 
-	LogMsg "LIS doesn't support for $DistroName distro..."
+if [ $DistroName == "SLES" -o $DistroName == "SUSE" -o $DistroName == "UBUNTU" ]; then
+	LogMsg "LIS doesn't support distro $DistroName..."
 elif [ $DistroName == "CENTOS" -o $DistroName == "REDHAT" -o $DistroName == "FEDORA" -o $DistroName == "ORACLELINUX" ]; then
-	LogMsg "Installing packages git make tar gcc bc patch dos2unix wget ..."
+	LogMsg "Installing dependencies..."
 	sed -i '/^exclude/c\#exclude' /etc/yum.conf
-	yum install -y git make tar gcc bc patch dos2unix wget xz >> ~/build-CustomLIS.txt 2>&1
+	yum install -y git make tar gcc bc patch wget xz >> ~/build-CustomLIS.txt 2>&1
 	LogMsg "Downloading LIS source from ${LISSource}..."
 	git clone ${LISSource} >> ~/build-CustomLIS.txt 2>&1
 	cd ${sourceDir}
@@ -138,26 +137,26 @@ elif [ $DistroName == "CENTOS" -o $DistroName == "REDHAT" -o $DistroName == "FED
 	LogMsg "Downloaded LIS from this ${LISbranch} branch..."
 	if [[ $DistroVersion == *"5."* ]]; then
 		LISsourceDir=hv-rhel5.x/hv
-	elif [[ $DistroVersion == *"6."* ]]; then
+	elif [[ $DistroVersion == *"6\."* ]]; then
 		LISsourceDir=hv-rhel6.x/hv
 	elif [[ $DistroVersion == *"7."* ]]; then
 		LISsourceDir=hv-rhel7.x/hv
+		LogMsg "Installing kernel-devel and kernel-headers for LIS..."
+		yum -y install centos-release
+		yum clean all
+		yum -y install --enablerepo=C*-base --enablerepo=C*-updates kernel-devel-"$(uname -r)" kernel-headers-"$(uname -r)"
 	fi
+
 	cd $LISsourceDir
-	LISDir=$(pwd)
-	LogMsg "Installing kernel-devel-${kernel} for LIS..."
-	# TODO - code refactoring should fix non Microsoft blob access
-	yum install -y "https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/kernel-devel-${kernel}.rpm" ~/build-CustomLIS.txt 2>&1
-	LogMsg "LIS is installing from this ${LISDir} branch..."
+	LogMsg "LIS is installing from this $(pwd) branch..."
 	./*-hv-driver-install >> ~/build-CustomLIS.txt 2>&1
 	if [ $? -ne 0 ]; then
 		LogMsg "CUSTOM_LIS_FAIL"
 		UpdateTestState $ICA_TESTFAILED
 		exit 0
 	fi
-elif [ $DistroName == "UBUNTU" ]; then
-	LogMsg "LIS doesn't support for $DistroName distro..."
 fi
+
 UpdateTestState $ICA_TESTCOMPLETED
 sleep 10
 LogMsg "CUSTOM_LIS_SUCCESS"


### PR DESCRIPTION
Fixes #95 

Fix kernel-devel installation for running kernel, previous method was broken as it required constant maintenance of rpm files on a share.
Fix distro detection - centos 7.6 was detected as series 6.x and was trying to use the lis-next/6.x tree.
Fix indentation.
Clean code - incorrect use of netnext tree for upstream.

---

Previous behavior on centos 7.5/7.6:

```
04/30/2019 08:25:33 : [ERROR] LIS upgrade failed in 1 VMs.
04/30/2019 08:25:33 : [ERROR] Custom LIS: lisnext installation FAIL. Aborting tests.
04/30/2019 08:25:33 : [ERROR] Failed to set custom config in VMs, abort the test
```

After fixes:
```
04/30/2019 09:35:09 : [INFO ] Package Installation Status for LISAv2-vm-role-0 : CUSTOM_LIS_SUCCESS
...
04/30/2019 09:35:22 : [INFO ] LIS upgraded to "lisnext" successfully in all VMs.
```