### PR TITLE
HYPERV - reduce wait time for get ip via kvp

### DIFF
--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -298,12 +298,12 @@ function Wait-ForVMToStartKVP {
 	param (
 		[String] $VmName,
 		[String] $HvServer,
-		[int] $StepTimeout
+		[int] $StepTimeout = 10
 	)
 	$ipv4 = $null
 	$retVal = $False
 
-	$waitTimeOut = $StepTimeout
+	$waitTimeOut = ($StepTimeout,10 | Measure -Min).Minimum
 	while ($waitTimeOut -gt 0) {
 		$ipv4 = Get-IPv4ViaKVP $VmName $HvServer
 		if ($ipv4) {


### PR DESCRIPTION
Fix the issue: [177](https://github.com/LIS/LISAv2/issues/177)
Root cause: 
The $StepTimeout is set a large number in Wait-ForVMToStartKVP function.
In this patch, the max value of $StepTimeout  is set to 10, so the total time to get ip address is limited in 5 minutes.
