### PR TITLE
VERIFY-BOOT-ERROR-WARNINGS: Update and fix test case

### DIFF
--- a/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
@@ -37,15 +37,20 @@ def RunTest():
         if (errors or warnings or failures):
             RunLog.error('Found ERROR/WARNING/FAILURE messages in logs.')
             if(errors):
-               RunLog.info('Errors: ' + ''.join(errors))
+                SplitLog('Errors', errors)
             if(warnings):
-               RunLog.info('warnings: ' + ''.join(warnings))
+                SplitLog('warnings', warnings)
             if(failures):
-               RunLog.info('failures: ' + ''.join(failures))
+                SplitLog('failures', failures)
             ResultLog.error('FAIL')
         else:
             ResultLog.info('PASS')
     UpdateState("TestCompleted")
+
+
+def SplitLog(logType, logValues):
+    for logEntry in logValues:
+        RunLog.info(logType + ': ' + logEntry)
 
 
 def RemoveIgnorableMessages(messages, keywords_xml_node):

--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -21,6 +21,7 @@
             <keywords>Failed to access perfctr msr</keywords>
         </failures>
         <errors>
+            <keywords>Condition check resulted in Process error reports when automatic reporting is enabled (file watch) being skipped.</keywords>
             <keywords>error trying to compare the snap system key: system-key missing on disk</keywords>
             <keywords>open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory</keywords>
             <keywords>mitigating potential DNS violation DVE-2018-0001</keywords>
@@ -33,7 +34,7 @@
         <warnings>
             <keywords>Server preferred version:</keywords>
             <keywords>WARNING Hostname record does not exist,</keywords>
-            <keywords>WARNING Dhcp client is not running</keywords>
+            <keywords>Dhcp client is not running</keywords>
             <keywords>Starting Write warning to Azure ephemeral disk</keywords>
             <keywords>Added ephemeral disk warning to</keywords>
             <keywords>Started Write warning to Azure ephemeral disk</keywords>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -83,6 +83,7 @@
         <testScript>VERIFY-BOOT-ERROR-WARNINGS.py</testScript>
         <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\VERIFY-BOOT-ERROR-WARNINGS.py,.\XML\Other\ignorable-boot-errors.xml</files>
         <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_B4ms</OverrideVMSize>
         <Platform>Azure,WSL</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>


### PR DESCRIPTION
WIP - will be changed

* Use different Azure VM size for this test case in order to have LISA provision it from scratch even when tests running in batches. Standard_B4ms was chosen as it's not used elsewhere at the moment and it's not a big VM size. Previously when running tests by areas this test would fail sporadically since it didn't boot into a freshly provisioned VM.
* Update ignored error (present on Ubuntu 19.04)
* Update warnings (`WARNING ExtHandler Dhcp client is not running` was found on Ubuntu 19.04, removing **WARNING** to match for the same string)
* Split logging of errros that are not ignored as they are logged concatenated at the moment and it is harder to read if there are more than 1
