### PR TITLE
Fix 2 issues of Get-NetIPAddress and CreateIfupConfigFile

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1210,8 +1210,9 @@ CreateIfupConfigFile()
 					BOOTPROTO=dhcp
 				EOF
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 
 				;;
 			redhat_5|centos_5)
@@ -1380,8 +1381,9 @@ CreateIfupConfigFile()
 					EOF
 				fi
 
+				ip link set "$__interface_name" down
 				ip link set "$__interface_name" up
-				service network restart || service networking restart
+				service network restart || service networking restart || service NetworkManager restart
 				;;
 
 			debian*|ubuntu*)

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1368,7 +1368,6 @@ CreateIfupConfigFile()
 						BOOTPROTO=none
 						IPADDR="$__ip"
 						NETMASK="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				else
 					cat <<-EOF > "$__file_path"
@@ -1377,7 +1376,6 @@ CreateIfupConfigFile()
 						IPV6ADDR="$__ip"
 						IPV6INIT=yes
 						PREFIX="$__netmask"
-						NM_CONTROLLED=no
 					EOF
 				fi
 

--- a/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
+++ b/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
@@ -69,7 +69,12 @@ function Main {
         $privateIP = "fd00::4:10"
     }
 
-    $interfaces = (Invoke-Command -ComputerName $HvServer {Get-NetIPAddress -addressFamily $addressFamily})
+	if ($addressFamily -eq "IPv4") {
+		$interfaces = (Invoke-Command -ComputerName $HvServer {Get-NetIPAddress -addressFamily IPv4})
+	} else {
+		$interfaces = (Invoke-Command -ComputerName $HvServer {Get-NetIPAddress -addressFamily IPv6})
+	}
+
     foreach ($interface in $interfaces) {
         if ($interface.InterfaceAlias -like "*(Internal)*") {
             break

--- a/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
+++ b/Testscripts/Windows/SETUP-Inject-IP-Constants.ps1
@@ -69,7 +69,7 @@ function Main {
         $privateIP = "fd00::4:10"
     }
 
-    $interfaces = (Get-NetIPAddress -addressFamily $addressFamily)
+    $interfaces = (Invoke-Command -ComputerName $HvServer {Get-NetIPAddress -addressFamily $addressFamily})
     foreach ($interface in $interfaces) {
         if ($interface.InterfaceAlias -like "*(Internal)*") {
             break


### PR DESCRIPTION
Issue 1, for the Get-NetIPAddress in SETUP-Inject-IP-Constants.ps1:
Before fix, only can run it in local server, but if run it in remote server, will get wrong IP/interface as it still get the local IP/interface.
After fix, "Invoke-Command -ComputerName $HvServer" can run successful both in local and remote server as there is parameter $HvServer which can specify the right server.

The test results before and after fix the issue:
Before fix the script:
Errors in output:
09/27/2019 01:43:10 : [ERROR] EXCEPTION: You cannot call a method on a null-valued expression.
09/27/2019 01:43:10 : [ERROR] Source: Line 1575 in script .\Libraries\CommonFunctions.psm1.

[LISAv2 Test Results Summary]
Test Run On : 09/27/2019 01:42:11
VHD Under Test : D:\RHEL-8.1.0-xxxx-x86_64-GEN2-A.vhdx
Initial Kernel Version: xxxx.el8.x86_64
Final Kernel Version : xxxx.el8.x86_64
Total Test Cases : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

ID TestArea TestCaseName TestResult TestDuration(in minutes)
1 NETWORK              NET-INTERNAL                                                                      FAIL                 2.92 

After fix the script:
[LISAv2 Test Results Summary]
Test Run On : 09/27/2019 01:57:08
VHD Under Test : D:\RHEL-8.1.0-xxxx-x86_64-GEN2-A.vhdx
Initial Kernel Version: xxxx.el8.x86_64
Final Kernel Version : xxxx.el8.x86_64
Total Test Cases : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

ID TestArea TestCaseName TestResult TestDuration(in minutes)
1 NETWORK              NET-INTERNAL                                                                      PASS                 2.48