### PR TITLE
VERIFY-BOOT-ERROR-WARNINGS -  update ignorable-boot-errors.xml

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -21,6 +21,9 @@
             <keywords>Failed to access perfctr msr</keywords>
         </failures>
         <errors>
+            <keywords>TLS record write failed</keywords>
+            <keywords>state ensure error</keywords>
+            <keywords>got unexpected HTTP status code</keywords>
             <keywords>Error getting hardware address for "eth0": No such device</keywords>
             <keywords>codec can't encode character</keywords>
             <keywords>Failed to set certificate key file [gnutls error -64: Error while reading file.]</keywords>


### PR DESCRIPTION
Fix a part of the issue: https://github.com/LIS/LISAv2/issues/334
Before fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 06/24/2019 04:56:57
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : 16.04.201906170
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        FAIL                 3.16 
06/24/2019 01:54:01 AM : ERROR : Found ERROR/WARNING/FAILURE messages in logs.
06/24/2019 01:54:01 AM : INFO : Errors: 2865:Jun 24 01:52:13 LISAv2-OneVM-tx-LX47-20190623175221-role-0 rsyslogd-2353: omrelp[51.143.17.22:9514]: error 'TLS record write failed [gnutls error -53: Error in the push function.]', object  'conn to srvr 51.143.17.22:9514' - action may not work as intended [v8.16.0 try http://www.rsyslog.com/e/2353 ]
```

After fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 06/24/2019 05:56:30
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : 16.04.201906170
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 2.45 
```