### PR TITLE
TIMESYNC-NTP: Add a while to wait NTP daemon is running

### DIFF
--- a/Testscripts/Linux/TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/TIMESYNC-NTP.sh
@@ -196,10 +196,20 @@ else # other distro
     exit 0
 fi
 
-# Show a list of peers to check if the NTP daemon is running
-ntpq -p $loopbackIP
-if ! ntpq -p $loopbackIP
-then
+# check if the NTP daemon is running
+timeout=50
+while [ $timeout -ge 0 ]; do
+    ntpdVal=$(ntpq -p $loopbackIP)
+    if [ -n "$ntpdVal" ] ; then
+        break
+    else
+        LogMsg "Wait for NTP daemon is running"
+        timeout=$((timeout-5))
+        sleep 5
+    fi
+done
+
+if [ -z "$ntpdVal" ];then
     LogErr "Unable to query NTP deamon!"
     SetTestStateAborted
     exit 0


### PR DESCRIPTION
Before fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2019 09:25:00
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1014-azure
Final Kernel Version  : 5.0.0-1017-azure
Total Test Cases      : 15 (14 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:2:44

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIMESYNC-NTP-1                                                                    PASS                 2.95 
    2 CORE                 TIMESYNC-NTP-2                                                                    PASS                 2.78 
    3 CORE                 TIMESYNC-NTP-3                                                                    PASS                 2.79 
    4 CORE                 TIMESYNC-NTP-4                                                                    PASS                  2.7 
    5 CORE                 TIMESYNC-NTP-5                                                                    PASS                 2.81 
    6 CORE                 TIMESYNC-NTP-6                                                                    PASS                 2.73 
    7 CORE                 TIMESYNC-NTP-7                                                                    PASS                 3.38 
    8 CORE                 TIMESYNC-NTP-8                                                                    PASS                 2.64 
    9 CORE                 TIMESYNC-NTP-9                                                                 ABORTED                 3.15 
   10 CORE                 TIMESYNC-NTP-10                                                                   PASS                 2.84 
   11 CORE                 TIMESYNC-NTP-11                                                                   PASS                 2.82 
   12 CORE                 TIMESYNC-NTP-12                                                                   PASS                 2.81 
   13 CORE                 TIMESYNC-NTP-13                                                                   PASS                  2.8 
   14 CORE                 TIMESYNC-NTP-14                                                                   PASS                 2.77 
   15 CORE                 TIMESYNC-NTP-15                                                                   PASS                 2.69 
```
After fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2019 07:45:04
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1014-azure
Final Kernel Version  : 5.0.0-1017-azure
Total Test Cases      : 15 (15 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:2:35

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIMESYNC-NTP-1                                                                    PASS                 2.78 
    2 CORE                 TIMESYNC-NTP-2                                                                    PASS                 2.77 
    3 CORE                 TIMESYNC-NTP-3                                                                    PASS                 2.83 
    4 CORE                 TIMESYNC-NTP-4                                                                    PASS                 2.76 
    5 CORE                 TIMESYNC-NTP-5                                                                    PASS                 2.76 
    6 CORE                 TIMESYNC-NTP-6                                                                    PASS                  2.8 
    7 CORE                 TIMESYNC-NTP-7                                                                    PASS                 2.82 
    8 CORE                 TIMESYNC-NTP-8                                                                    PASS                  2.9 
    9 CORE                 TIMESYNC-NTP-9                                                                    PASS                 3.07 
   10 CORE                 TIMESYNC-NTP-10                                                                   PASS                 2.81 
   11 CORE                 TIMESYNC-NTP-11                                                                   PASS                  2.9 
   12 CORE                 TIMESYNC-NTP-12                                                                   PASS                 2.77 
   13 CORE                 TIMESYNC-NTP-13                                                                   PASS                  2.8 
   14 CORE                 TIMESYNC-NTP-14                                                                   PASS                 2.73 
   15 CORE                 TIMESYNC-NTP-15                                                                   PASS                 2.72 
```
	
	
