### PR TITLE
dpdk: retry to download source on transient connectivity errors

### DIFF
--- a/Testscripts/Linux/dpdkSetup.sh
+++ b/Testscripts/Linux/dpdkSetup.sh
@@ -83,7 +83,7 @@ function install_dpdk () {
 		dpdkSrcTar="${dpdkSrcLink##*/}"
 		dpdk_version=$(echo "$dpdkSrcTar" | grep -Po "(\d+\.)+\d+")
 		LogMsg "Installing DPDK from source file $dpdkSrcTar"
-		ssh "${1}" "wget $dpdkSrcLink -P /tmp"
+		wget_retry "${dpdkSrcLink}" "/tmp" "${1}"
 		ssh "${1}" "tar xf /tmp/$dpdkSrcTar"
 		check_exit_status "tar xf /tmp/$dpdkSrcTar on ${1}" "exit"
 		dpdkSrcDir="${dpdkSrcTar%%".tar"*}"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -180,7 +180,7 @@ function Install_Dpdk() {
 	if [[ $DPDK_LINK =~ .tar ]]; then
 		ssh ${install_ip} "mkdir ${DPDK_DIR}"
 		dpdk_download_file="${DPDK_LINK##*/}"
-		ssh "${install_ip}" "wget '${DPDK_LINK}' -P /tmp"
+		wget_retry "${DPDK_LINK}" "/tmp" "${install_ip}"
 		ssh "${install_ip}" "tar -xf '/tmp/${dpdk_download_file}' -C ${DPDK_DIR} --strip-components=1"
 		check_exit_status "Get DPDK sources from '${DPDK_LINK}' on ${install_ip}" "exit"
 	elif [[ $DPDK_LINK =~ ".git" ]] || [[ $DPDK_LINK =~ "git:" ]]; then


### PR DESCRIPTION
Fixes issue https://github.com/LIS/LISAv2/issues/286

Sometimes, there are network connectivity or server down issues when downloading DPDK sources. A retry should be added in those scenarios.

Example:

```
wget http://git.dpdk.org/dpdk-stable/snapshot/dpdk-stable-18.11.2-rc1.tar.xz
Resolving git.dpdk.org (git.dpdk.org)... 92.243.14.124
Connecting to git.dpdk.org (git.dpdk.org)|92.243.14.124|:80... connected.
HTTP request sent, awaiting response... 504 Gateway Time-out
2019-05-30 19:49:33 ERROR 504: Gateway Time-out.
```