### PR TITLE
SRIOV test cases: Add -runAsSudo option to run linux command

### DIFF
--- a/Testscripts/Windows/SETUP-SR-IOV-Configure.ps1
+++ b/Testscripts/Windows/SETUP-SR-IOV-Configure.ps1
@@ -33,22 +33,27 @@ function Set-VFInGuest {
     }
     Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort -command "cp sriov_constants.sh constants.sh"
     # Install dependencies
-    Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort -command ". SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo -ignoreLinuxExitCode:$true
+    Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort `
+        -command ". SR-IOV-Utils.sh; InstallDependencies" -RunAsSudo -ignoreLinuxExitCode:$true
     if (-not $?) {
         Write-LogErr "Failed to install dependencies on $VMName"
         return $False
     }
     # Configure VF
-    Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort -command ". SR-IOV-Utils.sh; ConfigureVF $VMNumber" -RunAsSudo
+    Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort `
+        -command ". SR-IOV-Utils.sh; ConfigureVF $VMNumber" -RunAsSudo
     if (-not $?) {
         Write-LogErr "Failed to configure VF on $VMName"
         return $False
     }
     # Check VF
-    $retVal = Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort -command "ip a | grep -c $VfIPToCheck" -ignoreLinuxExitCode:$true -RunAsSudo
-    if ($retVal -ne 1) {
-        Write-LogErr "IP is not set on $VMName"
-        return $False
+    if ($VfIPToCheck) {
+        $retVal = Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort `
+            -command "ip a | grep -c $VfIPToCheck" -ignoreLinuxExitCode:$true -RunAsSudo
+        if ($retVal -ne 1) {
+            Write-LogErr "IP is not set on $VMName"
+            return $False
+        }
     }
     Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort -command "rm -f constants.sh" -RunAsSudo
     return $True

--- a/Testscripts/Windows/SRIOV-CHANGE-RSS.ps1
+++ b/Testscripts/Windows/SRIOV-CHANGE-RSS.ps1
@@ -45,7 +45,6 @@ function Main {
     }
     Write-LogInfo "The throughput before changing rss profile is $initialThroughput Gbits/sec"
 
-
     # Change Rss on test VM
     $rssProfile = Get-NetAdapterRss -Name "*$($TestParams.Switch_Name)*" -CimSession $HvServer
     $rssProfile = $rssProfile.Profile
@@ -59,7 +58,7 @@ function Main {
 
     # Check if the SR-IOV module is still loaded
     $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true
+        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true -runAsSudo
     if ($moduleCount -lt 1) {
         Write-LogErr "Module is not loaded"
         Set-NetAdapterRss -Name "*$($TestParams.Switch_Name)*" -Profile $rssProfile -CimSession $HvServer

--- a/Testscripts/Windows/SRIOV-DETACH-NIC.ps1
+++ b/Testscripts/Windows/SRIOV-DETACH-NIC.ps1
@@ -43,7 +43,8 @@ function Main {
     $sriovSwitch = $nicInfo.SwitchName
 
     # Connect a non-SRIOV vSwitch. We will use the same vSwitch as the management NIC
-    [string]$managementSwitch = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer | Select-Object -First 1 | Select-Object -ExpandProperty SwitchName
+    [string]$managementSwitch = Get-VMNetworkAdapter -VMName $VMName -ComputerName $HvServer `
+        | Select-Object -First 1 | Select-Object -ExpandProperty SwitchName
     Connect-VMNetworkAdapter -VMNetworkAdapter $nicInfo -SwitchName $managementSwitch -Confirm:$False
     if (-not $?) {
         Write-LogErr "Failed to attach another NIC in place of the SR-IOV one"
@@ -52,7 +53,7 @@ function Main {
 
     # Check if the  SR-IOV module is still loaded
     $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true
+        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true -runAsSudo
     if ($moduleCount -gt 0) {
         Write-LogErr "Module is still loaded"
         return "FAIL"

--- a/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLE-NIC.ps1
@@ -65,7 +65,7 @@ function Main {
 
         # Check if the SR-IOV module is still loaded
         $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
-            $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true
+            $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true -runAsSudo
         if ($moduleCount -gt 0) {
             Write-LogErr "Module is still loaded"
             return "FAIL"

--- a/Testscripts/Windows/SRIOV-DISABLE-VMQ.ps1
+++ b/Testscripts/Windows/SRIOV-DISABLE-VMQ.ps1
@@ -51,7 +51,7 @@ function Main {
     # Check if the SR-IOV module is still loaded
     $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
         $VMPassword -command "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'" `
-        -ignoreLinuxExitCode:$true
+        -ignoreLinuxExitCode:$true -runAsSudo
     if ($moduleCount -lt 1) {
         Write-LogErr "Module is not loaded"
         return "FAIL"


### PR DESCRIPTION
1. Without -runAsSudo option to run the blow script, hit the "lspci: command not found" issue:

    $moduleCheckCMD = "lspci -vvv | grep -c 'mlx[4-5]_core\|mlx4_en\|ixgbevf'"
    $moduleCount = Run-LinuxCmd -ip $ipv4 -port $VMPort -username $VMUsername -password `
        $VMPassword -command $moduleCheckCMD -ignoreLinuxExitCode:$true

    [DBG]: PS C:\Users\v-hoxian\LISAv2>>  $moduleCount 
    runtest.sh: line 1: lspci: command not found
    0

Add the --runAsSudo option to fix it.

2. Split long line into short ones.
