### PR TITLE
Update fcopy related cases for Check-FileInLinuxGuest command

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1126,11 +1126,12 @@ function Check-FileInLinuxGuest {
 	.Description
 		Checks if test file is present or not, if set $checkSize as $True, return file size,
 		if set checkContent as $True, will return file content.
-#>
-	$check = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "stat ${fileName} >/dev/null"
-	if ($check) {
-		Write-Loginfo "File $fileName exists"
-		return $true
+   #>
+
+	$check = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "[ -f ${fileName} ] && echo 1 || echo 0"
+	if (-not $check) {
+		Write-Loginfo "File $fileName does not exists"
+		return $False
 	}
 	if ($checkSize) {
 		$size = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "wc -c < $fileName"
@@ -1140,6 +1141,7 @@ function Check-FileInLinuxGuest {
 		$content = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "cat ${fileName}"
 		return "$content"
 	}
+	return $True
 }
 
 function Mount-Disk{

--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -669,7 +669,7 @@ function Copy-CheckFileInLinuxGuest{
 	# Write the file
 	$filecontent = Generate-RandomString -length $contentlength
 
-	$filecontent | Out-File $testfile
+	$filecontent | Out-File $testfile -Encoding UTF8
 	if (-not $?) {
 		Write-LogErr "Cannot create file $testfile'."
 		return $False
@@ -693,16 +693,17 @@ function Copy-CheckFileInLinuxGuest{
 		Copy-VMFile -vmName $vmName -ComputerName $hvServer -SourcePath $filePath -DestinationPath "/tmp/" -FileSource host -ErrorAction SilentlyContinue
 	}
 	if ($Error.Count -eq 0) {
-		$sts = Check-FileInLinuxGuest -vmUserName $vmUserName -vmPassword $vmPassword -vmPort $vmPort -ipv4 $ipv4 -fileName "/tmp/$testfile" -checkSize $True -checkContent $True
+		$sts = Check-FileInLinuxGuest -vmUserName $vmUserName -vmPassword $vmPassword -vmPort $vmPort -ipv4 $ipv4 -fileName "/tmp/$testfile" -checkSize $True
 		if (-not $sts) {
-			Write-LogErr "File is not present on the guest VM '${vmName}'!"
+			Write-LogErr "File check error on the guest VM '${vmName}'!"
 			return $False
 		}
 		elseif ($sts -ne $filesize) {
 			Write-LogErr "The copied file doesn't match the $filesize size."
 			return $False
 		}
-		elseif ($sts[1] -ne $filecontent) {
+		$sts = Check-FileInLinuxGuest -vmUserName $vmUserName -vmPassword $vmPassword -vmPort $vmPort -ipv4 $ipv4 -fileName "/tmp/$testfile" -checkContent $True
+		if ($sts -ne $filecontent) {
 			Write-LogErr "The copied file doesn't match the content '$filecontent'."
 			return $False
 		}

--- a/Testscripts/Windows/FCOPY-DISABLE-ENABLE.ps1
+++ b/Testscripts/Windows/FCOPY-DISABLE-ENABLE.ps1
@@ -191,8 +191,8 @@ function Main {
     }
 
     # Check for the file to be copied
-    Test-Path $filePathFormatted
-    if ($? -ne "True") {
+
+    if ( (Test-Path \\$HvServer\$filePathFormatted) -ne "True") {
         Write-LogErr "File to be copied not found."
         return "FAIL"
     }
@@ -220,7 +220,6 @@ function Main {
     }
     elseif ($sts -eq $fileToCopySize) {
         Write-LogInfo "The file copied matches the $FcopyFileSize size."
-        return "PASS"
     }
     else {
         Write-LogErr "The file copied doesn't match the $FcopyFileSize size!"
@@ -229,23 +228,10 @@ function Main {
 
     # Removing the temporary test file
     Remove-Item -Path \\$HvServer\$filePathFormatted -Force
-    if (-not $?) {
+    if ($? -ne "True") {
         Write-LogErr "Cannot remove the test file '${testfile}'!"
-        return "FAIL"
     }
 
-    $sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort "echo 'sleep 5 && bash ~/check_traces.sh ~/check_traces.log &' > runtest.sh" -runAsSudo
-    $sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort "chmod +x ~/runtest.sh" -runAsSudo
-    $sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort "./runtest.sh > check_traces.log 2>&1" -runAsSudo
-    Start-Sleep 6
-    $sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort "cat ~/check_traces.log | grep ERROR" -runAsSudo
-    Start-Sleep 6
-    if ($sts.Contains("ERROR")) {
-        Write-LogInfo "Warning: Call traces have been found on VM"
-    }
-    if ($sts -eq $NULL) {
-        Write-LogInfo " No Call traces have been found on VM"
-    }
     return "PASS"
 }
 

--- a/Testscripts/Windows/FCOPY-FILE-EXISTS.ps1
+++ b/Testscripts/Windows/FCOPY-FILE-EXISTS.ps1
@@ -152,20 +152,21 @@ function Main {
     $Error.Clear()
     # Second copy file attempt must fail with the below error code pattern
     Copy-VMFile -vmName $VMName -ComputerName $hvServer -SourcePath $filePath -DestinationPath "/tmp/" -FileSource host -ErrorAction SilentlyContinue
+
     if ($error.Count -eq 0) {
         Write-LogInfo "Test PASS! File could not be copied as it already exists on guest VM '${vmName}'"
-        return "PASS"
     }
-    elseif ($error.Count -eq 1) {
+    else{
         Write-LogErr "File '${testfile}' has been copied twice to guest VM '${vmName}'!"
         return "FAIL"
     }
+
     # Removing the temporary test file
     Remove-Item -Path \\$HvServer\$file_path_formatted -Force
-    if ($LASTEXITCODE -ne "0") {
+    if ($? -ne "True") {
         Write-LogErr "cannot remove the test file '${testfile}'!"
-        return "FAIL"
     }
+    return "PASS"
 }
 Main -VMName $AllVMData.RoleName -HvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `
     -Ipv4 $AllVMData.PublicIP -VMPort $AllVMData.SSHPort `

--- a/Testscripts/Windows/FCOPY-LARGE-FILE.ps1
+++ b/Testscripts/Windows/FCOPY-LARGE-FILE.ps1
@@ -149,7 +149,6 @@ if  (-not $sts) {
 }
 elseif ($sts -eq $filesize) {
     Write-LogInfo "The file copied matches the size: $filesize bytes."
-    return "PASS"
 }
 else {
 	Write-LogErr "The file copied doesn't match the size: $filesize bytes!"
@@ -159,10 +158,11 @@ else {
 # Removing the temporary test file
 #
 Remove-Item -Path \\$HvServer\$file_path_formatted -Force
-if (-not $?) {
+if ($? -ne "True") {
     Write-LogErr "ERROR: Cannot remove the test file '${testfile}'!"
-    return "FAIL"
 }
+return "PASS"
+
 }
 
 Main -VMName $AllVMData.RoleName -HvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `

--- a/Testscripts/Windows/FCOPY-NEGATIVE.ps1
+++ b/Testscripts/Windows/FCOPY-NEGATIVE.ps1
@@ -208,7 +208,6 @@ function Main {
 
         return "PASS"
     }
-
 }
 
 Main -VMName $AllVMData.RoleName -HvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `

--- a/Testscripts/Windows/FCOPY-NON-ASCII.ps1
+++ b/Testscripts/Windows/FCOPY-NON-ASCII.ps1
@@ -112,10 +112,10 @@ function Main {
         }
 
         # Multiply the contents of the sample file up to an 100MB auxiliary file
-        New-Item $MyDir"auxFile" -type file | Out-Null
+        New-Item $CurrentDir"auxFile" -type file | Out-Null
         2..130| ForEach-Object {
             $testfileContent = Get-Content $pathToFile
-            Add-Content $MyDir"auxFile" $testfileContent
+            Add-Content $CurrentDir"auxFile" $testfileContent
         }
 
         # Checking if auxiliary file was successfully created
@@ -125,7 +125,7 @@ function Main {
         }
 
         # Move the auxiliary file to testfile
-        Move-Item -Path $MyDir"auxFile" -Destination $pathToFile -Force
+        Move-Item -Path $CurrentDir"auxFile" -Destination $pathToFile -Force
 
         # Checking file size. It must be over 85MB
         $testfileSize = (Get-Item $pathToFile).Length
@@ -134,7 +134,7 @@ function Main {
             $testfileSize = $testfileSize / 1MB
             $testfileSize = [math]::round($testfileSize, 2)
             Write-LogErr "File not big enough (over 85MB)! File size: $testfileSize MB"
-            Remove-TestFile -pathToFile $pathToFile -tesfile $testfile
+            Remove-TestFile -pathToFile $pathToFile -testfile $testfile
             return "FAIL"
         }
         else {
@@ -147,12 +147,11 @@ function Main {
         $local_chksum = Get-FileHash .\$testfile -Algorithm MD5 | Select-Object -ExpandProperty hash
         if (-not $?) {
             Write-LogErr "Unable to get MD5 checksum!"
-            Remove-TestFile -pathToFile $pathToFile -tesfile $testfile
+            Remove-TestFile -pathToFile $pathToFile -testfile $testfile
             return "FAIL"
         }
         else {
             Write-LogInfo "MD5 file checksum on the host-side: $local_chksum"
-            return "PASS"
         }
 
         # Get vhd folder
@@ -183,14 +182,13 @@ function Main {
         -FileSource host -ErrorAction SilentlyContinue
     if ($Error.Count -eq 0) {
         Write-LogInfo "File has been successfully copied to guest VM '${vmName}'"
-        return "PASS"
     }
     elseif (($Error.Count -gt 0) -and ($Error[0].Exception.Message  `
                 -like "*FAIL to initiate copying files to the guest: The file exists. (0x80070050)*")) {
         Write-LogErr "Test FAIL! File could not be copied as it already exists on guest VM '${vmName}'"
         return "FAIL"
     }
-    Remove-TestFile -pathToFile $pathToFile -tesfile $testfile
+    Remove-TestFile -pathToFile $pathToFile -testfile $testfile
 
     #
     # Verify if the file is present on the guest VM
@@ -227,7 +225,6 @@ function Main {
     Remove-Item -Path \\$HvServer\$file_path_formatted -Force
     if ($? -ne "True") {
         Write-LogErr "Cannot remove the test file '${testfile}'!"
-        return "FAIL"
     }
     #
     # If we made it here, everything worked

--- a/Testscripts/Windows/FCOPY-OVERWRITE.ps1
+++ b/Testscripts/Windows/FCOPY-OVERWRITE.ps1
@@ -121,7 +121,6 @@ if (-not $sts) {
 }
 else {
     Write-LogInfo "The file has been initially copied to the VM '${vmName}'."
-    return "PASS"
 }
 #
 # Second copy file overwrites the initial file. Re-write the text file with 15 characters, and then copy it with -Force parameter.
@@ -133,15 +132,15 @@ if (-not $sts) {
 }
 else {
     Write-LogInfo "The file has been overwritten to the VM '${vmName}'."
-    return "PASS"
-}
 
+}
 # Removing the temporary test file
 Remove-Item -Path \\$HvServer\$file_path_formatted -Force
 if ($? -ne "True") {
     Write-LogErr "Cannot remove the test file '${testfile}'!"
-    return "FAIL"
 }
+
+return "PASS"
 }
 
 Main -VMName $AllVMData.RoleName -HvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `

--- a/XML/TestCases/FunctionalTests-FCOPY.xml
+++ b/XML/TestCases/FunctionalTests-FCOPY.xml
@@ -73,7 +73,6 @@
 		<testName>FCOPY-DISABLE-ENABLE</testName>
 		<setupScript>.\Testscripts\Windows\AddVhdxHardDisk.ps1</setupScript>
 		<testScript>FCOPY-DISABLE-ENABLE.ps1</testScript>
-		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\check_traces.sh</files>
 		<setupType>OneVM</setupType>
 		<testParameters>
 			<param>SCSI=1,0,Fixed,512,7GB</param>


### PR DESCRIPTION
Original Check-FileInLinuxGuest has bugs when migration from lis-test to lisav2.
Details update lists as below:
1. Separate check-size and check-content, before use sts[-1], sts[0], now change to sts
2. Before without return $False if file does not exist
3. Out-File $testfile -Encoding UTF8 to avoid mess code, before use dos2unix.
4. Add parse parmeter FilesSize
5. Fix Run-LinuxCmd without output for $sts if only use "rm -f file"
$sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -port $VMPort -ip $Ipv4 "rm -f /mnt/test/$testfile" -runAsSudo
6. Change "File is not present" as "File check error", since when file is empty, it will get file size 0, but the file is present.

Have run all the TestTag fcopy cases, all the cases are passed. Before update, FCOPY-REPEATED-DELETE and FCOPY-OVERWRITE failed.

Thank you so much.