### PR TITLE
Refine the runtime memory test cases

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -1739,7 +1739,7 @@ Function Start-StressNg {
         -username $user -password $password -upload
     # execute command as job
     $retVal = Run-LinuxCmd -username $user -password $password -ip $VMIpv4 -port $VMSSHPort `
-        -command "echo $password | cd /home/$user && chmod u+x ${FILE_NAME} && sed -i 's/\r//g' ${FILE_NAME} && ./${FILE_NAME}" -runAsSudo
+        -command "echo $password | cd /home/$user && chmod u+x ${FILE_NAME} && sed -i 's/\r//g' ${FILE_NAME} && ./${FILE_NAME}" -runAsSudo -RunInBackground
     return $retVal
 }
 # This function runs the remote script on VM.
@@ -1867,7 +1867,7 @@ function Get-MemoryStressNG([String]$VMIpv4, [String]$VMSSHPort, [int]$timeoutSt
     Write-LogInfo "Copy-RemoteFiles done"
     # execute command
     $sendCommand = "echo $password | cd /home/$user && chmod u+x ${FILE_NAME} && sed -i 's/\r//g' ${FILE_NAME} && ./${FILE_NAME}"
-    $retVal = Run-LinuxCmd -username $user -password $password -ip $VMIpv4 -port $VMSSHPort -command $sendCommand  -runAsSudo
+    $retVal = Run-LinuxCmd -username $user -password $password -ip $VMIpv4 -port $VMSSHPort -command $sendCommand -runAsSudo -RunInBackground
     return $retVal
 }
 

--- a/Testscripts/Windows/DM-HOTADD-STRESS-NG.ps1
+++ b/Testscripts/Windows/DM-HOTADD-STRESS-NG.ps1
@@ -146,9 +146,9 @@ function Main {
         if (-not $startMemory){
            Throw "Unable to start job for creating pressure on $vm1Name" | Tee-Object -Append -file $summaryLog
         }
-        [int64]$vm1Demand = ($vmInfo.MemoryDemand/1MB)
         # Wait for stress-ng to start and the memory assigned/demand gets updated
         Start-Sleep -s $sleepTime
+        [int64]$vm1Demand = ($vmInfo.MemoryDemand/1MB)
         # Get memory stats for vm1 after stress-ng starts
         [int64]$vm1Assigned = ($vmInfo.MemoryAssigned/1MB)
         Write-LogInfo "Memory stats for $vm1Name after stress-ng started"

--- a/Testscripts/Windows/RUNTIME-MEM-HOTADD.ps1
+++ b/Testscripts/Windows/RUNTIME-MEM-HOTADD.ps1
@@ -142,9 +142,9 @@ function Main {
         if (-not $run) {
             Throw  "Unable to start stress-ng for creating pressure on $vmName"
         }
-        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
         Start-Sleep -s 50
+        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # get memory stats while stress-ng is running
         [int64]$vm1Assigned = ($VmInfo.MemoryAssigned/1MB)
         Write-LogInfo "Memory stats after $vmName started stress-ng"
@@ -154,7 +154,8 @@ function Main {
             $testResult = $resultFail
             Throw "Memory Demand did not increase after starting stress-ng"
         }
-        # get memory stats after stress-ng tool stopped running
+        # Wait stress-ng stopped running, and then get memory stats
+        Start-Sleep -s 100
         [int64]$vm1AfterStressAssigned = ($VmInfo.MemoryAssigned/1MB)
         [int64]$vm1AfterStressDemand = ($VmInfo.MemoryDemand/1MB)
         Write-LogInfo "Memory stats after $vmName stress-ng run"

--- a/Testscripts/Windows/RUNTIME_MEM_HOTADD_CHUNKS.ps1
+++ b/Testscripts/Windows/RUNTIME_MEM_HOTADD_CHUNKS.ps1
@@ -159,9 +159,9 @@ function Main {
         if (-not $run) {
             Throw "Unable to start stress-ng for creating pressure on $vmName"
         }
-        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
         Start-Sleep -s 50
+        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # get memory stats while stress-ng is running
         [int64]$vm1Assigned = ($VmInfo.MemoryAssigned/1MB)
         Write-LogInfo "Memory stats after $vmName started stress-ng"
@@ -170,7 +170,8 @@ function Main {
         if ($vm1Demand -le $vm1BeforeDemand) {
             Write-LogInfo "Memory Demand did not increase after starting stress-ng"
         }
-        # get memory stats after stress-ng stopped running
+        # Wait stress-ng stopped running, and then get memory stats
+        Start-Sleep -s 100
         [int64]$vm1AfterStressAssigned = ($VmInfo.MemoryAssigned/1MB)
         [int64]$vm1AfterStressDemand = ($VmInfo.MemoryDemand/1MB)
         Write-LogInfo "Memory stats after $vmName stress-ng run"

--- a/Testscripts/Windows/RUNTIME_MEM_MULTIPLEADDREMOVE.ps1
+++ b/Testscripts/Windows/RUNTIME_MEM_MULTIPLEADDREMOVE.ps1
@@ -227,9 +227,9 @@ function Main {
             Throw "Unable to start stress-ng for creating pressure on $vmName"
         }
 
-        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
         Start-Sleep -s 80
+        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # get memory stats while stress-ng is running
         [int64]$vm1Assigned = ($VmInfo.MemoryAssigned/1MB)
         Write-LogInfo "Memory stats after $vmName started stress-ng"
@@ -238,7 +238,8 @@ function Main {
         if ($vm1Demand -le $vm1BeforeDemand ) {
             Throw "Memory Demand did not increase after starting stress-ng"
         }
-        # get memory stats after tool stress-ng stopped running
+        # Wait stress-ng stopped running, and then get memory stats
+        Start-Sleep -s 100
         [int64]$vm1AfterStressAssigned = ($VmInfo.MemoryAssigned/1MB)
         [int64]$vm1AfterStressDemand = ($VmInfo.MemoryDemand/1MB)
         Write-LogInfo "Memory stats after $vmName stress-ng run"

--- a/Testscripts/Windows/RUNTIME_MEM_STRESSHOTREMOVE.ps1
+++ b/Testscripts/Windows/RUNTIME_MEM_STRESSHOTREMOVE.ps1
@@ -94,9 +94,9 @@ function Main {
         if ( -not $run ) {
             Throw "Unable to start stress-ng for creating pressure on $vmName"
         }
-        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # sleep a few seconds so stress-ng starts and the memory assigned/demand gets updated
         Start-Sleep -s 80
+        [int64]$vm1Demand = ($VmInfo.MemoryDemand/1MB)
         # get memory stats while stress-ng is running
         [int64]$vm1Assigned = ($VmInfo.MemoryAssigned/1MB)
         Write-LogInfo "Memory stats after $vm1Name started stress-ng"
@@ -149,7 +149,8 @@ function Main {
         Write-LogInfo "Memory stats after $vmName memory was changed"
         Write-LogInfo "${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
         Write-LogInfo "Reported free memory inside ${vmName}: Before - $vm1BeforeAssignedGuest KB | After - $vm1AfterAssignedGuest KB"
-        # get memory stats after stress-ng stopped running
+        # Wait stress-ng stopped running, and then get memory stats
+        Start-Sleep -s 100
         [int64]$vm1AfterStressAssigned = ($VmInfo.MemoryAssigned/1MB)
         [int64]$vm1AfterStressDemand = ($VmInfo.MemoryDemand/1MB)
         Write-LogInfo "Memory stats after $vmName stress-ng run"


### PR DESCRIPTION
The stress-ng should be run in background, otherwise, the demand memory is not right. 