### PR TITLE
Skipped when coreos unsupport.

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -59,6 +59,11 @@ Install_Kexec(){
                 UpdateSummary "Warning: Kexec-tools failed to install."
             fi
         ;;
+        coreos*)
+            LogMsg "Distro not supported. Skip the test."
+            SetTestStateSkipped
+            exit 0
+        ;;
         *)
             LogErr "Warning: Distro '${distro}' not supported. Kexec-tools failed to install."
         ;;

--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -41,6 +41,11 @@ Install_KVM_Dependencies()
     if [ $DISTRO_NAME == "sles" ] || [ $DISTRO_NAME == "sle_hpc" ]; then
         add_sles_network_utilities_repo
     fi
+    if [ $DISTRO_NAME == "coreos" ]; then
+        LogMsg "Distro not supported. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    fi
     update_repos
     install_package qemu-kvm
     install_package bridge-utils

--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -172,6 +172,11 @@ Main() {
         SetTestStateSkipped
         exit 0
     fi
+    if [ $DISTRO == "coreos" ]; then
+        LogMsg "Distro not supported. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    fi
     # Configure XFS Tools
     ConfigureXFSTestTools
 


### PR DESCRIPTION
Test Result:
```
[LISAv2 Test Results Summary]
Test Run On           : 09/04/2019 01:57:43
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                  SKIPPED                 2.71 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 09/04/2019 06:49:25
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-FILE-SYSTEM-VERIFICATION-GENERIC                                          SKIPPED                 5.52 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 09/04/2019 06:13:13
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                        SKIPPED                 3.39 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 09/05/2019 01:38:01
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SINGLE-CORE                                                        SKIPPED                 2.25 

[LISAv2 Test Results Summary]
Test Run On           : 09/05/2019 01:48:52
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SMP                                                                SKIPPED                 2.16 

[LISAv2 Test Results Summary]
Test Run On           : 09/05/2019 01:50:46
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU                                                     SKIPPED                 2.24 

[LISAv2 Test Results Summary]
Test Run On           : 09/05/2019 01:50:27
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.4.1
Initial Kernel Version: 4.19.66-coreos
Final Kernel Version  : 4.19.66-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-16-CORES                                                           SKIPPED                 2.22 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 09/05/2019 07:16:16
ARM Image Under Test  : CoreOS : CoreOS : Stable : 2191.5.0
Initial Kernel Version: 4.19.68-coreos
Final Kernel Version  : 4.19.68-coreos
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                         SKIPPED                 3.13 
```
```
[LISAv2 Test Results Summary]
Test Run On           : 09/09/2019 08:48:53
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1018-azure
Final Kernel Version  : 5.0.0-1018-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SMP                                                                   PASS                 6.63 
```