### PR TITLE
Fix test case issues for python detect and NESTED-KVM-BASIC-VERIFICATION

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -341,7 +341,7 @@ Class TestController
 		}
 		if ($CurrentTestData.files -imatch ".py") {
 			$pythonPath = Run-LinuxCmd -Username $Username -password $Password -ip $VMData.PublicIP -Port $VMData.SSHPort `
-				-Command "which python || which python2 || which python3 || (which /usr/libexec/platform-python && ln -s /usr/libexec/platform-python /sbin/python)" -runAsSudo
+				-Command "which python 2> /dev/null || which python2 2> /dev/null || which python3 2> /dev/null || (which /usr/libexec/platform-python && ln -s /usr/libexec/platform-python /sbin/python)" -runAsSudo
 			if (!$pythonPath.Contains("platform-python") -and (($pythonPath -imatch "python2") -or ($pythonPath -imatch "python3"))) {
 				$pythonPathSymlink  = $pythonPath.Substring(0, $pythonPath.LastIndexOf("/") + 1)
 				$pythonPathSymlink  += "python"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2357,13 +2357,13 @@ function install_sshpass () {
 		echo "sshpass not installed\n Installing now..."
 		check_package "sshpass"
 		if [ $? -ne 0 ]; then
+			install_package "gcc make wget"
 			echo "sshpass not installed\n Build it from source code now..."
 			package_name="sshpass-1.06"
 			source_url="https://sourceforge.net/projects/sshpass/files/sshpass/1.06/$package_name.tar.gz"
 			wget $source_url
-			tar -xvf "$package_name.tar.gz"
+			tar -xf "$package_name.tar.gz"
 			cd $package_name
-			install_package "gcc make wget"
 			./configure --prefix=/usr/ && make && make install
 			cd ..
 		else

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2319,9 +2319,9 @@ function remove_package ()
 function install_epel () {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos)
-			if [[ $DISTRO_VERSION =~ 6\. ]]; then
+			if [[ $DISTRO_VERSION =~ ^6\. ]]; then
 				epel_rpm_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
-			elif [[ $DISTRO_VERSION =~ 7\. ]]; then
+			elif [[ $DISTRO_VERSION =~ ^7\. ]]; then
 				epel_rpm_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 			else
 				echo "Unsupported version to install epel repository"
@@ -2355,8 +2355,7 @@ function install_sshpass () {
 	which sshpass
 	if [ $? -ne 0 ]; then
 		echo "sshpass not installed\n Installing now..."
-		install_package sshpass
-		which sshpass
+		check_package "sshpass"
 		if [ $? -ne 0 ]; then
 			echo "sshpass not installed\n Build it from source code now..."
 			package_name="sshpass-1.06"
@@ -2364,9 +2363,11 @@ function install_sshpass () {
 			wget $source_url
 			tar -xvf "$package_name.tar.gz"
 			cd $package_name
-			install_package "gcc make"
+			install_package "gcc make wget"
 			./configure --prefix=/usr/ && make && make install
 			cd ..
+		else
+			install_package sshpass
 		fi
 		which sshpass
 		check_exit_status "install_sshpass"


### PR DESCRIPTION
canonical ubuntuserver 18.04-lts Latest 
credativ Debian 9-backports Latest
RedHat RHEL 7.5 Latest
OpenLogic CentOS 7.6 Latest
Oracle Oracle-Linux 7.6 Latest
SUSE SLES 15 Latest
**WALA-VERIFY-HOSTNAME PASS,NESTED-KVM-BASIC-VERIFICATION PASS**

CoreOS CoreOS Stable Latest 
clear-linux-project clear-linux-os basic latest
RedHat RHEL 8 8.0.2019050711
**WALA-VERIFY-HOSTNAME PASS**

RedHat RHEL 8 8.0.2019050711
**NESTED-KVM-BASIC-VERIFICATION Fail**, will try to fix it later
