### PR TITLE
Azure Deployment: get deploy fail reason from Azure

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -99,14 +99,14 @@ function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
                                     $HyperVGroupCount = $HyperVGroupCount + 1
                                     $DeployedHyperVGroup += $HyperVGroupName
                                 } else {
-                                    Write-LogErr "Unable to start one or more VM's"
+                                    Write-LogErr "Unable to start one or more VM's."
                                     $retryDeployment = $retryDeployment + 1
                                     $retValue = "False"
                                     $isHyperVGroupDeployed = "False"
                                 }
                             }
                         } else {
-                            Write-LogErr "Unable to Deploy one or more VM's"
+                            Write-LogErr "Unable to Deploy one or more VM's."
                             $retryDeployment = $retryDeployment + 1
                             $retValue = "False"
                             $isHyperVGroupDeployed = "False"
@@ -118,7 +118,7 @@ function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
                         $isHyperVGroupDeployed = "False"
                     }
                 } else {
-                    Write-LogErr "Unable to delete existing HyperV Group - $HyperVGroupName"
+                    Write-LogErr "Unable to delete existing HyperV Group - $HyperVGroupName ."
                     $retryDeployment += 1
                     $retValue = "False"
                     $isHyperVGroupDeployed = "False"

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -392,3 +392,22 @@ Function Get-SystemDetailLogs($AllVMData, $User, $Password)
 		}
 	}
 }
+
+Function Trim-ErrorLogMessage($text) {
+	<#	.SYNOPSIS
+		Given an error text, it trims the text to 160 characters and adds "...".
+		If there is phrase affected by the trim, it also removes the phrase.
+		In all scenarios, it adds new line characters at the end.
+	#>
+
+	$maxLength = 160
+	if ($text.Length -ge $maxLength) {
+		$text = $text.Substring(0,$maxLength)
+		$splitByPeriod = $text.split(".")
+		if ($splitByPeriod.Count -gt 1) {
+			$maxLength -= $splitByPeriod[$splitByPeriod.Count - 1].Length
+		}
+		$text = $text.Substring(0,$maxLength) + ".."
+	}
+	return $text + "`r`n"
+}

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -465,7 +465,7 @@ Class TestController
 			Write-LogErr "EXCEPTION: $errorMessage"
 			Write-LogErr "Source: Line $line in script $scriptName."
 			$currentTestResult.TestResult = $global:ResultFail
-			$currentTestResult.testSummary += $errorMessage
+			$currentTestResult.testSummary += Trim-ErrorLogMessage $errorMessage
 		}
 
 		# Upload results to database
@@ -576,7 +576,7 @@ Class TestController
 						$deployErrors = ""
 						if ($deployVMStatus) {
 							$vmData = $deployVMStatus
-							$deployErrors = $deployVMStatus.Error
+							$deployErrors = Trim-ErrorLogMessage $deployVMStatus.Error
 							if ($deployVMStatus.Keys -and ($deployVMStatus.Keys -contains "VmData")) {
 								$vmData = $deployVMStatus.VmData
 							}

--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -53,7 +53,7 @@ Class AzureProvider : TestProvider
 					$DeploymentElapsedTime = $isAllDeployed[3]
 					$allVMData = Get-AllDeploymentData -ResourceGroups $deployedGroups
 				} else {
-					$ErrorMessage = "One or more deployments failed."
+					$ErrorMessage = "One or more deployments failed. " + $isAllDeployed[4]
 					Write-LogErr $ErrorMessage
 					return @{"VmData" = $null; "Error" = $ErrorMessage}
 				}


### PR DESCRIPTION
Fixes #308  For azure deployments.
* Add test resource group deployment call, this catches quota issues where there are enough cores but the image size is not available or when the azure JSON file is invalid due to parameters sent to LISAv2.
* If the deployment failed, get the list of all deployment operations that were not successful and grab the error messages.
* Log and pass deployment failure reason to test controller.   

Smaller generic fixes to Create-ResourceGroupDeployment
* remove retry pattern with 1 try, code has no purpose,
* Fix bool variables having string values ("False" is evaluated as $true in Powershell)