### PR TITLE
CustomKernelInstall: skip if kernel is already installed

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -379,6 +379,14 @@ function InstallKernel() {
         esac
         customKernelFilesUnExpanded="${CustomKernel#$LOCAL_FILE_PREFIX}"
         LogMsg "Removing packages that do not allow the kernel to be installed"
+        kernel_version_of_rpm=$(rpm -qp --queryformat='%{Version}-%{Release}.%{Arch}\n' ${customKernelFilesUnExpanded})
+        if [ "$kernel_version_of_rpm" = "$(uname -r)" ]; then
+            LogMsg "Kernel is already installed. So skipping $customKernelFilesUnExpanded installation."
+            LogMsg "CUSTOM_KERNEL_ALREADY_INSTALLED"
+            LogMsg "CUSTOM_KERNEL_SUCCESS"
+            SetTestStateCompleted
+            exit 0
+        fi
         if [[ "${customKernelFilesUnExpanded}" == *'*.rpm'* ]]; then
             LogMsg "Removing: ${KERNEL_CONFLICTING_PACKAGES}"
             remove_package "${KERNEL_CONFLICTING_PACKAGES}"


### PR DESCRIPTION
Fixes #453 

Added a check to skip kernel installation, if customKernel is already installed and returns true to proceed further installation.
