### PR TITLE
VMBUS_VERIFY_HEARTBEAT_PROPERTIES: remove VM size

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -497,7 +497,6 @@
         <testScript>verify_vmbus_heartbeat_properties.sh</testScript>
         <files>.\Testscripts\Linux\verify_vmbus_heartbeat_properties.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_A3</OverrideVMSize>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>LIS</Area>


### PR DESCRIPTION
Size is not needed for this test case, it was initially made to fit with the other vmbus tests