### PR TITLE
RELOAD-MODULES-SMP - Add default route when miss it after run ip link down/up

### DIFF
--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -134,6 +134,12 @@ if (printf '%s\n' "${HYPERV_MODULES[@]}" | grep -xq "hyperv_fb"); then
     fi
 fi
 
+# install bc tool if not exist
+which "bc"
+if [ $? -ne 0 ]; then
+    install_package bc
+fi
+
 pass=0
 START=$(date +%s)
 while [ $pass -lt $LoopCount ]
@@ -152,8 +158,17 @@ END=$(date +%s)
 DIFF=$(echo "$END - $START" | bc)
 
 LogMsg "Info: Finished testing, bringing up eth0"
+default_route=$(ip route show | grep default)
+
 ip link set eth0 down
 ip link set eth0 up
+
+ip route show | grep default
+# Add default route when miss it after run ip link down/up
+if [ $? -ne 0 ]; then
+    LogMsg "Run ip route add $default_route"
+    ip route add $default_route
+fi
 
 ipAddress=$(ip addr show eth0 | grep "inet\b")
 if [ -z "$ipAddress" ]; then


### PR DESCRIPTION
Solve issue: https://github.com/LIS/LISAv2/issues/292

The following is the test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 06/11/2019 09:59:43
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : 16.04.201905303
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 6.38 

[LISAv2 Test Results Summary]
Test Run On           : 06/11/2019 09:58:33
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 6.49 
```