### PR TITLE
STRESSTEST-RELOAD-LIS-MODULES: fix issue in distro ubuntu16.04

### DIFF
--- a/Testscripts/Windows/RELOAD-MODULES.ps1
+++ b/Testscripts/Windows/RELOAD-MODULES.ps1
@@ -42,8 +42,8 @@ function Check-Result {
         $attempts++
         $isVmAlive = Is-VmAlive -AllVMDataObject $AllVMData -MaxRetryCount 5
         if ($isVmAlive -eq "True") {
-            $tcpTestResult = (Test-NetConnection -ComputerName $VmIp -Port $VMPort).TcpTestSucceeded
-            if ($tcpTestResult) {
+            $TestConnection = .\Tools\plink.exe -C -batch -pw $Password -P $VMPort $User@$VmIp "echo Connected"
+            if ($TestConnection -eq "Connected") {
                 $state = Run-LinuxCmd -ip $VmIp -port $VMPort -username $User -password $Password -command "cat state.txt" -ignoreLinuxExitCode:$true
                 if (-not $state) {
                     if ($TestPlatform -eq "HyperV" -and (Get-VMIntegrationService $VMName -ComputerName $HvServer | `
@@ -69,6 +69,7 @@ function Check-Result {
                     }
                 }
             } else {
+                Write-LogInfo "Current VM is inaccessible, please wait for a while."
                 continue
             }
         } else {


### PR DESCRIPTION
STRESSTEST-RELOAD-LIS-MODULES: 
Before fix: It is probability PASS in ubuntu16.04, It's probability to come across problem: Error in upload after 10 attempt, hence giving up.
After fix: Its PASS rate is 100 percent.

Test results:
Before fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 08/12/2019 02:15:48
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1052-azure
Final Kernel Version  : 4.15.0-1052-azure
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:40

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STRESS               STRESSTEST-RELOAD-LIS-MODULES                                                     FAIL                37.58 
Calling function - Upload-RemoteFile. Error in upload after 10 attempt, hence giving up
```

After fix-
```
[LISAv2 Test Results Summary]
Test Run On           : 08/12/2019 02:20:55
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1052-azure
Final Kernel Version  : 4.15.0-1052-azure
Total Test Cases      : 5 (5 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:3:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STRESS               STRESSTEST-RELOAD-LIS-MODULES-1                                                   PASS                37.07 
    2 STRESS               STRESSTEST-RELOAD-LIS-MODULES-2                                                   PASS                36.72 
    3 STRESS               STRESSTEST-RELOAD-LIS-MODULES-3                                                   PASS                37.12 
    4 STRESS               STRESSTEST-RELOAD-LIS-MODULES-4                                                   PASS                36.72 
    5 STRESS               STRESSTEST-RELOAD-LIS-MODULES-5                                                   PASS                37.26 

[LISAv2 Test Results Summary]
Test Run On           : 08/12/2019 02:58:25
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1052-azure
Final Kernel Version  : 4.15.0-1052-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 5.99
```