### PR TITLE
KVP-TestRescind.ps1: Enhance the KVP-TEST-RESCIND test

### DIFF
--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -136,5 +136,6 @@ Class HyperVController : TestController
 
 		Set-Variable -Name VMGeneration -Value $this.TestProvider.VMGeneration -Scope Global
 		Set-Variable -Name VMIntegrationGuestService -Value "Guest Service Interface" -Scope Global
+		Set-Variable -Name VMIntegrationKeyValuePairExchange -Value "Key-Value Pair Exchange" -Scope Global
 	}
 }


### PR DESCRIPTION
1. In previous codes, it's not a good idea to check the VM is whether the Redhat core or not by running the below command. 
$null = .\Tools\plink.exe -C -pw $VMPassword -P $VMPort $VMUserName@$ipv4 "yum --version 2> /dev/null"

2. Using a global constant to replace the "Key-Value Pair Exchange"
3. Replace the plink method with Run-LinuxCmd() to run Linux command
