### PR TITLE
RDMA: Added SKIPPED state for Ubuntu versions <18

### DIFF
--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -68,6 +68,17 @@ function Main {
 			Write-LogInfo "Waiting 5 minutes to finish RDMA update for NC series VMs."
 			Start-Sleep -Seconds 300
 		}
+		# Ubuntu extra step: make sure the VM supports RDMA
+		if (@("UBUNTU").contains($global:detectedDistro)) {
+			$cmd = "lsb_release -r | awk '{print `$2}'"
+			$release = Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username `
+				$user -password $password $cmd -ignoreLinuxExitCode:$true
+			if ($release.Split(".")[0] -lt "18") {
+				Write-LogInfo "Ubuntu $release is not supported! Test skipped"
+				$testResult = "SKIPPED"
+				return "SKIPPED"
+			}
+		}
 		$VM_Size = ($ServerVMData.InstanceSize -split "_")[1] -replace "[^0-9]",''
 		Write-LogInfo "Getting VM instance size: $VM_Size"
 		#region CONFIGURE VMs for TEST


### PR DESCRIPTION
Only Ubuntu versions higher than 18.04 will be tested, the others will be skipped.

[LISAv2 Test Results Summary]
Test Run On           : 05/07/2019 10:23:52
ARM Image Under Test  : Canonical : UbuntuServer : **16.04-LTS** : latest
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                     SKIPPED                 1.07


[LISAv2 Test Results Summary]
Test Run On           : 05/07/2019 08:36:38
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:4:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS               246.68
        InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
        InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS
        InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-IO : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS
        InfiniBand-Verification-2-Reboot : eth0 IP : PASS
        InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS
        InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS
        InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
        InfiniBand-Verification-2-Reboot : IMB-P2P : PASS
        InfiniBand-Verification-2-Reboot : IMB-IO : PASS
        InfiniBand-Verification-2-Reboot : IMB-RMA : PASS
        InfiniBand-Verification-2-Reboot : IMB-NBC : PASS
