### PR TITLE
VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC - fix perf results TestMode and TestCaseName

### DIFF
--- a/Testscripts/Linux/dpdk-testFailsafe.sh
+++ b/Testscripts/Linux/dpdk-testFailsafe.sh
@@ -127,10 +127,15 @@ function Testfailsafe_Parser() {
 		SetTestStateAborted
 		exit 1
 	fi
+	if [ -z "${MODES}" ]; then
+		MODES="txonly"
+		LogMsg "MODES parameter not found in environment; using default ${MODES}"
+	fi
 
 	local csv_file=$(Create_Csv)
-	echo "dpdk_version,phase,fwdrx_pps_avg,fwdtx_pps_avg" > "${csv_file}"
+	echo "dpdk_version,test_mode,phase,fwdrx_pps_avg,fwdtx_pps_avg" > "${csv_file}"
 	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
+	local test_mode=${MODES}
 
 	local trimmed_prefix="trimmed-forwarder"
 	local trimmed_log="${LOG_DIR}/${trimmed_prefix}.log"
@@ -161,7 +166,7 @@ function Testfailsafe_Parser() {
 		else
 			phase="overall"
 		fi
-		echo "${dpdk_version},${phase},${fwdrx_pps_avg},${fwdtx_pps_avg}" >> "${csv_file}"
+		echo "${dpdk_version},${test_mode},${phase},${fwdrx_pps_avg},${fwdtx_pps_avg}" >> "${csv_file}"
 	done
 
 	column -s, -t "${csv_file}"

--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -293,6 +293,9 @@ collect_VM_properties
 				$resultMap["ProtocolType"] = "TCP"
 				$resultMap["TestPlatFrom"] = $global:TestPlatForm
 				$resultMap["TestCaseName"] = $global:GlobalConfig.Global.Azure.ResultsDatabase.testTag
+				if (!$resultMap.TestCaseName) {
+					$resultMap["TestCaseName"] = $CurrentTestData.testName
+				}
 				$resultMap["TestDate"] = $testDate
 				$resultMap["LISVersion"] = "Inbuilt"
 				if ($currentTestData.AdditionalHWConfig.Networking -imatch "SRIOV") {

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -9,6 +9,7 @@
         <files>.\Testscripts\Linux\dpdk-testFailsafe.sh,.\Testscripts\Windows\dpdk-testFailsafe.ps1</files>
         <TestParameters>
             <param>DPDK_LINK="DPDK_SOURCE_URL"</param>
+            <param>MODES="txonly"</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/282

Before fix-
```
SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txp
ps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdb
ytes,DataPath,TestMode,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) 
VALUES (0,'18.11.0',0,'Azure',0,'2019-07-11',0,0,1883934,0,0,'
TCP','Linux',0,'Azure',0,'Standard_DS15_v2',0,0,'westus2','14393-10.0-0-0.299',0,'SRIOV',,,'Inbuilt',
'ubuntu 18.04','4.18.0-1024-azure','IPv4')
```

After fix-
```
SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txp
ps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdb
ytes,DataPath,TestMode,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) 
VALUES (0,'18.11.0',0,'Azure',0,'2019-07-11',0,0,1883934,0,0,'
TCP','Linux',0,'Azure',0,'Standard_DS15_v2',0,0,'westus2','14393-10.0-0-0.299',0,'SRIOV','txonly','VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC','Inbuilt',
'ubuntu 18.04','4.18.0-1024-azure','IPv4')
```