### PR TITLE
VERIFY-DEPLOYMENT-PROVISION-EPHEMERAL-MANAGED-DISK: update vm size

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -15,7 +15,7 @@
         <testScript>VERIFY-DEPLOYMENT-PROVISION.ps1</testScript>
         <files></files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_DS1_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
             <OSDiskType>Ephemeral</OSDiskType>


### PR DESCRIPTION
Test will fail with the below error, and only on the RHEL LVM SKU:
`"OS disk of Ephemeral VM with size greater than 43 GB is not allowed for VM size Standard_DS1_v2"`
Example SKU: RedHat RHEL 7-LVM 7.6.2019060521

Choosing Standard_DS4_v2 instead, as it is used by other Functional tests and we don't have to re-deploy.

```
[Azure VERIFY-DEPLOYMENT-PROVISION-EPHEMERAL-MANAGED-DISK eastus2]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Azure VERIFY-DEPLOYMENT-PROVISION-EPHEMERAL-MANAGED-DISK eastus2]     1 CORE                 VERIFY-DEPLOYMENT-PROVISION-EPHEMERAL-MANAGED-DISK                                PASS                  2.7
```