### PR TITLE
Refine test summary for DPDK test cases.

### DIFF
--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -320,11 +320,11 @@ collect_VM_properties
 			}
 		}
 		Write-LogInfo "Test result : $testResult"
-		$perfData = $testDataCsv | Format-Table | Out-String
+		$perfData = ($testDataCsv | Format-Table | Out-String).Trim()
 		Write-LogInfo $perfData
 		if ($perfData) {
-			$currentTestResult.TestSummary +=  New-ResultSummary -testResult $perfData `
-				-metaData "Performance report" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+			$currentTestResult.TestSummary +=  (New-ResultSummary -testResult $perfData `
+				-checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName).Trim()
 		}
 	}
 	catch {


### PR DESCRIPTION
Remove "Performance report : " and redundant empty lines in test summary for DPDK test cases.
Before:
```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 02:23:45
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:52

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            PASS                22.33 
	Performance report : 
dpdk_version core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg
------------ ---- ---------- ------------- ------------- ----------
18.11.0      2    17450885   10537107      10537107      10142188  
18.11.0      4    16455837   10568753      10568753      10287037  
18.11.0      8    14794738   10604030      10604030      10405696  


 
    2 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS4                                                     PASS                16.15 
	Performance report :
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.0      rxonly    1    11467225   11367995   10989336   0             44137212846 42818523052 0          
18.11.0      io        1    8824566    11369448   8239843    8239843       44137898562 32137036338 32137034887


 
```

After:
```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 01:36:11
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:52

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            PASS                22.07 
dpdk_version core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg
------------ ---- ---------- ------------- ------------- ----------
18.11.0      2    20020430   10864755      10812357      10655785  
18.11.0      4    15638980   10948002      10947103      10614864  
18.11.0      8    17290901   10940171      10940078      10582737 
    2 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS4                                                     PASS                16.42 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.0      rxonly    1    11378181   11379752   10860478   0             44415989484 42128775867 0          
18.11.0      io        1    9253801    11379242   8460420    8460420       44119914537 33245388729 33245387210 
```