### PR TITLE
Fix GPU CUDA|GRID driver test issues in RHEL 8.x

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -34,8 +34,8 @@ grid_driver="https://go.microsoft.com/fwlink/?linkid=874272"
 #######################################################################
 function InstallRequirements() {
     case $DISTRO in
-    redhat_7|centos_7)
-        if [[ $DISTRO -eq centos_7 ]]; then
+    redhat_7|centos_7|redhat_8)
+        if [[ $DISTRO == "centos_7" ]]; then
             # for all releases that are moved into vault.centos.org
             # we have to update the repositories first
             yum -y install centos-release
@@ -128,8 +128,8 @@ function InstallCUDADrivers() {
             return 1
         fi
     ;;
-    suse*)
-        echo "$DISTRO not supported. Skip the test."
+    suse*|redhat_8)
+        LogMsg "$DISTRO not supported. Skip the test."
         SetTestStateSkipped
         exit 0
     ;;
@@ -187,7 +187,7 @@ UtilsInit
 
 GetDistro
 update_repos
-install_package "wget lshw gcc"
+install_package "wget lshw gcc make"
 
 InstallRequirements
 check_exit_status "Install requirements" "exit"
@@ -205,6 +205,13 @@ if [ $? -ne 0 ]; then
     LogErr "Could not install the $driver drivers!"
     SetTestStateFailed
     exit 0
+fi
+
+if [[ $DISTRO == "redhat_8" ]]; then
+    ln -s /usr/libexec/platform-python /sbin/python
+    wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
+    chmod +x lsvmbus
+    mv lsvmbus /usr/sbin
 fi
 
 SetTestStateCompleted

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2294,6 +2294,8 @@ function install_epel () {
 				epel_rpm_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
 			elif [[ $DISTRO_VERSION =~ ^7\. ]]; then
 				epel_rpm_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+			elif [[ $DISTRO_VERSION =~ ^8\. ]]; then
+				epel_rpm_url="https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
 			else
 				echo "Unsupported version to install epel repository"
 				return 1


### PR DESCRIPTION
Fix https://github.com/LIS/LISAv2/issues/349
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 09/03/2019 02:38:55
ARM Image Under Test  : RedHat : RHEL : 8 : Latest
Initial Kernel Version: 4.18.0-80.4.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.4.2.el8_0.x86_64
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                  SKIPPED                 4.19 
	Using nVidia driver : CUDA 
	Unsupported kernel version! 

[LISAv2 Test Results Summary]
Test Run On           : 09/03/2019 02:39:07
ARM Image Under Test  : RedHat : RHEL : 8 : Latest
Initial Kernel Version: 4.18.0-80.4.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.4.2.el8_0.x86_64
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                  SKIPPED                  4.2 
	Using nVidia driver : GRID 
	Unsupported kernel version! 

[LISAv2 Test Results Summary]
Test Run On           : 09/03/2019 02:39:29
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.11.6.el7.x86_64
Final Kernel Version  : 3.10.0-862.11.6.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                16.93 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 09/03/2019 02:40:08
ARM Image Under Test  : RedHat : RHEL : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.34.2.el7.x86_64
Final Kernel Version  : 3.10.0-862.34.2.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:24

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                19.55 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```
