### PR TITLE
LSVMBUS.sh: fix scsi controller spread check on cores

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -90,14 +90,23 @@ for optional_token in "${optional_tokens[@]}"; do
     fi
 done
 
+msg="Info: All VMBus device IDs have been found."
+LogMsg "$msg"
+UpdateSummary "$msg"
+
 # SECOND TEST CASE
+# install bc tool if not exist
+if ! which bc; then
+    update_repos
+    install_package bc
+fi
+
 $lsvmbus_path -vvv > lsvmbus.log
 
 # Check number of NICs on VM
 nics=$( grep -o "Synthetic network adapter" lsvmbus.log | wc -l)
 if [ "$nics" -gt 1 ]; then
     LogMsg "Counting the cores spread only for the first NIC..."
-    UpdateSummary "Counting the cores spread only for the first NIC..."
     sed -i ':a;N;$!ba;s/Synthetic network adapter/ignored adapter/2' lsvmbus.log && \
     sed -i '/ignored adapter/,/^$/d' lsvmbus.log
 fi
@@ -106,7 +115,6 @@ fi
 scsiAdapters=$( grep -o "Synthetic SCSI Controller" lsvmbus.log | wc -l)
 if [ "$scsiAdapters" -gt 1 ]; then
     LogMsg "Counting the cores spread only for the first SCSI Adapter..."
-    UpdateSummary "Counting the cores spread only for the first SCSI Adapter..."
     sed -i ':a;N;$!ba;s/Synthetic SCSI Controller/ignored controller/2' lsvmbus.log && \
     sed -i '/ignored controller/,/^$/d' lsvmbus.log
 fi
