### PR TITLE
Remove azure platform for case TIMESYNC-BASIC

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -326,7 +326,7 @@
             <param>TestDelay=10</param>
             <param>MaxTimeDiff=1.0</param>
         </TestParameters>
-        <Platform>Azure,HyperV</Platform>
+        <Platform>HyperV</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>
         <Tags>timesync</Tags>


### PR DESCRIPTION
test-case is not valid for Azure, as we use the host time to compare to the one in the guest, but comparing agent/local server time to a VM in Azure is not accurate.
On Hyper-V this is more appropriate, as the delay between checking the times is minimal.