### PR TITLE
NETWORK.ETHTOOL: Skip Get/Set msg level test if kernel symbols missing

### DIFF
--- a/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
+++ b/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
@@ -23,18 +23,29 @@ UtilsInit
 #######################################################################
 # Main script body
 #######################################################################
-# Check if feature is suppoorted by the kernel
+# Check if feature is supported by the kernel
 if ! which nm; then
     update_repos
     install_package binutils
 fi
 
 kernel_version=$(uname -r)
-msg_level_symbols=$(nm /lib/modules/"$kernel_version"/kernel/drivers/net/hyperv/hv_netvsc.ko | grep msglevel)
-if [[ "$msg_level_symbols" != *netvsc_get_msglevel* ]] || [[ "$msg_level_symbols" != *netvsc_set_msglevel* ]]; then
-    UpdateSummary "Getting / Setting the driver message type flags from ethtool is not supported on $kernel_version, skipping test."
-    SetTestStateSkipped
-    exit 0
+# if the module is not builtin
+if [ $(grep -c netvsc < /lib/modules/"$kernel_version"/modules.builtin) == 0 ]; then
+    # get the path to the netvsc kernel module
+    kernel_module=$(ls /lib/modules/"$kernel_version"/kernel/drivers/net/hyperv/hv_netvsc.ko*)
+    # if the module is archived as xz, extract it to check symbols
+    if [ $(echo "$kernel_module" | grep -c ".xz") -ne 0 ]; then
+        cp "$kernel_module" .
+        xz -d $(basename $kernel_module)
+        kernel_module=$(ls hv_netvsc*)
+    fi
+    msg_level_symbols=$(nm "$kernel_module" | grep msglevel)
+    if [[ "$msg_level_symbols" != *netvsc_get_msglevel* ]] || [[ "$msg_level_symbols" != *netvsc_set_msglevel* ]]; then
+        UpdateSummary "Getting / Setting the driver message type flags from ethtool is not supported on $kernel_version, skipping test."
+        SetTestStateSkipped
+        exit 0
+    fi
 fi
 
 # Check if ethtool exist and install it if not

--- a/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
+++ b/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
@@ -24,15 +24,14 @@ UtilsInit
 # Main script body
 #######################################################################
 # Check if feature is supported by the kernel
-if ! which nm; then
-    update_repos
-    install_package binutils
-fi
-
 kernel_version=$(uname -r)
 # if the module is not builtin
 modules_path="/lib/modules/$kernel_version"
 if [ "$(grep -c netvsc < "$modules_path"/modules.builtin)" == 0 ]; then
+    if ! which nm; then
+        update_repos
+        install_package binutils
+    fi
     LogMsg "looking for msg level symbols in netvsc module..."
     # get the path to the netvsc kernel module
     kernel_module=$(ls "$modules_path"/kernel/drivers/net/hyperv/hv_netvsc.ko*)

--- a/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
+++ b/Testscripts/Linux/ETHTOOL-MSG-LEVEL.sh
@@ -31,10 +31,11 @@ fi
 
 kernel_version=$(uname -r)
 # if the module is not builtin
-if [ "$(grep -c netvsc < /lib/modules/"$kernel_version"/modules.builtin)" == 0 ]; then
+modules_path="/lib/modules/$kernel_version"
+if [ "$(grep -c netvsc < "$modules_path"/modules.builtin)" == 0 ]; then
     LogMsg "looking for msg level symbols in netvsc module..."
     # get the path to the netvsc kernel module
-    kernel_module=$(ls /lib/modules/"$kernel_version"/kernel/drivers/net/hyperv/hv_netvsc.ko*)
+    kernel_module=$(ls "$modules_path"/kernel/drivers/net/hyperv/hv_netvsc.ko*)
     # if the module is archived as xz, extract it to check symbols
     if [ "$(echo "$kernel_module" | grep -c ".xz")" -ne 0 ]; then
         cp "$kernel_module" .
@@ -44,11 +45,11 @@ if [ "$(grep -c netvsc < /lib/modules/"$kernel_version"/modules.builtin)" == 0 ]
     msg_level_symbols=$(nm "$kernel_module" | grep msglevel)
 else
     LogMsg "netvsc module is builtin, looking for msg level symbols in System.map..."
-    msg_level_symbols=$(grep 'netvsc.*msglevel' "/boot/System.map-$(uname -r)")
+    msg_level_symbols=$(grep 'netvsc.*msglevel' "/boot/System.map-$kernel_version")
 fi
 LogMsg "Msg level symbols: $msg_level_symbols"
 if [[ "$msg_level_symbols" != *netvsc_get_msglevel* ]] || [[ "$msg_level_symbols" != *netvsc_set_msglevel* ]]; then
-    UpdateSummary "Getting / Setting the driver message type flags from ethtool is not supported on $kernel_version, skipping test."
+    UpdateSummary "Get/Set message level not supported on $kernel_version, skipping test."
     SetTestStateSkipped
     exit 0
 fi


### PR DESCRIPTION
* check for get / set msg level symbols in the lib of the current kernel, if missing skip the test.
* if module is builtin check in /boot/System.map of the current kernel.

Fixes #341 
(Continued #363)


Canonical UbuntuServer 18.04-LTS 18.04.201906040
Kernel module, contains functionality: expected pass
```
[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 06/25/2019 16:18:25
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : 18.04.201906040
[azure] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] 
[azure]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[azure] -------------------------------------------------------------------------------------------------------------------------------------------
[azure]     1 NETWORK              ETHTOOL-GET-SET-MSG-LEVEL                                                         PASS                 1.14 
```

Canonical UbuntuServer 16.04-LTS 16.04.201906050
Kernel module, does not contain functionality: expect skipped
```
[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 06/25/2019 16:18:16
[azure] ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : 16.04.201906050
[azure] Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] 
[azure]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[azure] -------------------------------------------------------------------------------------------------------------------------------------------
[azure]     1 NETWORK              ETHTOOL-GET-SET-MSG-LEVEL                                                      SKIPPED                 0.69 
```

RedHat RHEL 7-RAW 7.6.2019062020
Archived kernel module, does not contain functionality: expect skipped
```
[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 06/25/2019 16:17:04
[azure] ARM Image Under Test  : RedHat : RHEL : 7-RAW : 7.6.2019062020
[azure] Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
[azure] Total Time (dd:hh:mm) : 0:0:3
[azure] 
[azure]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[azure] -------------------------------------------------------------------------------------------------------------------------------------------
[azure]     1 NETWORK              ETHTOOL-GET-SET-MSG-LEVEL                                                      SKIPPED                 0.72 
```

SUSE SLES 15 2019.06.17
Kernel builtin, contains functionality, expect pass
```
[azure] [LISAv2 Test Results Summary]
[azure] Test Run On           : 06/25/2019 16:16:10
[azure] ARM Image Under Test  : SUSE : SLES : 15 : 2019.06.17
[azure] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[azure] Total Time (dd:hh:mm) : 0:0:5
[azure] 
[azure]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[azure] -------------------------------------------------------------------------------------------------------------------------------------------
[azure]     1 NETWORK              ETHTOOL-GET-SET-MSG-LEVEL                                                         PASS                  0.5 
```