### PR TITLE
Refine the storage test cases (Priority=2) on HyperV

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2313,3 +2313,26 @@ Function Restart-VMFromShell($VMData, [switch]$SkipRestartCheck) {
         return $false
     }
 }
+
+# This function get a data disk name on the guest
+# Background:
+#    If the vm has more than one disk controller, the order in which their corresponding device nodes are added is arbitrary.
+#    This may result in device names like /dev/sda and /dev/sdc switching around on each boot.
+# Note:
+#    If the size of data disk is the same as the resource disk (default size: 1GB), the return value may the device name of resource disk.
+#    It's recommended that the data disk size is more than 1GB to call this function.
+Function Get-DeviceName
+{
+    param (
+        [String] $ip,
+        [String] $port,
+        [String] $username,
+        [String] $password
+    )
+
+    Copy-RemoteFiles -upload -uploadTo $ip -username $username -port $port -password $password `
+        -files '.\Testscripts\Linux\get_data_disk_dev_name.sh' | Out-Null
+    $ret = Run-LinuxCmd -ip $ip -port $port -username $username -password $password `
+        -command "bash get_data_disk_dev_name.sh" -runAsSudo
+    return $ret
+}

--- a/Testscripts/Linux/get_data_disk_dev_name.sh
+++ b/Testscripts/Linux/get_data_disk_dev_name.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+
+lsblk -V >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+    update_repos >/dev/null 2>&1
+    install_package "util-linux" >/dev/null 2>&1
+fi
+
+# Get the OS disk
+os_disk=$(get_OSdisk)
+
+for dev in /dev/sd*[^0-9]; do
+    # Skip the OS disk
+    if [ $dev == "/dev/$os_disk" ]; then
+        continue
+    fi
+    # Skip the resource disk based on the disk size.
+    # It's not an accurate method when size of other data disks is 1GB,
+    # but it does not effect the test because the resource disk is also a data disk.
+    lsblk  --output SIZE -n -d $dev 2> /dev/null | grep -i "1G" > /dev/null
+    if [ 0 -eq $? ]; then
+        # Set a default name in case size of all data disks is 1GB
+        deviceName=$dev
+        continue
+    fi
+    deviceName=$dev
+    break
+done
+
+echo "$deviceName"
+exit 0

--- a/Testscripts/Windows/CLEANUP-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/CLEANUP-DiffDiskGrowth.ps1
@@ -122,10 +122,10 @@ function Main {
         Write-LogErr "No vhdFormat specified in the test parameters"
         return $False
     }
