### PR TITLE
xfstesting.sh: Skip BTRFS cases when check CONFIG_BTRFS_FS is not set in config file

### DIFF
--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -166,6 +166,18 @@ Main() {
         exit 0
     fi
     GetDistro
+    config_path="/boot/config-$(uname -r)"
+    if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
+        config_path="/usr/lib/kernel/config-$(uname -r)"
+    elif [[ $(detect_linux_distribution) == coreos ]];then
+        config_path="/usr/boot/config-$(uname -r)"
+    fi
+    grep -q "CONFIG_BTRFS_FS is not set" $config_path
+    if [ $? -eq 0 ];then
+        LogMsg "CONFIG_BTRFS_FS is not set in $config_path file in ${DISTRO}, skip the test"
+        SetTestStateSkipped
+        exit 0
+    fi
     #Refer https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/file-systems-and-storage_considerations-in-adopting-rhel-8
     if [ $DISTRO == "redhat_8" ] && [ $FSTYP == "btrfs" ]; then
         LogMsg "${DISTRO} doesn't support $FSTYP filesystem."


### PR DESCRIPTION
Provide the built RPM packages for other team.
```
[LISAv2 Test Results Summary]
Test Run On           : 09/09/2019 10:59:49
VHD Under Test        : EOSG-AUTOBUILT-OpenLogic-CentOS-7.5-latest-msftk-m-445.vhd
Initial Kernel Version: 4.19.67-e0ea5c2d9592
Final Kernel Version  : 4.19.67-e0ea5c2d9592
Total Test Cases      : 2 (0 Passed, 0 Failed, 0 Aborted, 2 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-FILE-SYSTEM-VERIFICATION-BTRFS                                            SKIPPED                 1.94 
    2 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-BTRFS                                           SKIPPED                 1.83 

[LISAv2 Test Results Summary]
Test Run On           : 09/09/2019 11:07:01
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1018-azure
Final Kernel Version  : 5.0.0-1018-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-FILE-SYSTEM-VERIFICATION-BTRFS                                               PASS                10.81 
```