### PR TITLE
Fix for unavailable nvme-cli package on 6.x

### DIFF
--- a/Testscripts/Linux/nvme_basic_validation.sh
+++ b/Testscripts/Linux/nvme_basic_validation.sh
@@ -54,7 +54,7 @@ fi
 
 # Install nvme-cli tool
 update_repos
-install_package "nvme-cli"
+install_nvme_cli
 
 # Check namespaces in nvme cli
 namespace_list=$(ls -l /dev | grep -w nvme[0-9]n[0-9]$ | awk '{print $10}')

--- a/Testscripts/Linux/nvme_blkdiscard.sh
+++ b/Testscripts/Linux/nvme_blkdiscard.sh
@@ -20,7 +20,7 @@ UtilsInit
 Run_Blkdiscard() {
     # Install nvme-cli tool and parted
     update_repos
-    install_package "nvme-cli"
+    install_nvme_cli
     # Count NVME namespaces
     namespace_count=$(echo /dev/*nvme*n[0-9] | wc -w)
     if [ "$namespace_count" -eq "0" ]; then

--- a/Testscripts/Linux/nvme_fstrim.sh
+++ b/Testscripts/Linux/nvme_fstrim.sh
@@ -25,7 +25,7 @@ UtilsInit
 Run_Fstrim() {
     # Install nvme-cli tool and parted
     update_repos
-    install_package "nvme-cli"
+    install_nvme_cli
     # Count NVME namespaces
     namespace_count=$(echo /dev/nvme*n[0-9] | wc -w)
     if [ "$namespace_count" -eq "0" ]; then

--- a/Testscripts/Linux/nvme_functional.sh
+++ b/Testscripts/Linux/nvme_functional.sh
@@ -21,7 +21,7 @@ UtilsInit
 
 # Install nvme-cli tool
 update_repos
-install_package "nvme-cli"
+install_nvme_cli
 
 # Count NVME namespaces
 namespace_count=$(ls -l /dev | grep -w nvme[0-9]n[0-9]$ | awk '{print $10}' | wc -l)

--- a/Testscripts/Linux/nvme_functional_expected_fails.sh
+++ b/Testscripts/Linux/nvme_functional_expected_fails.sh
@@ -18,7 +18,7 @@ UtilsInit
 
 # Install nvme-cli tool
 update_repos
-install_package "nvme-cli"
+install_nvme_cli
 
 # Count NVME namespaces
 namespace_count=$(ls -l /dev | grep -w nvme[0-9]n[0-9]$ | awk '{print $10}' | wc -l)

--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -176,7 +176,7 @@ CreateRAID0()
 
 ConfigNVME()
 {
-	install_package "nvme-cli"
+	install_nvme_cli
 	namespace_list=$(ls -l /dev | grep -w nvme[0-9]n[0-9]$ | awk '{print $10}')
 	nvme_namespaces=""
 	for namespace in ${namespace_list}; do

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3500,3 +3500,57 @@ function CreateFile()
 		LogMsg "Error: $file_path failed to create with size $size"
 	fi
 }
+
+# Check available packages
+function check_package ()
+{
+	local package_list=("$@")
+	for package_name in "${package_list[@]}"; do
+		case "$DISTRO_NAME" in
+			oracle|rhel|centos)
+				yum provides "$package_name" | grep -i Matched
+				return $?
+				;;
+
+			ubuntu|debian)
+				apt-cache policy "$package_name" | grep Candidate
+				return $?
+				;;
+
+			suse|opensuse|sles)
+				zypper search "$package_name"
+				return $?
+				;;
+
+			clear-linux-os)
+				swupd search "$package_name" | grep -v "failed"
+				return $?
+				;;
+			*)
+				echo "Unknown distribution"
+				return 1
+		esac
+	done
+}
+
+# Install nvme
+function install_nvme_cli()
+{
+    which nvme
+    if [ $? -ne 0 ]; then
+        echo "nvme is not installed\n Installing now..."
+        check_package "nvme-cli"
+        if [ $? -ne 0 ]; then
+            yum -y groupinstall "Development Tools"
+            wget https://github.com/linux-nvme/nvme-cli/archive/${nvme_version}.tar.gz
+            tar xvf ${nvme_version}.tar.gz
+            pushd nvme-cli-${nvme_version/v/} && make && make install
+            popd
+            yes | cp -f /usr/local/sbin/nvme /sbin
+        else
+            install_package "nvme-cli"
+        fi
+    fi
+    which nvme
+    check_exit_status "install_nvme"
+}

--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -47,7 +47,8 @@ ConfigureXFSTestTools() {
     # Install common & specific dependencies
     update_repos
     install_fio
-    install_package "acl attr automake bc dos2unix dump e2fsprogs gawk gcc git indent libtool lvm2 make nvme-cli parted python quota sed xfsdump xfsprogs"
+    install_package "acl attr automake bc dos2unix dump e2fsprogs gawk gcc git indent libtool lvm2 make parted python quota sed xfsdump xfsprogs"
+    install_nvme_cli
     install_package $pack_list
     LogMsg "Packages installation complete."
     # Install dbench

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -478,4 +478,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>EXPECTED_MLNX_VERSION</ReplaceThis>
 		<ReplaceWith>4.5-0.0.8</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>NVME_VERSION</ReplaceThis>
+		<ReplaceWith>v1.8.1</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -8,6 +8,7 @@
         <OverrideVMSize>Standard_L16s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=2</param>
+            <param>nvme_version=NVME_VERSION</param>
         </testParameters>
         <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
@@ -23,6 +24,9 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nvme_basic_validation.sh</files>
         <setupType>OneVM</setupType>
         <OverrideVMSize>Standard_L80s_v2</OverrideVMSize>
+        <testParameters>
+            <param>nvme_version=NVME_VERSION</param>
+        </testParameters>
         <Timeout>1200</Timeout>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
@@ -39,6 +43,7 @@
         <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
+            <param>nvme_version=NVME_VERSION</param>
         </testParameters>
         <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
@@ -57,6 +62,7 @@
         <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
+            <param>nvme_version=NVME_VERSION</param>
         </testParameters>
         <Timeout>1200</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
@@ -75,6 +81,7 @@
         <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
+            <param>nvme_version=NVME_VERSION</param>
         </testParameters>
         <Timeout>3600</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
@@ -93,6 +100,7 @@
         <OverrideVMSize>Standard_L8s_v2</OverrideVMSize>
         <testParameters>
             <param>HYPERV_DISK_COUNT=1</param>
+            <param>nvme_version=NVME_VERSION</param>
         </testParameters>
         <Timeout>3600</Timeout>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
@@ -114,6 +122,7 @@
             <param>TEST_DIR=/root/test</param>
             <param>NVME=yes</param>
             <param>GENERIC=yes</param>
+            <param>nvme_version=NVME_VERSION</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -605,6 +605,7 @@
             <param>maxIO=4</param>
             <param>PHYSICAL_NUMBER=1</param>
             <param>parseTimeout=FIO_LOG_PARSE_TIMEOUT</param>
+            <param>nvme_version=NVME_VERSION</param>
         </TestParameters>
         <cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
         <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
on RHEL/Centos/Oracle 6.x series "yum install nvme-cli"  is failed, due to  no nvme-cli package is available. So, Handled a check in the code to download and install the latest nvme package