### PR TITLE
Disable-Enable-PCI: add generic test script and test case for 10 nvme + 7 SR-IOV NICs

### DIFF
--- a/Testscripts/Linux/SRIOV-VerifyVF-Connection.sh
+++ b/Testscripts/Linux/SRIOV-VerifyVF-Connection.sh
@@ -33,10 +33,10 @@ if [ $? -ne 0 ]; then
     exit 0
 fi
 
-if [ "$rescind_pci" = "yes" ]; then
-    # call rescind function with param SRIOV
-    if ! RescindPCI "SR-IOV"; then
-        LogErr "Could not rescind pci device."
+if [ "$disable_enable_pci" = "yes" ]; then
+    # call function with param SRIOV
+    if ! DisableEnablePCI "SR-IOV"; then
+        LogErr "Could not disable and reenable pci device."
         SetTestStateFailed
         exit 0
     fi

--- a/Testscripts/Linux/disableEnablePci.sh
+++ b/Testscripts/Linux/disableEnablePci.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 2
+}
+UtilsInit
+
+install_package "pciutils lshw"
+
+if [ ! -z "$expectedNvme" ] && [ "$expectedNvme" -gt 0 ]; then
+    # Count the NVME disks
+    disk_count=$(ls -l /dev | grep -w nvme[0-9]$ | awk '{print $10}' | wc -l)
+    if [ "$disk_count" -ne "$expectedNvme" ]; then
+        LogErr "NVME disks count does not match expected inside the VM, expected $expectedNvme found $disk_count"
+        LogErr "lspci output: $(lspci)"
+        LogErr "lshw output: $(lshw -c storage -businfo)"
+        SetTestStateFailed
+        exit 0
+    fi
+fi
+
+if [ ! -z "$expectedSriov" ] && [ "$expectedSriov" -gt 0 ]; then
+    #count SR-IOV NICs
+    nics_count=$(find /sys/devices -name net -a -ipath '*vmbus*' | grep -c pci)
+    if [ "$nics_count" -ne "$expectedSriov" ]; then
+        LogErr "SR-IOV NICs count does not match expected inside the VM, expected $expectedSriov found $nics_count"
+        LogErr "lspci output: $(lspci)"
+        LogErr "lshw output: $(lshw -c network -businfo)"
+        SetTestStateFailed
+        exit 0
+    fi
+fi
+
+if [ ! -z "$expectedGpu" ] && [ "$expectedGpu" -gt 0 ]; then
+    #count GPUs
+    gpu_count=$(lspci | grep -ic nvidia)
+    if [ "$gpu_count" -ne "$expectedGpu" ]; then
+        LogErr "GPU count does not match expected inside the VM, expected $expectedGpu found $gpu_count"
+        LogErr "lspci output: $(lspci)"
+        LogErr "lshw output: $(lshw -c display -businfo)"
+        SetTestStateFailed
+        exit 0
+    fi
+fi
+
+if ! DisableEnablePCI "ALL"; then
+    LogErr "Could not disable and reenable the pci devices."
+    SetTestStateFailed
+    exit 0
+fi
+
+SetTestStateCompleted
+exit 0

--- a/Testscripts/Linux/nvme_basic_validation.sh
+++ b/Testscripts/Linux/nvme_basic_validation.sh
@@ -27,10 +27,10 @@ if [ "$disk_count" -eq "0" ]; then
     exit 0
 fi
 
-if [ "$rescind_pci" = "yes" ]; then
-    # call rescind function with param NVMe
-    if ! RescindPCI "NVME"; then
-        LogErr "Could not rescind pci device."
+if [ "$disable_enable_pci" = "yes" ]; then
+    # call function with param NVMe
+    if ! DisableEnablePCI "NVME"; then
+        LogErr "Could not disable and reenable the pci device."
         SetTestStateFailed
         exit 0
     fi

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3420,7 +3420,11 @@ function DisableEnablePCI ()
         LogErr "No PCI devices of type $vf_pci_type were found."
         return 1
     else
-        LogMsg "Found the following $vf_pci_type devices: $vf_pci_addresses"
+        LogMsg "Found the following $vf_pci_type devices:"
+        # Remove the VF for each address
+        for addr in ${vf_pci_addresses[@]}; do
+            LogMsg "$(lspci | grep $addr)"
+        done
     fi
 
     # Remove the VF for each address

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3394,14 +3394,16 @@ function Format_Mount_NVME()
 
 # Remove and reattach PCI devices of a certain type inside the VM
 # @param1 DeviceType: supported values are "NVME", "SR-IOV", "GPU"
+# and "ALL" for all 3 previous types
 # @return 0 if the devices were removed and reattached successfully
-function RescindPCI ()
+function DisableEnablePCI ()
 {
     case "$1" in
         "SR-IOV") vf_pci_type="Ethernet" ;;
         "NVME")   vf_pci_type="Non-Volatile" ;;
         "GPU")    vf_pci_type="NVIDIA" ;;
-        *)        LogErr "Unsupported device type for RescindPCI." ; return 1 ;;
+        "ALL")    vf_pci_type="NVIDIA\|Non-Volatile\|Ethernet" ;;
+        *)        LogErr "Unsupported device type for DisableEnablePCI." ; return 1 ;;
     esac
 
     if ! lspci --version > /dev/null 2>&1; then

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -14,8 +14,8 @@
     4. Check if the nVidia driver is loaded
     5. Compare number of expected GPU adapters with the actual count.
     6. The following tools are used for validation: lsvmbus, lspci, lshw and nvidia-smi
