### PR TITLE
Fix: handled devided by zero exception in Get-SubscriptionUsage.ps1

### DIFF
--- a/Utilities/Get-SubscriptionUsage.ps1
+++ b/Utilities/Get-SubscriptionUsage.ps1
@@ -203,6 +203,9 @@ foreach ($region in $allRegions)
     $currentRegionUsage =  Get-AzureRmVMUsage -Location $region
     Write-LogInfo "Get-AzureRmVMUsage -Location $region"
     $currentRegionAllowedCores = ($currentRegionUsage | Where-Object { $_.Name.Value -eq "cores"}).Limit
+    if (-not $currentRegionAllowedCores) {
+        $currentRegionAllowedCores = 0
+    }
 
     $regionCounter+= 1
     Write-LogInfo "[$regionCounter/$($allRegions.Count)]. $($region)"
@@ -236,6 +239,11 @@ foreach ($region in $allRegions)
             $currentPublicIPs += 1
         }
     }
+    if ( $currentRegionAllowedCores -gt 0) {
+        $RegionUsagePercent = $([math]::Round($currentUsedCores*100/$currentRegionAllowedCores,1))
+    } else {
+        $RegionUsagePercent = 0
+    }
     Write-LogInfo "|--Current VMs: $currentVMs"
     Write-LogInfo "|--Current Storages: $currentStorageAccounts"
     Write-LogInfo "|--Current VNETs: $currentVNETs"
@@ -250,8 +258,8 @@ foreach ($region in $allRegions)
     $currentHTMLNode = $currentHTMLNode.Replace("Region_Used_Cores","$currentUsedCores")
     $currentHTMLNode = $currentHTMLNode.Replace("Region_Deallocated_Cores","$currentDeallocatedCores")
     $currentHTMLNode = $currentHTMLNode.Replace("Region_Allowed_Cores","$currentRegionAllowedCores")
-    $currentHTMLNode = $currentHTMLNode.Replace("Region_Core_Percent","$([math]::Round($currentUsedCores*100/$currentRegionAllowedCores,1))")
-    if ( [math]::Round($currentUsedCores*100/$currentRegionAllowedCores,1) -gt 80 )
+    $currentHTMLNode = $currentHTMLNode.Replace("Region_Core_Percent","$RegionUsagePercent")
+    if ( $RegionUsagePercent -gt 80 )
     {
         $currentHTMLNode = $currentHTMLNode.Replace("CORE_CLASS","tg-amwmred")
     }
@@ -280,7 +288,7 @@ foreach ($region in $allRegions)
     $TimeStamp = "$($psttime.Year)-$($psttime.Month)-$($psttime.Day) $($psttime.Hour):$($psttime.Minute):$($psttime.Second)"
     if ($UploadToDB)
     {
-        $SQLQuery += "('$SubscriptionID','$SubscriptionName','$currentRegion','$TimeStamp',$currentVMs,$currentUsedCores,$currentDeallocatedCores,$($currentUsedCores+$currentDeallocatedCores),$currentRegionAllowedCores,$([math]::Round($currentUsedCores*100/$currentRegionAllowedCores,1)),$PremiumStorages,$StanardStorages,$currentStorageAccounts,$currentPublicIPs,$currentVNETs),"
+        $SQLQuery += "('$SubscriptionID','$SubscriptionName','$currentRegion','$TimeStamp',$currentVMs,$currentUsedCores,$currentDeallocatedCores,$($currentUsedCores+$currentDeallocatedCores),$currentRegionAllowedCores,$RegionUsagePercent,$PremiumStorages,$StanardStorages,$currentStorageAccounts,$currentPublicIPs,$currentVNETs),"
     }
 
 }
@@ -290,8 +298,8 @@ $htmlSummary = $htmlSummary.Replace("Total_VMs","$totalVMs")
 $htmlSummary = $htmlSummary.Replace("Total_Used_Cores","$totalUsedCores")
 $htmlSummary = $htmlSummary.Replace("Total_Deallocated_Cores","$totalDeallocatedCores")
 $htmlSummary = $htmlSummary.Replace("Total_Allowed_Cores","$totalAllowedCores")
-$htmlSummary = $htmlSummary.Replace("Total_Core_Percent","$([math]::Round($totalUsedCores*100/$totalAllowedCores,1))")
-if ( $([math]::Round($totalUsedCores*100/$totalAllowedCores,1)) -gt 80 )
+$htmlSummary = $htmlSummary.Replace("Total_Core_Percent","$RegionUsagePercent")
+if ( $RegionUsagePercent -gt 80 )
 {
     $htmlSummary = $htmlSummary.Replace("CORE_CLASS","tg-l2ozred")
 }
@@ -309,7 +317,7 @@ $UsageReport += '</table>'
 #region Upload usage to DB
 if ($UploadToDB)
 {
-    $SQLQuery += "('$SubscriptionID','$SubscriptionName','Total','$TimeStamp',$totalVMs,$totalUsedCores,$totalDeallocatedCores,$($totalUsedCores+$totalDeallocatedCores),$totalAllowedCores,$([math]::Round($totalUsedCores*100/$totalAllowedCores,1)),$PremiumStorages,$StanardStorages,$totalStorageAccounts,$totalPublicIPs,$totalVNETs)"
+    $SQLQuery += "('$SubscriptionID','$SubscriptionName','Total','$TimeStamp',$totalVMs,$totalUsedCores,$totalDeallocatedCores,$($totalUsedCores+$totalDeallocatedCores),$totalAllowedCores,$RegionUsagePercent,$PremiumStorages,$StanardStorages,$totalStorageAccounts,$totalPublicIPs,$totalVNETs)"
     try
     {
         Write-LogInfo $SQLQuery


### PR DESCRIPTION
This PR fixes the problem generated due to newly launched azure regions, where querying the resources results in exception. This further creates two problems.
1. At one point, it divides by zero.
2. Subscription usage upload to DB fails due to BLANK value, caused by issue 1.

Before this patch:

```
06/05/2019 06:41:29 : [INFO ] System.Management.Automation.MethodInvocationException: Exception calling "ExecuteNonQuery" with "0" argument(s): "Incorrect syntax near ','." ---> System.Data.SqlClient.SqlException: Incorrect syntax near ','.
   at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
   at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at System.Data.SqlClient.SqlCommand.RunExecuteNonQueryTds(String methodName, Boolean async, Int32 timeout, Boolean asyncWrite)
   at System.Data.SqlClient.SqlCommand.InternalExecuteNonQuery(TaskCompletionSource`1 completion, String methodName, Boolean sendToPipe, Int32 timeout, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry)
   at System.Data.SqlClient.SqlCommand.ExecuteNonQuery()
   at CallSite.Target(Closure , CallSite , Object )
   --- End of inner exception stack trace ---
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
```

After this patch:
```
('2cd20493-fe97-42ef-9ace-ab95b63d82c4','Linux Integration Services Dev & Test','Total','2019-6-4 23:52:39',319,4752,2230,6982,44370,16.1,NULL,NULL,289,456,274)
06/05/2019 06:54:53 : [INFO ] Uploading data to DB done!!
```