### PR TITLE
ETHTOOL-CHECK-STATISTICS: fix support for centos

### DIFF
--- a/Testscripts/Linux/NET-Netperf-Server.sh
+++ b/Testscripts/Linux/NET-Netperf-Server.sh
@@ -30,6 +30,10 @@ if [ "${STATIC_IP2:-UNDEFINED}" = "UNDEFINED" ]; then
     exit 1
 fi
 
+# Install the dependencies
+update_repos
+install_package "wget make gcc"
+
 #Download NETPERF
 wget https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz > /dev/null 2>&1
 if [ $? -ne 0 ]; then
@@ -150,7 +154,6 @@ suse_12)
         iptables -t nat -F
     fi;;
 esac
-
 ./configure > /dev/null 2>&1
 if [ $? -ne 0 ]; then
     LogMsg "Unable to configure make file for netperf."


### PR DESCRIPTION
1. The ~ is equal to root not /home/TESTUSER expected on Centos once the script is excueted with **sudo**. In order to support more distros,  an explicit path is defined to replace ~. 
2. Split long lines into short ones.
3. Install dependencies
