### PR TITLE
Update RDMA cases use consistent size.

### DIFF
--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -4,7 +4,7 @@
 		<testName>INFINIBAND-INTEL-MPI-2VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -43,7 +43,7 @@
 		<testName>INFINIBAND-INTEL-MPI-32VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -122,7 +122,7 @@
 		<testName>INFINIBAND-OPEN-MPI-32VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -162,7 +162,7 @@
 		<testName>INFINIBAND-IBM-MPI-2VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -201,7 +201,7 @@
 		<testName>INFINIBAND-IBM-MPI-32VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -241,7 +241,7 @@
 		<testName>INFINIBAND-MVAPICH-MPI-2VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
@@ -280,7 +280,7 @@
 		<testName>INFINIBAND-MVAPICH-MPI-32VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
-		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
 		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>


### PR DESCRIPTION
Fix #396 Use the same sizes in one region. (westus2)