### PR TITLE
Get-IPv4ViaKVP: Fix infinite loop

### DIFF
--- a/Libraries/IntegrationServiceLibrary.psm1
+++ b/Libraries/IntegrationServiceLibrary.psm1
@@ -237,12 +237,12 @@ function Get-IPv4ViaKVP {
 						if ($addr) {
 							return $addr
 						}
-						$retryTime++
-						Start-Sleep -Seconds 10
 					}
 				}
 			}
 		}
+		$retryTime++
+		Start-Sleep -Seconds 10
 	}
 
 	Write-LogWarn "Get-IPv4ViaKVP: No IPv4 address found for VM ${VmName}"


### PR DESCRIPTION
The var '$retryTime' maybe never be updated if the condition '$found' is not equal to 2 in function Get-IPv4ViaKVP(). 