### PR TITLE
WALA-VERIFY-WAAGENT-LOG - add 'latin-1' error into ignorable-walalog-errors.xml

### DIFF
--- a/XML/Other/ignorable-walalog-errors.xml
+++ b/XML/Other/ignorable-walalog-errors.xml
@@ -2,7 +2,7 @@
 <messages>		
     <errors>
         <!-- https://github.com/Azure/WALinuxAgent/issues/1523 -->
-        <keywords>'latin-1' codec can't encode character</keywords>
+        <keywords>.*'latin-1' codec can't encode character.*</keywords>
         <keywords>.*Error Code is 127\n[^\n]*parted /dev/sdb print\n[^\n]*parted: command not found</keywords>		
         <keywords>.*Failed to config rdma device.*</keywords>
         <keywords>.*ERROR:CalledProcessError.  Error Code is 1\n[^\n]*ERROR:CalledProcessError.  Command string was chcon unconfined_u:object_r:ssh_home_t:s0[^\n]*\n[^\n]*ERROR:CalledProcessError.  Command result was chcon: invalid context: unconfined_u:object_r:ssh_home_t:s0: Operation not supported</keywords>


### PR DESCRIPTION
Fix #335 

Before fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 06/19/2019 12:59:34
ARM Image Under Test  : RedHat : RHEL : 8 : Latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-WAAGENT-LOG                                                           FAIL                 3.17 
06/19/2019 01:01:16 PM : INFO : Ignorable ERROR message:
'latin-1' codec can't encode character
06/19/2019 01:01:16 PM : INFO : Errors are present in wala log.
06/19/2019 01:01:16 PM : INFO : Errors: 2019/06/19 12:52:17.820035 ERROR ExtHandler [ProtocolError] [Wireserver Exception]  '\u2192' in position 1265: Body ('\u2192') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

After fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 06/19/2019 13:19:03
ARM Image Under Test  : RedHat : RHEL : 8 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-WAAGENT-LOG                                                           PASS                 2.37 

06/19/2019 01:20:45 PM : INFO : Checking for ERROR messages in waagent.log...
06/19/2019 01:20:45 PM : DEBUG : b"2019/06/19 12:52:17.820035 ERROR ExtHandler [ProtocolError] [Wireserver Exception] 'latin-1' codec can't encode character '\\u2192' in position 1265: Body ('\\u2192') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.\n"
06/19/2019 01:20:45 PM : INFO : Checking ignorable walalog ERROR messages...
06/19/2019 01:20:45 PM : INFO : Ignorable ERROR message:
2019/06/19 12:52:17.820035 ERROR ExtHandler [ProtocolError] [Wireserver Exception] 'latin-1' codec can't encode character '\u2192' in position 1265: Body ('\u2192') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.

```