### PR TITLE
Azure: Dynamic mapping of Azure VM size to their family

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -28,12 +28,12 @@
 Function Validate-SubscriptionUsage($RGXMLData, $Location, $OverrideVMSize, $StorageAccount) {
     #region VM Cores...
     Try {
-        Function Set-Usage($currentStatus, $text, $usage, $AllowedUsagePercentage) {
+        Function Set-Usage($currentStatus, $VMFamily, $usage, $AllowedUsagePercentage) {
             $counter = 0
             foreach ($item in $currentStatus) {
-                if ($item.Name.Value -eq $text) {
+                if ($item.Name.Value -eq $VMFamily) {
                     $allowedCount = [int](($currentStatus[$counter].Limit) * ($AllowedUsagePercentage / 100))
-                    Write-LogInfo "  Current $text usage : $($currentStatus[$counter].CurrentValue) cores. Requested:$usage. Estimated usage=$($($currentStatus[$counter].CurrentValue) + $usage). Max Allowed cores:$allowedCount/$(($currentStatus[$counter].Limit))"
+                    Write-LogInfo "  Current $VMFamily usage : $($currentStatus[$counter].CurrentValue) cores. Requested:$usage. Estimated usage=$($($currentStatus[$counter].CurrentValue) + $usage). Max Allowed cores:$allowedCount/$(($currentStatus[$counter].Limit))"
                     $currentStatus[$counter].CurrentValue = $currentStatus[$counter].CurrentValue + $usage
                 }
                 if ($item.Name.Value -eq "cores") {
@@ -47,15 +47,15 @@ Function Validate-SubscriptionUsage($RGXMLData, $Location, $OverrideVMSize, $Sto
             return $currentStatus
         }
 
-        Function Test-Usage($currentStatus, $text, $AllowedUsagePercentage) {
+        Function Test-Usage($currentStatus, $VMFamily, $AllowedUsagePercentage) {
             $overFlowErrors = 0
             $counter = 0
             foreach ($item in $currentStatus) {
-                if ($item.Name.Value -eq $text) {
+                if ($item.Name.Value -eq $VMFamily) {
                     $allowedCount = [int](($currentStatus[$counter].Limit) * ($AllowedUsagePercentage / 100))
                     #Write-LogInfo "Max allowed $($item.Name.LocalizedValue) usage : $allowedCount out of $(($currentStatus[$counter].Limit))."
                     if ($currentStatus[$counter].CurrentValue -gt $allowedCount) {
-                        Write-LogErr "  Current $text Estimated use: $($currentStatus[$counter].CurrentValue)"
+                        Write-LogErr "  Current $VMFamily Estimated use: $($currentStatus[$counter].CurrentValue)"
                         $overFlowErrors += 1
                     }
                 }
@@ -93,6 +93,10 @@ Function Validate-SubscriptionUsage($RGXMLData, $Location, $OverrideVMSize, $Sto
             }
         }
 
+        # Get the Azure Compute SKU details
+        Write-LogInfo "Getting Azure 'ComputeSKU' details..."
+        $ComputeSKU = Get-AzureRmComputeResourceSku
+
         #Define LISAv2's subscription usage limit. This is applicable for all the defined resources.
         #  e.g. If your subscription has below maximum limits:
         #    Resource Groups: 200
@@ -103,6 +107,13 @@ Function Validate-SubscriptionUsage($RGXMLData, $Location, $OverrideVMSize, $Sto
         #    LISAv2 Storage Accounts usage limit: 100
         #    LISAv2 Network Security Groups usage limit: 25
         $AllowedUsagePercentage = 100
+
+        $PremiumStorageVMFamilies = @("standardDSFamily",
+        "standardDSv2Family",
+        "standardDSv2PromoFamily",
+        "standardDSv3Family",
+        "standardFSFamily"
+        )
 
         #Get the region
         $currentStatus = Get-AzureRmVMUsage -Location $Location
@@ -124,46 +135,15 @@ Function Validate-SubscriptionUsage($RGXMLData, $Location, $OverrideVMSize, $Sto
                 $testVMUsage = (Get-AzureRmVMSize -Location $Location | Where-Object { $_.Name -eq $testVMSize}).NumberOfCores
             }
 
-            $testVMSize = $testVMSize.Replace("Standard_", "")
-            $regExpVmSize = @{
-                "standardDSv2Family" = @{ "Regexp" = "^DS.*v2$"; "isPremium"= 1};
-                "standardDSv3Family" = @{ "Regexp" = "^D.*s_v3$"; "isPremium"= 1};
-                "standardDSFamily" = @{ "Regexp" = "^DS((?!v2|s_v3).)*$"; "isPremium"= 1};
-                "standardDv2Family" = @{ "Regexp" = "^D[^S].*v2$"; "isPremium"= 0};
-                "standardDv3Family" = @{ "Regexp" = "^D[^S]((?!s_v3).)*v3$"; "isPremium"= 0};
-                "standardDFamily" = @{ "Regexp" = "^D[^S]((?!v2|v3).)*$"; "isPremium"= 0};
-                "standardESv3Family" = @{ "Regexp" = "^E.*s_v3$"; "isPremium"= 1};
-                "standardEv3Family" = @{ "Regexp" = "^E.*v3$"; "isPremium"= 0};
-                "standardA8_A11Family" = @{ "Regexp" = "A8|A9|A10|A11"; "isPremium"= 0};
-                "standardAv2Family"= @{ "Regexp" = "^A.*v2$"; "isPremium"= 0};
-                "standardA0_A7Family" = @{ "Regexp" = "A[0-7]$"; "isPremium"= 0};
-                "standardFSFamily" = @{ "Regexp" = "^FS"; "isPremium"= 1};
-                "standardFFamily" = @{ "Regexp" = '^F[^S]' ; "isPremium"= 0};
-                "standardGSFamily" = @{ "Regexp" = "^GS"; "isPremium"= 1};
-                "standardGFamily" = @{ "Regexp" = "^G[^S]"; "isPremium"= 0};
-                "standardNVFamily"= @{ "Regexp" = "^NV"; "isPremium"= 0};
-                "standardNCv2Family" = @{ "Regexp" = "^NC.*v2$"; "isPremium"= 0};
-                "standardNCFamily" = @{ "Regexp" = "^NC((?!v2).)*$"; "isPremium"= 0};
-                "standardNDFamily" = @{ "Regexp" = "^ND"; "isPremium"= 0};
-                "standardHBSFamily"= @{ "Regexp" = "^HB"; "isPremium"= 0};
-                "standardHCSFamily" = @{ "Regexp" = "^HC"; "isPremium"= 0};
-                "standardHFamily" = @{ "Regexp" = "^H[^BC]"; "isPremium"= 0};
-                "basicAFamily" = @{ "Regexp" = "^Basic"; "isPremium"= 0};
-                "standardMSFamily" = @{ "Regexp" = "^M"; "isPremium"= 0}
-            }
-            $identifierTest = ""
-            foreach ($vmFamily in $regExpVmSize.Keys) {
-                if ($testVMSize -match $regExpVMsize[$vmFamily].RegExp) {
-                    $identifierTest = $vmFamily
-                    $premiumVMs += $regExpVMsize[$vmFamily].isPremium
-                    break
-                }
-            }
-            if ($identifierTest) {
-                $currentStatus = Set-Usage -currentStatus $currentStatus -text $identifierTest  -usage $testVMUsage -AllowedUsagePercentage $AllowedUsagePercentage
-                $overFlowErrors += Test-Usage -currentStatus $currentStatus -text $identifierTest -AllowedUsagePercentage $AllowedUsagePercentage
+            $DetectedVMFamily = ($ComputeSKU | Where-Object { $_.Name -eq $testVMSize }).Family | Get-Unique
+            if ($DetectedVMFamily) {
+                $currentStatus = Set-Usage -currentStatus $currentStatus -VMFamily $DetectedVMFamily  -usage $testVMUsage -AllowedUsagePercentage $AllowedUsagePercentage
+                $overFlowErrors += Test-Usage -currentStatus $currentStatus -VMFamily $DetectedVMFamily -AllowedUsagePercentage $AllowedUsagePercentage
             } else {
                 Write-LogInfo "Requested VM size: $testVMSize is not yet registered to monitor. Usage simulation skipped."
+            }
+            if ($PremiumStorageVMFamilies.Contains($DetectedVMFamily)){
+                $premiumVMs += 1
             }
         }
     } catch {


### PR DESCRIPTION
This pull request addresses the issue of manual mapping of Azure VM sizes to their families.
**Now, the VM family will be detected automatically using the data obtained from Azure.**

Fixes #216 