-    if (-not $rootDir) {
+    if (-not $Global:WorkingDirectory) {
         Write-LogErr "no rootdir was specified"
     } else {
-        Set-Location $rootDir
+        Set-Location $Global:WorkingDirectory
     }
 
     $vmGeneration = Get-VMGeneration $vmName $hvServer
@@ -180,7 +180,7 @@ function Main {
     if ($vhdFileInfo) {
         $delSts = $vhdFileInfo.Delete()
         if (-not $delSts -or $delSts.ReturnValue -ne 0) {
-            Write-LogErr "unable to delete the existing $vhdFormat file: ${vhdFilename}"
+            Write-LogErr "unable to delete the existing $vhdFormat file: ${vhdName}"
             return $False
         }
     }

--- a/Testscripts/Windows/SETUP-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/SETUP-DiffDiskGrowth.ps1
@@ -134,10 +134,10 @@ function Main {
         }
     }
 
-    if (-not $rootDir) {
+    if (-not $Global:WorkingDirectory) {
         Write-LogErr "no rootdir was specified"
     } else {
-        Set-Location $rootDir
+        Set-Location $Global:WorkingDirectory
     }
 
     # Make sure we have all the required data
@@ -197,7 +197,6 @@ function Main {
         }
     }
 
-
     if ($vmGeneration -eq 1) {
         $lun = [int]($diskArgs[1].Trim())
     } else {
@@ -240,7 +239,7 @@ function Main {
     if ($vhdFileInfo) {
         $delSts = $vhdFileInfo.Delete()
         if (-not $delSts -or $delSts.ReturnValue -ne 0) {
-            LofErr "unable to delete the existing .vhd file: ${vhdFilename}"
+            LofErr "unable to delete the existing .vhd file: ${vhdName}"
             return $False
         }
     }

--- a/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
+++ b/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
@@ -54,15 +54,18 @@ Function Set-HardDiskSize
 	}
 
 	Write-LogInfo "Check if the guest detects the new space"
-	$sd = "sdc"
-	if ( $controllerType -eq "IDE" ) {
-		$sd = "sdb"
-	}
-	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "echo 'deviceName=/dev/$sd' >> constants.sh" -runAsSudo
+	$deviceName = Get-DeviceName -ip $ip -port $port -username $user -password $password
+	Write-LogInfo "The disk device name: $deviceName"
+	$sd = "$deviceName" -replace "/dev/",""
+	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+		-command "echo 'deviceName=/dev/$sd' >> constants.sh" -runAsSudo
 	# Do a request & rescan to refresh the disks info
-	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "fdisk -l > /dev/null" -runAsSudo
-	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "echo 1 > /sys/block/$sd/device/rescan" -runAsSudo
-	$diskSize = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "fdisk -l /dev/$sd  2> /dev/null | grep Disk | grep $sd | cut -f 5 -d ' '" -runAsSudo
+	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+		-command "fdisk -l > /dev/null" -runAsSudo
+	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+		-command "echo 1 > /sys/block/$sd/device/rescan" -runAsSudo
+	$diskSize = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+		-command "fdisk -l /dev/$sd  2> /dev/null | grep Disk | grep $sd | cut -f 5 -d ' '" -runAsSudo
 	if (-not $diskSize) {
 		Throw "Unable to determine disk size from within the guest after growing the VHDX"
 	}
@@ -74,11 +77,14 @@ Function Set-HardDiskSize
 	# if file size larger than 2T (2048G), use parted to format disk
 	if ([int]($newSize/1gb) -gt 2048) {
 		$guestScript = "STOR_VHDXResize_PartitionDiskOver2TB.sh"
-		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "./$guestScript" -runAsSudo -runMaxAllowedTime 1200
+		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+			-command "bash $guestScript" -runAsSudo -runMaxAllowedTime 1200
 	} else {
 		$guestScript = "STOR_VHDXResize_PartitionDisk.sh"
-		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "echo 'rerun=yes' >> constants.sh" -runAsSudo
-		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "./$guestScript" -runAsSudo
+		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+			-command "echo 'rerun=yes' >> constants.sh" -runAsSudo
+		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+			-command "bash $guestScript" -runAsSudo
 	}
 	if (-not $ret) {
 		Throw "Running '${guestScript}'script failed on VM. check VM logs , exiting test case execution"
@@ -133,12 +139,14 @@ Function Main
 		Write-LogInfo "Verify the file is a .vhdx"
 		if (-not $vhdPath.EndsWith(".vhdx") -and -not $vhdPath.EndsWith(".avhdx")) {
 			$testResult = "FAIL"
-			Throw "$controllerType $vhdxDrive.ControllerNumber $vhdxDrive.ControllerLocation virtual disk is not a .vhdx file."
+			Throw "$controllerType $vhdxDrive.ControllerNumber $vhdxDrive. `
+				ControllerLocation virtual disk is not a .vhdx file."
 		}
 
 		# Make sure there is sufficient disk space to grow the VHDX to the specified size
 		$deviceID = $vhdxInfo.Drive
-		$diskInfo = Get-CimInstance -Query "SELECT * FROM Win32_LogicalDisk Where DeviceID = '${deviceID}'" -ComputerName $hvServer
+		$diskInfo = Get-CimInstance -Query "SELECT * FROM Win32_LogicalDisk Where DeviceID = '${deviceID}'" `
+			-ComputerName $hvServer
 		if (-not $diskInfo) {
 			$testResult = "FAIL"
 			Throw "Unable to collect information on drive ${deviceID}"
@@ -146,12 +154,18 @@ Function Main
 		$sizeFlag = Convert-StringToUInt64 "20GB"
 		if ($diskInfo.FreeSpace -le $sizeFlag + 10MB) {
 			$testResult = "FAIL"
-			Throw "Insufficent disk free space, This test case requires ${testParameters.NewSize} free, Current free space is $($diskInfo.FreeSpace)"
+			Throw "Insufficent disk free space, This test case requires ${testParameters.NewSize} free, `
+				Current free space is $($diskInfo.FreeSpace)"
 		}
 
 		# Make sure if we can perform Read/Write operations on the guest VM
-		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "echo 'deviceName=/dev/sdc' >> constants.sh" -runAsSudo
-		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "./STOR_VHDXResize_PartitionDisk.sh" -runAsSudo
+		Write-LogInfo "Check if the guest detects the new space"
+		$deviceName = Get-DeviceName -ip $ip -port $port -username $user -password $password
+		Write-LogInfo "The disk device name: $deviceName"
+		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+			-command "echo 'deviceName=$deviceName' >> constants.sh" -runAsSudo
+		$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password `
+			-command "bash STOR_VHDXResize_PartitionDisk.sh" -runAsSudo
 		if (-not $ret) {
 			$testResult = "FAIL"
 			Throw "Running '${guestScript}'script failed on VM. check VM logs , exiting test case execution"
@@ -184,4 +198,5 @@ Function Main
 	return Get-FinalResultHeader -resultarr $resultArr
 } # end Main
 
-Main -vmName $VM.RoleName -hvServer $VM.HyperVHost -ip $VM.PublicIP -port $VM.SSHPort -testParameters (ConvertFrom-StringData $TestParams.Replace(";","`n"))
+Main -vmName $VM.RoleName -hvServer $VM.HyperVHost -ip $VM.PublicIP -port $VM.SSHPort `
+	-testParameters (ConvertFrom-StringData $TestParams.Replace(";","`n"))

--- a/Testscripts/Windows/STORAGE-HotRemove.ps1
+++ b/Testscripts/Windows/STORAGE-HotRemove.ps1
@@ -27,7 +27,7 @@ function Main {
     Run-SetupScript -Script $SETUP_SCRIPT -Parameters $params -VMData $AllVMData -CurrentTestData $CurrentTestData
 
     Run-LinuxCmd -Command "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;bash ${TEST_SCRIPT} > ${testName}_summary.log 2>&1`"" `
-        -Username $VMUserName -password $VMPassword -ip $Ipv4 -Port $VMPort `
+        -Username $VMUserName -password $VMPassword -ip $Ipv4 -Port $VMPort
 
     $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName "STORAGE-HotRemove" -TestType "sh" `
         -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `

--- a/Testscripts/Windows/STORAGE-HotRemoveVhdx.ps1
+++ b/Testscripts/Windows/STORAGE-HotRemoveVhdx.ps1
@@ -27,7 +27,7 @@ function Main {
     Run-SetupScript -Script $SETUP_SCRIPT -Parameters $params -VMData $AllVMData -CurrentTestData $CurrentTestData
 
     Run-LinuxCmd -Command "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;bash ${TEST_SCRIPT} > ${testName}_summary.log 2>&1`"" `
-        -Username $VMUserName -password $VMPassword -ip $Ipv4 -Port $VMPort `
+        -Username $VMUserName -password $VMPassword -ip $Ipv4 -Port $VMPort
 
     $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName "STORAGE-HotRemove" -TestType "sh" `
         -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `

--- a/Testscripts/Windows/STORAGE-HotUnplug.ps1
+++ b/Testscripts/Windows/STORAGE-HotUnplug.ps1
@@ -139,7 +139,7 @@ function Main {
 
         #verify if vm sees that disks were dettached
         $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "bash ~/${REMOTE_SCRIPT}" -RunAsSudo
+            -command "bash ${REMOTE_SCRIPT}" -RunAsSudo
 
         #Attaching the 1st VHDx again
         $retVal = Add-VHDxDiskDrive $vmName $hvServer $path1 $controllerType $controllerID1 $lun1

--- a/XML/TestCases/FunctionalTests-Storage.xml
+++ b/XML/TestCases/FunctionalTests-Storage.xml
@@ -345,8 +345,9 @@
     <test>
         <testName>STORAGE-VHD-ADD-DIFF-DISK-IDE</testName>
         <setupScript>.\TestScripts\Windows\SETUP-DiffDiskGrowth.ps1</setupScript>
-        <testScript>.\TestScripts\Windows\STORAGE-DiffDiskGrowth.ps1</testScript>
+        <testScript>STORAGE-DiffDiskGrowth.ps1</testScript>
         <cleanupScript>.\TestScripts\Windows\CLEANUP-DiffDiskGrowth.ps1</cleanupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\PartitionDisks.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>IDE=1,1,Diff</param>
@@ -362,8 +363,9 @@
     <test>
         <testName>STORAGE-VHD-ADD-DIFF-DISK-SCSI</testName>
         <setupScript>.\TestScripts\Windows\SETUP-DiffDiskGrowth.ps1</setupScript>
-        <testScript>.\TestScripts\Windows\STORAGE-DiffDiskGrowth.ps1</testScript>
+        <testScript>STORAGE-DiffDiskGrowth.ps1</testScript>
         <cleanupScript>.\TestScripts\Windows\CLEANUP-DiffDiskGrowth.ps1</cleanupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\PartitionDisks.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>SCSI=0,1,Diff</param>
@@ -483,8 +485,9 @@
     <test>
         <testName>STORAGE-VHDX-ADD-DIFF-DISK-IDE</testName>
         <setupScript>.\TestScripts\Windows\SETUP-DiffDiskGrowth.ps1</setupScript>
-        <testScript>.\TestScripts\Windows\STORAGE-DiffDiskGrowth.ps1</testScript>
+        <testScript>STORAGE-DiffDiskGrowth.ps1</testScript>
         <cleanupScript>.\TestScripts\Windows\CLEANUP-DiffDiskGrowth.ps1</cleanupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\PartitionDisks.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>IDE=1,1,Diff</param>
@@ -500,8 +503,9 @@
     <test>
         <testName>STORAGE-VHDX-ADD-DIFF-DISK-SCSI</testName>
         <setupScript>.\TestScripts\Windows\SETUP-DiffDiskGrowth.ps1</setupScript>
-        <testScript>.\TestScripts\Windows\STORAGE-DiffDiskGrowth.ps1</testScript>
+        <testScript>STORAGE-DiffDiskGrowth.ps1</testScript>
         <cleanupScript>.\TestScripts\Windows\CLEANUP-DiffDiskGrowth.ps1</cleanupScript>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\PartitionDisks.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>SCSI=1,1,Diff</param>


### PR DESCRIPTION
1. Move the Get-DeviceName() to CommonFunctions.psm1 
2. Replace the hard code like $sd = "sdc" with Get-DeviceName()
3. In STORAGE-DiffDiskGrowth.ps1, there is 50% chance that resource disk is operated as the differencing disk in previous code.

A full storage test is ongoing.