### PR TITLE
NET-IFUP-IFDOWN: Install packages before running test

### DIFF
--- a/Testscripts/Linux/NET-IFUP-IFDOWN.sh
+++ b/Testscripts/Linux/NET-IFUP-IFDOWN.sh
@@ -9,7 +9,6 @@ LoopCount=10
 
 PingCheck()
 {
-    install_package wget
     if ! ping "$REMOTE_SERVER" -c 4; then
         # On azure ping is disabled so we need another test method
         if ! wget google.com; then
@@ -67,6 +66,11 @@ if [ $netvsc_includes ]; then
     LogMsg "Info: Skiping case since hv_netvsc module as it is built-in."
     SetTestStateSkipped
     exit 0
+fi
+
+if ! which wget; then
+    update_repos
+    install_package wget
 fi
 
 while [ "$TestCount" -lt "$LoopCount" ]


### PR DESCRIPTION
`install_package wget` was being called for each test iteration without checking if it's installed
if this fails it's unclear why test failed whether because package manager of the test itself or other reason.

* fix this by installing prerequisite package only once before test starts

```
Need to get 316 kB of archives.
After this operation, 0 B of additional disk space will be used.
Ign:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 wget amd64 1.19.4-1ubuntu2.2
Err:1 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 wget amd64 1.19.4-1ubuntu2.2
  Temporary failure resolving 'archive.ubuntu.com'
apt_get_install wget: Failed (exit code: 100)
Tue May 21 19:10:49 2019 : apt_get_install wget Failed·(exit·code:·100)
```
