### PR TITLE
Fix issue when run dhclient return error against SLES15.1

### DIFF
--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -164,12 +164,15 @@ LogMsg "Info: Finished testing, bringing up eth0"
 ip link set eth0 down
 ip link set eth0 up
 
-if ! (dhclient -r && dhclient)
-then
-    msg="Error: dhclient exited with an error"
-    LogMsg "${msg}"
-    SetTestStateFailed
-    exit 0
+ipAddress=$(ip addr show eth0 | grep "inet\b")
+if [ -z "$ipAddress" ]; then
+    if ! (dhclient -r && dhclient)
+    then
+        msg="Error: dhclient exited with an error"
+        LogMsg "${msg}"
+        SetTestStateFailed
+        exit 0
+    fi
 fi
 VerifyModules
 


### PR DESCRIPTION
Before fix, test case failed against SLES15.1 which from distro vendor.
After fix
```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 04:43:12
VHD Under Test        : http://eosgwestus2.blob.core.windows.net/vhds/suse-sles-15-sp1-gmc-byos-v20190517-prepare.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                13.62 


[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 05:02:50
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                13.37 



[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 05:23:49
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                13.14 

[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 05:44:17
ARM Image Under Test  : SUSE : SLES-Standard : 15 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 2.88 
```