### PR TITLE
Heterogeneous ARMImageName

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1925,15 +1925,18 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         $vmAdded = $true
         $role = $role + 1
         $vmCount = $role
-        $heteroImageIndex = $heteroImageIndex + 1
-        if( $heteroImageIndex -lt $heteroImageCount )
+        if( $heteroImages )
         {
-            $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')
-            $publisher = $imageInfo[0]
-            $offer = $imageInfo[1]
-            $sku = $imageInfo[2]
-            $version = $imageInfo[3]
-            Write-LogInfo "Switching to next heterogeneous image [$heteroImageIndex] $publisher $offer $sku $version"
+            $heteroImageIndex = $heteroImageIndex + 1
+            if( $heteroImageIndex -lt $heteroImageCount )
+            {
+                $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')
+                $publisher = $imageInfo[0]
+                $offer = $imageInfo[1]
+                $sku = $imageInfo[2]
+                $version = $imageInfo[3]
+                Write-LogInfo "Switching to next heterogeneous image [$heteroImageIndex] $publisher $offer $sku $version"
+            }
         }
     }
     Add-Content -Value "$($indents[1])]" -Path $jsonFile

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -825,10 +825,10 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
 
     if ($ImageName -and !$osVHD) {
         #Allow for heterogeneous images to be used
-        if( $ImageName -Match(";") )
+        if( $ImageName -Match(",") )
         {
             Write-LogInfo "Heterogeneous Images in use."
-            $heteroImages = $ImageName.Split(';')
+            $heteroImages = $ImageName.Split(',')
             $heteroImageCount = $HeteroImages.Count
             $heteroImageIndex = 0
             $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1928,13 +1928,12 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         $heteroImageIndex = $heteroImageIndex + 1
         if( $heteroImageIndex -lt $heteroImageCount )
         {
-            Write-Host -ForegroundColor Green "------------- Switching to next heterogenous image."
             $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')
             $publisher = $imageInfo[0]
             $offer = $imageInfo[1]
             $sku = $imageInfo[2]
             $version = $imageInfo[3]
-            Write-Host -ForegroundColor Green "------<$heteroImageIndex>> $publisher $offer $sku $version"
+            Write-LogInfo "Switching to next heterogeneous image [$heteroImageIndex] $publisher $offer $sku $version"
         }
     }
     Add-Content -Value "$($indents[1])]" -Path $jsonFile

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -824,11 +824,27 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
     $jsonFile = $azuredeployJSONFilePath
 
     if ($ImageName -and !$osVHD) {
-        $imageInfo = $ImageName.Split(' ')
-        $publisher = $imageInfo[0]
-        $offer = $imageInfo[1]
-        $sku = $imageInfo[2]
-        $version = $imageInfo[3]
+        #Allow for heterogeneous images to be used
+        if( $ImageName -Match(";") )
+        {
+            Write-LogInfo "Heterogeneous Images in use."
+            $heteroImages = $ImageName.Split(';')
+            $heteroImageCount = $HeteroImages.Count
+            $heteroImageIndex = 0
+            $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')
+            $publisher = $imageInfo[0]
+            $offer = $imageInfo[1]
+            $sku = $imageInfo[2]
+            $version = $imageInfo[3]
+            Write-LogInfo "Heterogeneous Image [$heteroImageIndex] $publisher $offer $sku $version"
+        } else {
+            $imageInfo = $ImageName.Split(' ')
+            $publisher = $imageInfo[0]
+            $offer = $imageInfo[1]
+            $sku = $imageInfo[2]
+            $version = $imageInfo[3]
+        }
+
     }
     if($osVHD) {
         $osVHD = $osVHD.Split("?")[0].split('/')[-1]
@@ -1909,6 +1925,17 @@ Function Generate-AzureDeployJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, 
         $vmAdded = $true
         $role = $role + 1
         $vmCount = $role
+        $heteroImageIndex = $heteroImageIndex + 1
+        if( $heteroImageIndex -lt $heteroImageCount )
+        {
+            Write-Host -ForegroundColor Green "------------- Switching to next heterogenous image."
+            $imageInfo = $heteroImages[$heteroImageIndex].Split(' ')
+            $publisher = $imageInfo[0]
+            $offer = $imageInfo[1]
+            $sku = $imageInfo[2]
+            $version = $imageInfo[3]
+            Write-Host -ForegroundColor Green "------<$heteroImageIndex>> $publisher $offer $sku $version"
+        }
     }
     Add-Content -Value "$($indents[1])]" -Path $jsonFile
 

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -354,6 +354,12 @@ function Is-VmAlive {
         foreach ( $vm in $AllVMDataObject) {
             if ($global:IsWindowsImage) {
                 $port = $vm.RDPPort
+                if( $null -eq $port )
+                {
+                    # Note(seansp): When using heterogeneous tests, some VMs won't be using RDP. Allow these to validate using SSH.
+                    Write-LogInfo "RDP is <NULL> -- SSH is available and used instead."
+                    $port = $vm.SSHPort
+                }
             } else {
                 $port = $vm.SSHPort
             }
@@ -369,7 +375,7 @@ function Is-VmAlive {
                     return "False"
                 }
             } else {
-                Write-LogInfo "Connecting to $($vm.PublicIP):$port succeeded."
+                Write-LogInfo "[$($vm.RoleName)]Connecting to $($vm.PublicIP):$port succeeded."
             }
         }
 

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -353,11 +353,10 @@ function Is-VmAlive {
         $retryCount += 1
         foreach ( $vm in $AllVMDataObject) {
             if ($global:IsWindowsImage) {
-                $port = $vm.RDPPort
-                if( $null -eq $port )
-                {
-                    # Note(seansp): When using heterogeneous tests, some VMs won't be using RDP. Allow these to validate using SSH.
-                    Write-LogInfo "RDP is <NULL> -- SSH is available and used instead."
+                # Note(seansp): When using heterogeneous tests, some VMs won't be using RDP. Allow these to validate using SSH.
+                if( $vm.RDPPort ) {
+                    $port = $vm.RDPPort
+                } else {
                     $port = $vm.SSHPort
                 }
             } else {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Linux Integration Services Automation (LISA), version 2
+# Linux Integration Services Automation (LISA), version 2
 
 Nov 2018
 
@@ -203,6 +203,9 @@ Please follow the steps mentioned at [here](https://docs.microsoft.com/en-us/azu
 
         Multiple override virtual machine size example:
         .\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "westus" -RGIdentifier "deployment" -ARMImageName "canonical ubuntuserver 18.04-lts Latest" -TestNames "VERIFY-DEPLOYMENT-PROVISION" -OverrideVMSize "Standard_A2,Standard_DS1_v2"
+        
+        Multiple ARMImageName example:
+        .\Run-LisaV2.ps1 -TestPlatform "Azure" -TestLocation "westus" -RGIdentifier "seansp" -ARMImageName "canonical ubuntuserver 18.04-lts Latest;canonical ubuntuserver 16.04-lts latest" -TestNames "SRIOV-VERIFY-SINGLE-VF-CONNECTION"
 
    b. Provide parameters in .\XML\TestParameters.xml.
 

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -52,21 +52,13 @@ Class AzureController : TestController
 			$parameterErrors += "-ARMImageName '<Publisher> <Offer> <Sku> <Version>', or -OsVHD <'VHD_Name.vhd'> is required."
 		}
 		if (!$this.OsVHD) {
-			if (($this.ARMImageName.Trim().Split(" ").Count -ne 4) -and ($this.ARMImageName -ne "")) {
-				if( $this.ARMImageName -Match(";") )
+			# Validate that each image is valid when heterogeneous images are used.
+			$allImageNames = $this.ARMImageName.Trim().Split(";")
+			foreach( $singleImageName in $allImageNames )
+			{
+				if(($singleImageName.Trim().Split(" ").Count -ne 4 ) -and ($singleImageName -ne "" ))
 				{
-					# Validate that each image is valid when heterogeneous images are used.
-					$allImageNames = $this.ARMImageName.Trim().Split(";")
-					foreach( $singleImageName in $allImageNames )
-					{
-						if(($singleImageName.Trim().Split(" ").Count -ne 4 ) -and ($singleImageName -ne "" ))
-						{
-							$parameterErrors += ("Invalid value for one of the provided ARMImageName parameters when using ; delimited format: <'$($singleImageName)'>." + `
-							"The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
-						}
-					}
-				} else {
-					$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
+					$parameterErrors += ("Invalid value for one of the provided ARMImageName parameters: <'$($singleImageName)'>." + `
 					"The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
 				}
 			}

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -53,8 +53,22 @@ Class AzureController : TestController
 		}
 		if (!$this.OsVHD) {
 			if (($this.ARMImageName.Trim().Split(" ").Count -ne 4) -and ($this.ARMImageName -ne "")) {
-				$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
-									 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
+				if( $this.ARMImageName -Match(";") )
+				{
+					# Validate that each image is valid when heterogeneous images are used.
+					$allImageNames = $this.ARMImageName.Trim().Split(";")
+					foreach( $singleImageName in $allImageNames )
+					{
+						if(($singleImageName.Trim().Split(" ").Count -ne 4 ) -and ($singleImageName -ne "" ))
+						{
+							$parameterErrors += ("Invalid value for one of the provided ARMImageName parameters when using ; delimited format: <'$($singleImageName)'>." + `
+							"The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
+						}
+					}
+				} else {
+					$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
+					"The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>'.")
+				}
 			}
 		}
 		if (!$this.ARMImageName) {


### PR DESCRIPTION
This specifically allows for the parameter -ARMImageName to consume a ';' delimited list of image definitions.  These are applied to the template as it is constructed and iterated until the last one ... and then all remaining VMs use the final image name.  Additionally, there is some added checking to use the SSHPort to verify TCP connectivity when OSType=Windows and the next VM is Ubuntu as in the case below.  This can be used to leverage existing multi-vm tests to verify cross-platform interactions.

  **-ARMImageName "MicrosoftWindowsServer WindowsServer 2019-Datacenter latest;Canonical UbuntuServer 18.04-LTS latest"**

>>PS C:\LISA> .\Run-LisaV2.ps1 -RGIdentifier 'SOME-RG' -TestPlatform 'Azure' `
>>       -TestNames 'MY-MULTI-MACHINE-TEST' -TestLocation 'westus2' `
>>       -ARMImageName "MicrosoftWindowsServer WindowsServer 2019-Datacenter latest;Canonical UbuntuServer 18.04-LTS latest" `
>>       -CustomParameters "OSType=Windows"
