### PR TITLE
VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC  - Refine log info.

### DIFF
--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -315,7 +315,9 @@ collect_VM_properties
 				$resultMap["Fwdpackets"] = [int64]($mode.fwd_packets)
 				$resultMap["Tx_PacketSize_KBytes"] = [Decimal]($mode.tx_packet_size)
 				$resultMap["Rx_PacketSize_KBytes"] = [Decimal]($mode.rx_packet_size)
-				Write-LogInfo "Collected performance data for $($mode.test_mode) mode."
+				if ($mode.test_mode) {
+					Write-LogInfo "Collected performance data for $($mode.test_mode) mode."
+				}
 				$currentTestResult.TestResultData += $resultMap
 			}
 		}


### PR DESCRIPTION
For case VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC:
When there is no test_mode, the relevant information for the parameter $mode.test_mode is not printed.

Before:
```
06/11/2019 10:49:25 : [INFO ] Parsing the performance data for database insertion 
06/11/2019 10:49:25 : [INFO ] Collected performance data for  mode. 
06/11/2019 10:49:25 : [INFO ] Collected performance data for  mode. 
06/11/2019 10:49:25 : [INFO ] Collected performance data for  mode.
06/11/2019 10:49:25 : [INFO ] Collected performance data for  mode.
06/11/2019 10:49:25 : [INFO ] Test result : PASS
```

After:
```
06/12/2019 07:34:39 : [INFO ] Parsing the performance data for database insertion
06/12/2019 07:34:39 : [INFO ] Test result : PASS
```

