### PR TITLE
Fix for VF device not found on 6.x

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -76,7 +76,12 @@ VerifyVF()
         vf_interface=$(ls /sys/class/net/ | grep -v 'eth0\|eth1\|lo' | head -1)
     else
         synthetic_interface=$(ip addr | grep "$VF_IP1" | awk '{print $NF}')
-        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ $DISTRO_VERSION =~ ^6\. ]]; then
+            synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
+            vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
+        else
+            vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
 
     ip addr show "$vf_interface"

--- a/Testscripts/Linux/SRIOV-DisableVF.sh
+++ b/Testscripts/Linux/SRIOV-DisableVF.sh
@@ -46,7 +46,12 @@ UpdateSummary "Expected VF count: $NIC_COUNT. Actual VF count: $vf_count"
 # Extract VF name
 synthetic_interface=$(ip addr | grep "$VF_IP1" | awk '{print $NF}')
 LogMsg  "Synthetic interface found: $synthetic_interface"
-vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+if [[ $DISTRO_VERSION =~ ^6\. ]]; then
+    synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
+    vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
+else
+    vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+fi
 LogMsg "Virtual function found: $vf_interface"
 
 # Put VF down

--- a/Testscripts/Linux/SRIOV-ModuleReload.sh
+++ b/Testscripts/Linux/SRIOV-ModuleReload.sh
@@ -46,7 +46,12 @@ UpdateSummary "Expected VF count: $NIC_COUNT. Actual VF count: $vf_count"
 # Extract VF name
 synthetic_interface=$(ip addr | grep "$VF_IP1" | awk '{print $NF}')
 LogMsg  "Synthetic interface found: $synthetic_interface"
-vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+if [[ $DISTRO_VERSION =~ ^6\. ]]; then
+    synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
+    vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
+else
+    vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+fi
 LogMsg "Virtual function found: $vf_interface"
 # Extract module name
 module_name_in_use=$(lspci -vvv | grep -i kernel | tail -1 | awk '{print $NF}')


### PR DESCRIPTION
This PR meets below requirements

1) For 6.x, VF interface is returning blank since soft link is not created.So, added a logic to get VF interface based upon the MAC address of Synthetic interface
2) Execute dhclient to get IP for the Extra NICs attached
3) Added a condition check to skip testcase for distro below 6.7, since SRIOV is supported from 6.7 onwards