### PR TITLE
NVIDIA-GRID-DRIVER: Added support for SLES15

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -51,6 +51,16 @@ function InstallRequirements() {
     ubuntu*)
         apt -y install build-essential libelf-dev linux-tools-"$(uname -r)" linux-cloud-tools-"$(uname -r)"
     ;;
+
+    suse_15*)
+        kernel=$(uname -r)
+        if [[ "${kernel}" == *azure ]];
+        then
+            zypper install -y kernel-devel-azure
+        else
+            zypper install -y kernel-default-devel
+        fi
+    ;;
 esac
 }
 

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -160,7 +160,9 @@ function Main {
         # Start the test script
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "/$superuser/${testScript}" -runMaxAllowedTime 1800 | Out-Null
-        if (-not $?) {
+        $installState = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
+            -password $password -command "cat /$superuser/state.txt"
+        if ($installState -ne "TestCompleted") {
             Write-LogErr "Unable to install the CUDA drivers!"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "FAIL"
             return $currentTestResult


### PR DESCRIPTION
Test results - 
```
.\Run-LisaV2.ps1 -TestPlatform Azure -TestLocation westus2 -RGIdentifier lili `
-ARMImageName "SUSE SLES 15 2019.05.20" `
-XMLSecretFile E:\AzureSecretsTESTONLY.xml -TestNames NVIDIA-GRID-DRIVER-VALIDATION

[LISAv2 Test Results Summary]
Test Run On           : 05/24/2019 09:01:27
ARM Image Under Test  : SUSE : SLES : 15 : 2019.05.20
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                 8.46 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 

.\Run-LisaV2.ps1 -TestPlatform Azure -TestLocation westus2 -RGIdentifier lili `
-ARMImageName "SUSE SLES 15 latest" `
-XMLSecretFile E:\AzureSecretsTESTONLY.xml -TestNames NVIDIA-GRID-DRIVER-VALIDATION

[LISAv2 Test Results Summary]
Test Run On           : 05/24/2019 09:23:43
ARM Image Under Test  : SUSE : SLES : 15 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                 9.31 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```