### PR TITLE
ETHTOOL-GET-SET-CHANNEL: check all values from 1 - max_channels

### DIFF
--- a/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
@@ -49,10 +49,11 @@ if [[ "$sts" = *"Operation not supported"* ]]; then
     exit 0
 fi
 
+ethtool_output=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | grep -o '[0-9]*')
 # Get number of channels
-channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 2p | grep -o '[0-9]*')
+channels=$(echo "$ethtool_output" | sed -n 2p)
 # Get max number of channels
-max_channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 1p | grep -o '[0-9]*')
+max_channels=$(echo "$ethtool_output" | sed -n 1p)
 # Get number of cores
 cores=$(grep -c processor < /proc/cpuinfo)
 

--- a/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
@@ -8,9 +8,8 @@
 # Description:
 #   This script will first check the existence of ethtool on vm and that
 #   the channel parameters are supported from ethtool.
-#   It will check if number of cores is matching with number of current 
-#   channel.
-#   At last, this script will change the channel from the ethtool.
+#   This script will change the channel from the ethtool with all the allowed
+#   values.
 #
 #############################################################################
 # Source utils.sh
@@ -52,42 +51,34 @@ fi
 
 # Get number of channels
 channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 2p | grep -o '[0-9]*')
+# Get max number of channels
+max_channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 1p | grep -o '[0-9]*')
 # Get number of cores
 cores=$(grep -c processor < /proc/cpuinfo)
 
-if [ "$channels" != "$cores" ]; then
-    LogErr "Expected: $cores channels and actual $channels."
-    SetTestStateFailed
-    exit 0
-fi
+LogMsg "Number of channels: $channels, max number of channels: $max_channels and number of cores: $cores."
 
-LogMsg "Number of channels: $channels and number of cores: $cores."
+# Change number of channels with all values supported
+for new_channels in $(seq 1 $max_channels); do
+    old_channels=$channels
+    # Change the number of channels
+    sts=$(ethtool -L "${SYNTH_NET_INTERFACES[@]}" combined $new_channels 2>&1)
+    if [[ "$sts" = *"Operation not supported"* ]]; then
+        LogErr "$sts"
+        LogErr "Change the number of channels of ${SYNTH_NET_INTERFACES[@]} with $new_channels channels failed, old value: $old_channels"
+        SetTestStateFailed
+        exit 0
+    fi
 
-let new_channels=cores-1
-if [ $new_channels == 0 ]; then
-    LogErr "The number of cores should be greater than 1"
-    SetTestStateFailed
-    exit 0
-fi
-
-# Change the number of channels
-sts=$(ethtool -L "${SYNTH_NET_INTERFACES[@]}" combined $new_channels 2>&1)
-if [[ "$sts" = *"Operation not supported"* ]]; then
-    LogErr "$sts"
-    LogErr "Change the number of channels of ${SYNTH_NET_INTERFACES[@]} with $new_channels channels failed"
-    SetTestStateFailed
-    exit 0
-fi
-
-# Get number of channels
-channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 2p | grep -o '[0-9]*')
-if [ "$new_channels" != "$channels" ]; then
-    LogErr "Expected: $new_channels channels and actual $channels after change the channels."
-    SetTestStateFailed
-    exit 0
-fi
-
-LogMsg "Change number of channels from $cores to $new_channels successfully"
+    # Get number of channels
+    channels=$(ethtool -l "${SYNTH_NET_INTERFACES[@]}" | grep "Combined" | sed -n 2p | grep -o '[0-9]*')
+    if [ "$new_channels" != "$channels" ]; then
+        LogErr "Expected: $new_channels channels and actual $channels after change the channels."
+        SetTestStateFailed
+        exit 0
+    fi
+    LogMsg "Change number of channels from $old_channels to $new_channels successfully"
+done
 
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
@@ -62,9 +62,7 @@ LogMsg "Number of channels: $channels, max number of channels: $max_channels and
 for new_channels in $(seq 1 $max_channels); do
     old_channels=$channels
     # Change the number of channels
-    sts=$(ethtool -L "${SYNTH_NET_INTERFACES[@]}" combined $new_channels 2>&1)
-    if [[ "$sts" = *"Operation not supported"* ]]; then
-        LogErr "$sts"
+    if ! ethtool -L "${SYNTH_NET_INTERFACES[@]}" combined "$new_channels" ; then
         LogErr "Change the number of channels of ${SYNTH_NET_INTERFACES[@]} with $new_channels channels failed, old value: $old_channels"
         SetTestStateFailed
         exit 0

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1966,7 +1966,7 @@ VerifyIsEthtool()
                 ;;
             ubuntu*|debian*)
                 apt update -y
-		apt install ethtool -y
+                apt install ethtool -y
                 if [ $? -ne 0 ]; then
                     msg="ERROR: Failed to install Ethtool"
                     LogMsg "$msg"


### PR DESCRIPTION
Fixes #230 

* remove check against cpu cores, not relevant as for bigger VM sizes channels are limited so core count doesn't matter
* set number of channels from 1 to maximum to verify the value changes.
* fix indent in `VerifyIsEthtool` function