### PR TITLE
Update ntttcp version into latest release one 1.4.0

### DIFF
--- a/Testscripts/Linux/perf_ntttcp.sh
+++ b/Testscripts/Linux/perf_ntttcp.sh
@@ -210,11 +210,21 @@ Get_VFName()
 	ntttcpVersion="${1}"
 	ip="${2}"
 	ntttcp_cmd="${3}"
-	# The -K and -I options are supported if the ntttcp version is greater than v1.3.5, or equal to v1.3.5 or master
-	if [ $ntttcpVersion ] && ( [ $ntttcpVersion \> "v1.3.5" ] || [ $ntttcpVersion == "v1.3.5" ] || [ $ntttcpVersion == "master" ] ); then
+	if [ $ntttcpVersion ] && [[ $ntttcpVersion == v* ]]; then
+		currentVersion="${ntttcpVersion:1}"
+	else
+		currentVersion="${ntttcpVersion}"
+	fi
+	# The -K and -I options are supported if the ntttcp version is greater than 1.4.0, or equal to 1.4.0
+	# -K changed into --show-nic-packets, -I changed into --show-dev-interrupts in master branch
+	if [ $currentVersion ] && ( [ $currentVersion \> "1.4.0" ] || [ $currentVersion == "1.4.0" ] || [ $currentVersion == "master" ] ); then
 		vf_interface=$(ssh "$ip" lshw -c network -businfo | grep -i "Virtual Function" | awk '{print $2}')
 		if [ $vf_interface ]; then
-			ntttcp_cmd="$ntttcp_cmd -K $vf_interface -I mlx4"
+			if [[ $currentVersion == "master" ]]; then
+				ntttcp_cmd="$ntttcp_cmd --show-nic-packets $vf_interface --show-dev-interrupts mlx4"
+			else
+				ntttcp_cmd="$ntttcp_cmd -K $vf_interface -I mlx4"
+			fi
 		fi
 	fi
 	echo "$ntttcp_cmd"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2661,8 +2661,8 @@ function install_lagscope () {
 
 # Build and install ntttcp
 function build_ntttcp () {
-	ntttcp_version="v1.3.4"
-	# If the ntttcpVersion is provided in xml then it will go for that version, otherwise default to v1.3.4.
+	ntttcp_version="1.4.0"
+	# If the ntttcpVersion is provided in xml then it will go for that version, otherwise default to 1.4.0.
 	if [ "${1}" ]; then
 		ntttcp_version=${1}
 	fi

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -382,7 +382,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_VERSION</ReplaceThis>
-		<ReplaceWith>master</ReplaceWith>
+		<ReplaceWith>1.4.0</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_LOG_PARSE_TIMEOUT</ReplaceThis>


### PR DESCRIPTION
master branch has below change which break ntttcp SRIOV 
https://github.com/microsoft/ntttcp-for-linux/commit/1f520c7ec6ca5a998230131ea77d202a71c52d66
1. '-R' -> '--show-tcp-retrans'
2. '-K' -> '--show-nic-packets'
3. '-I' -> '--show-dev-interrupts'

Before the URL is https://github.com/microsoft/ntttcp-for-linux/archive/**v1.3.4.tar.gz**
Current one is https://github.com/microsoft/ntttcp-for-linux/archive/**1.4.0.tar.gz**