### PR TITLE
IB: Small fixes

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -140,6 +140,15 @@ function Main() {
 			install_package "expect glibc-32bit glibc-devel libgcc_s1 libgcc_s1-32bit make gcc-c++ gcc-fortran rdma-core libibverbs-devel librdmacm1 libibverbs-utils bison flex"
 			# force install package that is known to have broken dependencies
 			zypper --non-interactive in libibmad-devel
+			if [ $? -eq 4 ]; then
+				expect -c "spawn zypper in libibmad-devel
+					expect -timeout -1 \"Choose from\"
+					send \"2\r\"
+					expect -timeout -1 \"Continue\"
+					send \"y\r\"
+					interact
+				"
+			fi
 			# Enable mlx5_ib module on boot
 			echo "mlx5_ib" >> /etc/modules-load.d/mlx5_ib.conf
 			;;
@@ -148,7 +157,7 @@ function Main() {
 			# IBM Platform MPI & Intel MPI do not seem to work. Under investigation.
 			if [[ $mpi_type == "ibm" || $mpi_type == "intel" ]]; then
 				LogErr "Distro '$DISTRO' not supported or not implemented"
-				SetTestStateFailed
+				SetTestStateSkipped
 				exit 0
 			fi
 			LogMsg "Installing required packages ..."

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -675,8 +675,17 @@ function Main() {
 	Run_IMB_MPI1
 	Run_IMB_RMA
 	Run_IMB_NBC
-	Run_IMB_P2P
-	Run_IMB_IO
+	# Sometimes IMB-P2P and IMB-IO aren't available, skip them if it's the case
+	if [ ! -z "$imb_p2p_path" ]; then
+		Run_IMB_P2P
+	else
+		LogMsg "INFINIBAND_VERIFICATION_SKIPPED_P2P_ALLNODES"
+	fi
+	if [ ! -z "$imb_io_path" ]; then
+		Run_IMB_IO
+	else
+		LogMsg "INFINIBAND_VERIFICATION_SKIPPED_IO_ALLNODES"
+	fi
 
 	# Get all results and finish the test
 	Collect_Logs


### PR DESCRIPTION
1. Fixed SLES 12 SP4 run - Added retry for libibmad-devel in case the
dependencies are broken
2. Added Skipped state for Ubuntu - IBM and Intel MPIs (instead of
Failed state)
3. Cleaned unwanted powershell return output
4. Added extra checks for IMB-P2P and IMB-IO. There are cases where
these 2 benchmarks are not available and the test will fail. Changed the
test behavior to continue testing with the available benchmarks
5. Better handling for aborted/failed state in SetupRDMA.sh runs

# Test results
## No IMB-IO available
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-2VM                                                          PASS               135.14
        InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
        InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS
        InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-IO : SKIPPED
        InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS
        InfiniBand-Verification-2-Reboot : eth0 IP : PASS
        InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS
        InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS
        InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
        InfiniBand-Verification-2-Reboot : IMB-IO : SKIPPED
        InfiniBand-Verification-2-Reboot : IMB-RMA : PASS
        InfiniBand-Verification-2-Reboot : IMB-NBC : PASS

## SLES 12 SP4 fixed
[LISAv2 Test Results Summary]
Test Run On           : 05/24/2019 10:22:31
ARM Image Under Test  : SUSE : SLES : 12-SP4 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:4:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS               259.16 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-IO : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-IO : PASS 
	InfiniBand-Verification-2-Reboot : IMB-RMA : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
