### PR TITLE
function add_sles_benchmark_repo: update repo for sles12sp4

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2387,7 +2387,10 @@ function add_sles_benchmark_repo () {
 				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_11_SP4/benchmark.repo"
 				;;
 			12*)
-				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_12_SP3_Backports/benchmark.repo"
+				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_12_SP4/benchmark.repo"
+				;;
+			15*)
+				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_15_SP1/benchmark.repo"
 				;;
 			*)
 				echo "Unsupported SLES version $DISTRO_VERSION for add_sles_benchmark_repo"


### PR DESCRIPTION
Also add benchmark repo for SLES15, now available.