### PR TITLE
Get-Counter dont accept -ComputerName for localhost

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -901,7 +901,11 @@ function Get-HostMemory($HvServer, [int]$RequestedMemory) {
     $totalMemory = [math]::Round((Get-WmiObject -Class Win32_ComputerSystem -Computer $HvServer).TotalPhysicalMemory/1MB)
     $bufferMemory = [int](0.1 * $totalMemory)
     # Get available memory and decrease the buffer from it
-    $availableMemory = [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName $HvServer).CounterSamples[0].CookedValue
+    if ($HvServer -ne "localhost") {
+        $availableMemory = [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName $HvServer).CounterSamples[0].CookedValue
+    } else {
+        $availableMemory = [int](Get-Counter -Counter "\Memory\Available MBytes").CounterSamples[0].CookedValue
+    }
     $availableMemory = $availableMemory - $bufferMemory
     # Check if there is enough memory to deploy the VM
     $availableMemoryAfterDeploy = $availableMemory - $RequestedMemory


### PR DESCRIPTION
Before: 

PS C:\Users\v-santy\lisav2> [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName "localhost").CounterSamples[0].CookedValue
Get-Counter : Unable to connect to the specified computer or the computer is offline.
At line:1 char:7
+ [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName " ...
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidResult: (:) [Get-Counter], Exception
    + FullyQualifiedErrorId : CounterApiError,Microsoft.PowerShell.Commands.GetCounterCommand
 
Cannot index into a null array.
At line:1 char:1
+ [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName " ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : NullArray


After: 

PS C:\Users\v-santy\lisav2> [int](Get-Counter -Counter "\Memory\Available MBytes").CounterSamples[0].CookedValue
3399