### PR TITLE
Temp fix build error in linux-next.

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -159,7 +159,14 @@ function Build_Kernel() {
     check_exit_status "Make kernel config" "exit"
 
     LogMsg "Start to build kernel"
-    make -j"$thread_number" >> $LOG_FILE 2>&1
+    if [ "${CustomKernel}" == "linuxnext" ]; then
+        # Workaround for build break in linuxnext bring in by commit 057fc695e934a77bae0c6c7f3be01251774b61cf
+        # Will revert this once it is fixed in linuxnext
+        sed -i 's/CONFIG_DRM_AMD_DC=y/ONFIG_DRM_AMD_DC=n/g' .config
+        echo n | make -j"$thread_number" >> $LOG_FILE 2>&1
+    else
+        make -j"$thread_number" >> $LOG_FILE 2>&1
+    fi
     check_exit_status "Build kernel" "exit"
 
     LogMsg "Start to install modules"


### PR DESCRIPTION
As Michael suggested, I didn't set CONFIG_DRM_AMD_DC, build Linux-next without error.
Will revert it back, once this issue got fixed in Linux-next.