### PR TITLE
TIMESYNC-NTP: Enable test-case against COREOS

### DIFF
--- a/Testscripts/Linux/TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/TIMESYNC-NTP.sh
@@ -168,12 +168,12 @@ elif is_suse ; then
     fi
 
 elif [[ $(detect_linux_distribution) == coreos ]]; then
-    # Refer to https://github.com/coreos/docs/blob/6ecaa639f0dd2098de037310d97c192fc49fce17/os/configuring-date-and-timezone.md#time-synchronization
+    # Refer to https://github.com/coreos/docs/blob/master/os/configuring-date-and-timezone.md#time-synchronization
     systemctl stop systemd-timesyncd
     systemctl mask systemd-timesyncd
     systemctl enable ntpd
     systemctl start ntpd
-
+    check_exit_status "Start ntpd service"
     # set rtc clock to system time & restart NTPD
     if ! hwclock --systohc
     then

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -319,6 +319,9 @@ GetDistro()
 		suse*)
 			OS_FAMILY="Sles"
 		;;
+		coreos*)
+			OS_FAMILY="CoreOS"
+		;;
 		*)
 			OS_FAMILY="unknown"
 			return 1


### PR DESCRIPTION
From pipline pipeline-azure-latest-image
```
CORE                 TIMESYNC-NTP                                                                   ABORTED                 0.85  
```

After fix
```
.\Run-LisaV2.ps1 -TestPlatform Azure -TestLocation westus2 -RGIdentifier lilitest -ARMImageName "CoreOS CoreOS Stable 2079.4.0" -TestNames "TIMESYNC-NTP" 

[LISAv2 Test Results Summary]
Test Run On           : 05/17/2019 04:58:25
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2079.4.0
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIMESYNC-NTP                                                                      PASS                 5.36 
```