### PR TITLE
Correct the count of NVME namespaces

### DIFF
--- a/Testscripts/Linux/nvme_blkdiscard.sh
+++ b/Testscripts/Linux/nvme_blkdiscard.sh
@@ -22,7 +22,7 @@ Run_Blkdiscard() {
     update_repos
     install_nvme_cli
     # Count NVME namespaces
-    namespace_count=$(echo /dev/*nvme*n[0-9] | wc -w)
+    namespace_count=$(ls /dev/ | grep -wc nvme[0-9]n[0-9]$)
     if [ "$namespace_count" -eq "0" ]; then
         LogErr "No NVME namespaces detected inside the VM"
         SetTestStateFailed

--- a/Testscripts/Linux/nvme_fstrim.sh
+++ b/Testscripts/Linux/nvme_fstrim.sh
@@ -27,7 +27,7 @@ Run_Fstrim() {
     update_repos
     install_nvme_cli
     # Count NVME namespaces
-    namespace_count=$(echo /dev/nvme*n[0-9] | wc -w)
+    namespace_count=$(ls /dev/ | grep -wc nvme[0-9]n[0-9]$)
     if [ "$namespace_count" -eq "0" ]; then
         LogErr "No NVME namespaces detected inside the VM"
         SetTestStateFailed


### PR DESCRIPTION
Found this issue by running P0 cases in HyperV, NVME-FSTRIM and NVME-BLKDISCARD always pass even there is no NVME disk on server.