### PR TITLE
HyperV - Make sure that SRIOV is enabled after test

### DIFF
--- a/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
@@ -25,84 +25,94 @@ function Main {
     )
     $moduleCheckCMD = "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'"
     $vfCheckCMD = "find /sys/devices -name net -a -ipath '*vmbus*' | grep -c pci"
+    try {
+        # Get IP
+        $ipv4 = Get-IPv4ViaKVP $VMName $HvServer
+        $vm2ipv4 = Get-IPv4ViaKVP $DependencyVmName $DependencyVmHost
 
-    # Get IP
-    $ipv4 = Get-IPv4ViaKVP $VMName $HvServer
-    $vm2ipv4 = Get-IPv4ViaKVP $DependencyVmName $DependencyVmHost
+        # Start client on dependency VM
+        Run-LinuxCmd -ip $vm2ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "iperf3 -s > client.out" -RunInBackGround
+        Start-Sleep -s 5
 
-    # Start client on dependency VM
-    Run-LinuxCmd -ip $vm2ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "iperf3 -s > client.out" -RunInBackGround
-    Start-Sleep -s 5
+        # Run iPerf on client side for 30 seconds with SR-IOV enabled
+        Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
 
-    # Run iPerf on client side for 30 seconds with SR-IOV enabled
-    Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
+        [decimal]$vfEnabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
+            -ignoreLinuxExitCode:$true
+        if (-not $vfEnabledThroughput){
+            Write-LogErr "No result was logged! Check if iPerf was executed!"
+            return "FAIL"
+        }
+        Write-LogInfo "The throughput before disabling NIC is $vfEnabledThroughput Gbits/sec"
 
-    [decimal]$vfEnabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
-        -ignoreLinuxExitCode:$true
-    if (-not $vfEnabledThroughput){
-        Write-LogErr "No result was logged! Check if iPerf was executed!"
-        return "FAIL"
+        # Disable SR-IOV on test VM
+        $switchName = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer | `
+            Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
+        $hostNICName = Get-VMSwitch -Name $switchName -ComputerName $HvServer | `
+            Select-Object -ExpandProperty NetAdapterInterfaceDescription
+        Write-LogInfo "Disabling $hostNICName"
+        Disable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $HvServer -Confirm:$False | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to disable $hostNICName!"
+            return "FAIL"
+        }
+        # Wait 1 minute to make sure VF has changed. It is an expected behavior
+        Write-LogInfo "Wait 1 minute for VF to be put down"
+        Start-Sleep -s 60
+
+        # Check if the SR-IOV module is still loaded
+        $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true
+        if ($moduleCount -gt 0) {
+            Write-LogErr "Module is still loaded"
+            return "FAIL"
+        }
+        # Check if the VF is still present
+        $vfCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command $vfCheckCMD -ignoreLinuxExitCode:$true
+        if ($vfCount -gt 0) {
+            Write-LogErr "VF is still present"
+            return "FAIL"
+        }
+
+        # Enable SR-IOV on test VM
+        Write-LogInfo "Enable VF on on $hostNICName"
+        Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $HvServer -Confirm:$False | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to enable $hostNIC_name! Please try to manually enable it"
+            return "FAIL"
+        }
+        # Wait 1 minute to make sure VF has changed. It is an expected behavior
+        Write-LogInfo "Wait 1 minute for VF to be put up"
+        Start-Sleep -s 60
+        # Read the throughput again, it should be higher than before
+        Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
+        [decimal]$vfEnabledThroughput  = $vfEnabledThroughput * 0.7
+        [decimal]$vfFinalThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
+            -ignoreLinuxExitCode:$true
+        Write-LogInfo "The throughput after re-enabling NIC is $vfFinalThroughput Gbits/sec"
+        if ($vfEnabledThroughput -gt $vfFinalThroughput) {
+            Write-LogErr "After re-enabling NIC, the throughput has not increased enough"
+            return "FAIL"
+        }
+
+        return "PASS"
+    } catch {
+        $ErrorMessage = $_.Exception.Message
+        $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+        Write-LogErr "$ErrorMessage at line: $ErrorLine"
+        return "Aborted"
+    } finally {
+        # Enable SR-IOV on test VM
+        if ($hostNICName){
+            Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $hvServer -Confirm:$False | Out-Null
+        }
     }
