### PR TITLE
fix lsvmbus test case for patched/customized kernel installed

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -43,9 +43,9 @@ fi
 VCPU=$(nproc)
 LogMsg "Number of CPUs detected on VM: $VCPU"
 
-# check if lsvmbus exists
+# check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
 lsvmbus_path=$(which lsvmbus)
-if [ -z "$lsvmbus_path" ]; then
+if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
     install_package wget
     wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
     chmod +x lsvmbus

--- a/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
+++ b/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
@@ -19,9 +19,9 @@
 # Source constants file and initialize most common variables
 UtilsInit
 
-# check if lsvmbus exists
+# check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
 lsvmbus_path=$(which lsvmbus)
-if [ -z "$lsvmbus_path" ]; then
+if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
     install_package wget
     wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
     chmod +x lsvmbus


### PR DESCRIPTION
When a customized kernel are running with test cases related to lsvmbus, test cases always failed. As a workaround, scripts should try run lsvmbus first and then download a remote version of lsvmbus if execution exit unsuccessfully.