### PR TITLE
Fix find python issues against RHEL8, since it has internal interpreter.

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -341,8 +341,8 @@ Class TestController
 		}
 		if ($CurrentTestData.files -imatch ".py") {
 			$pythonPath = Run-LinuxCmd -Username $Username -password $Password -ip $VMData.PublicIP -Port $VMData.SSHPort `
-				-Command "which python || which python2 || which python3" -runAsSudo
-			if (($pythonPath -imatch "python2") -or ($pythonPath -imatch "python3")) {
+				-Command "which python || which python2 || which python3 || (which /usr/libexec/platform-python && ln -s /usr/libexec/platform-python /sbin/python)" -runAsSudo
+			if (!$pythonPath.Contains("platform-python") -and (($pythonPath -imatch "python2") -or ($pythonPath -imatch "python3"))) {
 				$pythonPathSymlink  = $pythonPath.Substring(0, $pythonPath.LastIndexOf("/") + 1)
 				$pythonPathSymlink  += "python"
 				Run-LinuxCmd -Username $Username -password $Password -ip $VMData.PublicIP -Port $VMData.SSHPort `


### PR DESCRIPTION
Fixes #185 

RHEL8 has internal interpreter platform-python, either we set up soft link to /usr/libexec/platform-python or install the python3 package in RHEL8 (this one need judge the distro type and version)