### PR TITLE
Fix Socket.Connect Exception and ambiguous overload

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -705,7 +705,7 @@ Function Set-DistroSpecificVariables($detectedDistro)
 	}
 }
 
-Function Test-TCP($testIP, $testport)
+Function Test-TCP([string]$testIP, [Int32]$testport)
 {
 	$socket = New-Object Net.Sockets.TcpClient
 	$isConnected = "False"
@@ -713,7 +713,7 @@ Function Test-TCP($testIP, $testport)
 	{
 		$socket.Connect($testIP, $testPort)
 	}
-	catch [System.Net.Sockets.SocketException]
+	catch
 	{
 		Write-LogWarn "TCP test failed"
 	}


### PR DESCRIPTION
Fixes #477 

* set specific types for the Socket.Connect overload we are using
* remove SocketException and catch everything

[Ref](https://stackoverflow.com/questions/34950866/getting-past-an-error-multiple-ambiguous-overloads-found-for-save)