### PR TITLE
VERIFY-BOOT-ERROR-WARNINGS： Ignore when syslog or message not present

### DIFF
--- a/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
@@ -9,9 +9,9 @@ white_list_xml = "ignorable-boot-errors.xml"
 def RunTest():
     UpdateState("TestRunning")
     RunLog.info("Checking for ERROR and WARNING messages in system logs.")
-    errors = Run("grep -nw '/var/log/syslog' -e 'error' --ignore-case && grep -nw '/var/log/messages' -e 'error' --ignore-case")
-    warnings = Run("grep -nw '/var/log/syslog' -e 'warning' --ignore-case && grep -nw '/var/log/messages' -e 'warning' --ignore-case")
-    failures = Run("grep -nw '/var/log/syslog' -e 'fail' --ignore-case && grep -nw '/var/log/messages' -e 'fail' --ignore-case")
+    errors = Run("grep -nw '/var/log/syslog' -e 'error' --ignore-case --no-message && grep /var/log/messages -e error --ignore-case --no-message")
+    warnings = Run("grep -nw '/var/log/syslog' -e 'warning' --ignore-case --no-message && grep /var/log/messages -e warning --ignore-case --no-message")
+    failures = Run("grep -nw '/var/log/syslog' -e 'fail' --ignore-case --no-message && grep /var/log/messages -e fail --ignore-case --no-message")
     if (not errors and not warnings and not failures):
         RunLog.info('Could not find ERROR/WARNING/FAILURE messages in syslog/messages log file.')
         ResultLog.info('PASS')


### PR DESCRIPTION
fix #488 
RedHat syslog not present and Ubuntu messages not present.

After fix:

- [root@LISAv2-OneVM-ava-QC78-20190801142052-role-0 lisa]#  python VERIFY-BOOT-ERROR-WARNINGS.py
 2.7.5 (default, Jun 11 2019, 12:19:05)
 [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
 [root@LISAv2-OneVM-ava-QC78-20190801142052-role-0 lisa]#

```
[LISAv2 Test Results Summary]
Test Run On           : 08/01/2019 06:20:29
VHD Under Test        : http://lisaeastus2.blob.core.windows.net/vhds/RHEL-7.7-20190530.1-wala-2.2.32-1.vhd
Initial Kernel Version: 3.10.0-1049.el7.x86_64
Final Kernel Version  : 3.10.0-1049.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 3.46 
```

```
[LISAv2 Test Results Summary]
Test Run On           : 08/01/2019 06:20:20
ARM Image Under Test  : RedHat : RHEL : 7.6 : 7.6.2019062116
Initial Kernel Version: 3.10.0-957.21.3.el7.x86_64
Final Kernel Version  : 3.10.0-957.21.3.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 3.16 
```