-    Write-LogInfo "The throughput before disabling NIC is $vfEnabledThroughput Gbits/sec"
-
-    # Disable SR-IOV on test VM
-    $switchName = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer | Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
-    $hostNICName = Get-VMSwitch -Name $switchName -ComputerName $HvServer| Select-Object -ExpandProperty NetAdapterInterfaceDescription
-    Write-LogInfo "Disabling $hostNICName"
-    Disable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $HvServer -Confirm:$False
-    if (-not $?) {
-        Write-LogErr "Failed to disable $hostNICName!"
-        Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $hvServer -Confirm:$False
-        return "FAIL"
-    }
-    # Wait 1 minute to make sure VF has changed. It is an expected behavior
-    Write-LogInfo "Wait 1 minute for VF to be put down"
-    Start-Sleep -s 60
-
-    # Check if the SR-IOV module is still loaded
-    $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true
-    if ($moduleCount -gt 0) {
-        Write-LogErr "Module is still loaded"
-        Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $hvServer -Confirm:$False
-        return "FAIL"
-    }
-    # Check if the VF is still present
-    $vfCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command $vfCheckCMD -ignoreLinuxExitCode:$true
-    if ($vfCount -gt 0) {
-        Write-LogErr "VF is still present"
-        Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $hvServer -Confirm:$False
-        return "FAIL"
-    }
-
-    # Enable SR-IOV on test VM
-    Write-LogInfo "Enable VF on on $hostNICName"
-    Enable-NetAdapter -InterfaceDescription $hostNICName -CIMsession $HvServer -Confirm:$False
-    if (-not $?) {
-        Write-LogErr "Failed to enable $hostNIC_name! Please try to manually enable it"
-        return "FAIL"
-    }
-    # Wait 1 minute to make sure VF has changed. It is an expected behavior
-    Write-LogInfo "Wait 1 minute for VF to be put up"
-    Start-Sleep -s 60
-    # Read the throughput again, it should be higher than before
-    Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
-    [decimal]$vfEnabledThroughput  = $vfEnabledThroughput * 0.7
-    [decimal]$vfFinalThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
-        -ignoreLinuxExitCode:$true
-    Write-LogInfo "The throughput after re-enabling NIC is $vfFinalThroughput Gbits/sec"
-    if ($vfEnabledThroughput -gt $vfFinalThroughput) {
-        Write-LogErr "After re-enabling NIC, the throughput has not increased enough"
-        return "FAIL"
-    }
-
-    return "PASS"
 }
 
 Main -VMName $AllVMData.RoleName -hvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `

--- a/Testscripts/Windows/SRIOV-DISABLEVF-ONHOST.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLEVF-ONHOST.ps1
@@ -24,105 +24,115 @@ function Main {
         $VMPassword
     )
 
-    # Get IP
-    $ipv4 = Get-IPv4ViaKVP $VMName $HvServer
-    $vm2ipv4 = Get-IPv4ViaKVP $DependencyVmName $DependencyVmHost
+    try {
+        # Get IP
+        $ipv4 = Get-IPv4ViaKVP $VMName $HvServer
+        $vm2ipv4 = Get-IPv4ViaKVP $DependencyVmName $DependencyVmHost
 
-    # Start client on dependency VM
-    Run-LinuxCmd -ip $vm2ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "iperf3 -s > client.out" -RunInBackGround
-    Start-Sleep -s 5
+        # Start client on dependency VM
+        Run-LinuxCmd -ip $vm2ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "iperf3 -s > client.out" -RunInBackGround
+        Start-Sleep -s 5
 
-    # Run iPerf on client side for 30 seconds with SR-IOV enabled
-    Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
+        # Run iPerf on client side for 30 seconds with SR-IOV enabled
+        Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
 
-    [decimal]$vfEnabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
-        -ignoreLinuxExitCode:$true
-    if (-not $vfEnabledThroughput){
-        Write-LogErr "No result was logged! Check if iPerf was executed!"
-        return "FAIL"
+        [decimal]$vfEnabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
+            -ignoreLinuxExitCode:$true
+        if (-not $vfEnabledThroughput){
+            Write-LogErr "No result was logged! Check if iPerf was executed!"
+            return "FAIL"
+        }
+        Write-LogInfo "The throughput before disabling SR-IOV is $vfEnabledThroughput Gbits/sec"
+
+        # Disable SR-IOV on test host and dependency host
+        $switchName = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer | `
+            Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
+        $hostNICName = Get-VMSwitch -Name $switchName -ComputerName $HvServer | `
+            Select-Object -ExpandProperty NetAdapterInterfaceDescription
+        $dependencySwitchName = Get-VMNetworkAdapter -VMName $DependencyVmName -ComputerName $DependencyVmHost `
+            | Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
+        $dependencyHostNICName = Get-VMSwitch -Name $dependencySwitchName -ComputerName $DependencyVmHost `
+            | Select-Object -ExpandProperty NetAdapterInterfaceDescription
+
+        Write-LogInfo "Disabling VF on $hostNICName"
+        Disable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $HvServer | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to disable SR-IOV on $hostNICName!"
+            return "FAIL"
+        }
+        Disable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to disable SR-IOV on $dependencyHostNICName!"
+            return "FAIL"
+        }
+
+        # Wait 1 minute to make sure VF has changed. It is an expected behavior
+        Write-LogInfo "Wait 1 minute for VF to be put down"
+        Start-Sleep -s 60
+        # Get the throughput with SR-IOV disabled; it should be lower
+        Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
+
+        [decimal]$vfDisabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
+            -ignoreLinuxExitCode:$true
+        if (-not $vfDisabledThroughput){
+            Write-LogErr "No result was logged after SR-IOV was disabled!"
+            return "FAIL"
+        }
+
+        Write-LogInfo "The throughput with SR-IOV disabled is $vfDisabledThroughput Gbits/sec"
+        if ($vfDisabledThroughput -ge $vfEnabledThroughput) {
+            Write-LogErr "The throughput was higher with SR-IOV disabled, it should be lower"
+            return "FAIL"
+        }
+
+        # Enable SR-IOV on test host and dependency host
+        Write-LogInfo "Enable VF on on $hostNICName"
+        Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to enable SR-IOV on $hostNICName! Please try to manually enable it"
+            return "FAIL"
+        }
+        Enable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost | Out-Null
+        if (-not $?) {
+            Write-LogErr "Failed to enable SR-IOV on $dependencyHostNICName!"
+            return "FAIL"
+        }
+
+        # Wait 1 minute to make sure VF has changed. It is an expected behavior
+        Write-LogInfo "Wait 1 minute for VF to be put up"
+        Start-Sleep -s 60
+        # Read the throughput again, it should be higher than before
+        Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
+        [decimal]$vfDisabledThroughput = $vfDisabledThroughput * 1.5
+        [decimal]$vfFinalThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
+            $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
+            -ignoreLinuxExitCode:$true
+        Write-LogInfo "The throughput after re-enabling SR-IOV is $vfFinalThroughput Gbits/sec"
+        if ($vfDisabledThroughput -gt $vfFinalThroughput) {
+            Write-LogErr "After re-enabling SR-IOV, the throughput has not increased enough"
+            return "FAIL"
+        }
+
+        return "PASS"
+    } catch {
+        $ErrorMessage = $_.Exception.Message
+        $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+        Write-LogErr "$ErrorMessage at line: $ErrorLine"
+        return "Aborted"
+    } finally {
+        if ($hostNICName) {
+            Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer | Out-Null
+        }
+        if ($dependencyHostNICName) {
+            Enable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost | Out-Null
+        }
     }
-    Write-LogInfo "The throughput before disabling SR-IOV is $vfEnabledThroughput Gbits/sec"
-
-    # Disable SR-IOV on test host and dependency host
-    $switchName = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer | `
-        Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
-    $hostNICName = Get-VMSwitch -Name $switchName -ComputerName $HvServer | `
-        Select-Object -ExpandProperty NetAdapterInterfaceDescription
-    $dependencySwitchName = Get-VMNetworkAdapter -VMName $DependencyVmName -ComputerName $DependencyVmHost `
-        | Where-Object {$_.SwitchName -like 'SRIOV*'} | Select-Object -ExpandProperty SwitchName
-    $dependencyHostNICName = Get-VMSwitch -Name $dependencySwitchName -ComputerName $DependencyVmHost `
-        | Select-Object -ExpandProperty NetAdapterInterfaceDescription
-
-    Write-LogInfo "Disabling VF on $hostNICName"
-    Disable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $HvServer
-    if (-not $?) {
-        Write-LogErr "Failed to disable SR-IOV on $hostNICName!"
-        Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer
-        return "FAIL"
-    }
-    Disable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost
-    if (-not $?) {
-        Write-LogErr "Failed to disable SR-IOV on $dependencyHostNICName!"
-        Enable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost
-        return "FAIL"
-    }
-
-    # Wait 1 minute to make sure VF has changed. It is an expected behavior
-    Write-LogInfo "Wait 1 minute for VF to be put down"
-    Start-Sleep -s 60
-    # Get the throughput with SR-IOV disabled; it should be lower
-    Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
-
-    [decimal]$vfDisabledThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
-        -ignoreLinuxExitCode:$true
-    if (-not $vfDisabledThroughput){
-        Write-LogErr "No result was logged after SR-IOV was disabled!"
-        Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer
-        return "FAIL"
-    }
-
-    Write-LogInfo "The throughput with SR-IOV disabled is $vfDisabledThroughput Gbits/sec"
-    if ($vfDisabledThroughput -ge $vfEnabledThroughput) {
-        Write-LogErr "The throughput was higher with SR-IOV disabled, it should be lower"
-        Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer
-        return "FAIL"
-    }
-
-    # Enable SR-IOV on test host and dependency host
-    Write-LogInfo "Enable VF on on $hostNICName"
-    Enable-NetAdapterSriov -InterfaceDescription $hostNICName -CIMsession $hvServer
-    if (-not $?) {
-        Write-LogErr "Failed to enable SR-IOV on $hostNICName! Please try to manually enable it"
-        return "FAIL"
-    }
-    Enable-NetAdapterSriov -InterfaceDescription $dependencyHostNICName -CIMsession $DependencyVmHost
-    if (-not $?) {
-        Write-LogErr "Failed to enable SR-IOV on $dependencyHostNICName!"
-        return "FAIL"
-    }
-
-    # Wait 1 minute to make sure VF has changed. It is an expected behavior
-    Write-LogInfo "Wait 1 minute for VF to be put up"
-    Start-Sleep -s 60
-    # Read the throughput again, it should be higher than before
-    Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "source sriov_constants.sh ; iperf3 -t 30 -c `$VF_IP2 --logfile PerfResults.log"
-    [decimal]$vfDisabledThroughput = $vfDisabledThroughput * 1.5
-    [decimal]$vfFinalThroughput = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command "tail -4 PerfResults.log | head -1 | awk '{print `$7}'" `
-        -ignoreLinuxExitCode:$true
-    Write-LogInfo "The throughput after re-enabling SR-IOV is $vfFinalThroughput Gbits/sec"
-    if ($vfDisabledThroughput -gt $vfFinalThroughput) {
-        Write-LogErr "After re-enabling SR-IOV, the throughput has not increased enough"
-        return "FAIL"
-    }
-
-    return "PASS"
 }
 
 Main -VMName $AllVMData.RoleName -hvServer $GlobalConfig.Global.Hyperv.Hosts.ChildNodes[0].ServerName `


### PR DESCRIPTION
For SRIOV-DISABLE-NIC and SRIOV-DISABLEVF-ONHOST test:
 - Add try...catch to resolve the potential exceptions
 -  Enable the SRIOV in "finally" block  

Typically, the above changes fixes the below issue:
A vm with debug kernel may panic once the sriov is disabled on the host, and then an exception happens, which leads the "Enable-NetAdapter" lines have no chance to be executed in the former design. 