### PR TITLE
Enhance LIS-Deploy scenarios to handle Minor LIS version upgrade/dowgrade

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -693,15 +693,12 @@ function Install-CustomLIS ($CustomLIS, $customLISBranch, $allVMData, [switch]$R
 					}
 					else
 					{
-						if ( !(Test-Path -Path "$LogDir\$($job.RoleName)-build-CustomLIS.txt" ) )
+						Copy-RemoteFiles -download -downloadFrom $job.PublicIP -port $job.SSHPort -files "build-CustomLIS.txt" -username "root" -password $password -downloadTo $LogDir
+						if ( ( Get-Content "$LogDir\build-CustomLIS.txt" ) -imatch "CUSTOM_LIS_SUCCESS" )
 						{
-							Copy-RemoteFiles -download -downloadFrom $job.PublicIP -port $job.SSHPort -files "build-CustomLIS.txt" -username "root" -password $password -downloadTo $LogDir
-							if ( ( Get-Content "$LogDir\build-CustomLIS.txt" ) -imatch "CUSTOM_LIS_SUCCESS" )
-							{
-								$lisSuccess += 1
-							}
-							Rename-Item -Path "$LogDir\build-CustomLIS.txt" -NewName "$($job.RoleName)-build-CustomLIS.txt" -Force | Out-Null
+							$lisSuccess += 1
 						}
+						Move-Item -Path "$LogDir\build-CustomLIS.txt" -Destination "${LogDir}\$($job.RoleName)-build-CustomLIS.txt" -Force | Out-Null
 					}
 				}
 				if ( $packageInstallJobsRunning )
@@ -1750,7 +1747,7 @@ Function Invoke-RemoteScriptAndCheckStateFile
         -downloadTo $LogDir -port $VMPort -username $VMUser -password $password
     Copy-RemoteFiles -download -downloadFrom $VMIpv4 -files "/home/${user}/${remoteScript}.log" `
         -downloadTo $LogDir -port $VMPort -username $VMUser -password $VMPassword
-    rename-item -path "${LogDir}\state.txt" -newname $stateFile
+    Move-Item -Path "${LogDir}\state.txt" -Destination "${LogDir}\$stateFile" -Force
     $contents = Get-Content -Path $LogDir\$stateFile
     if (($contents -eq "TestAborted") -or ($contents -eq "TestFailed")) {
         return $False

--- a/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
+++ b/Testscripts/Windows/LIS-INSTALL-SCENARIOS.ps1
@@ -11,6 +11,25 @@ $ErrorActionPreference = "Stop"
 [xml]$configfile = Get-Content ".\XML\Other\ignorable-test-warnings.xml"
 $IgnorableWarnings = @($configfile.messages.warnings.keywords.Trim())
 
+# Minor version like 4.3.3.1 doesnt require source code change so the modinfo version will be same as the major version like 4.3.3
+# Hence we are comparing to check whether it is a minor LIS version upgrade
+Function Check-MinorLISVersionUpgrade($LISTarballUrlOld,$LISTarballUrlCurrent) {
+    $oldversion=(($LISTarballUrlOld -split ".*rpms?-")[1] -split ".tar.gz" -split "-")[0]
+    $oldversion=$oldversion.Split(".")
+    Write-LogInfo "LISTarballUrlOld version - $oldversion"
+    $currentversion=(($LISTarballUrlCurrent -split ".*rpms?-")[1] -split ".tar.gz" -split "-")[0]
+    $currentversion=$currentversion.Split(".")
+    Write-LogInfo "LISTarballUrlCurrent version - $currentversion"
+    $minorupgrade=$true
+    for ($index=0; $index -lt 3; $index++) {
+        if ($oldversion[$index] -ne $currentversion[$index] ) {
+            $minorupgrade=$false
+            break
+        }
+    }
+    return $minorupgrade
+}
+
 Function Check-Modules() {
     Write-LogInfo "Check if module are loaded after LIS installation"
     $remoteScript = "LIS-MODULES-CHECK.py"
@@ -46,7 +65,7 @@ Function Install-LIS ($LISTarballUrl, $allVMData) {
     }
     $sts = Check-Modules
     if( -not $sts[-1]) {
-        Write-LogErr "Failed due to either modules are not loaded or version mismatch"
+        Write-LogErr "Failed due to either modules not loaded or version mismatch"
         return $false
     }
     return $true
@@ -60,8 +79,9 @@ Function Upgrade-LIS ($LISTarballUrlOld, $LISTarballUrlCurrent, $allVMData , $Te
             Write-LogErr "OLD LIS installation FAILED. Aborting tests."
             return $false
         }
-        $OldlisVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
-        Write-LogInfo "LIS version with previous LIS drivers: $OldlisVersion"
+        $OldLISVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
+        $OldLISmoduleVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus|grep -w `"version:`""
+        Write-LogInfo "LIS version with previous LIS drivers: $OldLISVersion"
         Write-LogInfo "Ugrading LIS to $LISTarballUrlCurrent"
         $CurrentLISExtractCommand = "rm -rf LISISO^wget $($LISTarballUrlCurrent)^tar -xzf $($LISTarballUrlCurrent | Split-Path -Leaf)^cp -ar LISISO/* ."
         $LISExtractCommands = $CurrentLISExtractCommand.Split("^")
