### PR TITLE
KVP-BASIC-CHECKS - Modify the result of the KVP test to skip when daemon is not running by default

### DIFF
--- a/Testscripts/Linux/KVP-BasicChecks.sh
+++ b/Testscripts/Linux/KVP-BasicChecks.sh
@@ -40,8 +40,9 @@ fi
 #
 pid=$(pgrep "hypervkvpd|hv_kvp_daemon")
 if [ $? -ne 0 ]; then
-    LogErr "KVP Daemon is not running by default"
-    SetTestStateFailed
+    LogMsg "KVP Daemon is not running by default"
+    UpdateSummary "KVP Daemon is not running by default"
+    SetTestStateSkipped
     exit 0
 fi
 LogMsg "KVP Daemon is running"


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/371

After fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 02:05:53
ARM Image Under Test  : RedHat : RHEL : 7-RAW : 7.6.2019062120
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KVP                  KVP-BASIC-CHECKS                                                               SKIPPED                 2.74 

[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 02:22:57
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2135.4.0
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KVP                  KVP-BASIC-CHECKS                                                               SKIPPED                 2.69 
```