### PR TITLE
NET-IFUP-IFDOWN: Fix waiting for SSH during test, new ip would get value 'False'

### DIFF
--- a/Testscripts/Windows/NET-IFUP-IFDOWN.ps1
+++ b/Testscripts/Windows/NET-IFUP-IFDOWN.ps1
@@ -30,7 +30,9 @@ function Main {
         if ($TestPlatform -eq "HyperV") {
             $newIp = Get-IPv4AndWaitForSSHStart -VMName $VMName -HvServer $HvServer `
                 -VmPort $VmPort -User $VMUserName -Password $VMPassword -StepTimeout 30
-            $allVmData.PublicIP = $newIp
+            if($newIp) {
+                $allVmData.PublicIP = $newIp
+            }
         }
         else {
             $newIp = $allVmData.PublicIP


### PR DESCRIPTION
Related to #477 

When running test on Hyper-V `Get-IPv4AndWaitForSSHStart` can return false, (which is expected as the test reloads hv_netvsc and takes the interface up and down repeatedly during the test) but it is not handled properly and leads to `$allVmData.PublicIP = $False`
this happens when the VM is issued a different ip over dhcp

---

After change:

Expected behavior as ip is changing:
```
07-25-2019 12:37:08 : [ERROR] Wait-ForVMToStartSSH: VM did not start SSH within timeout period (30)
07-25-2019 12:37:08 : [ERROR] Get-IPv4AndWaitForSSHStart: Failed to connect 192.168.0.36 port 22 within timeout period (30)
[...]
07-25-2019 12:38:54 : [ERROR] Wait-ForVMToStartSSH: VM did not start SSH within timeout period (30)
07-25-2019 12:38:54 : [ERROR] Get-IPv4AndWaitForSSHStart: Failed to connect 192.168.0.38 port 22 within timeout period (30)
```

```
[LISAv2 Test Results Summary]
Test Run On           : 07/25/2019 12:34:16
VHD Under Test        : Ubuntu-18.04-gen1.vhdx
Initial Kernel Version: 4.15.0-46-generic
Final Kernel Version  : 4.15.0-46-generic
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-IFUP-IFDOWN                                                                   PASS                  4.7

```