### PR TITLE
WALA-VERIFY-WAAGENT-LOG - add 'name=WALinuxAgent..' error into ignorable-walalog-errors.xml

### DIFF
--- a/XML/Other/ignorable-walalog-errors.xml
+++ b/XML/Other/ignorable-walalog-errors.xml
@@ -3,6 +3,7 @@
     <errors>
         <!-- https://github.com/Azure/WALinuxAgent/issues/1523 -->
         <keywords>.*'latin-1' codec can't encode character.*</keywords>
+        <keywords>.*name=WALinuxAgent, op=AutoUpdate, message=, duration=0</keywords>
         <keywords>.*Error Code is 127\n[^\n]*parted /dev/sdb print\n[^\n]*parted: command not found</keywords>		
         <keywords>.*Failed to config rdma device.*</keywords>
         <keywords>.*ERROR:CalledProcessError.  Error Code is 1\n[^\n]*ERROR:CalledProcessError.  Command string was chcon unconfined_u:object_r:ssh_home_t:s0[^\n]*\n[^\n]*ERROR:CalledProcessError.  Command result was chcon: invalid context: unconfined_u:object_r:ssh_home_t:s0: Operation not supported</keywords>


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/340
Before fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 06/20/2019 00:56:53
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-WAAGENT-LOG                                                           FAIL                 4.08 
06/20/2019 01:03:29 AM : INFO : Errors are present in wala log.
06/20/2019 01:03:29 AM : INFO : Errors: 2019/06/20 01:00:50.902007 ERROR ExtHandler Event: name=WALinuxAgent, op=AutoUpdate, message=, duration=0
```

After fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 06/20/2019 01:09:45
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-WAAGENT-LOG                                                           PASS                 3.14 
06/20/2019 01:11:58 AM : INFO : Checking for ERROR messages in waagent.log...
06/20/2019 01:11:58 AM : DEBUG : 2019/06/20 01:00:50.902007 ERROR ExtHandler Event: name=WALinuxAgent, op=AutoUpdate, message=, duration=0
2019/06/20 01:03:51.222339 ERROR ExtHandler [ProtocolError] [Wireserver Exception] 'latin-1' codec can't encode character '\u2192' in position 25675: Body ('\u2192') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
06/20/2019 01:11:58 AM : INFO : Checking ignorable walalog ERROR messages...
06/20/2019 01:11:58 AM : INFO : Ignorable ERROR message:
2019/06/20 01:03:51.222339 ERROR ExtHandler [ProtocolError] [Wireserver Exception] 'latin-1' codec can't encode character '\u2192' in position 25675: Body ('\u2192') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
06/20/2019 01:11:58 AM : INFO : Ignorable ERROR message:
2019/06/20 01:00:50.902007 ERROR ExtHandler Event: name=WALinuxAgent, op=AutoUpdate, message=, duration=0
```
