### PR TITLE
Add NetworkManager restart in CreateIfupConfigFile for redhat_8

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1210,8 +1210,9 @@ CreateIfupConfigFile()
 					BOOTPROTO=dhcp
 				EOF
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 
 				;;
 			redhat_5|centos_5)
@@ -1380,8 +1381,9 @@ CreateIfupConfigFile()
 					EOF
 				fi
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 				;;
 
 			debian*|ubuntu*)


### PR DESCRIPTION
For redhat_8(such as RHEL_8), there is no network/networking service by default, only NetworkManager service in RHEL_8, so need to run 'service NetworkManager restart' to obtain dhcp IP for new NIC interface.