### PR TITLE
Azure: Restart VM from shell if Azure fails to restart the VM

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2260,3 +2260,17 @@ function Collect-GcovData {
 
     return $status
 }
+
+Function Restart-VMFromShell($VMData, [switch]$SkipRestartCheck) {
+    Write-LogInfo "Restarting $($VMData.RoleName) from shell..."
+    $Null = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password -command "sleep 5 && reboot" -runAsSudo -RunInBackground
+    if ($SkipRestartCheck) {
+        return $true
+    } else {
+        Start-Sleep -Seconds 5
+        if ((Is-VmAlive -AllVMDataObject $AllVMData) -eq "True") {
+            return $true
+        }
+        return $false
+    }
+}


### PR DESCRIPTION
We're seeing that, Restart-AzureRmVM command is taking more than 30 minutes to exit ( in case of failure).
So, this PR adds a timeout of 10 minutes to finish all restart operations.

**Azure Restart Error Sample:** 
```
05/14/2019 09:17:56 : [ERROR] Long Running Operation for 'Restart-AzureRmVM' on resource 'LISAv2-OneVM-NVME-rh69-PT64-20190514084129-role-0' failed with error: Long running operation failed with status 'Canceled'. Additional Info:'Operation restart was requested a long time ago and couldn't be executed successfully. Abandoning the operation in order not to cause unexpected results.'
ErrorCode: InternalOperationError
ErrorMessage: Operation restart was requested a long time ago and couldn't be executed successfully. Abandoning the operation in order not to cause unexpected results.
ErrorTarget: 
StartTime: 5/14/2019 8:49:23 AM
EndTime: 5/14/2019 9:17:45 AM
OperationID: 5cc1f623-c67f-4597-ba5f-f2648e310956
Status: Canceled

```