### PR TITLE
GCOV Kernel: Wait for dpkg lock; use apt-get

### DIFF
--- a/Testscripts/Linux/build_gcov_kernel.sh
+++ b/Testscripts/Linux/build_gcov_kernel.sh
@@ -19,11 +19,16 @@ function report_error {
     report_result "NO_CONSTANTS"
 }
 
+. utils.sh || {
+    report_result "NO_UTILS"
+}
+
 set -x
 
 function install_ubuntu_deps {
-    apt -y update
-    DEBIAN_FRONTEND=noninteractive apt install -y build-essential flex bison kernel-package libncurses-dev libelf-dev libssl-dev bzip2 git
+    apt-get -y update
+    CheckInstallLockUbuntu
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential flex bison kernel-package libncurses-dev libelf-dev libssl-dev bzip2 git
     report_error $? "INSTALL_DEPS_ERROR"
 }
 


### PR DESCRIPTION
Need to check dpkg install locks before installing required packages
* Use utils function for checking install locks on Ubuntu (test case uploads utils to VM)
* Use apt-get instead of apt


```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 13:31:19
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1                      BUILD-GCOV-KERNEL                                                                 PASS                20.67 
[...]
05/28/2019 14:04:07 : [INFO ] Old kernel: 4.18.0-1018-azure
05/28/2019 14:04:07 : [INFO ] New kernel: 4.19.45-9fe49f71298d

```



```
[LISAv2 Test Results Summary]
Test Run On           : 05/28/2019 13:31:20
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1                      BUILD-GCOV-KERNEL                                                                 PASS                20.27 
[...]    
05/28/2019 14:06:02 : [INFO ] Old kernel: 4.18.0-1018-azure
05/28/2019 14:06:02 : [INFO ] New kernel: 4.19.45-9fe49f71298d
```