### PR TITLE
DPDK fixes and improvements

### DIFF
--- a/Testscripts/Linux/dpdkSetup.sh
+++ b/Testscripts/Linux/dpdkSetup.sh
@@ -174,7 +174,7 @@ function install_dpdk () {
 	check_exit_status "${1} CONFIG_RTE_LIBRTE_MLX4_PMD=y" "exit"
 	ssh "${1}" "cd $RTE_SDK && make config O=$RTE_TARGET T=$RTE_TARGET"
 	LogMsg "Starting DPDK build make on ${1}"
-	ssh "${1}" "cd $RTE_SDK/$RTE_TARGET && make -j8 && make install"
+	ssh "${1}" "cd $RTE_SDK/$RTE_TARGET && make -j 2>&1 && make install 2>&1"
 	check_exit_status "dpdk build on ${1}" "exit"
 
 	LogMsg "*********INFO: Installed DPDK version on ${1} is ${dpdkVersion} ********"

--- a/Testscripts/Linux/dpdkTestPmd.sh
+++ b/Testscripts/Linux/dpdkTestPmd.sh
@@ -96,12 +96,19 @@ runTestPmd()
 		
 		LogMsg "TestPmd is starting on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
 		trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${server}")
-		echo "echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages && echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} testpmd -l 0-1 -w 0002:00:02.0 --vdev='net_vdev_netvsc0,iface=eth1,force=1' -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
-		echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout "${testDuration}" testpmd -l 0-1 -w 0002:00:02.0 --vdev='net_vdev_netvsc0,iface=eth1,force=1' -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 "${trx_rx_ips}" 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-sender-$(date +"%m%d%Y-%H%M%S").log &
+		echo "timeout ${testDuration} testpmd -l 0-1 -w 0002:00:02.0 --vdev='net_vdev_netvsc0,iface=eth1,force=1' -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
+		echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages \
+			&& echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages \
+			&& modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib
+		timeout "${testDuration}" testpmd -l 0-1 -w 0002:00:02.0 --vdev='net_vdev_netvsc0,iface=eth1,force=1' -- \
+			--port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 \
+			--forward-mode=txonly --stats-period 1 "${trx_rx_ips}" 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-sender-$(date +"%m%d%Y-%H%M%S").log &
 		checkCmdExitStatus "TestPmd started on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
 		sleep "${testDuration}"
 		LogMsg "reset used huge pages"
-		echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages && grep -i hug /proc/meminfo
+		echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages \
+			&& echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages \
+			&& grep -i hug /proc/meminfo
 		ssh "${server}" "echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages && grep -i hug /proc/meminfo"
 		pkill testpmd
 		ssh "${server}" "pkill testpmd"

--- a/Testscripts/Linux/ovs_setup.sh
+++ b/Testscripts/Linux/ovs_setup.sh
@@ -52,10 +52,9 @@ function install_ovs () {
 	elif [[ $ovsSrcLink =~ ".git" ]] || [[ $ovsSrcLink =~ "git:" ]];
 	then
 		ovsSrcDir="${ovsSrcLink##*/}"
-		LogMsg "Installing OVS from source file $ovsSrcDir"
-		ssh "${1}" git clone "$ovsSrcLink"
-		check_exit_status "git clone $ovsSrcLink on ${1}" "exit"
-		LogMsg "ovs source on ${1} $ovsSrcLink"
+		LogMsg "Installing OVS from git repo ${ovsSrcLink} to ${ovsSrcDir}"
+		ssh "${1}" git clone --single-branch --branch "${ovsSrcBranch}" "${ovsSrcLink}"
+		check_exit_status "git clone --single-branch --branch ${ovsSrcBranch} ${ovsSrcLink} on ${1}" "exit"
 	else
 		LogMsg "Provide proper link $ovsSrcLink"
 	fi
@@ -66,7 +65,7 @@ function install_ovs () {
 	ssh "${1}" "cd ${OVS_DIR} && ./configure --with-dpdk=${RTE_SDK}/${RTE_TARGET} --prefix=/usr --localstatedir=/var --sysconfdir=/etc"
 
 	LogMsg "Starting OVS build on ${1}"
-	ssh "${1}" "cd ${OVS_DIR} && make -j16 && make install"
+	ssh "${1}" "cd ${OVS_DIR} && make -j && make install"
 	check_exit_status "ovs build on ${1}" "exit"
 
 	vf_ip=$(ssh "${1}" "ip a | grep ${nicName} -A 2| grep inet | grep ${nicName} | awk '{print \$2}'")

--- a/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
+++ b/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
@@ -150,6 +150,8 @@ collect_VM_properties
 			-username $superUser -password $password -command "cat /root/state.txt"
 		$testResult = Get-TestStatus $dpdkStatus
 		if ($testResult -ne "PASS") {
+			Copy-RemoteFiles -downloadFrom $clientVMData.PublicIP -port $clientVMData.SSHPort `
+				-username $superUser -password $password -download -downloadTo $LogDir -files "*.txt, *.log"
 			return $testResult
 		}
 
@@ -180,6 +182,9 @@ collect_VM_properties
 		$ovsStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
 			-username $superUser -password $password -command "cat /root/state.txt"
 		$testResult = Get-TestStatus $ovsStatus
+
+		Copy-RemoteFiles -downloadFrom $clientVMData.PublicIP -port $clientVMData.SSHPort `
+			-username $superUser -password $password -download -downloadTo $LogDir -files "*.txt, *.log"
 	} catch {
 		$ErrorMessage =  $_.Exception.Message
 		$ErrorLine = $_.InvocationInfo.ScriptLineNumber

--- a/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
+++ b/Testscripts/Windows/VERIFY-DPDK-OVS.ps1
@@ -64,18 +64,16 @@ function Main {
 		Write-LogInfo "  Internal IP : $($serverVMData.InternalIP)"
 
 		# Checking OVS DPDK compatibility
-		$detectedDistro = Detect-LinuxDistro -VIP $vmData.PublicIP -SSHport $vmData.SSHPort `
-			-testVMUser $user -testVMPassword $password
-		if ($detectedDistro -like "*debian*" -or $detectedDistro -like "*ubuntu*") {
-			Write-LogInfo "Confirmed supported distro: $detectedDistro"
+		if (@("UBUNTU").contains($global:detectedDistro)) {
+			Write-LogInfo "Confirmed supported distro: ${global:detectedDistro}"
 		} else {
-			$msg = "Unsupported distro: $detectedDistro"
+			$msg = "Unsupported distro: ${global:detectedDistro}"
 			Write-LogWarn $msg
 			return $global:ResultSkipped
 		}
 		$currentKernelVersion = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort `
 			-username $user -password $password -command "uname -r"
-		if (IsGreaterKernelVersion -actualKernelVersion $currentKernelVersion -detectedDistro $detectedDistro) {
+		if (IsGreaterKernelVersion -actualKernelVersion $currentKernelVersion -detectedDistro $global:detectedDistro) {
 			Write-LogInfo "Confirmed Kernel version supported: $currentKernelVersion"
 		} else {
 			$msg = "Unsupported Kernel version: $currentKernelVersion"

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -50,6 +50,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>https://github.com/openvswitch/ovs.git</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>OVS_SOURCE_BRANCH</ReplaceThis>
+		<ReplaceWith>dpdk-latest</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>NTTTCP_RUNTIME_IN_SECONDS</ReplaceThis>
 		<ReplaceWith>300</ReplaceWith>
 	</Parameter>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -39,7 +39,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 <ReplaceableTestParameters>
 	<Parameter>
 		<ReplaceThis>DPDK_SOURCE_URL</ReplaceThis>
-		<ReplaceWith>https://fast.dpdk.org/rel/dpdk-18.08.tar.xz</ReplaceWith>
+		<ReplaceWith>https://fast.dpdk.org/rel/dpdk-18.11.tar.xz</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_PERF_CORES</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -84,6 +84,7 @@
         <TestParameters>
             <param>dpdkSrcLink="DPDK_SOURCE_URL"</param>
             <param>ovsSrcLink="OVS_SOURCE_URL"</param>
+            <param>ovsSrcBranch="OVS_SOURCE_BRANCH"</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Fixes:
https://github.com/LIS/LISAv2/issues/199
https://github.com/LIS/LISAv2/issues/200

Addedd a testpmd --no-pci stage in Testscripts/Linux/dpdkTestPmd.sh.
VERIFY-DPDK-OVS skips non-debian OSses.

Changes DPDK 18.08 default version to 18.11

Adds DPDK_SOURCE_BRANCH for VERIFY-DPDK-OVS TC, so that dpdk-latest branch can be tested in favor of master.