-    7. If test parameter "rescind_pci=yes" is provided, the 3D controller PCI device
-    will be rescinded first.
+    7. If test parameter "disable_enable_pci=yes" is provided, the 3D controller PCI device
+    will be disabled and reenabled first.
 
 #>
 
@@ -189,15 +189,15 @@ function Main {
 
         Write-LogInfo "Azure VM Size: $($allVMData.InstanceSize), expected GPU Adapters total: $expectedGPUCount"
 
-        # rescind the PCI device first if the parameter is given
-        if ($TestParams.rescind_pci -eq "yes") {
+        # Disable and enable the PCI device first if the parameter is given
+        if ($TestParams.disable_enable_pci -eq "yes") {
             Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP -port $allVMData.SSHPort `
-                -command ". utils.sh && RescindPCI GPU" -RunAsSudo -ignoreLinuxExitCode | Out-Null
+                -command ". utils.sh && DisableEnablePCI GPU" -RunAsSudo -ignoreLinuxExitCode | Out-Null
             if (-not $?) {
-                $metaData = "Could not rescind PCI device."
+                $metaData = "Could not disable and reenable PCI device."
                 Write-LogErr "$metaData"
             } else {
-                $metaData = "Successfully rescinded the PCI device."
+                $metaData = "Successfully disabled and reenabled the PCI device."
                 Write-LogInfo "$metaData"
             }
             $CurrentTestResult.TestSummary += New-ResultSummary -metaData "$metaData" -testName $CurrentTestData.testName

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -61,7 +61,7 @@
         <files>.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\utils.sh</files>
         <TestParameters>
             <param>CUDADriverVersion="CUDA_DRIVER"</param>
-            <param>rescind_pci=yes</param>
+            <param>disable_enable_pci=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -186,7 +186,7 @@
         <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
-            <param>rescind_pci=yes</param>
+            <param>disable_enable_pci=yes</param>
         </testParameters>
         <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -583,7 +583,7 @@
             <param>NETMASK=255.255.255.0</param>
             <param>Switch_Name=SRIOV_MLNX</param>
             <param>SECRET_PARAMS=(VM2Name,CheckpointName)</param>
-            <param>rescind_pci=yes</param>
+            <param>disable_enable_pci=yes</param>
         </TestParameters>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -564,4 +564,31 @@
         <Tags>sriov,network</Tags>
         <Priority>2</Priority>
     </test>
+    <test>
+        <testName>SRIOV-DISABLE-ENABLE-PCI</testName>
+        <setupScript>.\Testscripts\Windows\SETUP-SR-IOV-Configure.ps1</setupScript>
+        <testScript>SRIOV-RUN-COMMON-TEST.ps1</testScript>
+        <setupType>TwoVM2Host1Dep</setupType>
+        <AdditionalHWConfig>
+            <Networking>SRIOV</Networking>
+        </AdditionalHWConfig>
+        <files>.\Testscripts\Linux\SRIOV-VerifyVF-Connection.sh,.\Testscripts\Linux\SR-IOV-Utils.sh,.\Testscripts\Linux\utils.sh</files>
+        <TestParameters>
+            <param>Remote_Script=SRIOV-VerifyVF-Connection.sh</param>
+            <param>Install_Dependencies=yes</param>
+            <param>Set_SSH=yes</param>
+            <param>NIC_COUNT=1</param>
+            <param>VF_IP1=10.0.0.34</param>
+            <param>VF_IP2=10.0.0.54</param>
+            <param>NETMASK=255.255.255.0</param>
+            <param>Switch_Name=SRIOV_MLNX</param>
+            <param>SECRET_PARAMS=(VM2Name,CheckpointName)</param>
+            <param>rescind_pci=yes</param>
+        </TestParameters>
+        <Platform>Azure,HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>SRIOV</Area>
+        <Tags>sriov,network</Tags>
+        <Priority>1</Priority>
+    </test>
 </TestCases>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -1132,4 +1132,23 @@
         <Tags>linux_setting</Tags>
         <Priority>0</Priority>
     </test>
+    <test>
+        <testName>PCI-DEVICE-DISABLE-ENABLE-SRIOV-NVME</testName>
+        <testScript>disableEnablePci.sh</testScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\disableEnablePci.sh</files>
+        <setupType>OneVM8NIC</setupType>
+        <OverrideVMSize>Standard_L80s_v2</OverrideVMSize>
+        <AdditionalHWConfig>
+            <Networking>SRIOV</Networking>
+        </AdditionalHWConfig>
+        <TestParameters>
+            <param>expectedSriov=7</param>
+            <param>expectedNvme=10</param>
+        </TestParameters>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>CORE</Area>
+        <Tags>pci_hyperv,nvme,sriov</Tags>
+        <Priority>1</Priority>
+    </test>
 </TestCases>


### PR DESCRIPTION
* Add back old SRIOV-PCI-RESCIND test case with new name
* Rename instances of rescind-pci to Disable-enable-pci (rescind refers to when the request is triggered by the host) 
* Add test script for disable-enable PCI testing of multiple configurations of NVME + SR-IOV + GPU 
* Add test case for disable-enable PCI with 10 nvme disks and 7 SR-IOV NICs