### PR TITLE
Code Coverage: Exclude Test because of VM size

### DIFF
--- a/Utilities/Launch-GcovTest.ps1
+++ b/Utilities/Launch-GcovTest.ps1
@@ -22,7 +22,9 @@ $CURRENT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $WORK_DIR = $CURRENT_DIR.Directory.FullName
 # VM-HOT-RESIZE test takes a long time to run and it is
 # not relevant for coverage
-$EXCLUDED_TESTS = "VM-HOT-RESIZE"
+# PCI-DEVICE-DISABLE-ENABLE-SRIOV-NVME is deployed on L80_v2,
+# uses too much quota and the same test is run on GPU and SRIOV
+$EXCLUDED_TESTS = "VM-HOT-RESIZE,PCI-DEVICE-DISABLE-ENABLE-SRIOV-NVME"
 
 function Main {
     $SrcPackagePath = Resolve-Path $SrcPackagePath


### PR DESCRIPTION
PCI-DEVICE-DISABLE-ENABLE-SRIOV-NVME requires too many resources to run and does not affect code coverage, the same test is run by GPU and SRIOV areas as far as VMBUS is concerned