### PR TITLE
Fix NET-BOOT-NONIC-HOT-ADD-NIC test case issue and remove redundant invoke of Detect-LinuxDistro

### DIFF
--- a/Testscripts/Windows/GPU-TENSORFLOW.ps1
+++ b/Testscripts/Windows/GPU-TENSORFLOW.ps1
@@ -92,8 +92,6 @@ function Main {
                 }
             }
 
-            $detectedDistro = Detect-LinuxDistro -VIP $vmData.PublicIP -SSHport $vmData.SSHPort `
-                    -testVMUser $user -testVMPassword $password
             $properties = Get-VMProperties -PropertyFilePath "$LogDir\VM_properties.csv"
             $testDate = $(Get-Date -Format yyyy-MM-dd)
             $testDataCsv = Import-Csv -Path $LogDir\tensorflowBenchmark.csv
@@ -109,7 +107,7 @@ function Main {
                 $resultMap["TensorflowVersion"] = $TensorflowVersion
                 $resultMap["HostType"] = $global:TestPlatform
                 $resultMap["HostBy"] = $global:TestLocation
-                $resultMap["GuestOSType"] = $detectedDistro
+                $resultMap["GuestOSType"] = $global:detectedDistro
                 $resultMap["GuestSize"] = $AllVMData.InstanceSize
                 $resultMap["TestCaseName"] = $global:GlobalConfig.Global.Azure.ResultsDatabase.testTag
                 $resultMap["TestDate"] = $testDate

--- a/Testscripts/Windows/NET-Boot-NoNIC-HotAdd-NIC.ps1
+++ b/Testscripts/Windows/NET-Boot-NoNIC-HotAdd-NIC.ps1
@@ -61,8 +61,7 @@ function Main {
 
     # Configure the NET-Verify-Boot-NoNIC.sh script to be run automatically
     # on boot
-    $linuxRelease = Detect-LinuxDistro
-    if ($linuxRelease -eq "CENTOS" -or $linuxRelease -eq "FEDORA" -or $linuxRelease -eq "REDHAT") {
+    if ($global:detectedDistro -eq "CENTOS" -or $global:detectedDistro -eq "FEDORA" -or $global:detectedDistro -eq "REDHAT") {
         Run-LinuxCmd -Command "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;chmod +x /etc/rc.d/rc.local`"" `
             -Username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -runMaxAllowedTime $Timeout
@@ -73,7 +72,7 @@ function Main {
             -Username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -runMaxAllowedTime $Timeout
     }
-    elseif ($linuxRelease -eq "UBUNTU" -or $linuxRelease -eq "DEBIAN") {
+    elseif ($global:detectedDistro -eq "UBUNTU" -or $global:detectedDistro -eq "DEBIAN") {
         Run-LinuxCmd -Command "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;systemctl start cron.service`"" `
             -Username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -runMaxAllowedTime $Timeout
@@ -87,7 +86,7 @@ function Main {
             -Username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -runMaxAllowedTime $Timeout
     }
-    elseif ($linuxRelease -eq "SLES") {
+    elseif ($global:detectedDistro -eq "SLES") {
         $cmdToVM = @"
 [Unit]
 ConditionFileIsExecutable=/home/$VMUserName/NET-Verify-Boot-NoNIC.sh
@@ -114,7 +113,7 @@ RemainAfterExit=yes
             -runMaxAllowedTime $Timeout
     }
     else {
-        Write-LogErr "Unsupported linux distribution '${linuxRelease}'"
+        Write-LogErr "Unsupported linux distribution '${global:detectedDistro}'"
         return "ABORTED"
     }
 

--- a/Testscripts/Windows/STRESS-Web.ps1
+++ b/Testscripts/Windows/STRESS-Web.ps1
@@ -115,8 +115,7 @@ function Main() {
         Write-LogInfo "  Second Internal IP : $serverSecondInternalIP"
         Write-LogInfo "  SSH Port : $serverSSHPort"
 
-        $linuxRelease = Detect-LinuxDistro -VIP $serverPublicIP -SSHPort $serverSSHPort -testVMuser $username -testVMPassword $password
-        if (!@("UBUNTU", "DEBIAN").contains($linuxRelease)) {
+        if (!@("UBUNTU", "DEBIAN").contains($global:detectedDistro)) {
             Write-LogInfo "Test is only supported on Debian\Ubuntu based distributions."
             return "SKIPPED"
         }

--- a/Testscripts/Windows/VERIFY-VHD-PREREQUISITES.ps1
+++ b/Testscripts/Windows/VERIFY-VHD-PREREQUISITES.ps1
@@ -11,34 +11,33 @@ function Main {
     try {
         $testScript = "VERIFY-VHD-PREREQUISITES.py"
 
-        $detectedDistro = Detect-LinuxDistro -VIP $AllVMData.PublicIP -SSHport $AllVMData.SSHPort -testVMUser $user -testVMPassword $password
-        if ($detectedDistro -imatch "UBUNTU") {
+        if ($global:detectedDistro -imatch "UBUNTU") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_GRUB_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
         }
-        if ($detectedDistro -imatch "DEBIAN") {
+        if ($global:detectedDistro -imatch "DEBIAN") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
         }
-        elseif ($detectedDistro -imatch "SUSE") {
+        elseif ($global:detectedDistro -imatch "SUSE") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_GRUB_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
         }
-        elseif ($detectedDistro -imatch "CENTOS") {
+        elseif ($global:detectedDistro -imatch "CENTOS") {
             $matchstrings = @("_TEST_NETWORK_MANAGER_NOT_INSTALLED","_TEST_NETWORK_FILE_SUCCESS", "_TEST_IFCFG_ETH0_FILE_SUCCESS", "_TEST_UDEV_RULES_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE", "_TEST_GRUB_VERIFICATION_SUCCESS")
         }
-        elseif ($detectedDistro -imatch "ORACLELINUX") {
+        elseif ($global:detectedDistro -imatch "ORACLELINUX") {
             $matchstrings = @("_TEST_NETWORK_MANAGER_NOT_INSTALLED","_TEST_NETWORK_FILE_SUCCESS", "_TEST_IFCFG_ETH0_FILE_SUCCESS", "_TEST_UDEV_RULES_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE", "_TEST_GRUB_VERIFICATION_SUCCESS")
         }
-        elseif ($detectedDistro -imatch "REDHAT") {
+        elseif ($global:detectedDistro -imatch "REDHAT") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_NETWORK_MANAGER_NOT_INSTALLED","_TEST_NETWORK_FILE_SUCCESS", "_TEST_IFCFG_ETH0_FILE_SUCCESS", "_TEST_UDEV_RULES_SUCCESS", "_TEST_GRUB_VERIFICATION_SUCCESS","_TEST_RHUIREPOSITORIES_AVAILABLE")
         }
-        elseif ($detectedDistro -imatch "FEDORA") {
+        elseif ($global:detectedDistro -imatch "FEDORA") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_NETWORK_MANAGER_NOT_INSTALLED","_TEST_NETWORK_FILE_SUCCESS", "_TEST_IFCFG_ETH0_FILE_SUCCESS", "_TEST_UDEV_RULES_SUCCESS", "_TEST_GRUB_VERIFICATION_SUCCESS")
         }
-        elseif ($detectedDistro -imatch "SLES") {
+        elseif ($global:detectedDistro -imatch "SLES") {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_GRUB_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
             # to avoid extra blank space
-            $detectedDistro="SLES"
+            $global:detectedDistro="SLES"
         }
-        if ($detectedDistro -imatch "COREOS") {
+        if ($global:detectedDistro -imatch "COREOS") {
             $matchstrings = @("_TEST_UDEV_RULES_SUCCESS")
         }
 
@@ -52,9 +51,9 @@ function Main {
         $errorCount = 0
         foreach ($testString in $matchstrings) {
             if( $consoleOut -imatch $testString) {
-                Write-LogInfo "$detectedDistro$testString"
+                Write-LogInfo "$global:detectedDistro$testString"
             } else {
-                Write-LogErr "Expected String : $detectedDistro$testString not present. Please check logs."
+                Write-LogErr "Expected String : $global:detectedDistro$testString not present. Please check logs."
                 $errorCount += 1
             }
         }


### PR DESCRIPTION
Fix case NET-BOOT-NONIC-HOT-ADD-NIC and refine usage of Detect-LinuxDistro 
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/22/2019 09:49:17
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 4.18.0-1024-azure
Final Kernel Version  : 4.18.0-1024-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-VHD-PREREQUISITES                                                          PASS                 4.65 

[LISAv2 Test Results Summary]
Test Run On           : 07/22/2019 09:50:06
VHD Under Test        : C:\tx\tx-ubuntu1804-gen2.vhdx
Initial Kernel Version: 4.15.0-54-generic
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:20

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-BOOT-NONIC-HOT-ADD-NIC                                                        PASS                17.38 

[LISAv2 Test Results Summary]
Test Run On           : 07/22/2019 09:52:36
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 4.18.0-1024-azure
Final Kernel Version  : 4.18.0-1024-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:24

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STRESS               STRESSTEST-WEB-PARALLEL-ACCESS                                                    PASS                 16.5 

[LISAv2 Test Results Summary]
Test Run On           : 07/22/2019 09:46:06
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 4.18.0-1024-azure
Final Kernel Version  : 4.18.0-1024-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:47

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-TENSORFLOW                                                     PASS                40.69 
```