### PR TITLE
LIS Area: consolidate into LIS_DEPLOY

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -412,7 +412,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>hv_daemon</Tags>
         <Priority>2</Priority>
     </test>
@@ -423,7 +423,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>floppy_disk</Tags>
         <Priority>3</Priority>
     </test>
@@ -435,24 +435,9 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>cd</Tags>
         <Priority>3</Priority>
-    </test>
-    <test>
-        <testName>LIS-PREINSTALL-DISK-SIZE-VERIFICATION</testName>
-        <setupScript>.\TestScripts\Windows\LIS-Mount-CD.ps1</setupScript>
-        <testScript>Test_LIS_disk_check.sh</testScript>
-        <files>.\Testscripts\Linux\Test_LIS_disk_check.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>
-        <setupType>OneVM</setupType>
-        <Platform>Azure,HyperV</Platform>
-        <Category>Functional</Category>
-        <TestParameters>
-            <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
-        </TestParameters>
-        <Area>LIS</Area>
-        <Tags>lis</Tags>
-        <Priority>1</Priority>
     </test>
     <test>
         <testName>LIS-MOUNT-CD-HOTADD</testName>
@@ -465,7 +450,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>cd</Tags>
         <Priority>3</Priority>
     </test>
@@ -476,7 +461,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>vmbus</Tags>
         <Priority>0</Priority>
     </test>
@@ -488,7 +473,7 @@
         <OverrideVMSize>Standard_A3</OverrideVMSize>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>vmbus</Tags>
         <Priority>1</Priority>
     </test>
@@ -499,7 +484,7 @@
         <setupType>OneVM</setupType>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>vmbus</Tags>
         <Priority>3</Priority>
     </test>
@@ -510,7 +495,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>vmbus</Tags>
         <Priority>2</Priority>
     </test>
@@ -525,7 +510,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>vmbus</Tags>
         <Priority>2</Priority>
     </test>
@@ -536,7 +521,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>nmi</Tags>
         <Priority>0</Priority>
     </test>
@@ -546,7 +531,7 @@
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>CORE</Area>
         <Tags>nmi</Tags>
         <Priority>1</Priority>
     </test>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -406,7 +406,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>LIS-CHECK-HYPERVDAEMONS-FILES-STATUS</testName>
+        <testName>CHECK-HYPERVDAEMONS-FILES-STATUS</testName>
         <testScript>LIS-Check-HypervDaemons-Files-Status.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\LIS-Check-HypervDaemons-Files-Status.sh</files>
         <setupType>OneVM</setupType>
@@ -417,7 +417,7 @@
         <Priority>2</Priority>
     </test>
     <test>
-        <testName>LIS-MOUNT-FLOPPYDISK</testName>
+        <testName>MOUNT-FLOPPYDISK</testName>
         <testScript>LIS-Mount-FloppyDisk.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\LIS-Mount-FloppyDisk.sh</files>
         <setupType>OneVM</setupType>
@@ -428,7 +428,7 @@
         <Priority>3</Priority>
     </test>
     <test>
-        <testName>LIS-MOUNT-CD</testName>
+        <testName>MOUNT-CD</testName>
         <setupScript>.\TestScripts\Windows\LIS-Mount-CD.ps1</setupScript>
         <testScript>LIS-Mount-CD.sh</testScript>
         <files>.\Testscripts\Linux\LIS-Mount-CD.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>
@@ -440,7 +440,7 @@
         <Priority>3</Priority>
     </test>
     <test>
-        <testName>LIS-MOUNT-CD-HOTADD</testName>
+        <testName>MOUNT-CD-HOTADD</testName>
         <setupScript>.\TestScripts\Windows\LIS-Mount-CD.ps1</setupScript>
         <testScript>LIS-Mount-CD.sh</testScript>
         <files>.\Testscripts\Linux\LIS-Mount-CD.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>

--- a/XML/TestCases/LIS-Tests.xml
+++ b/XML/TestCases/LIS-Tests.xml
@@ -1,4 +1,4 @@
-﻿<TestCases>
+<TestCases>
     <test>
         <testName>LIS-DRIVER-VERSION-CHECK</testName>
         <testScript>LIS-VERSION-CHECK.sh</testScript>
@@ -6,9 +6,24 @@
         <setupType>OneVM</setupType>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
-        <Area>LIS</Area>
+        <Area>LIS_DEPLOY</Area>
         <Tags>lis</Tags>
         <Priority>0</Priority>
+    </test>
+    <test>
+        <testName>LIS-PREINSTALL-DISK-SIZE-VERIFICATION</testName>
+        <setupScript>.\TestScripts\Windows\LIS-Mount-CD.ps1</setupScript>
+        <testScript>Test_LIS_disk_check.sh</testScript>
+        <files>.\Testscripts\Linux\Test_LIS_disk_check.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>
+        <setupType>OneVM</setupType>
+        <Platform>Azure,HyperV</Platform>
+        <Category>Functional</Category>
+        <TestParameters>
+            <param>LIS_TARBALL_URL_CURRENT=LIS_CURRENT_URL</param>
+        </TestParameters>
+        <Area>LIS_DEPLOY</Area>
+        <Tags>lis</Tags>
+        <Priority>1</Priority>
     </test>
     <test>
         <testName>LIS-DEPLOY-SCENARIO-1</testName>


### PR DESCRIPTION
1. Make obsolete the LIS tag, just move them to CORE area to avoid too much disruption in pipelines
2. Rename tests to remove the LIS from title, tests are generic.
3. Move LIS RPMs related tests to the LIS_DEPLOY xml and area.
