### PR TITLE
 Hyper-V: Fix 2 issues of Get-NetIPAddress and CreateIfupConfigFile

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1210,8 +1210,9 @@ CreateIfupConfigFile()
 					BOOTPROTO=dhcp
 				EOF
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 
 				;;
 			redhat_5|centos_5)
@@ -1380,8 +1381,9 @@ CreateIfupConfigFile()
 					EOF
 				fi
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 				;;
 
 			debian*|ubuntu*)

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1368,7 +1368,6 @@ CreateIfupConfigFile()
 						BOOTPROTO=none
 						IPADDR="$__ip"
 						NETMASK="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				else
 					cat <<-EOF > "$__file_path"
@@ -1377,7 +1376,6 @@ CreateIfupConfigFile()
 						IPV6ADDR="$__ip"
 						IPV6INIT=yes
 						PREFIX="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				fi
 

--- a/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
+++ b/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
@@ -69,7 +69,7 @@ function Main {
         $privateIP = "fd00::4:10"
     }
 
-    $interfaces = (Get-NetIPAddress -addressFamily $addressFamily)
+    $interfaces = (Invoke-Command -ComputerName $HvServer {Get-NetIPAddress -addressFamily $addressFamily})
     foreach ($interface in $interfaces) {
         if ($interface.InterfaceAlias -like "*(Internal)*") {
             break


### PR DESCRIPTION
Fix the issue that run Get-NetIPAddress failed when run it in remote server. 
Before fix, only can run it in local server, but if run it in remote server, will get wrong IP/interface as it still get the local IP/interface.
After fix, "Invoke-Command -ComputerName $HvServer" can run successful both in local and remote server as there is parameter $HvServer which can specify the right server.