### PR TITLE
Utilities: Fixed deploy-vm job for CustomVHD

### DIFF
--- a/Utilities/Tool-Deploy-VM.ps1
+++ b/Utilities/Tool-Deploy-VM.ps1
@@ -180,7 +180,13 @@ try {
     $Command = ".\Run-LisaV2.ps1"
     $Command += " -TestPlatform Azure"
     $Command += " -TestLocation '$Region'"
-    $Command += " -ARMImageName '$ARMVMImage'"
+    if ($CustomVHD) {
+        $Command += " -OsVHD '$CustomVHD'"
+    } elseif ($ARMVMImage) {
+        $Command += " -ARMImageName '$ARMVMImage'"
+    } else {
+        Throw "Please provide -OsVHD / -ARMImageName parameter value."
+    }
     $Command += " -StorageAccount '$StorageAccountName'"
     $Command += " -RGIdentifier '$VMName'"
     $Command += " -TestNames 'TOOL-DEPLOYMENT-PROVISION'"


### PR DESCRIPTION
There was a bug that, CustomVHD parameter was not used in the Tool-Deploy-VM.ps1 file.
It was always demanding the ARMImageName.
This PR fixes the issue.