### PR TITLE
Mark GPU test results fail if one of sub-result fail.

### DIFF
--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -32,9 +32,9 @@ function Start-Validation {
     Set-Content -Value $PCIExpress -Path $LogDir\PCI-Express-passthrough.txt -Force
     $pciExpressCount = (Select-String -Path $LogDir\PCI-Express-passthrough.txt -Pattern "PCI Express pass-through").Matches.Count
     if ($pciExpressCount -eq $expectedGPUCount) {
-        $currentResult = "PASS"
+        $currentResult = $resultPass
     } else {
-        $currentResult = "FAIL"
+        $currentResult = $resultFail
         $failureCount += 1
     }
     $metaData = "lsvmbus: Expected `"PCI Express pass-through`" count: $expectedGPUCount, count inside the VM: $pciExpressCount"
@@ -49,9 +49,9 @@ function Start-Validation {
     Set-Content -Value $lspci -Path $LogDir\lspci.txt -Force
     $lspciCount = (Select-String -Path $LogDir\lspci.txt -Pattern "NVIDIA Corporation").Matches.Count
     if ($lspciCount -eq $expectedGPUCount) {
-        $currentResult = "PASS"
+        $currentResult = $resultPass
     } else {
-        $currentResult = "FAIL"
+        $currentResult = $resultFail
         $failureCount += 1
     }
     $metaData = "lspci: Expected `"3D controller: NVIDIA Corporation`" count: $expectedGPUCount, found inside the VM: $lspciCount"
@@ -66,9 +66,9 @@ function Start-Validation {
     Set-Content -Value $lshw -Path $LogDir\lshw-c-video.txt -Force
     $lshwCount = (Select-String -Path $LogDir\lshw-c-video.txt -Pattern "vendor: NVIDIA Corporation").Matches.Count
     if ($lshwCount -eq $expectedGPUCount) {
-        $currentResult = "PASS"
+        $currentResult = $resultPass
     } else {
-        $currentResult = "FAIL"
+        $currentResult = $resultFail
         $failureCount += 1
     }
     $metaData = "lshw: Expected Display adapters: $expectedGPUCount, total adapters found in VM: $lshwCount"
@@ -83,15 +83,16 @@ function Start-Validation {
     Set-Content -Value $nvidiasmi -Path $LogDir\nvidia-smi.txt -Force
     $nvidiasmiCount = (Select-String -Path $LogDir\nvidia-smi.txt -Pattern "Tesla").Matches.Count
     if ($nvidiasmiCount -eq $expectedGPUCount) {
-        $currentResult = "PASS"
+        $currentResult = $resultPass
     } else {
-        $currentResult = "FAIL"
+        $currentResult = $resultFail
         $failureCount += 1
     }
     $metaData = "nvidia-smi: Expected GPU count: $expectedGPUCount, found inside the VM: $nvidiasmiCount"
     $resultArr += $currentResult
     $CurrentTestResult.TestSummary += New-ResultSummary -testResult $currentResult -metaData $metaData `
         -checkValues "PASS,FAIL,ABORTED" -testName $CurrentTestData.testName
+    return $failureCount
     #endregion
 }
 
@@ -206,11 +207,11 @@ function Main {
         }
 
         # run the tools
-        Start-Validation
+        $failureCount = Start-Validation
         if ($failureCount -eq 0) {
-            $testResult = "PASS"
+            $testResult = $resultPass
         } else {
-            $testResult = "FAIL"
+            $testResult = $resultFail
         }
 
         # Get logs. An extra check for the previous $state is needed
@@ -221,10 +222,10 @@ function Main {
         # Collect-TestLogs function to work
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "cp * /home/$user" -ignoreLinuxExitCode:$true
-        $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName `
+        Collect-TestLogs -LogsDestination $LogDir -ScriptName `
             $currentTestData.files.Split('\')[3].Split('.')[0] -TestType "sh" -PublicIP `
             $allVMData.PublicIP -SSHPort $allVMData.SSHPort -Username $user `
-            -password $password -TestName $currentTestData.testName
+            -password $password -TestName $currentTestData.testName | Out-Null
         if ($driver -eq "CUDA") {
             # Copy the dkms build log for the nvidia driver
             Copy-RemoteFiles -download -downloadFrom $allVMData.PublicIP -files "nvidia_dkms_make.log, install_drivers.log" `
@@ -244,7 +245,7 @@ function Main {
         Write-LogInfo "EXCEPTION: $ErrorMessage at line: $ErrorLine"
     } finally {
         if (!$testResult) {
-            $testResult = "ABORTED"
+            $testResult = $resultAborted
         }
         $resultArr += $testResult
     }


### PR DESCRIPTION
Fix #393 

```
[LISAv2 Test Results Summary]
...
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     FAIL                 6.67 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 0 : FAIL 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```