### PR TITLE
Hyper-V: Update Storage cases for skipping IDE and VHD for gen2 vm

### DIFF
--- a/Testscripts/Linux/STOR-Lis-Disk.sh
+++ b/Testscripts/Linux/STOR-Lis-Disk.sh
@@ -60,6 +60,7 @@ SetTestStateRunning
 # Count the number of SCSI= and IDE= entries in constants
 #
 disk_count=0
+diskIDECount=0
 for entry in $(cat ./constants.sh); do
     # Convert to lower case
     lowStr="$(tr '[A-Z]' '[a-z' <<<"$entry")"
@@ -67,6 +68,7 @@ for entry in $(cat ./constants.sh); do
     # does it start wtih ide or scsi
     if [[ $lowStr == ide* ]]; then
         disk_count=$((disk_count + 1))
+        diskIDECount=$((diskIDECount+1))
     fi
 
     if [[ $lowStr == scsi* ]]; then
@@ -75,6 +77,15 @@ for entry in $(cat ./constants.sh); do
 done
 
 LogMsg "constants disk count = $disk_count"
+
+# Generation 2 VM does not support IDE or VHD format disk
+if [ -d /sys/firmware/efi ]; then
+    if [[ $diskIDECount -ge 1 ]] || [[ $vhdFormat == 'vhd' ]]; then 
+        UpdateSummary "Generation 2 VM does not support IDE or VHD format disk, skip test"
+        SetTestStateSkipped
+        exit 0
+    fi
+fi
 
 #
 # Compute the number of sd* drives on the system.

--- a/Testscripts/Linux/STORAGE-LargeDisk.sh
+++ b/Testscripts/Linux/STORAGE-LargeDisk.sh
@@ -153,6 +153,12 @@ done
 
 echo "constants disk count = $diskCount"
 
+# Generation 2 VM does not support vhd format disk
+if [[ $vhdFormat == 'vhd' ]] && [ -d /sys/firmware/efi ]; then
+    UpdateSummary "Generation 2 VM does not support vhd disk, skip test"
+    SetTestStateSkipped
+    exit 0
+fi
 
 # Compute the number of sd* drives on the system.
 sdCount=0

--- a/Testscripts/Windows/AddHardDisk.ps1
+++ b/Testscripts/Windows/AddHardDisk.ps1
@@ -340,11 +340,6 @@ function Main {
         return $False
     }
 
