### PR TITLE
CORE-InitrdModulesCheck.sh: Add keyboard module

### DIFF
--- a/Testscripts/Linux/CORE-InitrdModulesCheck.sh
+++ b/Testscripts/Linux/CORE-InitrdModulesCheck.sh
@@ -82,6 +82,7 @@ config_modulesDic=(
 [CONFIG_HYPERV=y]="hv_vmbus.ko"
 [CONFIG_HYPERV_STORAGE=y]="hv_storvsc.ko"
 [CONFIG_HYPERV_NET=y]="hv_netvsc.ko"
+[CONFIG_HYPERV_KEYBOARD=y]="hyperv-keyboard.ko"
 )
 for key in $(echo ${!config_modulesDic[*]})
 do
@@ -106,7 +107,7 @@ done
 hv_modules=("${tempList[@]}")
 
 if [ "${hv_modules:-UNDEFINED}" = "UNDEFINED" ]; then
-    LogMsg "hv_vmbus.ko, hv_storvsc.ko and hv_netvsc.ko modules are built-in, skip test"
+    LogMsg "hv_vmbus.ko, hv_storvsc.ko, hv_netvsc.ko and hyperv-keyboard.ko modules are built-in, skip test"
     SetTestStateSkipped
     exit 0
 fi


### PR DESCRIPTION
Before fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 09/02/2019 03:13:45
ARM Image Under Test  : SUSE : SLES : 12-sp4-gen2 : 2019.08.26
Initial Kernel Version: 4.12.14-6.23-azure
Final Kernel Version  : 4.12.14-6.23-azure
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 INITRD-MODULES-CHECK                                                              FAIL                 6.38 
Calling function - Run-LinuxCmd. Failed to execute : bash CORE-InitrdModulesCheck.sh > INITRD-
MODULES-CHECK_summary.log 2>&1.

cat INITRD-MODULES-CHECK_summary.log
Mon Sep 02 03:23:30 2019 : Module hyperv-keyboard.ko was NOT found.
```
After fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 09/02/2019 01:26:33
ARM Image Under Test  : SUSE : SLES : 12-sp4-gen2 : 2019.08.26
Initial Kernel Version: 4.12.14-6.23-azure
Final Kernel Version  : 4.12.14-6.23-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 INITRD-MODULES-CHECK                                                           SKIPPED                 2.04 

cat INITRD-MODULES-CHECK_summary.log
Mon Sep 02 04:42:04 2019 : hv_vmbus.ko, hv_storvsc.ko, hv_netvsc.ko and hyperv-keyboard.ko modules are built-in, skip test
```