### PR TITLE
Skip azure file test case when cifs module is not set.

### DIFF
--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -172,12 +172,21 @@ Main() {
     elif [[ $(detect_linux_distribution) == coreos ]];then
         config_path="/usr/boot/config-$(uname -r)"
     fi
+
     grep -q "CONFIG_BTRFS_FS is not set" $config_path
-    if [ $? -eq 0 ];then
+    if [ $? -eq 0 ] && [ $FSTYP == "btrfs" ];then
         LogMsg "CONFIG_BTRFS_FS is not set in $config_path file in ${DISTRO}, skip the test"
         SetTestStateSkipped
         exit 0
     fi
+
+    grep -q "CONFIG_CIFS is not set" $config_path
+    if [ $? -eq 0 ] && [ $FSTYP == "cifs" ];then
+        LogMsg "CONFIG_CIFS is not set in $config_path file in ${DISTRO}, skip the test"
+        SetTestStateSkipped
+        exit 0
+    fi
+
     #Refer https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/file-systems-and-storage_considerations-in-adopting-rhel-8
     if [ $DISTRO == "redhat_8" ] && [ $FSTYP == "btrfs" ]; then
         LogMsg "${DISTRO} doesn't support $FSTYP filesystem."


### PR DESCRIPTION
In upstream kernel, the cifs module is not set, so azure file case should be skipped.

Linux-stable + ubuntu 18.04
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2019 09:30:32
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1018-azure
Final Kernel Version  : 5.2.15-6e282ba6ff6b
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-AZURE-FILES                                     SKIPPED                 3.05 
```
gallery image ubuntu 18.04
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2019 09:59:22
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1018-azure
Final Kernel Version  : 5.0.0-1018-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:25
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-AZURE-FILES                                        PASS                82.17 
```
msft + centos7.5
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2019 10:02:32
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.11.6.el7.x86_64
Final Kernel Version  : 4.19.67-e0ea5c2d9592
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-BTRFS                                           SKIPPED                 1.89 
```
gallery image centos7.5
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2019 10:04:45
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.11.6.el7.x86_64
Final Kernel Version  : 3.10.0-862.11.6.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:27

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-BTRFS                                              PASS                23.92 
```