### PR TITLE
Fix return unknown distro when run against Clear Linux OS.

### DIFF
--- a/Testscripts/Linux/DetectLinuxDistro.sh
+++ b/Testscripts/Linux/DetectLinuxDistro.sh
@@ -11,13 +11,13 @@
 #  FEDORA
 DetectDistro()
 {
-while echo "$1" | grep ^- > /dev/null; do
-    eval $( echo "$1" | sed 's/-//g' | tr -d '\012')="$2"
-    shift
-    shift
-done
+        while echo "$1" | grep ^- > /dev/null; do
+                eval $( echo "$1" | sed 's/-//g' | tr -d '\012')="$2"
+                shift
+                shift
+        done
         if [ -e /etc/debian_version ]; then
-		        tmp=$(cat /etc/*-release)
+                tmp=$(cat /etc/*-release)
                 if [[ "$tmp" == *Ubuntu* ]]; then
                     echo "UBUNTU"
                     exitVal=0
@@ -60,6 +60,10 @@ done
                 else
                     echo "Unknown"
                 fi
+        elif [ -e /usr/share/clear/version ]; then
+                tmp=$(cat /usr/share/clear/version)
+                echo "CLEARLINUX"
+                exitVal=0
         elif [ -e /etc/os-release ]; then
                 tmp=$(cat /etc/os-release)
                 if [[ "$tmp" == *coreos* ]]; then
@@ -74,11 +78,7 @@ done
                 else
                     echo "Unknown"
                 fi
-        elif [ -e /usr/share/clear/version ]; then
-                tmp=$(cat /usr/share/clear/version)
-                echo "CLEARLINUX"
-                exitVal=0
         fi
-return $exitVal
+        return $exitVal
 }
 DetectDistro


### PR DESCRIPTION
This is caused by /etc/os-release added into ClearOS.
Before fix - 
```
05/13/2019 09:11:59 : [INFO ] .\Tools\plink.exe -t -pw ****** -P 22 lisa@IP "echo ****** | sudo -S /home/USER/DetectLinuxDistro.sh"
05/13/2019 09:12:05 : [INFO ] /home/lisa/DetectLinuxDistro.sh executed successfully in 6.25 seconds.
05/13/2019 09:12:05 : [ERROR] Linux distro detected : Unknown
05/13/2019 09:12:05 : [INFO ] Set $fdisk > fdisk for Unknown
```

After Fix - 
```
05/13/2019 09:33:19 : [INFO ] .\Tools\plink.exe -t -pw ****** -P 22 lisa@IP "echo ****** | sudo -S /home/USER/DetectLinuxDistro.sh"
05/13/2019 09:33:25 : [INFO ] /home/lisa/DetectLinuxDistro.sh executed successfully in 6.6 seconds.
05/13/2019 09:33:25 : [INFO ] Set $fdisk > fdisk for CLEARLINUX
05/13/2019 09:33:25 : [INFO ] Linux distro detected: CLEARLINUX
```