### PR TITLE
dpdk: fix rx forwarder

### DIFF
--- a/Testscripts/Linux/dpdk-testFWD.sh
+++ b/Testscripts/Linux/dpdk-testFWD.sh
@@ -84,8 +84,9 @@ function Run_Testfwd() {
 	ssh "${forwarder}" "${forwarder_testfwd_cmd}" 2>&1 > "${LOG_DIR}"/dpdk-testfwd-forwarder-"${core}"-core-$(date +"%m%d%Y-%H%M%S").log &
 
 	sleep 5
-	
-	local sender_testfwd_cmd="$(Create_Timed_Testpmd_Cmd "${test_duration}" "${core}" "${sender_busaddr}" "${sender_iface}" txonly)"
+
+	trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${forwarder}")
+	local sender_testfwd_cmd="$(Create_Timed_Testpmd_Cmd "${test_duration}" "${core}" "${sender_busaddr}" "${sender_iface}" txonly "${trx_rx_ips}")"
 	LogMsg "${sender_testfwd_cmd}"
 	eval "${sender_testfwd_cmd} 2>&1 > ${LOG_DIR}/dpdk-testfwd-sender-${core}-core-$(date +"%m%d%Y-%H%M%S").log &"
 	

--- a/Testscripts/Linux/dpdk-testFailsafe.sh
+++ b/Testscripts/Linux/dpdk-testFailsafe.sh
@@ -74,8 +74,8 @@ function Run_Testfailsafe() {
 	ssh "${forwarder}" "${forwarder_testfwd_cmd}" 2>&1 > "${LOG_DIR}"/dpdk-testfailsafe-forwarder.log &
 
 	sleep 5
-	
-	local sender_testfwd_cmd="$(Create_Testpmd_Cmd ${core} "${sender_busaddr}" "${sender_iface}" txonly)"
+	trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${forwarder}")
+	local sender_testfwd_cmd="$(Create_Testpmd_Cmd ${core} "${sender_busaddr}" "${sender_iface}" txonly "${trx_rx_ips}")"
 	# reduce txd so VF revoke doesn't kill forwarder
 	sender_testfwd_cmd=$(echo "${sender_testfwd_cmd}" | sed -r 's,(--.xd=)4096,\110,')
 	LogMsg "${sender_testfwd_cmd}"

--- a/Testscripts/Linux/dpdk-testPMD.sh
+++ b/Testscripts/Linux/dpdk-testPMD.sh
@@ -80,7 +80,8 @@ function Run_Testpmd() {
 
 		sleep 5
 
-		local sender_testpmd_cmd="$(Create_Timed_Testpmd_Cmd "${test_duration}" "${core}" "${sender_busaddr}" "${sender_iface}" txonly)"
+		trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${receiver}")
+		local sender_testpmd_cmd="$(Create_Timed_Testpmd_Cmd "${test_duration}" "${core}" "${sender_busaddr}" "${sender_iface}" txonly "${trx_rx_ips}")"
 		LogMsg "${sender_testpmd_cmd}"
 		eval "${sender_testpmd_cmd} 2>&1 > ${LOG_DIR}/dpdk-testpmd-${test_mode}-sender-${core}-core-$(date +"%m%d%Y-%H%M%S").log &"
 


### PR DESCRIPTION
Because of https://github.com/DPDK/dpdk/commit/bf5b2126bf44b2afa8ac579c03036acf9dacdcff#diff-b1f56c61c5867be04350fea84eae0050, now there is a flag for testpmd that has to be set for DST|SRC IPs for TX packets instead of modifing the test-pmd code.

This patch keeps the backward compatibility with the former implementation.