### PR TITLE
Use yum clean all to refresh repos, makecache uses too much space

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2165,7 +2165,7 @@ function detect_linux_distribution() {
 function update_repos() {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos)
-			yum makecache
+			yum clean all
 			;;
 		ubuntu|debian)
 			apt-get update


### PR DESCRIPTION
Reason: Observed on RedHat RHEL 7-LVM 7.6.2019062414 that `yum makecache` fills /var partition when run and hangs all tests that use `update_repos`

Solution: 
`yum clean all` includes expire-cache and yum will refresh the repos on the next run
Ref: http://man7.org/linux/man-pages/man8/yum.8.html
```
makecache
      Is used to download and make usable all the metadata for the
      currently enabled yum repos. If the argument "fast" is passed,
      then we just try to make sure the repos are current (much like
      "yum clean expire-cache").

yum clean expire-cache
      Eliminate the local data saying when the metadata and
      mirrorlists were downloaded for each repo. This means yum will
      revalidate the cache for each repo. next time it is used.
      However if the cache is still valid, nothing significant was
      deleted.
```
