### PR TITLE
Ignore expected warning in LIS install Scenarios

### DIFF
--- a/Testscripts/Linux/LIS-MODULES-CHECK.py
+++ b/Testscripts/Linux/LIS-MODULES-CHECK.py
@@ -5,6 +5,9 @@
 from azuremodules import *
 from distutils.version import LooseVersion
 
+min_supported_distro_version="7.3"
+min_supported_LIS_version="4.3.0"
+
 
 def RunTest(command):
     UpdateState("TestStarted")
@@ -36,7 +39,7 @@ def RunTest(command):
     [current_distro, distro_version] = DetectDistro()
     lis_exists=Run("rpm -qa | grep hyper-v 2>/dev/null")
 
-    if distro_version.startswith("7") and lis_exists:
+    if LooseVersion(distro_version) >= LooseVersion(min_supported_distro_version) and lis_exists:
         hvModules.append("pci_hyperv")
         output = Run(command)
         if not ("pci_hyperv" in output):
@@ -44,7 +47,7 @@ def RunTest(command):
 
     if (distro_version.startswith("7.3") or distro_version.startswith("7.4")) and lis_exists:
         lis_version=Run("dmesg | grep 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:]")
-        if LooseVersion(lis_version) >= LooseVersion('4.3.0'):
+        if LooseVersion(lis_version) >= LooseVersion(min_supported_LIS_version):
             hvModules.append("mlx4_en")
             output = Run(command)
             if not ("mlx4_en" in output):

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -14,6 +14,8 @@
 
 exit_code="0"
 expected_lis_version=''
+min_supported_distro_version="7.3"
+min_supported_LIS_version="4.3.0"
 
 # Source utils.sh
 . utils.sh || {
@@ -25,8 +27,8 @@ expected_lis_version=''
 # Source constants file and initialize most common variables
 UtilsInit
 
-# Check if expected LIS version is greater than 4.3.0
-function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+# Check if version is greater than or equal to supported version
+function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
 
 # Check if vmbus string is recorded in dmesg
 hv_string=$(dmesg | grep "Vmbus version:")
@@ -69,7 +71,7 @@ isLISInstalled=$(rpm -qa | grep hyper-v 2>/dev/null)
 
 if [ ! -z "$isLISInstalled" ]; then
     expected_lis_version=$(dmesg | grep 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
-    if [[ $DISTRO_VERSION =~ 7\. ]]; then
+    if check_version_greater_equal $DISTRO_VERSION $min_supported_distro_version ; then
         HYPERV_MODULES+=('pci_hyperv')
         pci_module=$(lsmod | grep pci_hyperv)
         if [ -z $pci_module ]; then
@@ -77,7 +79,7 @@ if [ ! -z "$isLISInstalled" ]; then
         fi
     fi
     if [[ $DISTRO_VERSION =~ 7\.3 ]] || [[ $DISTRO_VERSION =~ 7\.4 ]] ; then
-        if version_ge $expected_lis_version "4.3.0" ; then
+        if check_version_greater_equal $expected_lis_version $min_supported_LIS_version ; then
             HYPERV_MODULES+=('mlx4_en')
             mlx4_module=$(lsmod | grep mlx4_en)
             if [ -z $mlx4_module ]; then

--- a/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
+++ b/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
@@ -8,6 +8,9 @@ param(
 )
 $ErrorActionPreference = "Stop"
 
+[xml]$configfile = Get-Content ".\XML\Other\ignorable-test-warnings.xml"
+$IgnorableWarnings = @($configfile.messages.warnings.keywords.Trim())
+
 Function Check-modules() {
     Write-LogInfo "Check if module are loaded after LIS installation"
     $remoteScript = "LIS-MODULES-CHECK.py"
@@ -72,7 +75,7 @@ Function Upgrade-LIS ($LISTarballUrlOld, $LISTarballUrlCurrent, $allVMData , $Te
             return $true
         }
         else {
-            if ($UpgradelLISConsoleOutput -imatch "error" -or $UpgradelLISConsoleOutput -imatch "warning" -or $UpgradelLISConsoleOutput -imatch "abort") {
+            if ($UpgradelLISConsoleOutput -imatch "error" -or ($UpgradelLISConsoleOutput -imatch "warning" -and ($null -eq ($IgnorableWarnings | ? {$UpgradelLISConsoleOutput -match $_ }))) -or $UpgradelLISConsoleOutput -imatch "abort") {
                 Write-LogErr "Latest LIS install is failed due found errors or warnings or aborted."
                 return $false
             }
@@ -160,7 +163,7 @@ Function Uninstall-LIS ( $LISTarballUrlCurrent, $allVMData , $TestProvider) {
             return $true
         }
         else {
-            if ($UninstallLISConsoleOutput -imatch "error" -or $UninstallLISConsoleOutput -imatch "warning" -or $UninstallLISConsoleOutput -imatch "abort") {
+            if ($UninstallLISConsoleOutput -imatch "error" -or ($UninstallLISConsoleOutput -imatch "warning" -and ($null -eq ($IgnorableWarnings | ? {$UninstallLISConsoleOutput -match $_ }))) -or $UninstallLISConsoleOutput -imatch "abort") {
                 Write-LogErr "Latest LIS install is failed due to found errors or warnings or aborted."
                 return $false
             }

--- a/XML/Other/ignorable-test-warnings.xml
+++ b/XML/Other/ignorable-test-warnings.xml
@@ -1,0 +1,7 @@
+﻿<!--#This list contains all the ignorable test warnings.-->
+<messages>
+    <warnings>
+        <keywords>warning: /etc/depmod.d/hyperv.conf saved as /etc/depmod.d/hyperv.conf.rpmsave</keywords>
+        <keywords>warning: waiting for transaction lock on /var/lib/rpm/.rpm.lock</keywords>
+    </warnings>
+</messages>


### PR DESCRIPTION
This PR meets below requirements

1) As part of fixing Depmod issue, the following warning is an expected one. Hence handled a check in the code to ignore this
2) Check whether pci_hyperv is loaded for Distro above 7.3, since it is not supported for < 7.3 