@@ -76,31 +96,59 @@ Function Upgrade-LIS ($LISTarballUrlOld, $LISTarballUrlCurrent, $allVMData , $Te
         }
         else {
             if ($UpgradelLISConsoleOutput -imatch "error" -or ($UpgradelLISConsoleOutput -imatch "warning" -and ($null -eq ($IgnorableWarnings | ? {$UpgradelLISConsoleOutput -match $_ }))) -or $UpgradelLISConsoleOutput -imatch "abort") {
-                Write-LogErr "Latest LIS install is failed due found errors or warnings or aborted."
+                Write-LogErr "Latest LIS install is failed due to found errors or warnings or aborted."
                 return $false
             }
             if ( $RestartAfterUpgrade ) {
                 Write-LogInfo "Now restarting VMs..."
                 if ( $TestProvider.RestartAllDeployments($allVMData) ) {
-                    $upgradedlisVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
-                    if ($OldlisVersion -ne $upgradedlisVersion) {
-                        Write-LogInfo "LIS upgraded to `"$LISTarballUrlCurrent`" successfully"
-                        Write-LogInfo "Old lis: $OldlisVersion"
-                        Write-LogInfo "New lis: $upgradedlisVersion"
-                        Add-Content -Value "Old lis: $OldlisVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
-                        Add-Content -Value "New lis: $upgradedlisVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
-                        $sts = Check-Modules
-                        if( -not $sts[-1]) {
-                            Write-LogErr "Failed due to either modules are not loaded or version mismatch"
+                    $upgradedLISVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
+                    $upgradedLISmoduleVersion = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus|grep -w `"version:`""
+                    if (Check-MinorLISVersionUpgrade -LISTarballUrlOld $LISTarballUrlOld -LISTarballUrlCurrent $LISTarballUrlCurrent) {
+                        if ($OldLISmoduleVersion -eq $upgradedLISmoduleVersion) {
+                            Write-LogInfo "LIS upgraded to `"$LISTarballUrlCurrent`" successfully"
+                            Write-LogInfo "Old LIS: $OldLISVersion"
+                            Write-LogInfo "New LIS: $upgradedLISVersion"
+                            Add-Content -Value "Old LIS: $OldLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            Add-Content -Value "New LIS: $upgradedLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            $sts = Check-Modules
+                            if( -not $sts[-1]) {
+                                Write-LogErr "Failed due to either modules not loaded or version mismatch"
+                                return $false
+                            }
+                            return $true
+                        }
+                        else {
+                            Write-LogErr "LIS upgradation failed"
+                            Write-LogInfo $OldLISVersion
+                            Write-LogInfo $upgradedLISVersion
+                            Add-Content -Value "Old LIS: $OldLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            Add-Content -Value "New LIS: $upgradedLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
                             return $false
                         }
-                        return $true
                     }
                     else {
-                        Write-LogErr "LIS upgradation failed"
-                        Add-Content -Value "Old lis: $OldlisVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
-                        Add-Content -Value "New lis: $upgradedlisVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
-                        return $false
+                        if ($OldLISVersion -ne $upgradedLISVersion) {
+                            Write-LogInfo "LIS upgraded to `"$LISTarballUrlCurrent`" successfully"
+                            Write-LogInfo "Old LIS: $OldLISVersion"
+                            Write-LogInfo "New LIS: $upgradedLISVersion"
+                            Add-Content -Value "Old LIS: $OldLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            Add-Content -Value "New LIS: $upgradedLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            $sts = Check-Modules
+                            if( -not $sts[-1]) {
+                                Write-LogErr "Failed due to either modules not loaded or version mismatch"
+                                return $false
+                            }
+                            return $true
+                        }
+                        else {
+                            Write-LogErr "LIS upgradation failed inside else"
+                            Write-LogInfo $OldLISVersion
+                            Write-LogInfo $upgradedLISVersion
+                            Add-Content -Value "Old LIS: $OldLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            Add-Content -Value "New LIS: $upgradedLISVersion" -Path ".\Report\AdditionalInfo-$TestID.html" -Force
+                            return $false
+                        }
                     }
                 }
                 else {
@@ -119,25 +167,39 @@ Function Upgrade-LIS ($LISTarballUrlOld, $LISTarballUrlCurrent, $allVMData , $Te
 Function Downgrade-LIS ($LISTarballUrlOld, $LISTarballUrlCurrent, $allVMData , $TestProvider) {
     try {
         $LIS_version_before_downgrade = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
+        $LIS_module_version_before_downgrade = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus|grep -w `"version:`""
         Write-LogInfo "LIS version before Downgrade: $LIS_version_before_downgrade"
         $UninstallLISStatus=Uninstall-LIS -LISTarballUrlCurrent $LISTarballUrlCurrent -allVMData $AllVMData -TestProvider $TestProvider
         if (-not $UninstallLISStatus[-1]) {
             return $false
         }
         Write-LogInfo "Downgrade to OLD LIS : $LISTarballUrlOld"
-        $OLDLisInstallStatus=Install-LIS -LISTarballUrl $LISTarballUrlOld -allVMData $AllVMData
-        if (-not $OLDLisInstallStatus[-1]) {
-            return $true
+        $OLDLISInstallStatus=Install-LIS -LISTarballUrl $LISTarballUrlOld -allVMData $AllVMData
+        if (-not $OLDLISInstallStatus[-1]) {
+            return $false
         }
         $LIS_version_after_downgraded = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus"
+        $LIS_module_version_after_downgraded = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username "root" -password $password -command "modinfo hv_vmbus|grep -w `"version:`""
         Write-LogInfo "LIS version after Downgrade: $LIS_version_after_downgraded"
-        if ( $LIS_version_before_downgrade -ne $LIS_version_after_downgraded) {
-            Write-LogInfo "Downgraded LIS Successfully"
-            return $true
+        if (Check-MinorLISVersionUpgrade -LISTarballUrlOld $LISTarballUrlOld -LISTarballUrlCurrent $LISTarballUrlCurrent) {
+            if ( $LIS_module_version_before_downgrade -eq $LIS_module_version_after_downgraded) {
+                Write-LogInfo "Downgraded LIS Successfully"
+                return $true
+            }
+            else {
+                Write-LogErr "LIS version has changed after downgrading"
+                return $false
+            }
         }
         else {
-            Write-LogErr "LIS version has not changed after downgrading"
-            return $false
+            if ( $LIS_version_before_downgrade -ne $LIS_version_after_downgraded) {
+                Write-LogInfo "Downgraded LIS Successfully"
+                return $true
+            }
+            else {
+                Write-LogErr "LIS version has not changed after downgrading"
+                return $false
+            }
         }
     }
     catch {

--- a/XML/Other/ignorable-test-warnings.xml
+++ b/XML/Other/ignorable-test-warnings.xml
@@ -3,5 +3,6 @@
     <warnings>
         <keywords>warning: /etc/depmod.d/hyperv.conf saved as /etc/depmod.d/hyperv.conf.rpmsave</keywords>
         <keywords>warning: waiting for transaction lock on /var/lib/rpm/.rpm.lock</keywords>
+        <keywords>hv_network_direct.ko needs unknown symbol</keywords>
     </warnings>
 </messages>


### PR DESCRIPTION
This PR meets below requirements:

1) with the latest changes done for lis-hotfix-release, Minor version like 4.3.3.1 doesn't require source code changes, So the modinfo version will be displayed same as major version(4.3.3). Due to this LIS deploy scenario is failing due to version mismatch.
So, Handle a check in code whether it is minor/major LIS version Upgrade/downgrade. 
2) Rename the state file is failing when the file with same name already exists. 
3) Added a new entry in the ignore expected warning file