### PR TITLE
Make sure all basic cgroup subsystems are mounted

### DIFF
--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -108,6 +108,16 @@ sysctl -w vm.dirty_ratio=10
 sysctl -w vm.dirty_background_ratio=5
 sysctl -p
 
+# For cgroup test cases, the below subsystem should be mounted
+cgroup_subsystem_names=("rdma" "blkio" "memory" "net_cls,net_prio" "cpu,cpuacct" "devices" "pids" "cpuset" "freezer")
+for name in ${cgroup_subsystem_names[*]}; do
+    mount_point=$(grep -w $name /proc/mounts | grep -w "cgroup" | cut -f 2 | cut -d " " -f2)
+    if [ X$mount_point == X ]; then
+        LogMsg "$name is not mounted. Try to mount it"
+        mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,$name cgroup /sys/fs/cgroup/$name
+    fi
+done
+
 # define regular stable releases in order to avoid unstable builds
 # https://github.com/linux-test-project/ltp/tags
 # 'ltp_version_git_tag' is passed from Test Definition in .\XML\TestCases\CommunityTests.xml.


### PR DESCRIPTION
The cgroup test cases depend on the mount points of cgroup subsystems. For example, if miss the "/sys/fs/cgroup/net_cls,net_prio" mount point, the all tests about it will fail.
...
cgroup_fj_stress_net_cls_1_200_each : FAIL
cgroup_fj_stress_net_cls_200_1_each : FAIL
cgroup_fj_stress_net_prio_2_2_none : FAIL
cgroup_fj_stress_net_prio_3_3_none : FAIL
...
