### PR TITLE
dpdk: fix sles deps install

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -121,15 +121,16 @@ function Install_Dpdk_Dependencies() {
 
 	elif [[ "${distro}" == "sles15" ]]; then
 		local kernel=$(uname -r)
-		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
+		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install --oldpackage gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
 		if [[ "${kernel}" == *azure ]]; then
-			dependencies_install_command="${dependencies_install_command} kernel-azure kernel-devel-azure"
+			kernel_major="${kernel%-azure}"
+			dependencies_install_command="${dependencies_install_command} kernel-azure kernel-devel-azure-${kernel_major}.1"
 		else
 			dependencies_install_command="${dependencies_install_command} kernel-default-devel"
 		fi
 
 		ssh "${install_ip}" "${dependencies_install_command}"
-		ssh ${install_ip} "ln -s /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
+		ssh ${install_ip} "ln -sf /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
 	else
 		LogErr "ERROR: unsupported distro ${distro} for DPDK on Azure"
 		SetTestStateAborted

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -65,7 +65,7 @@ function Modprobe_Setup() {
 	# known issue on sles15
 	local distro=$(detect_linux_distribution)$(detect_linux_distribution_version)
 	if [[ "${distro}" == "sles15" ]]; then
-		modprobe_cmd="${modprobe_cmd} mlx4_ib mlx5_ib"
+		modprobe_cmd="${modprobe_cmd} mlx4_ib mlx5_ib || true"
 	fi
 
 	ssh ${1} "${modprobe_cmd}"
@@ -121,10 +121,10 @@ function Install_Dpdk_Dependencies() {
 
 	elif [[ "${distro}" == "sles15" ]]; then
 		local kernel=$(uname -r)
-		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install --oldpackage gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
+		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
 		if [[ "${kernel}" == *azure ]]; then
-			kernel_major="${kernel%-azure}"
-			dependencies_install_command="${dependencies_install_command} kernel-azure kernel-devel-azure-${kernel_major}.1"
+			ssh "${install_ip}" "zypper install --oldpackage -y kernel-azure-devel=${kernel::-6}"
+			dependencies_install_command="${dependencies_install_command} kernel-devel-azure"
 		else
 			dependencies_install_command="${dependencies_install_command} kernel-default-devel"
 		fi

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -114,6 +114,7 @@ function Install_Dpdk_Dependencies() {
 			# we have to update the repositories first
 			ssh ${install_ip} "yum -y --nogpgcheck install centos-release"
 			ssh ${install_ip} "yum clean all"
+			ssh ${install_ip} "yum makecache"
 			yum_flags="--enablerepo=C*-base --enablerepo=C*-updates"
 		fi
 		ssh ${install_ip} "yum install --nogpgcheck ${yum_flags} --setopt=skip_missing_names_on_install=False -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -120,12 +120,14 @@ function Install_Dpdk_Dependencies() {
 
 	elif [[ "${distro}" == "sles15" ]]; then
 		local kernel=$(uname -r)
+		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
 		if [[ "${kernel}" == *azure ]]; then
-			ssh ${install_ip} "zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc kernel-azure kernel-devel-azure libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
+			dependencies_install_command="${dependencies_install_command} kernel-azure kernel-devel-azure"
 		else
-			ssh ${install_ip} "zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc kernel-default-devel libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel"
+			dependencies_install_command="${dependencies_install_command} kernel-default-devel"
 		fi
 
+		ssh "${install_ip}" "${dependencies_install_command}"
 		ssh ${install_ip} "ln -s /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
 	else
 		LogErr "ERROR: unsupported distro ${distro} for DPDK on Azure"


### PR DESCRIPTION
SLES 15 kernel modules are not correctly installed when a new kernel is available.

After the fix:

```
ARM Image Under Test  : SUSE : SLES : 15 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS15                                                    PASS                 8.68
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------
19.08.0-rc1  rxonly    1    13311424   12930380   12502740   0             50907537113 48566311611 0
19.08.0-rc1  io        1    10181647   13002980   8842664    8842628       51061547950 34050640717 34050505032
```