@@ -154,12 +162,18 @@ if [ "$network_counter" != "$expected_network_counter" ] && [ "$scsi_counter" !=
     error_msg="Error: values are wrong. Expected for network adapter: $VCPU and actual: $network_counter;
     expected for scsi controller: ${expected_scsi_counter}, actual: $scsi_counter."
     LogErr "$error_msg"
+    UpdateSummary "$error_msg"
     SetTestStateFailed
     exit 0
 fi
 
-LogMsg "Network driver is spread on all $network_counter cores as expected."
-LogMsg "Storage driver is spread on all $scsi_counter cores as expected."
-LogMsg "Info: All VMBus device IDs have been found."
+msg="Network driver is spread on all $network_counter cores as expected."
+LogMsg "$msg"
+UpdateSummary "$msg"
+
+msg="Storage driver is spread on all $scsi_counter cores as expected."
+LogMsg "$msg"
+UpdateSummary "$msg"
+
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -9,11 +9,7 @@ optional_tokens=("Guest services" "Dynamic Memory" )
 
 network_counter=0
 scsi_counter=0
-#######################################################################
-#
-# Main script body
-#
-#######################################################################
+
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
@@ -39,8 +35,13 @@ if [[ "$DISTRO" =~ "redhat" ]] || [[ "$DISTRO" =~ "centos" ]]; then
     fi
 fi
 
+#######################################################################
+#
+# Main script body
+#
+#######################################################################
 VCPU=$(nproc)
-LogMsg "Number of CPUs detected from this VM: $VCPU"
+LogMsg "Number of CPUs detected on VM: $VCPU"
 
 # check if lsvmbus exists
 lsvmbus_path=$(which lsvmbus)
@@ -93,19 +94,19 @@ $lsvmbus_path -vvv > lsvmbus.log
 # Check number of NICs on VM
 nics=$( grep -o "Synthetic network adapter" lsvmbus.log | wc -l)
 if [ "$nics" -gt 1 ]; then
-  LogMsg "Counting the cores spread only for the first NIC.."
-  UpdateSummary "Counting the cores spread only for the first NIC..."
-  sed -i ':a;N;$!ba;s/Synthetic network adapter/ignored adapter/2' lsvmbus.log && \
-  sed -i '/ignored adapter/,$d' lsvmbus.log
+    LogMsg "Counting the cores spread only for the first NIC..."
+    UpdateSummary "Counting the cores spread only for the first NIC..."
+    sed -i ':a;N;$!ba;s/Synthetic network adapter/ignored adapter/2' lsvmbus.log && \
+    sed -i '/ignored adapter/,$d' lsvmbus.log
 fi
 
 # Check number of SCSI Controllers on VM
 scsiAdapters=$( grep -o "Synthetic SCSI Controller" lsvmbus.log | wc -l)
 if [ "$scsiAdapters" -gt 1 ]; then
-  LogMsg "Counting the cores spread only for the first SCSI Adapter.."
-  UpdateSummary "Counting the cores spread only for the first SCSI Adapter..."
-  sed -i ':a;N;$!ba;s/Synthetic SCSI Controller/ignored controller/2' lsvmbus.log && \
-  sed -i '/ignored controller/,$d' lsvmbus.log
+    LogMsg "Counting the cores spread only for the first SCSI Adapter..."
+    UpdateSummary "Counting the cores spread only for the first SCSI Adapter..."
+    sed -i ':a;N;$!ba;s/Synthetic SCSI Controller/ignored controller/2' lsvmbus.log && \
+    sed -i '/ignored controller/,$d' lsvmbus.log
 fi
 
 while IFS='' read -r line || [[ -n "$line" ]]; do
@@ -128,19 +129,26 @@ done < "lsvmbus.log"
 
 # the cpu count that attached to the network driver is MIN(the number of vCPUs, 8).
 if [ "$VCPU" -gt 8 ];then
-    expected_netwok_counter=8
+    expected_network_counter=8
 else
-    expected_netwok_counter=$VCPU
+    expected_network_counter=$VCPU
 fi
 
 # the cpu count that attached to the SCSI driver is MIN(the number of vCPUs/4, 64).
 if [ "$VCPU" -gt 64 ];then
     expected_scsi_counter=64
 else
-    expected_scsi_counter=$(expr "$VCPU" / 4)
+    expected_scsi_counter=$(bc <<<"scale=2;$VCPU/4")
+    if [ "$expected_scsi_counter" != "${expected_scsi_counter#*.00}" ]; then
+        # In this case we have a float number that needs to be rounded up.
+        # For example with 6 cores, scsi controller is spread on 2 cores.
+        expected_scsi_counter=$(bc <<<"("$expected_scsi_counter"+0.5)/1")
+    fi
+    # normalizing the number to integer
+    expected_scsi_counter=${expected_scsi_counter%.*}
 fi
 
-if [ "$network_counter" != "$expected_netwok_counter" ] && [ "$scsi_counter" != "$expected_scsi_counter" ]; then
+if [ "$network_counter" != "$expected_network_counter" ] && [ "$scsi_counter" != "$expected_scsi_counter" ]; then
     error_msg="Error: values are wrong. Expected for network adapter: $VCPU and actual: $network_counter;
     expected for scsi controller: ${expected_scsi_counter}, actual: $scsi_counter."
     LogErr "$error_msg"

--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -97,7 +97,7 @@ if [ "$nics" -gt 1 ]; then
     LogMsg "Counting the cores spread only for the first NIC..."
     UpdateSummary "Counting the cores spread only for the first NIC..."
     sed -i ':a;N;$!ba;s/Synthetic network adapter/ignored adapter/2' lsvmbus.log && \
-    sed -i '/ignored adapter/,$d' lsvmbus.log
+    sed -i '/ignored adapter/,/^$/d' lsvmbus.log
 fi
 
 # Check number of SCSI Controllers on VM
@@ -106,7 +106,7 @@ if [ "$scsiAdapters" -gt 1 ]; then
     LogMsg "Counting the cores spread only for the first SCSI Adapter..."
     UpdateSummary "Counting the cores spread only for the first SCSI Adapter..."
     sed -i ':a;N;$!ba;s/Synthetic SCSI Controller/ignored controller/2' lsvmbus.log && \
-    sed -i '/ignored controller/,$d' lsvmbus.log
+    sed -i '/ignored controller/,/^$/d' lsvmbus.log
 fi
 
 while IFS='' read -r line || [[ -n "$line" ]]; do
@@ -139,7 +139,7 @@ if [ "$VCPU" -gt 64 ];then
     expected_scsi_counter=64
 else
     expected_scsi_counter=$(bc <<<"scale=2;$VCPU/4")
-    if [ "$expected_scsi_counter" != "${expected_scsi_counter#*.00}" ]; then
+    if [ "$expected_scsi_counter" != "${1#*.00}" ]; then
         # In this case we have a float number that needs to be rounded up.
         # For example with 6 cores, scsi controller is spread on 2 cores.
         expected_scsi_counter=$(bc <<<"("$expected_scsi_counter"+0.5)/1")

--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -69,8 +69,10 @@ if [ "$os_GENERATION" -eq "1" ]; then
     tokens+=("Synthetic IDE Controller")
 fi
 
-# python required for lsvmbus
-if ! which python; then
+# lsvmbus requires python
+if [[ $DISTRO == "redhat_8" ]]; then
+    which python || ln -s /usr/libexec/platform-python /sbin/python
+elif ! which python; then
     update_repos
     install_package python
 fi


### PR DESCRIPTION
Fixes #324

On a VM with 6 cores, scsi controller is spread on 2 cores. Handle this situation by checking the parity 4:1 better.

Other changes:
- Typo fixes and code indentation.
- Fix python detection compatibility with redhat 8.
- Display final results in test summary, not only LogMsg.

---

Test results:
SKU: Standard_NC6 - 6 cores

```
ARM Image Under Test  : RedHat : RHEL : 8 : 8.0.2019050711
ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
1 CORE                 LSVMBUS                                                                           PASS                 1.86
```

```
ARM Image Under Test  : Canonical : UbuntuServer : 19.04-DAILY : latest
ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
1 CORE                 LSVMBUS                                                                           PASS                 1.87
```
