### PR TITLE
Support switch to premium storage automatically

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -217,7 +217,7 @@ Function Change-StorageAccountType($TestCaseData, [string]$Location, $GlobalConf
     $storageAccount = $GlobalConfig.Global.Azure.Subscription.ARMStorageAccount
     $changedSC = ""
     $copyVHD = $false
-    if ($TestCaseData.AdditionalHWConfig.SCType -and $TestCaseData.AdditionalHWConfig.SCType.Contains("Premium")) {
+    if ($TestCaseData.AdditionalHWConfig.StorageAccountType -and $TestCaseData.AdditionalHWConfig.StorageAccountType.Contains("Premium")) {
         # if SC is ExistingStorage_Standard, switch to ExistingStorage_Premium
         if ($storageAccount -imatch "ExistingStorage_Standard") {
             $changedSC = Get-StorageAccountFromRegion -Region $Location -StorageAccount "ExistingStorage_Premium"
@@ -288,8 +288,6 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
     } else {
         $used_SC = $GlobalConfig.Global.Azure.Subscription.ARMStorageAccount
     }
-    $OsVHD = $OsVHD.Split("?")[0].split('/')[-1]
-    $global:BaseOSVHD = $OsVHD
     foreach ($RG in $setupTypeData.ResourceGroup ) {
         $validateStartTime = Get-Date
         Write-LogInfo "Checking the subscription usage..."
@@ -807,6 +805,9 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         $offer = $imageInfo[1]
         $sku = $imageInfo[2]
         $version = $imageInfo[3]
+    }
+    if($osVHD) {
+        $osVHD = $osVHD.Split("?")[0].split('/')[-1]
     }
 
     $vmCount = 0
@@ -1687,7 +1688,6 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         Add-Content -Value "$($indents[5])^osDisk^ : " -Path $jsonFile
         Add-Content -Value "$($indents[5]){" -Path $jsonFile
         if ($osVHD) {
-            $osVHD = $osVHD.Split('/')[-1]
             if ($UseManagedDisks) {
                 Write-LogInfo ">>> Using VHD : $osVHD (Converted to Managed Image)"
                 Add-Content -Value "$($indents[6])^osType^: ^Linux^," -Path $jsonFile

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -114,6 +114,13 @@ Class AzureController : TestController
 		}
 		elseif ($this.StorageAccount)
 		{
+			$sc = Get-AzureRmStorageAccount | Where-Object {$_.StorageAccountName -eq $this.StorageAccount}
+			if (!$sc) {
+				Throw "Provided storage account $($this.StorageAccount) does not exist, abort testing."
+			}
+			if($sc.Location -ne $this.TestLocation) {
+				Throw "Provided storage account $($this.StorageAccount) location $($sc.Location) is different from test location $($this.TestLocation), abort testing."
+			}
 			$azureConfig.Subscription.ARMStorageAccount = $this.StorageAccount.Trim()
 			Write-LogInfo "Selecting custom storage account : $($azureConfig.Subscription.ARMStorageAccount) as per your test region."
 		}
@@ -160,34 +167,51 @@ Class AzureController : TestController
 
 	[void] PrepareTestImage() {
 		#If Base OS VHD is present in another storage account, then copy to test storage account first.
-		if ($this.OsVHD -imatch "/") {
+		if ($this.OsVHD) {
+			$useSASURL = $false
+			if (($this.OsVHD -imatch 'sp=') -and ($this.OsVHD -imatch 'sig=')) {
+				$useSASURL = $true
+			}
+			$ARMStorageAccount = $this.GlobalConfig.Global.Azure.Subscription.ARMStorageAccount
+			if ($ARMStorageAccount -imatch "NewStorage_") {
+				Throw "LISAv2 only supports copying VHDs to existing storage account."
+			}
+
+			if (!$useSASURL -and ($this.OsVHD -inotmatch "/")) {
+				$this.OsVHD = 'http://{0}.blob.core.windows.net/vhds/{1}' -f $ARMStorageAccount, $this.OsVHD
+			}
+
 			#Check if the test storage account is same as VHD's original storage account.
 			$givenVHDStorageAccount = $this.OsVHD.Replace("https://","").Replace("http://","").Split(".")[0]
-			$ARMStorageAccount = $this.GlobalConfig.Global.Azure.Subscription.ARMStorageAccount
+			$sourceContainer =  $this.OsVHD.Split("/")[$this.OsVHD.Split("/").Count - 2]
+			$vhdName = $this.OsVHD.Split("?")[0].split('/')[-1]
 
-			if ($givenVHDStorageAccount -ne $ARMStorageAccount ) {
+			if ($givenVHDStorageAccount -ne $ARMStorageAccount) {
 				Write-LogInfo "Your test VHD is not in target storage account ($ARMStorageAccount)."
 				Write-LogInfo "Your VHD will be copied to $ARMStorageAccount now."
-				$sourceContainer =  $this.OsVHD.Split("/")[$this.OsVHD.Split("/").Count - 2]
-				$vhdName = $this.OsVHD.Split("?")[0].split('/')[-1]
-				if ($ARMStorageAccount -inotmatch "NewStorage_") {
-					#Copy the VHD to current storage account.
-					#Check if the OsVHD is a SasUrl
-					if ( ($this.OsVHD -imatch 'sp=') -and ($this.OsVHD -imatch 'sig=') ) {
-						$copyStatus = Copy-VHDToAnotherStorageAccount -SasUrl $this.OsVHD -destinationStorageAccount $ARMStorageAccount -destinationStorageContainer "vhds" -vhdName $vhdName
-					} else {
-						$copyStatus = Copy-VHDToAnotherStorageAccount -sourceStorageAccount $givenVHDStorageAccount -sourceStorageContainer $sourceContainer -destinationStorageAccount $ARMStorageAccount -destinationStorageContainer "vhds" -vhdName $vhdName
-					}
-					if (!$copyStatus) {
-						Throw "Failed to copy the VHD to $ARMStorageAccount"
-					} else {
-						Set-Variable -Name BaseOsVHD -Value $vhdName -Scope Global
-						Write-LogInfo "New Base VHD name - $vhdName"
-					}
+
+				#Copy the VHD to current storage account.
+				#Check if the OsVHD is a SasUrl
+				if ($useSASURL) {
+					$copyStatus = Copy-VHDToAnotherStorageAccount -SasUrl $this.OsVHD -destinationStorageAccount $ARMStorageAccount -destinationStorageContainer "vhds" -vhdName $vhdName
+					$this.OsVHD = 'http://{0}.blob.core.windows.net/vhds/{1}' -f $ARMStorageAccount, $vhdName
 				} else {
-					Throw "LISAv2 only supports copying VHDs to existing storage account."
+					$copyStatus = Copy-VHDToAnotherStorageAccount -sourceStorageAccount $givenVHDStorageAccount -sourceStorageContainer $sourceContainer -destinationStorageAccount $ARMStorageAccount -destinationStorageContainer "vhds" -vhdName $vhdName
+				}
+				if (!$copyStatus) {
+					Throw "Failed to copy the VHD to $ARMStorageAccount"
+				}
+			} else {
+				$sc = Get-AzureRmStorageAccount | Where-Object {$_.StorageAccountName -eq $ARMStorageAccount}
+				$storageKey = (Get-AzureRmStorageAccountKey -ResourceGroupName $sc.ResourceGroupName -Name $ARMStorageAccount)[0].Value
+				$context = New-AzureStorageContext -StorageAccountName $ARMStorageAccount -StorageAccountKey $storageKey
+				$blob = Get-AzureStorageBlob -Blob $vhdName -Container $sourceContainer -Context $context -ErrorAction Ignore
+				if (!$blob) {
+					Throw "Provided VHD not existed, abort testing."
 				}
 			}
+			Set-Variable -Name BaseOsVHD -Value $this.OsVHD -Scope Global
+			Write-LogInfo "New Base VHD name - $($this.OsVHD)"
 		}
 	}
 }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -286,7 +286,7 @@ Class TestController
 			if ($test.setupType) {
 				$key = "$($test.setupType),$($test.OverrideVMSize),$($test.AdditionalHWConfig.Networking),$($test.AdditionalHWConfig.DiskType)," +
 					"$($test.AdditionalHWConfig.OSDiskType),$($test.AdditionalHWConfig.SwitchName),$($test.AdditionalHWConfig.ImageType)," +
-					"$($test.AdditionalHWConfig.OSType)"
+					"$($test.AdditionalHWConfig.OSType),$($test.AdditionalHWConfig.StorageAccountType)"
 				if ($this.SetupTypeToTestCases.ContainsKey($key)) {
 					$this.SetupTypeToTestCases[$key] += $test
 				} else {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -498,4 +498,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>NVME_VERSION</ReplaceThis>
 		<ReplaceWith>v1.8.1</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>PERF_STORAGE_ACCOUNT_TYPE</ReplaceThis>
+		<ReplaceWith>Premium_LRS</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -281,6 +281,7 @@
         <setupType>OneVM12Disk</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
+            <SCType>Premium</SCType>
         </AdditionalHWConfig>
         <setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</setupScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -281,7 +281,7 @@
         <setupType>OneVM12Disk</setupType>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
-            <SCType>Premium</SCType>
+            <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
         </AdditionalHWConfig>
         <setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</setupScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>


### PR DESCRIPTION
Based on setting $TestCaseData.AdditionalHWConfig.SCType

Currently we're only able to specify storage type using command line, that makes it impossible to run a standard storage test case with a premium storage case (e.g. storage perf) using a single command.
Update code to support it in AdditionalHWConfig to allow running cases with different storage types using a single command.

