### PR TITLE
RELOAD-MODULES: changes to LIS drivers handling

### DIFF
--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -7,7 +7,7 @@
 # Description:
 #    This script will first check the existence of LIS modules.
 #    Then it will reload the modules in a loop in order to stress the system.
-#    It also checks that hyperv_fb cannot be unloaded.
+#    It also checks that hv_utils and hyperv_fb cannot be unloaded.
 #    When done it will bring up the eth0 interface and check again
 #    for the presence of modules.
 #
@@ -118,9 +118,17 @@ VerifyModules()
 # Main script body
 #
 #######################################################################
+if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hv_utils"); then
+    if modprobe -r hv_utils; then
+        msg="Error: hv_utils could be disabled!"
+        LogMsg "${msg}"
+        SetTestStateFailed
+        exit 0
+    fi
+fi
+
 if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hyperv_fb"); then
-    modprobe -r hyperv_fb
-    if [[ $? -eq 0 ]]; then
+    if modprobe -r hyperv_fb; then
         msg="Error: hyperv_fb could be disabled!"
         LogMsg "${msg}"
         SetTestStateFailed
@@ -138,21 +146,6 @@ do
         modprobe hv_netvsc
         sleep 1
     fi
-
-    if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hv_utils"); then
-        modprobe -r hv_utils
-        sleep 1
-        modprobe hv_utils
-        sleep 1
-    fi
-
-    if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hid_hyperv"); then
-        modprobe -r hid_hyperv
-        sleep 1
-        modprobe hid_hyperv
-        sleep 1
-    fi
-
     pass=$((pass+1))
     LogMsg $pass
 done

--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -119,18 +119,16 @@ VerifyModules()
 #
 #######################################################################
 if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hv_utils"); then
-    if ! modprobe -r hv_utils; then
-        msg="Error: hv_utils could be disabled!"
-        LogMsg "${msg}"
+    if modprobe -r hv_utils; then
+        LogErr "hv_utils can be disabled, this is unexpected behavior."
         SetTestStateFailed
         exit 0
     fi
 fi
 
 if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hyperv_fb"); then
-    if ! modprobe -r hyperv_fb; then
-        msg="Error: hyperv_fb could be disabled!"
-        LogMsg "${msg}"
+    if modprobe -r hyperv_fb; then
+        LogErr "hyperv_fb can be disabled, this is unexpected behavior."
         SetTestStateFailed
         exit 0
     fi

--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -119,7 +119,7 @@ VerifyModules()
 #
 #######################################################################
 if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hv_utils"); then
-    if modprobe -r hv_utils; then
+    if ! modprobe -r hv_utils; then
         msg="Error: hv_utils could be disabled!"
         LogMsg "${msg}"
         SetTestStateFailed
@@ -128,7 +128,7 @@ if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hv_utils"); then
 fi
 
 if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hyperv_fb"); then
-    if modprobe -r hyperv_fb; then
+    if ! modprobe -r hyperv_fb; then
         msg="Error: hyperv_fb could be disabled!"
         LogMsg "${msg}"
         SetTestStateFailed
@@ -147,7 +147,7 @@ do
         sleep 1
     fi
     pass=$((pass+1))
-    LogMsg $pass
+    LogMsg "Reload iteration ${pass}"
 done
 
 END=$(date +%s)


### PR DESCRIPTION
1. add check that hv_utils cannot be unloaded.
modprobe returns that the module is in use and cannot be unloaded.
2. remove hid_hyperv reload from loop, we care about the netvsc driver. reloading multiple lis drivers was the original design, as other modules might have been unloaded. nowadays, that is no longer the case.

---

Sample output after changes, previously it was a mix of cannot unload hv_utils and more text for reloading hid_hyperv.

```
printf '%s\n' hv_netvsc hv_utils hv_balloon hid_hyperv hyperv_keyboard hyperv_fb
grep -xq hv_netvsc
modprobe -r hv_netvsc
sleep 1
modprobe hv_netvsc
sleep 1
pass=7
```
