### PR TITLE
NVIDIA-CUDA-DRIVER-VALIDATION: Temporary fix for ubuntu 19.04

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -93,6 +93,10 @@ function InstallCUDADrivers() {
 
     ubuntu*)
         GetOSVersion
+        # Temporary fix till driver for ubuntu19 series list under http://developer.download.nvidia.com/compute/cuda/repos/
+        if [[ $os_RELEASE =~ 19.* ]]; then
+            os_RELEASE="18.10"
+        fi
         CUDA_REPO_PKG="cuda-repo-ubuntu${os_RELEASE//./}_${CUDADriverVersion}_amd64.deb"
         LogMsg "Using ${CUDA_REPO_PKG}"
 


### PR DESCRIPTION
Test result:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/31/2019 09:07:26
ARM Image Under Test  : Canonical : UbuntuServer : 19.04 : latest
Initial Kernel Version: 5.0.0-1012-azure
Final Kernel Version  : 5.0.0-1013-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                20.74 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```