### PR TITLE
Only count GPU pass-through devices

### DIFF
--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -28,9 +28,10 @@ param([object] $AllVmData,
 function Start-Validation {
     # region PCI Express pass-through in lsvmbus
     $PCIExpress = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
-        -username $superuser -password $password "lsvmbus" -ignoreLinuxExitCode
+        -username $superuser -password $password "lsvmbus -vv" -ignoreLinuxExitCode
     Set-Content -Value $PCIExpress -Path $LogDir\PCI-Express-passthrough.txt -Force
-    $pciExpressCount = (Select-String -Path $LogDir\PCI-Express-passthrough.txt -Pattern "PCI Express pass-through").Matches.Count
+    # Scope to match GPUs only since there can be other pass-through devices
+    $pciExpressCount = (Select-String -Path $LogDir\PCI-Express-passthrough.txt -Pattern "Device_ID.*47505500").Matches.Count
     if ($pciExpressCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
     } else {


### PR DESCRIPTION
Fix for GPU PCIe pass-through device count test: SR-IOV (and potentially other) devices will show up as PCIe pass-through devices so scoping the test to only check for GPU pass-through devices based on their Device_ID which starts with 47505500 in Azure