### PR TITLE
Fix install lagscope in ntttcp testing.

### DIFF
--- a/Testscripts/Linux/perf_lagscope.sh
+++ b/Testscripts/Linux/perf_lagscope.sh
@@ -74,7 +74,7 @@ fi
 #Make & build lagscope on client and server VMs
 
 LogMsg "Configuring client ${client}..."
-ssh "${client}" "export PATH=$PATH:/usr/local/bin && . $UTIL_FILE && install_lagscope"
+ssh "${client}" ". $UTIL_FILE && install_lagscope"
 if [ $? -ne 0 ]; then
 	LogMsg "Error: lagscope installation failed in ${client}.."
 	UpdateTestState "TestAborted"
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
 fi
 
 LogMsg "Configuring server ${server}..."
-ssh "${server}" "export PATH=$PATH:/usr/local/bin && . $UTIL_FILE && install_lagscope"
+ssh "${server}" ". $UTIL_FILE && install_lagscope"
 if [ $? -ne 0 ]; then
 	LogMsg "Error: lagscope installation failed in ${server}.."
 	UpdateTestState "TestAborted"
@@ -94,7 +94,7 @@ if [[ $(detect_linux_distribution) == coreos ]]; then
 	ssh root@"${server}" ". $UTIL_FILE && Delete_Containers"
 	ssh root@"${client}" ". $UTIL_FILE && Delete_Containers"
 else
-	cmd="export PATH=$PATH:/usr/local/bin && lagscope"
+	cmd="lagscope"
 fi
 
 #Now, start lagscope on server and client VMs.

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2616,6 +2616,7 @@ function build_lagscope () {
 	pushd build && cmake .. && cmake --build . && cmake --build . --target install
 	popd
 	popd
+	ln -s /usr/local/bin/lagscope /usr/bin/lagscope
 }
 
 # Install lagscope and required packages
@@ -2697,7 +2698,7 @@ function install_ntttcp () {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos)
 			install_epel
-			yum -y --nogpgcheck install wget libaio sysstat git bc make gcc dstat psmisc lshw
+			yum -y --nogpgcheck install wget libaio sysstat git bc make gcc dstat psmisc lshw cmake
 			build_ntttcp "${1}"
 			build_lagscope
 			iptables -F
@@ -2705,7 +2706,7 @@ function install_ntttcp () {
 
 		ubuntu|debian)
 			dpkg_configure
-			apt-get -y install wget libaio1 sysstat git bc make gcc dstat psmisc lshw
+			apt-get -y install wget libaio1 sysstat git bc make gcc dstat psmisc lshw cmake
 			build_ntttcp "${1}"
 			build_lagscope
 			;;
@@ -2713,7 +2714,7 @@ function install_ntttcp () {
 		sles|sle_hpc)
 			if [[ $DISTRO_VERSION =~ 12|15 ]]; then
 				add_sles_network_utilities_repo
-				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget sysstat git bc make gcc dstat psmisc lshw
+				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget sysstat git bc make gcc dstat psmisc lshw cmake
 				build_ntttcp "${1}"
 				build_lagscope
 				iptables -F


### PR DESCRIPTION
ntttcp results

```
[LISAv2 Test Results Summary]
Test Run On           : 07/23/2019 02:16:11
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : latest
Initial Kernel Version: 3.10.0-957.21.3.el7.x86_64
Final Kernel Version  : 3.10.0-957.21.3.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:44

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic                         PASS                99.37 
	Connections=8 : throughput=13.47Gbps cyclePerBytet=10.60 Avg_TCP_lat=5556.910 
	Connections=16 : throughput=18.07Gbps cyclePerBytet=8.83 Avg_TCP_lat=7399.919 
	Connections=32 : throughput=20.76Gbps cyclePerBytet=6.92 Avg_TCP_lat=7192.330 
	Connections=64 : throughput=21.33Gbps cyclePerBytet=6.26 Avg_TCP_lat=8845.006 
	Connections=128 : throughput=20.92Gbps cyclePerBytet=6.92 Avg_TCP_lat=11373.140 
	Connections=256 : throughput=20.27Gbps cyclePerBytet=7.46 Avg_TCP_lat=14085.706 
	Connections=512 : throughput=18.77Gbps cyclePerBytet=7.90 Avg_TCP_lat=15149.074 
	Connections=1024 : throughput=16.68Gbps cyclePerBytet=11.26 Avg_TCP_lat=13411.335 
	Connections=2048 : throughput=12.26Gbps cyclePerBytet=24.56 Avg_TCP_lat=15105.869 
	Connections=4096 : throughput=9.57Gbps cyclePerBytet=44.22 Avg_TCP_lat=15618.028 
	Connections=6144 : throughput=8.23Gbps cyclePerBytet=61.31 Avg_TCP_lat=14080.902 
	Connections=8192 : throughput=7.17Gbps cyclePerBytet=79.77 Avg_TCP_lat=17662.215 
	Connections=10240 : throughput=6.62Gbps cyclePerBytet=91.86 Avg_TCP_lat=16933.170 
```