### PR TITLE
TIME-CLOCKSOURCE - Add a loop about "sleep 10 seconds" for message show up in log file

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -74,10 +74,20 @@ function UnbindCurrentSource()
 	if echo $clocksource > $unbind_file
 	then
 		_clocksource=$(cat /sys/devices/system/clocksource/clocksource0/current_clocksource)
-		LogMsg "Sleep 10 seconds for message show up in log file"
-		sleep 10
-		grep -rnw '/var/log' -e 'Switched to clocksource acpi_pm' --ignore-case
-		if [ $? -eq 0 ] && [ "$_clocksource" == "acpi_pm" ]; then
+		retryTime=1
+		maxRetryTimes=5
+		while [ $retryTime -le $maxRetryTimes ]
+		do
+			LogMsg "Sleep 10 seconds for message show up in log file for the $retryTime time(s)."
+			sleep 10
+			val=$(grep -rnw '/var/log' -e 'Switched to clocksource acpi_pm' --ignore-case)
+			if [ -n "$val" ];then
+				break
+			fi
+			retryTime=$(($retryTime+1))
+		done
+
+		if [ -n "$val" ] && [ "$_clocksource" == "acpi_pm" ]; then
 			LogMsg "Test successful. After unbind, current clocksource is $_clocksource"
 		else
 			LogMsg "Test failed. After unbind, current clocksource is $_clocksource"


### PR DESCRIPTION
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 05:35:18
ARM Image Under Test  : RedHat : RHEL : 7-RAW : 7.6.2019062120
Total Test Cases      : 5 (5 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:34

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE-1                                                                PASS                 2.91 
    2 CORE                 TIME-CLOCKSOURCE-2                                                                PASS                 2.82 
    3 CORE                 TIME-CLOCKSOURCE-3                                                                PASS                 2.81 
    4 CORE                 TIME-CLOCKSOURCE-4                                                                PASS                  2.8 
    5 CORE                 TIME-CLOCKSOURCE-5                                                                PASS                  2.8 
```