### PR TITLE
Update STOR-VHDX-RESIZE-GROWFS and GROWSHRINK Get-VMHardDiskDrive to …

### DIFF
--- a/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
+++ b/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
@@ -122,7 +122,15 @@ Function Main
 		}
 
 		# Find the vhdx drive to operate on
-		$vhdxDrive = Get-VMHardDiskDrive -VMName $vmName  -ComputerName $hvServer -ControllerLocation 1
+		$vhdxName = $vmName + "-" + $controllerType
+		$vhdxDisks = Get-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer
+
+		foreach ($vhdx in $vhdxDisks){
+			$vhdxPath = $vhdx.Path
+			if ($vhdxPath.Contains($vhdxName)){
+				$vhdxDrive = Get-VMHardDiskDrive -VMName $vmName -Controllertype $controllerType -ControllerNumber $vhdx.ControllerNumber -ControllerLocation $vhdx.ControllerLocation -ComputerName $hvServer -ErrorAction SilentlyContinue
+			}
+		}
 		if (-not $vhdxDrive) {
 			$testResult = "FAIL"
 			Throw "No suitable virtual hard disk drives attached VM ${vmName}"


### PR DESCRIPTION
…support Gen2 VM

Fix the issue for all the storage resize test cases for gen 2 vm.

Main issue:
When the function  Get-VMHardDiskDrive uses "ControllerLocation 1" on Generation 2 VM, it will get the ResourceDisk file path which is 1G, then after resize this disk, the test cases get failure.

$vhdxDrive = Get-VMHardDiskDrive -VMName $vmName  -ComputerName $hvServer -ControllerLocation 1

Resolution: 
Copy old lis-test script content, get vhdxDrive by checking vhdx file name which contains the vm name and controller type.

Test result after fix:

08/26/2019 10:21:41 : [INFO ] Hyper-V VM group LISAv2-OneVM-201908-YU71-637024396782 removed!
08/26/2019 10:21:41 : [INFO ] Successfully delete HyperV group LISAv2-OneVM-201908-YU71-637024396782.
08/26/2019 10:21:41 : [INFO ] Test YU71 finished
08/26/2019 10:21:41 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 08/26/2019 10:07:58
VHD Under Test        : ..\RHEL-8.1.0-20190821.0-x86_64-GEN2-A.vhdx
Initial Kernel Version: 4.18.0-135.el8.x86_64
Final Kernel Version  : 4.18.0-135.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              VHDX-RESIZE-GROW-FILESYSTEM-512                                                   PASS                 8.73 


Logs can be found at C:\Users\xuli\LISAv2\TestResults\2019-26-08-18-07-54-6564