### PR TITLE
VERIFY-BOOT-ERROR-WARNINGS - add warnings into ignorable-boot-errors.xml

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -39,6 +39,8 @@
             <keywords>errors=remount-ro</keywords>
         </errors>
         <warnings>
+            <keywords>WARNING Daemon VM is provisioned, but the VM unique identifier has changed -- clearing cached state</keywords>
+            <keywords>WARNING! Cached DHCP leases will be deleted</keywords>
             <keywords>Unconfined exec qualifier (ux) allows some dangerous environment variables</keywords>
             <keywords>Stopped Write warning to Azure ephemeral disk</keywords>
             <keywords>reloading interface list</keywords>


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/443
Before fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/16/2019 02:56:24
VHD Under Test        : http://eosgwestus2.blob.core.windows.net/vhds/lp1795659x-uzjsck-osdisk.vhd
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        FAIL                 3.27
07/16/2019 03:01:21 AM : ERROR : Found ERROR/WARNING/FAILURE messages in logs.
07/16/2019 03:01:21 AM : INFO : warnings: 2772:Jul 16 02:59:13 LISAv2-OneVM-tx-EU27-20190715195702-role-0 python3[1207]: 2019/07/16 02:59:06.502593 WARNING Daemon VM is provisioned, but the VM unique identifier has changed -- clearing cached state
07/16/2019 03:01:21 AM : INFO : warnings: 2773:Jul 16 02:59:13 LISAv2-OneVM-tx-EU27-20190715195702-role-0 python3[1207]: WARNING! Cached DHCP leases will be deleted.
```

After fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/16/2019 03:15:50
VHD Under Test        : http://eosgwestus2.blob.core.windows.net/vhds/lp1795659x-uzjsck-osdisk.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 2.43 
```