### PR TITLE
Kdump cases: fix distro detect for 6.X and 7.X versions

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -161,9 +161,9 @@ Config_Rhel()
 
     if [ "$os_GENERATION" -eq 2 ] && [[ $os_RELEASE =~ 6.* ]]; then
         boot_filepath=/boot/efi/EFI/BOOT/bootx64.conf
-    elif [ "$os_GENERATION" -eq 1 ] && [[ $os_RELEASE =~ 6.* ]]; then
+    elif [ "$os_GENERATION" -eq 1 ] && [[ $os_RELEASE =~ ^6.* ]]; then
         boot_filepath=/boot/grub/grub.conf
-    elif [ "$os_GENERATION" -eq 1 ] && [[ $os_RELEASE =~ 7.* ]]; then
+    elif [ "$os_GENERATION" -eq 1 ] && [[ $os_RELEASE =~ ^7.* ]]; then
         boot_filepath=/boot/grub2/grub.cfg
     elif [ "$os_GENERATION" -eq 1 ] && [[ $os_RELEASE =~ 8.* ]]; then
         boot_filepath=/boot/grub2/grubenv


### PR DESCRIPTION
Before fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 07/15/2019 01:41:13
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : 7.6.20190708
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SINGLE-CORE                                                        ABORTED                 3.25 
```

After fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 07/15/2019 02:34:58
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : 7.6.20190708
Total Test Cases      : 5 (5 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:45

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SINGLE-CORE                                                           PASS                 5.51 
    2 KDUMP                KDUMP-CRASH-SMP                                                                   PASS                 5.84 
    3 KDUMP                KDUMP-CRASH-AUTO-SIZE                                                             PASS                 5.84 
    4 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU                                                        PASS                 5.83 
    5 KDUMP                KDUMP-CRASH-16-CORES                                                              PASS                 5.78 
```