### PR TITLE
Enable MVAPICH, Intel and Open MPI in Ubutnu 16.04 

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -181,7 +181,13 @@ function Main() {
 			apt update
 			apt upgrade -y
 
+			LogMsg "Required 32-bit java"
+			dpkg --add-architecture i386
+			apt update
+
 			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
+			install_package " openjdk-9-jre:i386"
+
 			LogMsg "*** Adding kernel modules to /etc/modules"
 			echo rdma_ucm >> /etc/modules
 			modprobe rdma_ucm

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -187,7 +187,7 @@ function Main() {
 
 			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
 			os_RELEASE=$(awk '/VERSION_ID=/' /etc/os-release | sed 's/VERSION_ID=//' | sed 's/\"//g')
-			if [ "$os_RELEASE" == "18.04"]; then
+			if [[ "$os_RELEASE" == "18.04" ]]; then
 				install_package "openjdk-8-jre:i386"
 			else
 				install_package "openjdk-9-jre:i386"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -258,11 +258,12 @@ function Main() {
 		# compile ping_pong
 		cd $ping_pong_help
 		LogMsg "Compiling ping_pong binary in Platform help directory"
-		ret=`make -j $(nproc)`
+		ret=`make`
 		if [ $? -ne 0 ]; then
 			pkey=$(cat /sys/class/infiniband/*/ports/1/pkeys/0)
 			export MPI_IB_PKEY=${pkey}
-			make -j $(nproc)
+			LogMsg "After setting pkeys in the system, recompile the ping_pong binary"
+			make
 			LogMsg "Ping-pong compilation completed"
 		else
 			LogErr "Failed to complie ping_pong binary: $ret"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -251,21 +251,26 @@ function Main() {
 		# compile ping_pong
 		cd $ping_pong_help
 		LogMsg "Compiling ping_pong binary in Platform help directory"
-		make -j $(nproc)
+		ret=`make -j $(nproc)`
 		if [ $? -ne 0 ]; then
 			pkey=$(cat /sys/class/infiniband/*/ports/1/pkeys/0)
 			export MPI_IB_PKEY=${pkey}
 			make -j $(nproc)
+			LogMsg "Ping-pong compilation completed"
+		else
+			LogErr "Failed to complie ping_pong binary: $ret"
 		fi
-		LogMsg "Ping-pong compilation completed"
 
 		# verify ping_pong binary
 		Verify_File $ping_pong_bin
 
 		# add IBM Platform MPI path to PATH
+		LogMsg "Exporting MPI_ROOT and PATH variables"
 		export MPI_ROOT=/opt/ibm/platform_mpi
+		LogMsg "MPI_ROOT: $MPI_ROOT"
 		export PATH=$PATH:$MPI_ROOT
 		export PATH=$PATH:$MPI_ROOT/bin
+		LogMsg "PATH: $PATH"
 	elif [ $mpi_type == "intel" ]; then
 		# if HPC images comes with MPI binary pre-installed, (CentOS HPC)
 		#   there is no action required except binary verification

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -186,7 +186,12 @@ function Main() {
 			apt update
 
 			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
-			install_package "openjdk-9-jre:i386"
+			os_RELEASE=$(awk '/VERSION_ID=/' /etc/os-release | sed 's/VERSION_ID=//' | sed 's/\"//g')
+			if [[ "$os_RELEASE" == "18.04"]]; then
+				install_package "openjdk-8-jre:i386"
+			else
+				install_package "openjdk-9-jre:i386"
+			fi
 
 			LogMsg "*** Adding kernel modules to /etc/modules"
 			echo rdma_ucm >> /etc/modules

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -186,13 +186,15 @@ function Main() {
 			apt update
 
 			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
-			install_package " openjdk-9-jre:i386"
+			install_package "openjdk-9-jre:i386"
 
 			LogMsg "*** Adding kernel modules to /etc/modules"
 			echo rdma_ucm >> /etc/modules
 			modprobe rdma_ucm
 			echo ib_ipoib >> /etc/modules
 			modprobe ib_ipoib
+			echo ib_umad >> /etc/modules
+			modprobe ib_umad
 			LogMsg "*** Adding Canoncial ppa for temporary fix"
 			add-apt-repository -y ppa:ci-train-ppa-service/3760
 			LogMsg "*** System updating with the customized ppa"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -204,7 +204,7 @@ function Main() {
 			add-apt-repository -y ppa:ci-train-ppa-service/3760
 			LogMsg "*** System updating with the customized ppa"
 			apt update
-			apt upgrade -y			
+			apt upgrade -y
 			;;
 		*)
 			LogErr "MPI type $mpi_type does not support on '$DISTRO' or not implement"
@@ -258,12 +258,11 @@ function Main() {
 		# compile ping_pong
 		cd $ping_pong_help
 		LogMsg "Compiling ping_pong binary in Platform help directory"
-		ret=`make`
+		ret=$(make -j $(nproc))
 		if [ $? -ne 0 ]; then
 			pkey=$(cat /sys/class/infiniband/*/ports/1/pkeys/0)
 			export MPI_IB_PKEY=${pkey}
-			LogMsg "After setting pkeys in the system, recompile the ping_pong binary"
-			make
+			make -j $(nproc)
 			LogMsg "Ping-pong compilation completed"
 		else
 			LogErr "Failed to complie ping_pong binary: $ret"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -187,7 +187,7 @@ function Main() {
 
 			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
 			os_RELEASE=$(awk '/VERSION_ID=/' /etc/os-release | sed 's/VERSION_ID=//' | sed 's/\"//g')
-			if [[ "$os_RELEASE" == "18.04"]]; then
+			if [ "$os_RELEASE" == "18.04"]; then
 				install_package "openjdk-8-jre:i386"
 			else
 				install_package "openjdk-9-jre:i386"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -174,7 +174,15 @@ function Main() {
 			LogMsg "This is Ubuntu"
 			hpcx_ver="ubuntu"$VERSION_ID
 			LogMsg "Installing required packages ..."
-			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2"
+			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 libmlx5 libmlx4-dev rdmacm-utils rdma-core bc"
+			LogMsg "*** Adding kernel modules to /etc/modules"
+			echo rdma_ucm >> /etc/modules
+			echo ib_ipoib >> /etc/modules
+			LogMsg "*** Adding Canoncial ppa for temporary fix"
+			add-apt-repository -y ppa:ci-train-ppa-service/3760
+			LogMsg "*** System updating with the customized ppa"
+			apt update
+			apt upgrade -y			
 			;;
 		*)
 			LogErr "MPI type $mpi_type does not support on '$DISTRO' or not implement"
@@ -292,6 +300,9 @@ function Main() {
 
 		# add Intel MPI path to PATH
 		export PATH=$PATH:"${mpirun_path%/*}"
+		# add sourcing file in each session
+		echo "source ${mpirun_path%/*}/mpivars.sh" >> $HOMEDIR/.bashrc
+		echo "source ${mpirun_path%/*}/mpivars.sh" >> /home/lisa/.bashrc
 
 		LogMsg "Completed Intel MPI installation"
 

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -174,10 +174,19 @@ function Main() {
 			LogMsg "This is Ubuntu"
 			hpcx_ver="ubuntu"$VERSION_ID
 			LogMsg "Installing required packages ..."
-			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 libmlx5 libmlx4-dev rdmacm-utils rdma-core bc"
+			LogMsg "*** Adding Canoncial ppa for temporary fix"
+			add-apt-repository -y ppa:ci-train-ppa-service/3760
+
+			LogMsg "*** System updating with the customized ppa"
+			apt update
+			apt upgrade -y
+
+			install_package "build-essential python-setuptools libibverbs-dev bison flex ibverbs-utils net-tools libdapl2 rdmacm-utils bc"
 			LogMsg "*** Adding kernel modules to /etc/modules"
 			echo rdma_ucm >> /etc/modules
+			modprobe rdma_ucm
 			echo ib_ipoib >> /etc/modules
+			modprobe ib_ipoib
 			LogMsg "*** Adding Canoncial ppa for temporary fix"
 			add-apt-repository -y ppa:ci-train-ppa-service/3760
 			LogMsg "*** System updating with the customized ppa"

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -140,7 +140,7 @@ function Run_IMB_MPI1() {
 				$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($mpi1_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			intel)
-				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $extra_params"
+				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params"
 				$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			mvapich)

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -73,17 +73,6 @@ function Main {
 			Start-Sleep -Seconds 300
 		}
 
-		# Ubuntu extra step: make sure the VM supports RDMA
-		if (@("UBUNTU").contains($global:detectedDistro)) {
-			$cmd = "lsb_release -r | awk '{print `$2}'"
-			$release = Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username `
-					$user -password $password $cmd -ignoreLinuxExitCode:$true
-			if ($release.Split(".")[0] -lt "18" -and $MpiType -eq 'hpcx') {
-				Write-LogInfo "$MpiType in Ubuntu $release is not supported! Test skipped"
-				return "SKIPPED"
-			}
-		}
-
 		#Skip test case against distro CLEARLINUX and COREOS based here https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-hpc
 		if (@("CLEARLINUX", "COREOS").contains($global:detectedDistro)) {
 			Write-LogInfo "$($global:detectedDistro) is not supported! Test skipped!"
@@ -147,9 +136,6 @@ function Main {
 			if ($TestParam -imatch "num_reboot") {
 				$RemainingRebootIterations = [string]($TestParam.Replace("num_reboot=", "").Trim('"'))
 				$ExpectedSuccessCount = [int]($TestParam.Replace("num_reboot=", "").Trim('"')) + 1
-			}
-			if ($TestParam -imatch "mpi_type") {
-				$MpiType = [string]($TestParam.Replace("mpi_type=", "").Trim('"'))
 			}
 		}
 		Add-Content -Value "master=`"$($ServerVMData.InternalIP)`"" -Path $constantsFile

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -73,6 +73,17 @@ function Main {
 			Start-Sleep -Seconds 300
 		}
 
+		# Ubuntu extra step: make sure the VM supports RDMA
+		if (@("UBUNTU").contains($global:detectedDistro)) {
+			$cmd = "lsb_release -r | awk '{print `$2}'"
+			$release = Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username `
+					$user -password $password $cmd -ignoreLinuxExitCode:$true
+			if ($release.Split(".")[0] -lt "18" -and $MpiType -eq 'hpcx') {
+				Write-LogInfo "$MpiType in Ubuntu $release is not supported! Test skipped"
+				return "SKIPPED"
+			}
+		}
+
 		#Skip test case against distro CLEARLINUX and COREOS based here https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-hpc
 		if (@("CLEARLINUX", "COREOS").contains($global:detectedDistro)) {
 			Write-LogInfo "$($global:detectedDistro) is not supported! Test skipped!"
@@ -136,6 +147,9 @@ function Main {
 			if ($TestParam -imatch "num_reboot") {
 				$RemainingRebootIterations = [string]($TestParam.Replace("num_reboot=", "").Trim('"'))
 				$ExpectedSuccessCount = [int]($TestParam.Replace("num_reboot=", "").Trim('"')) + 1
+			}
+			if ($TestParam -imatch "mpi_type") {
+				$MpiType = [string]($TestParam.Replace("mpi_type=", "").Trim('"'))
 			}
 		}
 		Add-Content -Value "master=`"$($ServerVMData.InternalIP)`"" -Path $constantsFile

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -553,7 +553,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INTEL_MPI_DOWNLOAD</ReplaceThis>
-		<ReplaceWith>https://partnerpipelineshare.blob.core.windows.net/mpi/l_mpi_2018.3.222.tgz</ReplaceWith>
+		<ReplaceWith>https://partnerpipelineshare.blob.core.windows.net/mpi/l_mpi_2019.5.281.tgz</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>OPEN_MPI_DOWNLOAD</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -158,7 +158,7 @@
 		<Area>INFINIBAND</Area>
 		<Tags>rdma</Tags>
 	</test>
-	<!-- HPC-X MPI -->
+<!-- 	HPC-X MPI: Mellanox HPC-X links constantly changed, so can not support HPC-X. Leave the code, however. 
 	<test>
 		<testName>INFINIBAND-HPCX-MPI-2VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
@@ -232,7 +232,7 @@
 		<Category>Functional</Category>
 		<Area>INFINIBAND</Area>
 		<Tags>rdma</Tags>
-	</test>
+	</test> -->
 <!-- IBM MPI -->
 	<test>
 		<testName>INFINIBAND-IBM-MPI-2VM</testName>


### PR DESCRIPTION
Recent GPU support in HPC VM, enable those MPI tests in Ubuntu 16.04.

HPC-X MPI installer from Mellanox is not available. The build schedule & its dependency broke the LISAv2 run-time a few times. Removed the HPC-X test cases by finding the best solution.

IBM Platform MPI in Ubuntu 16.04: Complexity of 32-bit binary file not softlink in the lib. Its runtime will skip Ubuntu 16.04

Will post the test result soon.