### PR TITLE
BACKUP: Change setup type for all tests in area

### DIFF
--- a/XML/TestCases/FunctionalTests-VSSBackup.xml
+++ b/XML/TestCases/FunctionalTests-VSSBackup.xml
@@ -6,7 +6,7 @@
 		<testScript>STOR-VSS-BACKUP-RESTORE-PARTITION.ps1</testScript>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<files>.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\PartitionMultipleDisks.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 			<param>SCSI_1=3,1,Dynamic</param>
 			<param>SCSI_2=2,1,Dynamic</param>
@@ -25,7 +25,7 @@
 		<testScript>STOR-VSS-BackupRestore-ISO-NoNetwork.ps1</testScript>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<files>.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\STOR_VSS_StopNetwork.sh,.\Testscripts\Linux\utils.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 			<param>CDISO=VSS_BACKUP_MINI_ISO</param>
 		</TestParameters>
@@ -40,7 +40,7 @@
 		<setupScript>.\Testscripts\Windows\SETUP-Backup-DISK.ps1</setupScript>
 		<testScript>STOR-VSS-3Chain-VHD-backup.ps1</testScript>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<Platform>HyperV</Platform>
 		<Category>Functional</Category>
@@ -53,7 +53,7 @@
 		<setupScript>.\Testscripts\Windows\SETUP-Backup-DISK.ps1</setupScript>
 		<testScript>STOR-VSS-BackupRestore-State.ps1</testScript>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 			<param>vmState=Paused</param>
 		</TestParameters>
@@ -70,7 +70,7 @@
 		<setupScript>.\TestScripts\Windows\AddHardDisk.ps1</setupScript>
 		<testScript>STOR-VSS-BackupRestore-Mount-Multi-Paths.ps1</testScript>
 		<files>.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Disk_Mount_Multi_Paths.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 				<param>IDE=1,1,Dynamic</param>
 				<param>FILESYS=ext4</param>
@@ -87,7 +87,7 @@
 		<setupScript>.\Testscripts\Windows\SETUP-Backup-DISK.ps1</setupScript>
 		<testScript>STOR-VSS-BackupRestore-Mount-Squashfs.ps1</testScript>
 		<files>.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Disk_Mount_Squashfs.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<Platform>HyperV</Platform>
 		<Category>Functional</Category>
@@ -100,7 +100,7 @@
 		<setupScript>.\Testscripts\Windows\SETUP-Backup-DISK.ps1</setupScript>
 		<testScript>STOR-VSS-Backup-Change-Hypervvssd.ps1</testScript>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\STOR_VSS_Set_VSS_Daemon.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<Platform>HyperV</Platform>
 		<Category>Functional</Category>
@@ -114,7 +114,7 @@
 		<testScript>STOR-VSS-BACKUP-RESTORE-DISKSTRESS.ps1</testScript>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<files>.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\STOR_VSS_Disk_Stress.sh,.\Testscripts\Linux\utils.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 			<param>iozoneVers=3_424</param>
 			<param>iozonesrclink="IOZONE_SRC_URL"</param>
@@ -131,7 +131,7 @@
 		<testScript>STOR-VSS-Backup-Disable-Enable-VSS.ps1</testScript>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<Platform>HyperV</Platform>
 		<Category>Functional</Category>
 		<Area>BACKUP</Area>
@@ -144,7 +144,7 @@
 		<testScript>STOR-VSS-BackupRestore-Fail.ps1</testScript>
 		<cleanupScript>.\TestScripts\Windows\CLEANUP-Backup-DISK.ps1</cleanupScript>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VSS_Check_VSS_Daemon.sh,.\Testscripts\Linux\STOR_VSS_Disk_Fail.sh</files>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMBackup</setupType>
 		<TestParameters>
 			<param>IDE=1,1,Dynamic</param>
 			<param>FILESYS=ext4</param>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -17,6 +17,24 @@
             </VirtualMachine>
         </ResourceGroup>
     </OneVM>
+    <OneVMBackup>
+        <isDeployed>NO</isDeployed>
+        <ResourceGroup>
+            <VirtualMachine>
+                <state></state>
+                <InstanceSize>Standard_DS1_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS1_v2</ARMInstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>SSH</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>22</LocalPort>
+                    <PublicPort>22</PublicPort>
+                </EndPoints>
+                <DataDisk></DataDisk>
+            </VirtualMachine>
+        </ResourceGroup>
+    </OneVMBackup>
     <OneVMWin>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>


### PR DESCRIPTION
If a backup fails to restore all subsequent tests of the same setup type fail because there is no more VM or common base checkpoint.

**Solution**: 
* Create setup type for backup tests so they do not impact other areas if failed.