### PR TITLE
 nvme_blkdiscard.sh: Added skip check for ubuntu_14.04

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -235,6 +235,9 @@ GetDistro()
 	#Get distro (snipper take from alsa-info.sh)
 	__DISTRO=$(grep -ihs "Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux\|clear-linux-os\|CoreOS" /{etc,usr/lib}/{issue,*release,*version})
 	case $__DISTRO in
+		*Ubuntu*14.04*)
+			DISTRO=ubuntu_14.04
+			;;
 		*Ubuntu*)
 			DISTRO=ubuntu_x
 			;;


### PR DESCRIPTION
Fixes #392 

ubuntu 14.04 trusty does not have blkdiscard binary in the util-linux package.

Added a Skip test case condition, there is no package update available to support it.

```
util-linux is already the newest version.
util-linux                             2.20.1-5.1ubuntu20.9
dpkg-query: no path found matching pattern *blkdiscard*
```

Before:
```
1 NVME                 NVME-BLKDISCARD                                                                   FAIL                 5.87 
Calling function - Run-LinuxCmd. Failed to execute : bash nvme_blkdiscard.sh > NVME-BLKDISCARD_summary.log 2>&1.
```

After:
```
1 NVME                 NVME-BLKDISCARD                                                                SKIPPED                 0.42 
```