### PR TITLE
Add initial and final kernel version to Test Summary

### DIFF
--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -311,6 +311,12 @@ Class TestSummary
 		if ($this.TestPriority) {
 			$str += "`r`nTest Priority         : $($this.TestPriority)"
 		}
+		if ( $global:InitialKernelVersion ) {
+			$str += "`r`nInitial Kernel Version: " + $global:InitialKernelVersion
+		}
+		if ( $global:FinalKernelVersion ) {
+			$str += "`r`nFinal Kernel Version  : " + $global:FinalKernelVersion
+		}
 		$str += "`r`nTotal Test Cases      : " + $this.TotalTc + " (" + $this.TotalPassTc + " Passed, " + `
 			$this.TotalFailTc + " Failed, " + $this.TotalAbortedTc + " Aborted, " + $this.TotalSkippedTc + " Skipped)"
 		$str += "`r`nTotal Time (dd:hh:mm) : $durationStr`r`n`r`n"

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -656,7 +656,7 @@ Class TestController
 				-command "bash CollectLogFile.sh -hostname $($vmData.RoleName)" -ignoreLinuxExitCode -runAsSudo
 			$Null = Copy-RemoteFiles -downloadFrom $vmData.PublicIP -port $vmData.SSHPort `
 				-username $user -password $password -files "$FilesToDownload" -downloadTo $global:LogDir -download
-			$KernelVersion = Get-Content "$global:LogDir\$($vmData.RoleName)-kernelVersion.txt"
+			$global:FinalKernelVersion = Get-Content "$global:LogDir\$($vmData.RoleName)-kernelVersion.txt"
 			$HardwarePlatform = Get-Content "$global:LogDir\$($vmData.RoleName)-hardwarePlatform.txt"
 			$GuestDistro = Get-Content "$global:LogDir\$($vmData.RoleName)-distroVersion.txt"
 			$LISMatch = (Select-String -Path "$global:LogDir\$($vmData.RoleName)-lis.txt" -Pattern "^version:").Line
@@ -702,7 +702,7 @@ Class TestController
 
 				$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $global:TestLocation -TestCategory $CurrentTestData.Category `
 					-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
-					-ExecutionTag $global:GlobalConfig.Global.$global:TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $KernelVersion `
+					-ExecutionTag $global:GlobalConfig.Global.$global:TestPlatform.ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $global:FinalKernelVersion `
 					-HardwarePlatform $HardwarePlatform -LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -VMGeneration $VMGeneration -Networking $Networking `
 					-ARMImageName $global:ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL -TableName $dataTableName
 


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/450
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/18/2019 06:54:56
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
Initial Kernel Version: 4.18.0-1024-azure
Final Kernel Version  : 4.18.0-1025-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1                      CAPTURE-VHD-BEFORE-TEST                                                           PASS                 7.57 

[LISAv2 Test Results Summary]
Test Run On           : 07/18/2019 06:43:58
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : 7.6.20190708
Initial Kernel Version: 3.10.0-957.21.3.el7.x86_64
Final Kernel Version  : 3.10.0-957.21.3.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 LIS_DEPLOY           LIS-DEPLOY-SCENARIO-1                                                             PASS                12.65 
	Install-LIS-Scenario-1 : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 07/18/2019 06:56:27
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 4.18.0-1024-azure
Final Kernel Version  : 4.18.0-1024-azure
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-LINUX-CONFIGURATION                                                        PASS                 2.98 
    2 CORE                 LIS-MODULES-CHECK                                                                 PASS                 2.91 
    3 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 2.65
```