### PR TITLE
Fix test issue for TIME-CLOCKSOURCE

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -74,6 +74,8 @@ function UnbindCurrentSource()
 	if echo $clocksource > $unbind_file
 	then
 		_clocksource=$(cat /sys/devices/system/clocksource/clocksource0/current_clocksource)
+		LogMsg "Sleep 10 seconds for message show up in log file"
+		sleep 10
 		grep -rnw '/var/log' -e 'Switched to clocksource acpi_pm' --ignore-case
 		if [ $? -eq 0 ] && [ "$_clocksource" == "acpi_pm" ]; then
 			LogMsg "Test successful. After unbind, current clocksource is $_clocksource"


### PR DESCRIPTION
Before fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 06/18/2019 07:12:22
VHD Under Test        : http://lisaeastus2.blob.core.windows.net/vhds/EOSG-AUTOBUILT-OpenLogic-CentOS-7.5-latest--u-1626.vhd
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  FAIL                 3.33 
```
Root cause, when check 'Switched to clocksource acpi_pm' in messages, it still not there at that time.

 grep -rnw '/var/log' -e 'Switched to clocksource acpi_pm' --ignore-case
/var/log/messages:11344:**Jun 18 09:44:10** localhost kernel: clocksource: Switched to clocksource acpi_pm

cat TIME-CLOCKSOURCE_summary.log  | grep -i fail
**Tue Jun 18 09:44:10 2019** : Test failed. After unbind, current clocksource is acpi_pm

After fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 06/18/2019 08:41:17
VHD Under Test        : http://lisaeastus2.blob.core.windows.net/vhds/EOSG-AUTOBUILT-OpenLogic-CentOS-7.5-latest--u-1626.vhd
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE-1                                                                PASS                 2.83 
    2 CORE                 TIME-CLOCKSOURCE-2                                                                PASS                 2.82 
    3 CORE                 TIME-CLOCKSOURCE-3                                                                PASS                 2.82 
```

