### PR TITLE
VSS tests: Install the Windows Server Backup feature

### DIFF
--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -748,6 +748,18 @@ Function New-BackupSetup {
 		[String] $VMName,
 		[String] $HvServer
 	)
+	# Install the Windows Server Backup
+	$winFeatureName = "Windows-Server-Backup"
+	if ((Get-WindowsFeature $winFeatureName).InstallState -ne "Installed") {
+		Write-LogInfo "Installing the $winFeatureName ..."
+		if ( (Add-WindowsFeature $winFeatureName).Success -eq "True" ) {
+			Write-LogInfo "Install the $winFeatureName successfully"
+		} else {
+			Write-LogErr "Install the $winFeatureName failed"
+			return $False
+		}
+	}
+
 	Write-LogInfo "Removing old backups"
 	try {
 		Remove-WBBackupSet -MachineName $HvServer -Force -WarningAction SilentlyContinue


### PR DESCRIPTION
If the Windows Server Backup feature is not installed on test server, the test cases about disk backup will be aborted due to the below error. The "New-WBPolicy" is available after installing the feature even without restarting the server.
Error:
New-WBPolicy : The term 'New-WBPolicy' is not recognized as the name of a cmdlet, function, script file, or operable program.