### PR TITLE
SecureBoot: skip instead of abort if VM is not gen 2

### DIFF
--- a/Testscripts/Windows/SECUREBOOT.ps1
+++ b/Testscripts/Windows/SECUREBOOT.ps1
@@ -97,6 +97,12 @@ function Main {
         $HvServer= $captureVMData.HyperVhost
         $Ipv4 = $captureVMData.PublicIP
         $VMPort= $captureVMData.SSHPort
+
+        $vmGeneration = Get-VMGeneration $VMName $HvServer
+        if ($vmGeneration -ne 2) {
+            Write-LogInfo "VM ${VMName} is not a Generation 2 VM, skipping test."
+            return $resultSkipped
+        }
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         #


### PR DESCRIPTION
* skip secure boot tests instead of aborting if not running on generation 2 VM, 

```
[LISAv2 Test Results Summary]
Test Run On           : 05/23/2019 13:05:18
VHD Under Test        : Ubuntu-18.04-gen1.vhdx
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SECUREBOOT           SECUREBOOT-BASIC                                                               SKIPPED                 3.29


[LISAv2 Test Results Summary]
Test Run On           : 05/23/2019 12:58:07
VHD Under Test        : Ubuntu-18.04-gen1.vhdx
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SECUREBOOT           SECUREBOOT-UPDATE-KERNEL                                                       SKIPPED                 2.23
```