### PR TITLE
Fix the bug that Check-FileInLinuxGuest always return true even a file does not exist

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1129,7 +1129,7 @@ function Check-FileInLinuxGuest {
    #>
 
 	$check = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "[ -f ${fileName} ] && echo 1 || echo 0"
-	if (-not $check) {
+	if (-not [convert]::ToInt32($check)) {
 		Write-Loginfo "File $fileName does not exists"
 		return $False
 	}

--- a/Testscripts/Windows/PRODUCTION-CHECKPOINT.ps1
+++ b/Testscripts/Windows/PRODUCTION-CHECKPOINT.ps1
@@ -52,7 +52,7 @@ function Main {
         Write-LogInfo "VSS Daemon is running"
 
         # Create a file on the VM
-        $testfile1="Testfile_$(Get-Random -minimum 1 -maximum 1000)"
+        $testfile1="Testfile1_" + (Get-Date).ToString("yyyyMMddmmss")
         Write-LogInfo "Creating ${testfile1}"
         New-Item -type file -name $testfile1 -force | Out-Null
         Copy-RemoteFiles -upload -uploadTo $Ipv4 -Port $VMPort `
@@ -72,7 +72,7 @@ function Main {
         }
 
         # Create another file on the VM
-        $testfile2="Testfile_$(Get-Random -minimum 1 -maximum 1000)"
+        $testfile2="Testfile2_" + (Get-Date).ToString("yyyyMMddmmss")
         Write-LogInfo "Creating ${testfile2}"
         New-Item -type file -name $testfile2 -force | Out-Null
         Copy-RemoteFiles -upload -uploadTo $Ipv4 -Port $VMPort `


### PR DESCRIPTION
1. The test file names maybe the same even it's only 1/1000 probability in PRODUCTION-CHECKPOINT.ps1.
2. In Check-FileInLinuxGuest function, the return value of  Run-LinuxCmd is a string, so -not "0" returns False.