### PR TITLE
dpdk: fix remaining tests after testpmd change

### DIFF
--- a/Testscripts/Linux/dpdkSetup.sh
+++ b/Testscripts/Linux/dpdkSetup.sh
@@ -141,6 +141,9 @@ function install_dpdk () {
 
 	ssh "${1}" "mv ${dpdkSrcDir} ${RTE_SDK}"
 
+	DPDK_DIR="${dpdkSrcDir}"
+	LogMsg "DPDK source directory: ${DPDK_DIR}"
+
 	if [ ! -z "$dpdk_server_ip" -a "$dpdk_server_ip" != " " ];
 	then
 		LogMsg "dpdk build with NIC SRC IP $dpdk_server_ip ADDR on ${1}"

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -24,7 +24,7 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <SubtestValues>This-tag-will-be-removed</SubtestValues>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\dpdkTestPmd.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\dpdkUtils.sh,.\Testscripts\Linux\dpdkTestPmd.sh</files>
         <TestParameters>
             <param>dpdkSrcLink="DPDK_SOURCE_URL"</param>
             <param>testDuration=DPDK_TEST_DURATION_IN_SECONDS</param>
@@ -43,7 +43,7 @@
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
-        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\dpdkTestPmd.sh</files>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\dpdkUtils.sh,.\Testscripts\Linux\dpdkTestPmd.sh</files>
         <TestParameters>
             <param>dpdkSrcLink="DPDK_SOURCE_URL"</param>
             <param>testDuration=30</param>


### PR DESCRIPTION
Continuation for https://github.com/LIS/LISAv2/pull/183