### PR TITLE
Code Coverage: Prepare KVP area by adding tools & daemons install alongside kernel

### DIFF
--- a/Utilities/Launch-GcovTest.ps1
+++ b/Utilities/Launch-GcovTest.ps1
@@ -7,6 +7,8 @@ param (
     [String] $TestArea,
     [String] $TestNames,
     [Switch] $OverallReport,
+    [bool] $RequiredTools = $True,
+    [bool] $RequiredDaemons = $True,
 
     # LISAv2 Params
     [Parameter(Mandatory=$true)] [String] $RGIdentifier,
@@ -71,6 +73,21 @@ function Main {
             $packagesPath = Get-ChildItem $packagesPath
         }
 
+        # some tests require tools or daemons to be installed
+        if ($RequiredDaemons) {
+            $LisDebPath=(Get-Item $SrcPackagePath).DirectoryName
+            if (-not (Test-Path "$LisDebPath\hyperv-daemons*.deb")) {
+                throw "Cannot find daemons for kernel"
+            }
+            Copy-Item -path "$LisDebPath\hyperv-daemons*.deb"  .\CodeCoverage\artifacts
+        }
+        if ($RequiredTools) {
+            $LisDebPath=(Get-Item $SrcPackagePath).DirectoryName
+            if (-not (Test-Path "$LisDebPath\hyperv-tools*.deb")) {
+                throw "Cannot find tools for kernel"
+            }
+            Copy-Item -path "$LisDebPath\hyperv-tools*.deb"  .\CodeCoverage\artifacts
+        }
         Push-Location $packagesPath.Directory.FullName
         & $TAR_PATH xf $packagesPath.Name
         Pop-Location


### PR DESCRIPTION
* Default parameters to true for installing daemons & tools, can be turned off manually if packages are not available..
* Install from same folder as Linux source deb package