### PR TITLE
RDMA IB: Added HPCX testing

### DIFF
--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -71,6 +71,14 @@ function Run_IMB_Intranode() {
 						LogMsg "$mpi_run_path --allow-run-as-root $non_shm_mpi_settings -np 2 --host $vm1,$vm2 $imb_mpi1_path pingpong"
 						ssh root@${vm1} "$mpi_run_path --allow-run-as-root $non_shm_mpi_settings -np 2 --host $vm1,$vm2 $imb_mpi1_path pingpong >> $log_file"
 					;;
+					hpcx)
+						if [ "$vm1" != "$vm2" ]; then
+							hpcx_init=$(find / -name hpcx-init.sh | grep root)
+							mpivars=$(find / -name mpivars.sh | grep open)
+							LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY $non_shm_mpi_settings -n 2 --H $vm1,$vm2 $imb_mpi1_path pingpong"
+							ssh root@${vm1} "source $hpcx_init; source $mpivars; hpcx_load; $mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY $non_shm_mpi_settings -n 2 --H $vm1,$vm2 $imb_mpi1_path pingpong >> $log_file"
+						fi
+					;;
 					intel)
 						LogMsg "$mpi_run_path -hosts $vm1,$vm2 -ppn 2 -n 2 $non_shm_mpi_settings $imb_mpi1_path pingpong"
 						ssh root@${vm1} "$mpi_run_path -hosts $vm1,$vm2 -ppn 2 -n 2 $non_shm_mpi_settings $imb_mpi1_path pingpong >> $log_file"
