### PR TITLE
HyperV: bring back the VM if the backup failed

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1521,7 +1521,7 @@ function Start-VMandGetIP {
         Write-LogErr "Error: Failed to start VM $VMName on $HvServer"
         return $False
     } else {
-        Write-LogInfo "$VMName started on $HvServe"
+        Write-LogInfo "$VMName started on $HvServer"
     }
 
     # Wait for VM to boot


### PR DESCRIPTION
During TC VSS-BACKUPRESTORE-MULTIFS-VHDX , the Start-WBHyperVRecovery will remove the VM from HyperV if the backup restore fails.

If run independently, there is no problem, as the VM just disappears from HyperV.

But if there are more tests running after this TC which have the same VM configuration, the next test will expect that the VM is still present and it has a snapshot called ICABase. And that requirement does not stand anymore, as the VM is "lost" (HyperV does not see it anymore).

This fix brings back the VM in case of a backup restore failure.