### PR TITLE
FCOPY-NEGATIVE.ps1: Refine the FCOPY-NEGATIVE test

### DIFF
--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -135,5 +135,6 @@ Class HyperVController : TestController
 		([TestController]$this).SetGlobalVariables()
 
 		Set-Variable -Name VMGeneration -Value $this.TestProvider.VMGeneration -Scope Global
+		Set-Variable -Name VMIntegrationGuestService -Value "Guest Service Interface" -Scope Global
 	}
 }


### PR DESCRIPTION
Main changes:
1. Replace check_fcopy_daemon() with Check-FcopyDaemon() in IntegrationServiceLibrary.psm1
2. Replace plink.exe with Run-LinuxCmd function to run Linux commands
3. Add a new step : verify the file can copy to vm when "Guest Service Interface" is enabled
4. Split the long lines into short ones