### PR TITLE
GPU: Refactor log collection; Collect test logs after driver install fail

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1134,7 +1134,7 @@ function Check-FileInLinuxGuest {
 
 	$check = Run-LinuxCmd -username $vmUserName -password $vmPassword -port $vmPort -ip $ipv4 -command "[ -f ${fileName} ] && echo 1 || echo 0"
 	if (-not [convert]::ToInt32($check)) {
-		Write-Loginfo "File $fileName does not exists"
+		Write-Loginfo "File $fileName does not exist."
 		return $False
 	}
 	if ($checkSize) {

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -144,6 +144,27 @@ function Collect-TestLogs {
 	return $currentTestResult
 }
 
+function Collect-CustomLogFile {
+	<#
+	.Synopsis
+		Checks if log file is present in VM and downloads it if so.
+    #>
+    param (
+        [string]$LogsDestination,
+		[string]$PublicIP,
+		[string]$SSHPort,
+		[string]$Username,
+		[string]$Password,
+        [string]$FileName
+    )
+    if (Check-FileInLinuxGuest -ipv4 $PublicIP -vmPassword $Password -vmPort $SSHPort -vmUserName $Username -fileName $FileName) {
+        Copy-RemoteFiles -download -downloadFrom $PublicIP -files $FileName `
+            -downloadTo $LogsDestination -port $SSHPort -username $Username -password $Password
+    } else {
+        Write-LogWarn "${fileName} does not exist on VM."
+    }
+}
+
 Function GetAndCheck-KernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword, $EnableCodeCoverage) {
 	try	{
 		if (!($status -imatch "Initial" -or $status -imatch "Final")) {

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -54,7 +54,7 @@ function InstallRequirements() {
     ;;
 
     ubuntu*)
-        apt -y install build-essential libelf-dev linux-tools-"$(uname -r)" linux-cloud-tools-"$(uname -r)"
+        apt -y install build-essential libelf-dev linux-tools-"$(uname -r)" linux-cloud-tools-"$(uname -r)" python
     ;;
 
     suse_15*)

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -96,18 +96,6 @@ function Start-Validation {
     #endregion
 }
 
-function Collect-CustomLogFile {
-    param (
-        [object] $fileName
-    )
-    if (Check-FileInLinuxGuest -ipv4 $allVMData.PublicIP -vmPassword $password -vmPort $allVMData.SSHPort -vmUserName $superuser -fileName $fileName) {
-        Copy-RemoteFiles -download -downloadFrom $allVMData.PublicIP -files $fileName `
-            -downloadTo $LogDir -port $allVMData.SSHPort -username $superuser -password $password
-    } else {
-        Write-LogWarn "${fileName} does not exist on VM."
-    }
-}
-
 function Collect-Logs {
     # Get logs. An extra check for the previous $state is needed
     # The test could actually hang. If state.txt is showing
@@ -123,11 +111,14 @@ function Collect-Logs {
         -password $password -TestName $currentTestData.testName | Out-Null
     # Depending on the stage of the test the files may or may not exist.
     if ($driver -eq "CUDA") {
-        Collect-CustomLogFile -fileName "install_drivers.log"
-        Collect-CustomLogFile -fileName "nvidia_dkms_make.log"
+        Collect-CustomLogFile -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort `
+            -Username $user -Password $password -LogsDestination $LogDir -FileName "install_drivers.log"
+        Collect-CustomLogFile -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort `
+            -Username $user -Password $password -LogsDestination $LogDir -FileName "nvidia_dkms_make.log"
     }
     if ($driver -eq "GRID") {
-        Collect-CustomLogFile -fileName "nvidia-installer.log"
+        Collect-CustomLogFile -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort `
+            -Username $user -Password $password -LogsDestination $LogDir -FileName "nvidia-installer.log"
     }
 }
 


### PR DESCRIPTION
Improve log collection for GPU tests. In case the driver install would fail we would not have a clear reasoning why as no logs are collected since the PowerShell script was just returning.

* Refactor log collection into function. Get custom driver build / install logs if they exist.
* Collect logs if driver install fail
* Collect logs if driver was not loaded after restart
* Do not attempt to collect logs if connection cannot be established with VM after restart. 

* Add `Collect-CustomLogFile` to Logging library will check if log file exists and will download it in the logging directory if it does.

* Add python to install dependencies (for lsvmbus on disco)

Fixes: #414 