### PR TITLE
LISAv2: add the provider error message or internal TC summary as TC failure information in the Junit report and LISAv2 summary

### DIFF
--- a/TestProviders/TestProvider.psm1
+++ b/TestProviders/TestProvider.psm1
@@ -33,7 +33,10 @@ Class TestProvider
 	[bool]   $ReuseVmOnFailure = $false
 
 	[object] DeployVMs([xml] $GlobalConfig, [object] $SetupTypeData, [object] $TestCaseData, [string] $TestLocation, [string] $RGIdentifier, [bool] $UseExistingRG, [string] $ResourceCleanup) {
-		return $null
+		return @{
+			"VmData" = $null;
+			"Error" = $null
+		}
 	}
 
 	[void] RunSetup($VmData, $CurrentTestData, $TestParameters, $ApplyCheckPoint) {}


### PR DESCRIPTION
Fixes https://github.com/LIS/LISAv2/issues/294

If LISAv2 fails, there is currently very hard to find in one easy to see line why a test failed.

Part 1:

add to the test summary the error cause if the provider fails to deploy for any reason (quota, RAM or disk issue)
Part 2:

add in the test summary all the error logs (LogErr from bash) to the TC summary