### PR TITLE
Fix issue when vf name changed during ntttcp testing.

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2684,7 +2684,7 @@ function install_ntttcp () {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos)
 			install_epel
-			yum -y --nogpgcheck install wget libaio sysstat git bc make gcc dstat psmisc
+			yum -y --nogpgcheck install wget libaio sysstat git bc make gcc dstat psmisc lshw
 			build_ntttcp "${1}"
 			build_lagscope
 			iptables -F
@@ -2692,7 +2692,7 @@ function install_ntttcp () {
 
 		ubuntu|debian)
 			dpkg_configure
-			apt-get -y install wget libaio1 sysstat git bc make gcc dstat psmisc
+			apt-get -y install wget libaio1 sysstat git bc make gcc dstat psmisc lshw
 			build_ntttcp "${1}"
 			build_lagscope
 			;;
@@ -2700,7 +2700,7 @@ function install_ntttcp () {
 		sles)
 			if [[ $DISTRO_VERSION =~ 12|15 ]]; then
 				add_sles_network_utilities_repo
-				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget sysstat git bc make gcc dstat psmisc
+				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget sysstat git bc make gcc dstat psmisc lshw
 				build_ntttcp "${1}"
 				build_lagscope
 				iptables -F

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -366,7 +366,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_VERSION</ReplaceThis>
-		<ReplaceWith>v1.3.4</ReplaceWith>
+		<ReplaceWith>master</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_LOG_PARSE_TIMEOUT</ReplaceThis>


### PR DESCRIPTION
@lizzha  Should we update ntttcp version into master branch? Since it contains fix for UDP mode.
https://github.com/LIS/LISAv2/blob/master/XML/Other/ReplaceableTestParameters.xml#L368
Test results -

```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 08:47:08
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICONNECTION-NTTTCP-Synthetic                   PASS                69.84 
	Connections=1 : tx_throughput=2.46Gbps rx_throughput=0.70Gbps datagram_loss=71.54 
	Connections=2 : tx_throughput=4.73Gbps rx_throughput=1.36Gbps datagram_loss=71.25 
	Connections=4 : tx_throughput=8.67Gbps rx_throughput=2.39Gbps datagram_loss=72.43 
	Connections=8 : tx_throughput=15.06Gbps rx_throughput=4.08Gbps datagram_loss=72.91 
	Connections=16 : tx_throughput=19.83Gbps rx_throughput=4.65Gbps datagram_loss=76.55 
	Connections=32 : tx_throughput=18.53Gbps rx_throughput=4.23Gbps datagram_loss=77.17 
	Connections=64 : tx_throughput=17.82Gbps rx_throughput=3.94Gbps datagram_loss=77.89 
	Connections=128 : tx_throughput=18.00Gbps rx_throughput=3.93Gbps datagram_loss=78.17 
	Connections=256 : tx_throughput=17.97Gbps rx_throughput=3.88Gbps datagram_loss=78.41 
	Connections=512 : tx_throughput=17.69Gbps rx_throughput=3.88Gbps datagram_loss=78.07 
	Connections=1024 : tx_throughput=17.31Gbps rx_throughput=3.88Gbps datagram_loss=77.58 

[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 04:33:36
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICONNECTION-NTTTCP-SRIOV                       PASS                69.06 
	Connections=1 : tx_throughput=1.43Gbps rx_throughput=0.92Gbps datagram_loss=35.66 
	Connections=2 : tx_throughput=2.68Gbps rx_throughput=2.15Gbps datagram_loss=19.78 
	Connections=4 : tx_throughput=4.82Gbps rx_throughput=3.32Gbps datagram_loss=31.12 
	Connections=8 : tx_throughput=8.91Gbps rx_throughput=5.22Gbps datagram_loss=41.41 
	Connections=16 : tx_throughput=13.61Gbps rx_throughput=12.52Gbps datagram_loss=8.01 
	Connections=32 : tx_throughput=16.27Gbps rx_throughput=15.21Gbps datagram_loss=6.51 
	Connections=64 : tx_throughput=16.20Gbps rx_throughput=15.15Gbps datagram_loss=6.48 
	Connections=128 : tx_throughput=16.37Gbps rx_throughput=16.15Gbps datagram_loss=1.34 
	Connections=256 : tx_throughput=16.50Gbps rx_throughput=16.18Gbps datagram_loss=1.94 
	Connections=512 : tx_throughput=16.67Gbps rx_throughput=16.47Gbps datagram_loss=1.20 
	Connections=1024 : tx_throughput=16.66Gbps rx_throughput=16.42Gbps datagram_loss=1.44 
```