### PR TITLE
GPU CUDA driver test skip in SUSE

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -128,6 +128,11 @@ function InstallCUDADrivers() {
             return 1
         fi
     ;;
+    suse*)
+        echo "$DISTRO not supported. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    ;;
     esac
 
     find /var/lib/dkms/nvidia* -name make.log -exec cp {} ${HOME}/nvidia_dkms_make.log \;

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -196,6 +196,11 @@ function Main {
         $installState = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "cat /$superuser/state.txt"
 
+        if ($installState -eq "TestSkipped") {
+            $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "SKIPPED"
+            return $currentTestResult
+        }
+
         if ($installState -imatch "TestAborted") {
             Write-LogErr "CUDA drivers installation aborted"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "ABORTED"


### PR DESCRIPTION
Fix a part of https://github.com/LIS/LISAv2/issues/349

Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 09/02/2019 08:59:47
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                  SKIPPED                 7.32 
	Using nVidia driver : CUDA 
[LISAv2 Test Results Summary]
Test Run On           : 09/02/2019 09:01:05
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU                                          SKIPPED                 5.35 
	Using nVidia driver : CUDA 
```