### PR TITLE
CustomKernelInstall: handle unexpected kernel upgrade in Ubuntu

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -299,7 +299,8 @@ function InstallKernel() {
             CheckInstallLockUbuntu
             LogMsg "Debian package web link detected. Downloading $CustomKernel"
             apt install -y wget
-            apt remove -y linux-cloud-tools-common
+			# use dpkg directly to force the removal of package without dependencies
+            dpkg --remove --force-depends linux-cloud-tools-common
             wget "$CustomKernel"
             LogMsg "Installing ${CustomKernel##*/}"
             dpkg -i "${CustomKernel##*/}"  >> $LOG_FILE 2>&1

--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -298,9 +298,7 @@ function InstallKernel() {
         if [[ $CustomKernel =~ "http" ]];then
             CheckInstallLockUbuntu
             LogMsg "Debian package web link detected. Downloading $CustomKernel"
-            apt install -y wget
-			# use dpkg directly to force the removal of package without dependencies
-            dpkg --remove --force-depends linux-cloud-tools-common
+            apt-get install -y wget
             wget "$CustomKernel"
             LogMsg "Installing ${CustomKernel##*/}"
             dpkg -i "${CustomKernel##*/}"  >> $LOG_FILE 2>&1
@@ -310,7 +308,8 @@ function InstallKernel() {
             CheckInstallLockUbuntu
             customKernelFilesUnExpanded="${CustomKernel#$LOCAL_FILE_PREFIX}"
             if [[ "${customKernelFilesUnExpanded}" == *'*.deb'* ]]; then
-                apt-get remove -y linux-cloud-tools-common
+                # use dpkg directly to force the removal of package without dependencies
+                dpkg --remove --force-depends linux-cloud-tools-common
             fi
 
             LogMsg "Installing ${customKernelFilesUnExpanded}"


### PR DESCRIPTION
Fixes #311 

Before:
```
root@vm:/home/user# apt remove linux-cloud-tools-common
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  linux-azure-headers-4.15.0-1046 linux-azure-tools-4.15.0-1046 linux-headers-4.15.0-1046-azure linux-headers-azure linux-image-4.15.0-1046-azure linux-image-azure linux-modules-4.15.0-1046-azure
  linux-tools-4.15.0-1046-azure linux-tools-azure
Suggested packages:
  fdutils linux-azure-doc-4.15.0 | linux-azure-source-4.15.0 linux-azure-tools
The following packages will be REMOVED:
  linux-azure linux-azure-cloud-tools-4.15.0-1045 linux-cloud-tools-4.15.0-1045-azure linux-cloud-tools-azure linux-cloud-tools-common
The following NEW packages will be installed:
  linux-azure-headers-4.15.0-1046 linux-azure-tools-4.15.0-1046 linux-headers-4.15.0-1046-azure linux-image-4.15.0-1046-azure linux-modules-4.15.0-1046-azure linux-tools-4.15.0-1046-azure
The following packages will be upgraded:
  linux-headers-azure linux-image-azure linux-tools-azure
3 upgraded, 6 newly installed, 5 to remove and 23 not upgraded.
```


After:
```
root@vm:/home/user# dpkg --remove --force-depends linux-cloud-tools-common
dpkg: linux-cloud-tools-common: dependency problems, but removing anyway as you requested:
 linux-azure-cloud-tools-4.15.0-1045 depends on linux-cloud-tools-common.

(Reading database ... 53456 files and directories currently installed.)
Removing linux-cloud-tools-common (4.4.0-148.174) ...
```