### PR TITLE
Modify parameter testconnection for ntttcp testing against nested VM.

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -273,6 +273,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>300</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>NESTED_NTTTCP_TCP_CONNECTIONS</ReplaceThis>
+		<ReplaceWith>(1 2 4 8 16 32 64 128 256 512 1024 2048 4096)</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>OPENSUSE_DOWNLOAD_URL</ReplaceThis>
 		<ReplaceWith>http://download.opensuse.org/repositories/Kernel:/stable/standard/</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -35,7 +35,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
@@ -190,7 +190,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testType=tcp</param>
             <param>testDuration=60</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
@@ -218,7 +218,7 @@
             <param>NestedMemMB=8192</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
@@ -246,7 +246,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Performance</Category>
@@ -299,7 +299,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Performance</Category>
@@ -520,7 +520,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
             <param>SkipVerifyKernelLogs=true</param>
         </TestParameters>
         <Platform>HyperV</Platform>
@@ -547,7 +547,7 @@
             <param>NestedNetDevice=virtio-net-pci</param>
             <param>testDuration=60</param>
             <param>testType=tcp</param>
-            <param>testConnections="1 2 4 8 16 32 64 128 256 512 1024 2048 4096"</param>
+            <param>testConnections=NESTED_NTTTCP_TCP_CONNECTIONS</param>
             <param>SkipVerifyKernelLogs=true</param>
         </TestParameters>
         <Platform>Azure</Platform>


### PR DESCRIPTION
Previously the connection format change for perf_ntttcp.sh, this is to align that change.
```
[LISAv2 Test Results Summary]
Test Run On           : 05/16/2019 10:36:05
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:42

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               AZURE-NESTED-KVM-NTTTCP-DIFFERENT-L1-NAT                                          PASS                37.35 
```