### PR TITLE
Hyper-V: Framework improvements

### DIFF
--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -65,6 +65,9 @@ Class HyperVProvider : TestProvider
 				$customStatus = Set-CustomConfigInVMs -CustomKernel $this.CustomKernel -CustomLIS $this.CustomLIS `
 					-AllVMData $allVMData -TestProvider $this -RegisterRhelSubscription
 				if (!$customStatus) {
+					foreach ($vm in $allVMData) {
+						Stop-HyperVGroupVMs -HyperVGroupName $vm.HyperVGroupName -HyperVHost $vm.HyperVHost
+					}
 					$ErrorMessage = "Failed to set custom config in VMs."
 					Write-LogErr $ErrorMessage
 					return @{"VmData" = $null; "Error" = $ErrorMessage}


### PR DESCRIPTION
## Stop VMs if Set-CustomConfigInVMs
Current behavior will leave all VMs from the lisav2 run in a Running state, leading to node free RAM saturation. VMs will be stopped from now on.
### Before
06/28/2019 09:34:03 : [ERROR] Kernel upgrade failed in 1 VMs.
06/28/2019 09:34:03 : [ERROR] Custom Kernel: proposed-azure installation FAIL. Aborting tests.
06/28/2019 09:34:03 : [ERROR] Failed to set custom config in VMs.
### After
06/28/2019 09:50:21 : [ERROR] Kernel upgrade failed in 1 VMs.
06/28/2019 09:50:21 : [ERROR] Custom Kernel: proposed-azure installation FAIL. Aborting tests.
**06/28/2019 09:50:21 : [INFO ] Shutting down LISAv2-OneVM-adsuhoCosmic-ZA91-636972869397-role-0 from LISAv2-OneVM-adsuhoCosmic-ZA91-636972869397...
06/28/2019 09:50:32 : [INFO ] VM stopped successfully.**
06/28/2019 09:50:32 : [ERROR] Failed to set custom config in VMs.

## Check host memory before starting the tests and don't start them if there isn't enough for each test
A check for each requested host's memory will now be made, before any files/VMs are created. Only if there is enough memory on the host + a buffer, the test will be started.
### Good situation
_06/28/2019 09:50:32 : [INFO ] Checking if there is enough memory on localhost
06/28/2019 09:50:33 : [INFO ] Available memory on localhost: 172974MB ::: Requested memory: 4096MB_
### Bad situation (POC)
_06/28/2019 08:12:50 : [INFO ] Checking if there is enough memory on localhost
06/28/2019 08:12:51 : [INFO ] Available memory on localhost: 173038MB ::: Requested memory: 200000MB_
**06/28/2019 08:12:51 : [ERROR] Exception detected. Source : DeployVMs()
06/28/2019 08:12:51 : [ERROR] EXCEPTION : Not enough memory on localhost
06/28/2019 08:12:51 : [ERROR] Source : Line 911 in script C:\Users\v-adsuho\Documents\LISAv2-4\Libraries\HyperV.psm1.**
 