### PR TITLE
Fix issue when set test state

### DIFF
--- a/Testscripts/Linux/nested_kvm_lagscope_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_lagscope_different_l1_public_bridge.sh
@@ -195,7 +195,7 @@ Collect_Logs()
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "nested_properties.csv" "get"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $IMAGE_NAME -source_image_url $NestedImageUrl
 Setup_Public_Bridge $BR_NAME $BR_ADDR
@@ -205,4 +205,7 @@ if [ "$role" == "client" ]; then
     Collect_Logs
     Stop_Nested_VM
 fi
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_netperf_pps.sh
+++ b/Testscripts/Linux/nested_kvm_netperf_pps.sh
@@ -206,7 +206,7 @@ Collect_Logs()
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "nested_properties.csv" "get"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 collect_VM_properties
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $IMAGE_NAME -source_image_url $NestedImageUrl
@@ -217,4 +217,7 @@ if [ "$role" == "client" ]; then
     Collect_Logs
     Stop_Nested_VM
 fi
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_netperf_pps_nat.sh
+++ b/Testscripts/Linux/nested_kvm_netperf_pps_nat.sh
@@ -234,7 +234,7 @@ Collect_Logs()
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "nested_properties.csv" "get"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 collect_VM_properties
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $IMAGE_NAME -source_image_url $NestedImageUrl
@@ -245,4 +245,7 @@ if [ "$role" == "client" ]; then
     Collect_Logs
     Stop_Nested_VM
 fi
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
@@ -228,7 +228,7 @@ Collect_Logs()
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcp-test-logs-receiver.tar" "get"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $IMAGE_NAME -source_image_url $NestedImageUrl
 Setup_Network
@@ -238,4 +238,7 @@ if [ "$role" == "client" ]; then
     Collect_Logs
     Stop_Nested_VM
 fi
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
@@ -209,7 +209,7 @@ Collect_Logs()
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcp-test-logs-receiver.tar" "get"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $IMAGE_NAME -source_image_url $NestedImageUrl
 Setup_Public_Bridge $BR_NAME $BR_ADDR
@@ -219,4 +219,7 @@ if [ "$role" == "client" ]; then
     Collect_Logs
     Stop_Nested_VM
 fi
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
@@ -227,7 +227,7 @@ Collect_Logs() {
 	check_exit_status "Get the NTTTCP report"
 }
 
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 Install_KVM_Dependencies
 Download_Image_Files -destination_image_name $CLIENT_IMAGE -source_image_url $NestedImageUrl
 cp $CLIENT_IMAGE $SERVER_IMAGE
@@ -236,4 +236,7 @@ Prepare_Nested_VMs
 Run_Ntttcp_On_Client
 Collect_Logs
 Stop_Nested_VM
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_kvm_storage_perf.sh
+++ b/Testscripts/Linux/nested_kvm_storage_perf.sh
@@ -155,7 +155,7 @@ Collect_Logs()
 ############################################################
 #   Main body
 ############################################################
-Update_Test_State $ICA_TESTRUNNING
+SetTestStateRunning
 
 disks=$(ls -l /dev | grep sd[c-z]$ | awk '{print $10}')
 Remove_Raid
@@ -190,4 +190,7 @@ Run_Fio
 Collect_Logs
 Stop_Nested_VM
 collect_VM_properties
-Update_Test_State $ICA_TESTCOMPLETED
+SetTestStateCompleted
+
+#Exiting with zero is important.
+exit 0

--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -75,7 +75,8 @@ Download_Image_Files()
        shift
        shift
     done
-    cd /mnt/resource
+    HOMEDIR=$(pwd)
+    cp -r $HOMEDIR/* /mnt/resource/ & cd /mnt/resource
     if [ "x$destination_image_name" == "x" ] || [ "x$source_image_url" == "x" ] ; then
         echo "Usage: GetImageFiles -destination_image_name <destination image name> -source_image_url <source nested image url>"
         Update_Test_State $ICA_TESTABORTED


### PR DESCRIPTION
Before fix: when test complete /home/$HOMEDIR state is TestRunning and /mnt/resource is TestCompleted.
After fix:  /home/$HOMEDIR test state is TestCompleted and the test result is consistent with the master.