### PR TITLE
GPU-NVIDIA: Modify the path of make.log

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -117,7 +117,7 @@ function InstallCUDADrivers() {
     ;;
     esac
 
-    cp /var/lib/dkms/nvidia/*/build/make.log ${HOME}/nvidia_dkms_make.log
+    cp /var/lib/dkms/nvidia/*/log/make.log ${HOME}/nvidia_dkms_make.log
 }
 
 function InstallGRIDdrivers() {


### PR DESCRIPTION
Fix break bring in by #269 

Before:
```
[LISAv2 Test Results Summary]
Test Run On           : 05/30/2019 04:39:29
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:21

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     FAIL                 16.7 
	Using nVidia driver : CUDA 
[LISAv2 Test Results Summary]
Test Run On           : 05/30/2019 06:51:38
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     FAIL                 8.14 
	Using nVidia driver : CUDA 
```

After:
```
[LISAv2 Test Results Summary]
Test Run On           : 05/30/2019 09:01:07
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:21

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                17.18 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
[LISAv2 Test Results Summary]
Test Run On           : 05/30/2019 09:02:11
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                10.41 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```