### PR TITLE
NVIDIA-CUDA-DRIVER-VALIDATION: copy the dkms make log

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -116,6 +116,8 @@ function InstallCUDADrivers() {
         fi
     ;;
     esac
+
+    cp /var/lib/dkms/nvidia/*/build/make.log ${HOME}/nvidia_dkms_make.log
 }
 
 function InstallGRIDdrivers() {

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -20,7 +20,12 @@
 #       The driver type is injected in the constants.sh file, in this format:
 #       driver="CUDA" or driver="GRID"
 #
+#   Please check the below URL for any new versions of the GRID driver:
+#   https://docs.microsoft.com/en-us/azure/virtual-machines/linux/n-series-driver-setup
+#
 ########################################################################
+
+grid_driver="https://go.microsoft.com/fwlink/?linkid=874272"
 
 #######################################################################
 #
@@ -110,11 +115,11 @@ function InstallCUDADrivers() {
             return 1
         fi
     ;;
-esac
+    esac
 }
 
 function InstallGRIDdrivers() {
-    wget https://go.microsoft.com/fwlink/?linkid=874272 -O /tmp/NVIDIA-Linux-x86_64-grid.run
+    wget "$grid_driver" -O /tmp/NVIDIA-Linux-x86_64-grid.run
     if [ $? -ne 0 ]; then
         LogErr "Failed to download the GRID driver!"
         SetTestStateAborted
@@ -155,10 +160,10 @@ UtilsInit
 
 GetDistro
 update_repos
-install_package wget lshw gcc
+install_package "wget lshw gcc"
 
 InstallRequirements
-check_exit_status "Install requirements" "exit"
+check_exit_status "Install requirements"
 
 if [ "$driver" == "CUDA" ]; then
     InstallCUDADrivers

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -228,7 +228,7 @@ function Main {
 
         # Copy the dkms build log for the nvidia driver
         Copy-RemoteFiles -download -downloadFrom $allVMData.PublicIP -files "nvidia_dkms_make.log" `
-            -downloadTo $LogDir -port $allVMData.SSHPort -username $user -password $password
+            -downloadTo $LogDir -port $allVMData.SSHPort -username $superuser -password $password
 
         Write-LogInfo "Test Completed."
         Write-LogInfo "Test Result: $testResult"

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -226,6 +226,10 @@ function Main {
             $allVMData.PublicIP -SSHPort $allVMData.SSHPort -Username $user `
             -password $password -TestName $currentTestData.testName
 
+        # Copy the dkms build log for the nvidia driver
+        Copy-RemoteFiles -download -downloadFrom $allVMData.PublicIP -files "nvidia_dkms_make.log" `
+            -downloadTo $LogDir -port $allVMData.SSHPort -username $user -password $password
+
         Write-LogInfo "Test Completed."
         Write-LogInfo "Test Result: $testResult"
     } catch {


### PR DESCRIPTION
Copy the dkms log, this contains any errors that might occur during the install process, however the exit code of the install is still 0. Must add later on some check in the log for errors and fail the test.

Other small code changes.