### PR TITLE
Dynamic Memory tests: Fix time out issue

### DIFF
--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -38,8 +38,10 @@ Function Set-VMDynamicMemory
 	$MaxMem = Convert-ToMemSize $MaxMem $VM.HyperVHost
 	$StartupMem = Convert-ToMemSize $StartupMem $VM.HyperVHost
 	Stop-VM -Name $VM.RoleName -ComputerName $VM.HyperVHost -force
+	Start-Sleep -s 1
 	Set-VMMemory -vmName $VM.RoleName -ComputerName $VM.HyperVHost -DynamicMemoryEnabled $true `
 		-MinimumBytes $MinMem -MaximumBytes $MaxMem -StartupBytes $StartupMem -Priority $MemWeight
+	Start-Sleep -s 1
 	# check if mem is set correctly
 	$vmMem = (Get-VMMemory -vmName $VM.RoleName -ComputerName $VM.HyperVHost).Startup
 	if( $vmMem -eq $StartupMem ) {

--- a/Testscripts/Windows/DM-MAXMEMHONOR.ps1
+++ b/Testscripts/Windows/DM-MAXMEMHONOR.ps1
@@ -137,7 +137,7 @@ function Main {
         }
         # sleep a few seconds so all stresstestapp processes start and the memory assigned/demand gets updated
         Start-Sleep -S 200
-        Write-LogInfo $job1.State
+        Write-LogInfo "The job status: $((Get-Job -Id $job1).State)"
         # get memory stats for vm1 and vm2
         [int64[]]$vm2Assigned = @()
         [int64[]]$vm2Demand = @()
@@ -147,7 +147,7 @@ function Main {
         $jobState = $false
         while ($timeout -gt 0)
         {
-            if ($job1.State -like "Completed" -and -not $jobState) {
+            if ((Get-Job -Id $job1).State -like "Completed" -and -not $jobState) {
                 $jobState = $true
                 $retVal = Receive-Job $job1
                 if (-not $retVal) {

--- a/Testscripts/Windows/DM-MINMEMHONOR.ps1
+++ b/Testscripts/Windows/DM-MINMEMHONOR.ps1
@@ -68,6 +68,7 @@ function Main {
         $HvServer = $VM1.HyperVHost
         $VM1Ipv4 = $VM1.PublicIP
         $VM2Ipv4 = $VM2.PublicIP
+        $VMPort = $VM2.SSHPort
         Write-LogInfo "VM1name is $vm1name"
         Write-LogInfo "VM2name is $vm2name"
         Write-LogInfo "Hvserver is $HvServer"

--- a/Testscripts/Windows/DM-PRESSURE-CHANGES-DEMAND.ps1
+++ b/Testscripts/Windows/DM-PRESSURE-CHANGES-DEMAND.ps1
@@ -148,7 +148,7 @@ function Main {
         $firstJobStatus = $false
         while ($timeout -gt 0)
         {
-            if($job1.Status -like "Completed"){
+            if((Get-Job -Id $job1).State -like "Completed"){
                 $firstJobStatus = $true
                 $retVal = Receive-Job $job1
                 if (-not $retVal[-1]) {

--- a/Testscripts/Windows/DM_HIGH-PRIORITY.ps1
+++ b/Testscripts/Windows/DM_HIGH-PRIORITY.ps1
@@ -159,7 +159,7 @@ function Main {
         $firstJobState = $false
         $secondJobState = $false
         while ($timeout -gt 0) {
-            if ($job1.State -like "Completed" -and -not $firstJobState) {
+            if ((Get-Job -Id $job1).State -like "Completed" -and -not $firstJobState) {
                 $firstJobState = $true
                 $retVal = Receive-Job $job1
                 if (-not $retVal) {
@@ -168,7 +168,7 @@ function Main {
                 $diff = $totalTimeout - $timeout
                 Write-LogInfo "Job1 finished in $diff seconds."
             }
-            if ($job2.State -like "Completed" -and -not $secondJobState) {
+            if ((Get-Job -Id $job2).State -like "Completed" -and -not $secondJobState) {
                 $secondJobState = $true
                 $retVal = Receive-Job $job2
                 if (-not $retVal) {
@@ -206,7 +206,7 @@ function Main {
             else {
                 $vm2bigger += 1
             }
-            Write-LogInfo "sample ${i}: vm1 = $vm1Assigned[$i] - vm2 = $vm2Assigned[$i]"
+            Write-LogInfo "sample ${i}: vm1 = $($vm1Assigned[$i]) - vm2 = $($vm2Assigned[$i])"
         }
         if ($vm1bigger -le $vm2bigger) {
             throw "$VM1Name didn't grow faster than $VM2Name"

--- a/XML/TestCases/FunctionalTests-DynamicMemory.xml
+++ b/XML/TestCases/FunctionalTests-DynamicMemory.xml
@@ -161,6 +161,7 @@
     <test>
         <testName>DYNAMIC-MEMORY-HIGH-PRIORITY</testName>
         <testScript>DM_HIGH-PRIORITY.ps1</testScript>
+        <files>.\Testscripts\Linux\utils.sh</files>
         <setupType>TwoVM</setupType>
         <TestParameters>
             <param>appGitURL=DYNAMIC_MEMORY_STRESSNG</param>
@@ -290,7 +291,7 @@
         <testName>DYNAMIC-MEMORY-DEMAND-PRESSURE</testName>
         <setupScript>.\Testscripts\Windows\DM-CONFIGURE-MEMORY.ps1</setupScript>
         <testScript>DM-PRESSURE-CHANGES-DEMAND.ps1</testScript>
-        <files>.\Testscripts\Linux\check_traces.sh</files>
+        <files>.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>enableDM=yes</param>


### PR DESCRIPTION
1. Sleep second(s) to make the VM/test stable
2. JobID.State is not right
3. DM-HOTADD-EATMEMORY.ps1: The "CheckEatmemory.sh" code  must be placed after the var $vmConsumeMem, otherwise its value is always null in CheckEatmemory.sh. At the same time, the MemoryDemand is a dynamic value, so trying many times is better from my opinion.
4. The final result is not right if the "return PASS" is omitted, even the test is really PASS.
5. Delete the unused parameter "-RootDir $WorkingDirectory`" which leads the test abort