### PR TITLE
Skip SECUREBOOT-VSS test if the VM is not gerneration 2

### DIFF
--- a/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-PARTITION.ps1
+++ b/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-PARTITION.ps1
@@ -20,10 +20,19 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $Ipv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
-        $HypervGroupName=$captureVMData.HyperVGroupName
+        $HvServer = $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
+        $HypervGroupName = $captureVMData.HyperVGroupName
+
+        if ($TestParams.secureBootVM) {
+            $vmGeneration = Get-VMGeneration $VMName $HvServer
+            if ($vmGeneration -ne 2) {
+                Write-LogInfo "VM ${VMName} is not a Generation 2 VM, skipping test."
+                return $resultSkipped
+            }
+        }
+
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $sts = New-BackupSetup $VMName $HvServer


### PR DESCRIPTION
Before fix:
09/24/2019 09:49:36 : [ERROR] The Generation 1 virtual machine or snapshot "LISAv2-OneVM-xhx-MR18-637048893053-role-0" does not support the VMFirmware cmdlets. Use Get-VMBios and Set-VMBios instead. at line: 46

```
[LISAv2 Test Results Summary]
Test Run On           : 09/24/2019 09:35:05
VHD Under Test        : D:\vhd\Centos_7.5.vhdx
Initial Kernel Version: 3.10.0-862.el7.x86_64
Final Kernel Version  : 4.19.67-e0ea5c2d9592
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SECUREBOOT           SECUREBOOT-VSS                                                                 ABORTED                 3.95
```