@@ -127,6 +135,10 @@ function Run_IMB_MPI1() {
 				LogMsg "$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($mpi1_ppn * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params"
 				$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($mpi1_ppn * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
 			;;
+			hpcx)
+				LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($mpi1_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_mpi1_path $extra_params"
+				$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($mpi1_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
+			;;
 			intel)
 				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $extra_params"
 				$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
@@ -178,6 +190,10 @@ function Run_IMB_RMA() {
 				LogMsg "$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($rma_ppn * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params"
 				$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($rma_ppn * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
 			;;
+			hpcx)
+				LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($rma_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_rma_path $extra_params"
+				$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($rma_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
+			;;
 			intel)
 				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params"
 				$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
@@ -228,6 +244,10 @@ function Run_IMB_NBC() {
 				open)
 					LogMsg "$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($nbc_ppn * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params"
 					$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($nbc_ppn * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params > IMB-NBC-AllNodes-output-Attempt-${attempt}.txt
+				;;
+				hpcx)
+					LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($nbc_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_nbc_path $extra_params"
+					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($nbc_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_nbc_path $extra_params > IMB-NBC-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
 					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $nbc_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params"
@@ -292,6 +312,10 @@ function Run_IMB_P2P() {
 					LogMsg "$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($p2p_ppn * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
 					$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($p2p_ppn * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
 				;;
+				hpcx)
+					LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($p2p_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_p2p_path $extra_params"
+					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($p2p_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
+				;;
 				intel)
 					# LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
 					# $mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
@@ -354,6 +378,10 @@ function Run_IMB_IO() {
 				open)
 					LogMsg "$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($io_ppn * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params"
 					$mpi_run_path --allow-run-as-root --host $master,$slaves -n $(($io_ppn * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params > IMB-IO-AllNodes-output-Attempt-${attempt}.txt
+				;;
+				hpcx)
+					LogMsg "$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($io_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_io_path $extra_params"
+					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($io_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_io_path $extra_params > IMB-IO-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
 					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $io_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params"
@@ -644,6 +672,13 @@ function Main() {
 		open)
 			total_virtual_machines=$(($total_virtual_machines + 1))
 			mpi_run_path=$(find / -name mpirun | grep -v gcc)
+		;;
+		hpcx)
+			total_virtual_machines=$(($total_virtual_machines + 1))
+			mpi_run_path=$(find / -name mpirun | head -n 1)
+			export UCX_IB_PKEY=$(printf '0x%04x' "$(( $MPI_IB_PKEY & 0x0FFF ))")
+			hpcx_init=$(find / -name hpcx-init.sh | grep root)
+			source $hpcx_init; hpcx_load
 		;;
 		intel)
 			vars=$(find / -name mpivars.sh | grep intel)

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -32,6 +32,10 @@ function Resolve-UninitializedIB {
 }
 
 function Main {
+    param (
+        $AllVmData,
+        $CurrentTestData
+    )
 	$resultArr = @()
 	$currentTestResult = Create-TestResultObject
 	# Define two different users in run-time
@@ -491,8 +495,9 @@ function Main {
 		} else {
 			$testResult = $resultFail
 		}
-		Write-LogInfo "Test result : $testResult"
+		$resultArr += $testResult
 		Write-LogInfo "Test Completed"
+		Write-LogInfo "Test result : $testResult"
 	} catch {
 		$ErrorMessage =  $_.Exception.Message
 		$ErrorLine = $_.InvocationInfo.ScriptLineNumber
@@ -507,4 +512,4 @@ function Main {
 	return $CurrentTestResult
 }
 
-Main
+Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -122,6 +122,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_TOTAL_REBOOT_COUNT</ReplaceThis>
+		<ReplaceWith>1</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_TOTAL_REBOOT_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
@@ -146,8 +150,16 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>--mca btl self,vader,tcp --mca btl_openib_cq_size 4096</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_MPI_SETTINGS_TCP</ReplaceThis>
+		<ReplaceWith>--map-by ppr:1:node --mca pml ucx</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_OPEN_MPI_SETTINGS_IB</ReplaceThis>
 		<ReplaceWith>--mca btl self,vader,openib --mca btl_openib_cq_size 4096</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_MPI_SETTINGS_IB</ReplaceThis>
+		<ReplaceWith>--map-by ppr:1:node --mca pml ucx</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_MPI_SETTINGS_TCP</ReplaceThis>
@@ -171,6 +183,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_OPEN_MPI_TESTNAMES</ReplaceThis>
+		<ReplaceWith>all</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_MPI_TESTNAMES</ReplaceThis>
 		<ReplaceWith>allreduce</ReplaceWith>
 	</Parameter>
 	<Parameter>
@@ -187,6 +203,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_OPEN_PPN</ReplaceThis>
+		<ReplaceWith>1</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_PPN</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
 	<Parameter>
@@ -211,6 +231,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>Unidir_put Unidir_get Bidir_put Bidir_get One_put_all One_get_all All_put_all All_get_all Put_local Put_all_local Exchange_put Exchange_get Fetch_and_op Compare_and_swap</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_RMA_TESTNAMES</ReplaceThis>
+		<ReplaceWith>all</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<!-- 08/02/2019 - 'Accumulate' and 'Get_accumulate' not working - removing them for now -->
 		<ReplaceThis>INFINIBAND_MVAPICH_RMA_TESTNAMES</ReplaceThis>
 		<ReplaceWith>Unidir_put Unidir_get Bidir_put Bidir_get One_put_all One_get_all All_put_all All_get_all Put_local Put_all_local Exchange_put Exchange_get Fetch_and_op Compare_and_swap</ReplaceWith>
@@ -225,6 +249,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_OPEN_RMA_TEST_COUNT</ReplaceThis>
+		<ReplaceWith>0</ReplaceWith>
+	</Parameter>
+	<!-- 15/07/2019 - IMB-RMA is taking too long to complete. Skiping the test for now -->
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_RMA_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>0</ReplaceWith>
 	</Parameter>
 	<Parameter>
@@ -245,6 +274,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>Ibcast Igather Igatherv Iscatter Iscatterv Ialltoall Ialltoallv Ireduce Ireduce_scatter Iallreduce Ibarrier</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_NBC_TESTNAMES</ReplaceThis>
+		<ReplaceWith>allreduce</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_NBC_TESTNAMES</ReplaceThis>
 		<ReplaceWith>allreduce</ReplaceWith>
 	</Parameter>
@@ -260,7 +293,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>INFINIBAND_OPEN_NBC_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
-		<Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_NBC_TEST_COUNT</ReplaceThis>
+		<ReplaceWith>1</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_NBC_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
@@ -276,7 +313,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>INFINIBAND_OPEN_P2P_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
-		<Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_P2P_TEST_COUNT</ReplaceThis>
+		<ReplaceWith>1</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_P2P_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
@@ -292,7 +333,12 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>INFINIBAND_OPEN_IO_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>0</ReplaceWith>
 	</Parameter>
-		<Parameter>
+	<!-- 15/07/2019 - IMB-IO is taking too long to complete. Skiping the test for now -->
+	<Parameter>
+		<ReplaceThis>INFINIBAND_HPCX_IO_TEST_COUNT</ReplaceThis>
+		<ReplaceWith>0</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_IO_TEST_COUNT</ReplaceThis>
 		<ReplaceWith>1</ReplaceWith>
 	</Parameter>
@@ -488,6 +534,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 	<Parameter>
 		<ReplaceThis>MLX_OFED_PARTIAL_LINK</ReplaceThis>
 		<ReplaceWith>http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>HPCX_PARTIAL_LINK</ReplaceThis>
+		<ReplaceWith>http://www.mellanox.com/downloads/hpc/hpc-x/v2.3/hpcx-v2.3.0-gcc-MLNX_OFED_LINUX-4.5-1.0.1.0-</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>IBM_PLATFORM_MPI_DOWNLOAD</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -157,6 +157,79 @@
 		<Area>INFINIBAND</Area>
 		<Tags>rdma</Tags>
 	</test>
+	<!-- HPC-X MPI -->
+	<test>
+		<testName>INFINIBAND-HPCX-MPI-2VM</testName>
+		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
+		<setupType>TwoVM1Dep</setupType>
+		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
+		<Priority>1</Priority>
+		<TestParameters>
+			<param>num_reboot="INFINIBAND_HPCX_TOTAL_REBOOT_COUNT"</param>
+			<param>mpi_settings="INFINIBAND_HPCX_MPI_SETTINGS_IB"</param>
+			<param>ib_nic="INFINIBAND_IB_NIC"</param>
+			<param>imb_mpi1_tests="INFINIBAND_HPCX_MPI_TESTNAMES"</param>
+			<param>mpi1_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_mpi1_tests_iterations=INFINIBAND_MPI_TEST_COUNT</param>
+			<param>imb_rma_tests="INFINIBAND_HPCX_RMA_TESTNAMES"</param>
+			<param>rma_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_rma_tests_iterations=INFINIBAND_HPCX_RMA_TEST_COUNT</param>
+			<param>imb_nbc_tests="INFINIBAND_HPCX_NBC_TESTNAMES"</param>
+			<param>nbc_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_nbc_tests_iterations=INFINIBAND_HPCX_NBC_TEST_COUNT</param>
+			<param>p2p_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_p2p_tests_iterations=INFINIBAND_HPCX_P2P_TEST_COUNT</param>
+			<param>io_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_io_tests_iterations=INFINIBAND_HPCX_IO_TEST_COUNT</param>
+			<param>mpi_type="hpcx"</param>
+			<param>mlx_ofed_partial_link=MLX_OFED_PARTIAL_LINK</param>
+			<param>hpcx_mpi=HPCX_PARTIAL_LINK</param>
+			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
+			<param>walaagent_repo=WALAAgent_REPO</param>
+		</TestParameters>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>INFINIBAND</Area>
+		<Tags>rdma</Tags>
+	</test>
+	<test>
+		<testName>INFINIBAND-HPCX-MPI-32VM</testName>
+		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
+		<setupType>RDMA32VMs</setupType>
+		<OverrideVMSize>Standard_HB60rs</OverrideVMSize>
+		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
+		<Priority>3</Priority>
+		<TestParameters>
+			<param>num_reboot="INFINIBAND_HPCX_TOTAL_REBOOT_COUNT"</param>
+			<param>mpi_settings="INFINIBAND_HPCX_MPI_SETTINGS_IB"</param>
+			<param>ib_nic="INFINIBAND_IB_NIC"</param>
+			<param>imb_mpi1_tests="INFINIBAND_HPCX_MPI_TESTNAMES"</param>
+			<param>mpi1_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_mpi1_tests_iterations=INFINIBAND_MPI_TEST_COUNT</param>
+			<param>imb_rma_tests="INFINIBAND_HPCX_RMA_TESTNAMES"</param>
+			<param>rma_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_rma_tests_iterations=INFINIBAND_HPCX_RMA_TEST_COUNT</param>
+			<param>imb_nbc_tests="INFINIBAND_HPCX_NBC_TESTNAMES"</param>
+			<param>nbc_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_nbc_tests_iterations=INFINIBAND_HPCX_NBC_TEST_COUNT</param>
+			<param>p2p_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_p2p_tests_iterations=INFINIBAND_HPCX_P2P_TEST_COUNT</param>
+			<param>io_ppn=INFINIBAND_HPCX_PPN</param>
+			<param>imb_io_tests_iterations=INFINIBAND_HPCX_IO_TEST_COUNT</param>
+			<param>mpi_type="hpcx"</param>
+			<param>mlx_ofed_partial_link=MLX_OFED_PARTIAL_LINK</param>
+			<param>hpcx_mpi=HPCX_PARTIAL_LINK</param>
+			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
+			<param>walaagent_repo=WALAAgent_REPO</param>
+		</TestParameters>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>INFINIBAND</Area>
+		<Tags>rdma</Tags>
+	</test>
 <!-- IBM MPI -->
 	<test>
 		<testName>INFINIBAND-IBM-MPI-2VM</testName>


### PR DESCRIPTION
HPCX MPI was added as the fifth MPI supported by the automation. Right
now, CentOS HPC images are expected to work. Ubuntu & SLES are still
under investigation / not supported

[LISAv2 Test Results Summary]
Test Run On           : 07/12/2019 11:25:09
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.6 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:31

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-HPCX-MPI-2VM                                                           PASS                27.25
        InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
        InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS
        InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS
        InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS
        InfiniBand-Verification-2-Reboot : eth0 IP : PASS
        InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS
        InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS
        InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
        InfiniBand-Verification-2-Reboot : IMB-P2P : PASS
        InfiniBand-Verification-2-Reboot : IMB-NBC : PASS