### PR TITLE
SRIOV test: Disable the NetworkManager

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -60,8 +60,8 @@ VerifyVF()
     # Using lsmod command, verify if driver is loaded
     lsmod | grep 'mlx[4-5]_core\|mlx4_en\|ixgbevf'
     if [ $? -ne 0 ]; then
-		# driver can be built-in, continuing to lspci
-		LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
+        # driver can be built-in, continuing to lspci
+        LogErr "Neither mlx[4-5]_core\mlx4_en or ixgbevf drivers are in use!"
     fi
 
     # Using the lspci command, verify if NIC has SR-IOV support
@@ -283,4 +283,16 @@ InstallDependencies()
     fi
 
     return 0
+}
+
+#
+# DisableNetworkManager - Disable the NetworkManager permanently if it's running
+#
+DisableNetworkManager()
+{
+    systemctl status NetworkManager | grep "Active:[ ]*active"
+    if [ $? -eq 0 ]; then
+        systemctl stop NetworkManager
+        systemctl disable NetworkManager
+    fi
 }

--- a/Testscripts/Windows/SETUP-SR-IOV-Configure.ps1
+++ b/Testscripts/Windows/SETUP-SR-IOV-Configure.ps1
@@ -39,6 +39,9 @@ function Set-VFInGuest {
         Write-LogErr "Failed to install dependencies on $VMName"
         return $False
     }
+    # Disable the NetworkManager
+    Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort `
+        -command ". SR-IOV-Utils.sh; DisableNetworkManager" -RunAsSudo
     # Configure VF
     Run-LinuxCmd -username $VMUser -password $VMPass -ip $VMIp -port $VMPort `
         -command ". SR-IOV-Utils.sh; ConfigureVF $VMNumber" -RunAsSudo


### PR DESCRIPTION
The static IP addresses are assigned to SRIOV network interfaces  with the 'ip' commands.
Sometimes, the static IP addresses may disappear. It is likely Network Manager is managing the interface. 
It may be resetting the address.