### PR TITLE
Skip DPDK tests against SLES12.

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2036,7 +2036,6 @@ function Is-DpdkCompatible() {
         # https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk
         $SUPPORTED_DISTRO_KERNEL = @{
             "UBUNTU" = "4.15.0-1015-azure";
-            "SLES" = "4.12.14-5.5-azure";
             "SLES 15" = "4.12.14-5.5-azure";
             "SUSE" = "4.12.14-5.5-azure";
             "REDHAT" = "3.10.0-862.9.1.el7";


### PR DESCRIPTION
Fix #347 
Test results -
```
[LISAv2 Test Results Summary]
Test Run On           : 07/19/2019 04:48:05
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                               PASS                12.88 
dpdk_version test_mode phase   fwdrx_pps_avg fwdtx_pps_avg
------------ --------- -----   ------------- -------------
18.11.0      txonly    after   3603989       3603989      
18.11.0      txonly    before  3521513       3521513      
18.11.0      txonly    during  159024        159024       
18.11.0      txonly    overall 2012860       2012860 

[LISAv2 Test Results Summary]
Test Run On           : 07/19/2019 05:07:40
ARM Image Under Test  : SUSE : SLES : 12-SP4 : 2019.06.17
Initial Kernel Version: 4.12.14-6.15-azure
Final Kernel Version  : 4.12.14-6.15-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                            SKIPPED                 1.46 
```