### PR TITLE
PRODUCTION-CHECKPOINT-3CHAIN-VHD: fix compatibility with lisav2 on Hyper-V

### DIFF
--- a/Testscripts/Windows/PRODUCTION-CHECKPOINT-3CHAIN-VHD.ps1
+++ b/Testscripts/Windows/PRODUCTION-CHECKPOINT-3CHAIN-VHD.ps1
@@ -139,13 +139,6 @@ function Main {
             throw "Wait-ForVMToStop fail"
         }
 
-        # Clean snapshots
-        Write-LogInfo "Cleaning up snapshots..."
-        $sts = Restore-LatestVMSnapshot $vmName $hvServer
-        if (-not $sts[-1]) {
-            throw "Error: Cleaning snapshots on $vmname failed."
-        }
-
         # Get Parent VHD
         $ParentVHD = Get-ParentVHD $vmName $hvServer
         if(-not $ParentVHD) {
@@ -266,7 +259,7 @@ function Main {
         }
 
         $sts2 = Check-FileInLinuxGuest -VMPassword $password -VMPort $port -VMUserName $user -Ipv4 $vm2ipv4 -fileName "/home/$user/TestFile2"
-        if (-not $sts2) {
+        if ($sts2) {
             $testResult = $resultFail
             throw "TestFile2 is present,it should not be present on the VM"
         }


### PR DESCRIPTION
Fixes #270 
* The snapshot cleanup is not needed as the test should already be in ICABase checkpoint by the stage the test script starts running, other checkpoints won't be touched,
* Fix test check on Testfile2 (created after child VM checkpoint) - false negative, testfile is not present, Check-FileInLinuxGuest returns false if file not present now.