### PR TITLE
FCOPY-NON-ASCII: fix get md5 hash from VM

### DIFF
--- a/Testscripts/Windows/FCOPY-NON-ASCII.ps1
+++ b/Testscripts/Windows/FCOPY-NON-ASCII.ps1
@@ -202,7 +202,7 @@ function Main {
     #
     # Verify if the file is present on the guest VM
     #
-    $remote_chksum = .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$Ipv4 "openssl MD5 /tmp/testfile-* | cut -f2 -d' '"
+    $remote_chksum = Run-LinuxCmd -username $VMUserName -password $VMPassword -port $VMPort -ip $Ipv4 -command "openssl MD5 /tmp/testfile-* | cut -f2 -d' '"
     if (-not $?) {
         Write-LogErr "Could not extract the MD5 checksum from the VM!"
         return "FAIL"
@@ -213,7 +213,7 @@ function Main {
     #
     # Check if checksums are matching
     #
-    $MD5IsMatching = @(Compare-Object $local_chksum $remote_chksum -SyncWindow 0).Length -eq 0
+    $MD5IsMatching = @(Compare-Object $local_chksum.ToLower() $remote_chksum.ToLower() -SyncWindow 0).Length -eq 0
     if ( -not $MD5IsMatching) {
         Write-LogErr "MD5 checksum missmatch between host and VM test file!"
         return "FAIL"


### PR DESCRIPTION
```
05/20/2019 15:33:01 : [INFO ] MD5 file checksum on the host-side: 5E641C66CD782EF014B28928AE9DA17E
05/20/2019 15:33:09 : [INFO ] File has been successfully copied to guest VM 'LISAv2-OneVM-v-stlups-UD35-636939338176-role-0'
05/20/2019 15:38:48 : [INFO ] MD5 file checksum on guest VM: Access granted. Press Return to begin session.  5e641c66cd782ef014b28928ae9da17e
05/20/2019 15:38:48 : [ERROR] MD5 checksum missmatch between host and VM test file!
```
* fix MD5 get from VM when using extra output would be included in the md5 variable from plink, use Run-LinuxCmd instead
* compare both against lowercase.