### PR TITLE
Ubuntu fix broken package

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2206,6 +2206,7 @@ function apt_get_install ()
 {
 	package_name=$1
 	dpkg_configure
+	sudo DEBIAN_FRONTEND=noninteractive apt --fix-broken install -y
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes $package_name
 	check_exit_status "apt_get_install $package_name" "exit"
 }


### PR DESCRIPTION
Sometimes, hit the below errors when trying to install a tool failed on Ubuntu. 
```
You might want to run 'apt --fix-broken install' to correct these.
The following packages have unmet dependencies:
...
E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
apt_get_install xxx: Failed (exit code: 100)
```
