### PR TITLE
Fix the parsing of CustomParameters and CustomTestParameters

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -294,7 +294,7 @@ function Parse-TestParameters {
             $testParams += Get-SecretParams -ParamsArray $paramsArray `
                  -GlobalConfig $GlobalConfig -AllVMData $AllVMData
         } else {
-            $value = $param.split("=")[1]
+            $value = $param.Substring($param.IndexOf("=")+1)
             $testParams[$name] = $value
         }
     }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -245,10 +245,11 @@ Class TestController
 		foreach ( $test in $allTests) {
 			# Inject replaceable parameters
 			foreach ($ReplaceableParameter in $ReplaceableTestParameters.ReplaceableTestParameters.Parameter) {
+				$replaceWith = [System.Security.SecurityElement]::Escape($ReplaceableParameter.ReplaceWith)
 				$FindReplaceArray = @(
-					("=$($ReplaceableParameter.ReplaceThis)<" ,"=$($ReplaceableParameter.ReplaceWith)<" ),
-					("=`"$($ReplaceableParameter.ReplaceThis)`"" ,"=`"$($ReplaceableParameter.ReplaceWith)`""),
-					(">$($ReplaceableParameter.ReplaceThis)<" ,">$($ReplaceableParameter.ReplaceWith)<")
+					("=$($ReplaceableParameter.ReplaceThis)<" ,"=$($replaceWith)<" ),
+					("=`"$($ReplaceableParameter.ReplaceThis)`"" ,"=`"$($replaceWith)`""),
+					(">$($ReplaceableParameter.ReplaceThis)<" ,">$($replaceWith)<")
 				)
 				foreach ($item in $FindReplaceArray) {
 					$Find = $item[0]

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -95,8 +95,9 @@ Class TestController
 		$this.TestProvider.CustomLIS = $ParamTable["CustomLIS"]
 		$this.CustomParams = @{}
 		if ( $ParamTable.ContainsKey("CustomParameters") ) {
-			$ParamTable["CustomParameters"].ToLower().Split(';').Trim() | ForEach-Object {
-				$key,$value = $_.ToLower().Split('=').Trim()
+			$ParamTable["CustomParameters"].Split(';').Trim() | ForEach-Object {
+				$key = $_.Split('=')[0].Trim()
+				$value = $_.Substring($_.IndexOf("=")+1)
 				$this.CustomParams[$key] = $value
 			}
 		}
@@ -230,7 +231,7 @@ Class TestController
 			{
 				$CustomParameter = $CustomParameter.Trim()
 				$ReplaceThis = $CustomParameter.Split("=")[0]
-				$ReplaceWith = $CustomParameter.Split("=")[1]
+				$ReplaceWith = $CustomParameter.Substring($CustomParameter.IndexOf("=")+1)
 
 				$OldValue = ($ReplaceableTestParameters.ReplaceableTestParameters.Parameter | Where-Object `
 					{ $_.ReplaceThis -eq $ReplaceThis }).ReplaceWith


### PR DESCRIPTION
Fix the parsing of CustomParameters, CustomTestParameters, and TestParameter in case of
1. the value contains '='
2. the value contains uppercase letters, and it's case sensitive
3. the value contains special characters, e.g. "&"