### PR TITLE
NESTED-KVM-BASIC-VERIFICATION: fix issue on RedHat7.7

### DIFF
--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -75,6 +75,7 @@ Download_Image_Files()
        shift
        shift
     done
+    cd /mnt/resource
     if [ "x$destination_image_name" == "x" ] || [ "x$source_image_url" == "x" ] ; then
         echo "Usage: GetImageFiles -destination_image_name <destination image name> -source_image_url <source nested image url>"
         Update_Test_State $ICA_TESTABORTED


### PR DESCRIPTION
Fix #540
Test result:
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:40:22
ARM Image Under Test  : RedHat : RHEL : 7-LVM : 7.7.2019081522
Initial Kernel Version: 3.10.0-1062.el7.x86_64
Final Kernel Version  : 3.10.0-1062.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                11.19 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:41:04
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 9.12 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:41:16
ARM Image Under Test  : SUSE : SLES : 12-SP4 : Latest
Initial Kernel Version: 4.12.14-6.15-azure
Final Kernel Version  : 4.12.14-6.15-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                    9 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:41:36
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.11.6.el7.x86_64
Final Kernel Version  : 3.10.0-862.11.6.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 10.1 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:41:45
ARM Image Under Test  : credativ : Debian : 9 : Latest
Initial Kernel Version: 4.9.0-9-amd64
Final Kernel Version  : 4.9.0-9-amd64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 8.78 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:42:02
ARM Image Under Test  : RedHat : RHEL : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.34.2.el7.x86_64
Final Kernel Version  : 3.10.0-862.34.2.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                10.87
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 05:42:21
ARM Image Under Test  : Oracle : Oracle-Linux : 7.6 : Latest
Initial Kernel Version: 4.14.35-1844.1.3.el7uek.x86_64
Final Kernel Version  : 4.14.35-1844.1.3.el7uek.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 8.95 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2019 06:20:51
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1014-azure
Final Kernel Version  : 5.0.0-1014-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 5.78 
```