### PR TITLE
RELOAD-MODULES-SMP - remove hv_utils from MODULES_NOT_TO_RELOAD.

### DIFF
--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -30,7 +30,7 @@ fi
 
 HYPERV_MODULES=(hv_vmbus hv_netvsc hv_storvsc hv_utils hv_balloon hid_hyperv hyperv_keyboard hyperv_fb)
 MODULES_TO_RELOAD=(hv_netvsc)
-MODULES_NOT_TO_RELOAD=(hv_utils hyperv_fb)
+MODULES_NOT_TO_RELOAD=(hyperv_fb)
 skip_modules=()
 config_path="/boot/config-$(uname -r)"
 if [[ $(detect_linux_distribution) == clear-linux-os ]]; then

--- a/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
+++ b/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
@@ -111,7 +111,7 @@ function Main {
             # Install dependencies on both VMs
             if ($TestParams.Install_Dependencies -eq "yes") {
                 Run-LinuxCmd -username $VMUsername -password $password -ip $publicIp -port $vmPort `
-                    -command "cp /home/$VMUsername/sriov_constants.sh . ; . SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo | Out-Null
+                    -command "cp /home/$VMUsername/sriov_constants.sh . ; . SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo -runMaxAllowedTime 600 | Out-Null
                 if (-not $?) {
                     Write-LogErr "Failed to install dependencies on $($testVmData.RoleName)"
                     return $False
@@ -123,7 +123,7 @@ function Main {
                     return $False
                 }
                 Run-LinuxCmd -username $VMUsername -password $password -ip $publicIp -port $dependencyVmData.SSHPort `
-                    -command "cp /home/$VMUsername/sriov_constants.sh . ; . SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo | Out-Null
+                    -command "cp /home/$VMUsername/sriov_constants.sh . ; . SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo -runMaxAllowedTime 600 | Out-Null
                 if (-not $?) {
                     Write-LogErr "Failed to install dependencies on $($dependencyVmData.RoleName)"
                     return $False


### PR DESCRIPTION
Confirmed with Dexuan, that hv_utils can be removed, I found the system will reload it automatically if we remove it from code by modprobe -r hv_utils

```
[ 1935.697905] hv_vmbus: unregistering driver hv_util
[ 1988.440335] pps_core: LinuxPPS API ver. 1 registered
[ 1988.446042] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[ 1988.458421] PTP clock support registered
[ 1988.466500] hv_utils: Registering HyperV Utility Driver
[ 1988.471033] hv_vmbus: registering driver hv_util
[ 1988.476275] hv_utils: Heartbeat IC version 3.0
[ 1988.481875] hv_utils: Shutdown IC version 3.0
[ 1988.487179] hv_utils: TimeSync IC version 4.0
[ 1988.492441] hv_utils: VSS IC version 5.0
```

Before fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 06/22/2019 02:00:03
ARM Image Under Test  : RedHat : RHEL : 7-RAW : 7.6.2019062020
    5 CORE                 RELOAD-MODULES-SMP                                                                FAIL                 1.54 
```

After fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 06/24/2019 02:57:30
ARM Image Under Test  : RedHat : RHEL : 7-RAW : 7.6.2019062020
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 6.44 
```