-    $vmGen = Get-VMGeneration $VMName $HvServer
-    if ($vmGen -ne 1) {
-        throw "VHD is not supported by Gen 2 VMs"
-    }
-
     # Parse the testParams string
     $params = $testParams.Split(';')
     foreach ($p in $params) {
@@ -357,6 +352,16 @@ function Main {
             Write-LogErr "test parameter '$p' is being ignored because it appears to be malformed"
             continue
         }
+
+        if ( "vhdFormat" -eq $temp[0] ) {
+            $vhdFormat = $temp[1]
+            $vmGen = Get-VMGeneration $VMName $HvServer
+            if ($vmGen -ne 1 -and $vhdFormat -eq 'vhd') {
+                Write-LogInfo "Generation 2 VM does not support vhd disk, please skip this case in the test script"
+                return $True
+            }
+        }
+
         $controllerType = $temp[0]
         if (@("IDE", "SCSI") -notcontains $controllerType) {
             continue

--- a/Testscripts/Windows/RemoveVhdxHardDisk.ps1
+++ b/Testscripts/Windows/RemoveVhdxHardDisk.ps1
@@ -167,8 +167,8 @@ function Main {
 
     $vmGeneration = Get-VMGeneration $vmName $hvServer
     if ($IDECount -ge 1 -and $vmGeneration -eq 2 ) {
-         Write-LogErr "Generation 2 VM does not support IDE disk, please skip this case in the test script"
-         return $false
+         Write-LogInfo "Generation 2 VM does not support IDE disk, please skip this case in the test script"
+         return $true
     }
 
     # if define diskCount number, only support one SCSI parameter

--- a/Testscripts/Windows/SETUP-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/SETUP-DiffDiskGrowth.ps1
@@ -146,12 +146,6 @@ function Main {
         return $False
     }
 
-    $vmGeneration = Get-VMGeneration $vmName $hvServer
-    if ( $controllerType -eq "IDE" -and $vmGeneration -eq 2 ) {
-        Write-LogInfo "Generation 2 VM does not support IDE disk, please skip this case in the test script"
-        return $True
-    }
-
     if (-not $controllerID) {
         Write-LogErr "No controller ID specified in the test parameters"
         return $False
@@ -165,6 +159,12 @@ function Main {
     if (-not $vhdFormat) {
         Write-LogErr "No vhdFormat specified in the test parameters"
         return $False
+    }
+
+    $vmGeneration = Get-VMGeneration $vmName $hvServer
+    if (( $controllerType -eq "IDE" -or $vhdFormat -eq "vhd" ) -and $vmGeneration -eq 2 ) {
+        Write-LogInfo "Generation 2 VM does not support IDE or vhd disk, please skip this case in the test script"
+        return $True
     }
 
     if (-not $parentVhd) {

--- a/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
+++ b/Testscripts/Windows/STOR-VHDX-RESIZE-GROWSHRINK.ps1
@@ -194,11 +194,14 @@ Function Main
 		$testResult = "PASS"
 
 	} catch {
-		$testResult = "FAIL"
 		$ErrorMessage =  $_.Exception.Message
 		$ErrorLine = $_.InvocationInfo.ScriptLineNumber
-		Write-LogErr "$ErrorMessage at line: $ErrorLine"
-
+		if ($testResult -eq "SKIPPED" ) {
+			Write-LogInfo "$ErrorMessage"
+		}
+		else {
+			Write-LogErr "$ErrorMessage at line: $ErrorLine"
+		}
 	} finally {
 		$resultArr += $testResult
 	}

--- a/Testscripts/Windows/STORAGE-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/STORAGE-DiffDiskGrowth.ps1
@@ -104,9 +104,9 @@ function Main {
     }
 
     $vmGeneration = Get-VMGeneration $vmName $hvServer
-    if ( $controllerType -eq "IDE" -and $vmGeneration -eq 2 ) {
-        Write-LogErr "Generation 2 VM does not support IDE disk, skip test"
-        return "FAIL"
+    if (( $controllerType -eq "IDE" -or $vhdFormat -eq "vhd" ) -and $vmGeneration -eq 2 ) {
+        Write-LogInfo "Generation 2 VM does not support IDE or vhd disk, skip test"
+        return "SKIPPED"
     }
     if (-not $controllerID) {
         Write-LogErr "Missing controller index in test parameters"

--- a/Testscripts/Windows/STORAGE-HotAdd.ps1
+++ b/Testscripts/Windows/STORAGE-HotAdd.ps1
@@ -5,7 +5,7 @@ param([String] $TestParams,
       [object] $AllVmData,
       [object] $CurrentTestData)
 
-$SETUP_SCRIPT = ".\TestScripts\Windows\AddVhdxHardDisk.ps1"
+$SETUP_SCRIPT = ".\TestScripts\Windows\AddHardDisk.ps1"
 $TEST_SCRIPT = "STOR-Lis-Disk.sh"
 
 function Main {

--- a/XML/TestCases/FunctionalTests-Storage.xml
+++ b/XML/TestCases/FunctionalTests-Storage.xml
@@ -208,7 +208,7 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\STOR_VHDXResize_ReadWrite.sh,.\Testscripts\Linux\STOR_VHDXResize_PartitionDisk.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\STOR_VHDXResize_PartitionDiskOver2TB.sh</files>
         <setupType>OneVM</setupType>
         <testParameters>
-            <param>IDE=0,1,Dynamic,512,3GB</param>
+            <param>SCSI=0,1,Dynamic,512,3GB</param>
             <param>NewSize=2304GB</param>
             <param>fileSystems=(ext4 xfs)</param>
         </testParameters>
@@ -390,6 +390,7 @@
             <param>SCSI=1,1,Dynamic</param>
             <param>SCSI=1,2,Fixed</param>
             <param>SCSI=1,3,Fixed</param>
+            <param>vhdFormat=vhd</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
@@ -406,6 +407,7 @@
         <TestParameters>
             <param>SCSI=0,1,Dynamic</param>
             <param>SCSI=0,2,Dynamic</param>
+            <param>vhdFormat=vhd</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
@@ -422,6 +424,7 @@
         <TestParameters>
             <param>SCSI=1,0,Dynamic</param>
             <param>SCSI=1,1,Dynamic</param>
+            <param>vhdFormat=vhd</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>
@@ -439,6 +442,7 @@
         <TestParameters>
             <param>SCSI=1,0,Dynamic,2039GB</param>
             <param>fileSystems=(xfs btrfs)</param>
+            <param>vhdFormat=vhd</param>
         </TestParameters>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Currently if run storage IDE and VHD test cases on Gen2 vm, it will fail directly but not skipped. When run full storage test cases on both gen1 and gen2 vm , need to check those failure cases reason after test run.

```
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes
-----------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              VHDX-RESIZE-TO-BIGGER512-FIXED-IDE                                             SKIPPED                 1.36
    2 STORAGE              VHDX-RESIZE-TO-BIGGER512-DYNAMIC-IDE                                           SKIPPED                 3.06
    3 STORAGE              VHDX-RESIZE-OVER2TB-SCSI                                                          PASS                 7.43
    4 STORAGE              VHDX-RESIZE-OVER2TB-IDE                                                        SKIPPED                 1.82
    5 STORAGE              VHDX-RESIZE-GROWSHRINK-IDE                                                     SKIPPED                 1.77
    6 STORAGE              VHDX-RESIZE-GROWOVER2TB-SHRINK-IDE                                             SKIPPED                 1.83
    7 STORAGE              STORAGE-VHD-ADD-DIFF-DISK-IDE                                                  SKIPPED                 2.09
    8 STORAGE              STORAGE-VHD-ADD-DIFF-DISK-SCSI                                                 SKIPPED                  3.6
    9 STORAGE              STORAGE-VHDX-ADD-DIFF-DISK-IDE                                                 SKIPPED 
```     