### PR TITLE
Fix: Handled a condition of incorrect parameter selection

### DIFF
--- a/JenkinsPipelines/Run-Linux-Tests.groovy
+++ b/JenkinsPipelines/Run-Linux-Tests.groovy
@@ -69,7 +69,7 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, OverrideVMSize, 
                 FinalVMSize = " -OverrideVMSize ''"
             }
 
-            if (TestByTestname != "" && TestByTestname != null)
+            if (TestByTestname != "" && TestByTestname != null && (!(TestByTestname ==~ "Select a.*"​)​)​​)
             {
                 def CurrentTests = [failFast: false]
                 for ( i = 0; i < TestByTestname.split(",").length; i++)
@@ -126,7 +126,7 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, OverrideVMSize, 
                 }
                 parallel CurrentTests
             }
-            if (TestByCategorisedTestname != "" && TestByCategorisedTestname != null)
+            if (TestByCategorisedTestname != "" && TestByCategorisedTestname != null && (!(TestByCategorisedTestname ==~ "Select a.*"​)​))
             {
                 def CurrentTests = [failFast: false]
                 for ( i = 0; i < TestByCategorisedTestname.split(",").length; i++)
@@ -185,7 +185,7 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, OverrideVMSize, 
                 }
                 parallel CurrentTests
             }
-            if (TestByCategory != "" && TestByCategory != null)
+            if (TestByCategory != "" && TestByCategory != null && (!(TestByCategory ==~ "Select a.*"​)​))
             {
                 def CurrentTests = [failFast: false]
                 for ( i = 0; i < TestByCategory.split(",").length; i++)
@@ -244,7 +244,7 @@ def ExecuteTest( JenkinsUser, UpstreamBuildNumber, ImageSource, OverrideVMSize, 
                 }
                 parallel CurrentTests
             }
-            if (TestByTag != "" && TestByTag != null)
+            if (TestByTag != "" && TestByTag != null && (!(TestByTag ==~ "Select a.*"​)​))
             {
                 def CurrentTests = [failFast: false]
                 for ( i = 0; i < TestByTag.split(",").length; i++)


### PR DESCRIPTION
When user tries to select a Multilevel string parameter, but at last moment cancels it, Jenkins still passes the variable as `"Select a ..."` string instead of Empty.

![image](https://user-images.githubusercontent.com/7985635/59911054-f5048580-93c7-11e9-83cd-90b33dab1dec.png)

This fix handles this condition and ignores "Select a" value.