### PR TITLE
Skip run Set-CustomConfigInVMs when VM is Windows OS.

### DIFF
--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -71,12 +71,14 @@ Class AzureProvider : TestProvider
 				}
 
 				$enableSRIOV = $TestCaseData.AdditionalHWConfig.Networking -imatch "SRIOV"
-				$customStatus = Set-CustomConfigInVMs -CustomKernel $this.CustomKernel -CustomLIS $this.CustomLIS -EnableSRIOV $enableSRIOV `
-					-AllVMData $allVMData -TestProvider $this
-				if (!$customStatus) {
-					$ErrorMessage = "Failed to set custom config in VMs."
-					Write-LogErr $ErrorMessage
-					return @{"VmData" = $null; "Error" = $ErrorMessage}
+				if (!$global:IsWindowsImage) {
+					$customStatus = Set-CustomConfigInVMs -CustomKernel $this.CustomKernel -CustomLIS $this.CustomLIS -EnableSRIOV $enableSRIOV `
+						-AllVMData $allVMData -TestProvider $this
+					if (!$customStatus) {
+						$ErrorMessage = "Failed to set custom config in VMs."
+						Write-LogErr $ErrorMessage
+						return @{"VmData" = $null; "Error" = $ErrorMessage}
+					}
 				}
 			}
 			else {

--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -62,15 +62,17 @@ Class HyperVProvider : TestProvider
 
 			$isVmAlive = Is-VmAlive -AllVMDataObject $allVMData
 			if ($isVmAlive -eq "True") {
-				$customStatus = Set-CustomConfigInVMs -CustomKernel $this.CustomKernel -CustomLIS $this.CustomLIS `
-					-AllVMData $allVMData -TestProvider $this -RegisterRhelSubscription
-				if (!$customStatus) {
-					foreach ($vm in $allVMData) {
-						Stop-HyperVGroupVMs -HyperVGroupName $vm.HyperVGroupName -HyperVHost $vm.HyperVHost
+				if (!$global:IsWindowsImage) {
+					$customStatus = Set-CustomConfigInVMs -CustomKernel $this.CustomKernel -CustomLIS $this.CustomLIS `
+						-AllVMData $allVMData -TestProvider $this -RegisterRhelSubscription
+					if (!$customStatus) {
+						foreach ($vm in $allVMData) {
+							Stop-HyperVGroupVMs -HyperVGroupName $vm.HyperVGroupName -HyperVHost $vm.HyperVHost
+						}
+						$ErrorMessage = "Failed to set custom config in VMs."
+						Write-LogErr $ErrorMessage
+						return @{"VmData" = $null; "Error" = $ErrorMessage}
 					}
-					$ErrorMessage = "Failed to set custom config in VMs."
-					Write-LogErr $ErrorMessage
-					return @{"VmData" = $null; "Error" = $ErrorMessage}
 				}
 
 				Inject-HostnamesInHyperVVMs -allVMData $allVMData


### PR DESCRIPTION
Found this issue when invoke .\Utilities\Tool-Deploy-VM.ps1 with SRIOV network, it will check SRIOV after VM is running, but for windows, we should either choose skip it or validation in another code path. Simon approved to skip it.

With Synthetic
```
[LISAv2 Test Results Summary]
Test Run On           : 08/09/2019 15:04:07
ARM Image Under Test  : MicrosoftWindowsServer : WindowsServer : 2019-Datacenter-smalldisk : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DEPLOYVM             TOOL-DEPLOYMENT-PROVISION                                                         PASS                 0.07 
```

With SRIOV
```
[LISAv2 Test Results Summary]
Test Run On           : 08/09/2019 14:53:54
ARM Image Under Test  : MicrosoftWindowsServer : WindowsServer : 2019-Datacenter-smalldisk : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DEPLOYVM             TOOL-DEPLOYMENT-PROVISION                                                         PASS                 0.08 
```
