### PR TITLE
Automatic trimming of TestNames and ARMImageName

### DIFF
--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -119,7 +119,13 @@ $MyInvocation.MyCommand.Parameters.Keys | ForEach-Object {
 	$value = (Get-Variable -Name $_ -Scope "Script" -ErrorAction "SilentlyContinue").Value
 	if ($value) {
 		$params[$_] = $value
-		Write-Host ($_ + " = " + $value)
+		if ($params.TestNames) {
+			$params.TestNames = $params.TestNames.replace(' ','')
+		}
+		if ($params.ARMImageName) {
+			$params.ARMImageName = $params.ARMImageName.trim() -replace '\s{2,}', ' '
+		}
+		Write-Host ($_ + " = " + $params[$_])
 	}
 }
 $params["Verbose"] = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/429

Before fix-
```
07/11/2019 07:50:52 : [INFO ] Setting parameter: ARMImageName =    canonical ubuntuserver 18.04-lts Latest
07/11/2019 07:50:52 : [INFO ] Setting parameter: TestNames =    KDUMP-CRASH-16-CORES,  VERIFY-DEPLOYMENT-PROVISION
```

After fix-
```
07/11/2019 07:52:20 : [INFO ] Setting parameter: ARMImageName = canonical ubuntuserver 18.04-lts Latest
07/11/2019 07:52:20 : [INFO ] Setting parameter: TestNames = KDUMP-CRASH-16-CORES,VERIFY-DEPLOYMENT-PROVISION
```