### PR TITLE
Remove extra output when check MellanoxAdapter.

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -760,7 +760,7 @@ function Verify-MellanoxAdapter($vmData)
 	{
 		Write-LogInfo "Install package pciutils to use lspci command."
 		Copy-RemoteFiles -uploadTo $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -file ".\Testscripts\Linux\utils.sh" -upload
-		Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "which lspci || (. ./utils.sh && install_package pciutils)" -runAsSudo
+		Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "which lspci || (. ./utils.sh && install_package pciutils)" -runAsSudo | Out-Null
 		$pciDevices = Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -command "lspci" -runAsSudo
 		if ( $pciDevices -imatch "Mellanox")
 		{


### PR DESCRIPTION
Before fix extra output will make code enter into if block.
https://github.com/LIS/LISAv2/blob/master/Libraries/CommonFunctions.psm1#L791 

After fix
```
07/17/2019 01:01:20 : [INFO ] lspci executed successfully in 3.21 seconds.
07/17/2019 01:01:20 : [ERROR] [Attempt 50/50] Mellanox Adapter NOT detected in lili-centos67-2.
07/17/2019 01:01:32 : [ERROR] Mellanox Adapter not detected in lili-centos67-2.
07/17/2019 01:01:43 : [ERROR] Failed to enable Accelerated Networking. Aborting tests.
07/17/2019 01:01:46 : [ERROR] Failed to set custom config in VMs.
07/17/2019 01:01:46 : [INFO ] CURRENT - PASS    - 0
07/17/2019 01:01:46 : [INFO ] CURRENT - SKIPPED - 0
07/17/2019 01:01:46 : [INFO ] CURRENT - FAIL    - 0
07/17/2019 01:01:46 : [INFO ] CURRENT - ABORTED - 1
```