### PR TITLE
SRIOV-INTERRUPTS-CHANGE: Added support for CoreOS

### DIFF
--- a/Testscripts/Linux/CORE-InitrdModulesCheck.sh
+++ b/Testscripts/Linux/CORE-InitrdModulesCheck.sh
@@ -20,7 +20,13 @@ CopyImage()
 SearchModules()
 {
     LogMsg "Searching for modules..."
-    [[ -d "/root/initr/usr/lib/modules" ]] && abs_path="/root/initr/usr/lib/modules/" || abs_path="/root/initr/lib/modules/"
+    if [[ -d "/root/initr/usr/lib/modules" ]]; then
+        abs_path="/root/initr/usr/lib/modules/"
+    elif [[ -d "/root/initr/lib/modules" ]]; then
+        abs_path="/root/initr/lib/modules/"
+    elif [[ -d "/usr/lib64/modules" ]]; then
+        abs_path="/usr/lib64/modules/"
+    fi
     if [[ $DISTRO == "suse_12" ]]; then
         abs_path="/lib/modules/"
     fi
@@ -68,6 +74,9 @@ fi
 # Rebuild array to exclude built-in modules
 skip_modules=()
 config_path="/boot/config-$(uname -r)"
+if [[ $(detect_linux_distribution) == 'coreos' ]]; then
+    config_path="/usr/lib/kernel/config-$(uname -r)"
+fi
 declare -A config_modulesDic
 config_modulesDic=(
 [CONFIG_HYPERV=y]="hv_vmbus.ko"

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -224,6 +224,9 @@ InstallDependencies()
         redhat*|centos*)
             service firewalld stop
         ;;
+        coreos)
+            LogMsg "No extra steps need here."
+        ;;
         *)
             LogErr "OS Version not supported in InstallDependencies!"
             SetTestStateFailed
@@ -244,7 +247,7 @@ InstallDependencies()
 
     # Check if iPerf3 is already installed
     iperf3 -v > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
+    if [ $? -ne 0 ] && [[ $(detect_linux_distribution) != coreos ]]; then
         update_repos
         gcc -v
         if [ $? -ne 0 ]; then
@@ -275,6 +278,8 @@ InstallDependencies()
             SetTestStateFailed
             exit 1
         fi
+    else
+        install_iperf3
     fi
 
     return 0


### PR DESCRIPTION
Fix #331 
For case SRIOV-INTERRUPTS-CHANGE , not use ruby to do columns and rows switch.
```
[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 09:22:21
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2135.4.0
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:24

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-INTERRUPTS-CHANGE                                                           PASS                16.84 

[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 09:22:49
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:24

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-INTERRUPTS-CHANGE                                                           PASS                17.85 

[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 10:30:01
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2135.4.0
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 INITRD-MODULES-CHECK                                                              PASS                 2.61 

[LISAv2 Test Results Summary]
Test Run On           : 06/27/2019 10:29:48
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 INITRD-MODULES-CHECK                                                              PASS                  2.6 
```