### PR TITLE
Judge if lock exists before delete resource group (with or without specify UseExistingRG)

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -557,11 +557,11 @@ Function Delete-ResourceGroup([string]$RGName, [switch]$KeepDisks, [bool]$UseExi
         Write-LogInfo "Failed to get resource group: $RGName; maybe this resource group does not exist."
     }
     if ($ResourceGroup) {
-        if ($UseExistingRG) {
-            # Get RG lock. If there is any lock in place, don't try to delete the Resource Group
-            # "Microsoft.Authorization/locks" is the standard ResourceType for RG locks
-            $rgLock = (Get-AzResourceLock -ResourceGroupName $RGName).ResourceType -eq "Microsoft.Authorization/locks"
-            if (-not $rgLock) {
+        # Get RG lock. If there is any lock in place, don't try to delete the Resource Group
+        # "Microsoft.Authorization/locks" is the standard ResourceType for RG locks
+        $rgLock = (Get-AzResourceLock -ResourceGroupName $RGName).ResourceType -eq "Microsoft.Authorization/locks"
+        if (-not $rgLock) {
+            if ($UseExistingRG) {
                 $CurrentResources = Get-AzResource -ResourceGroupName $RGName | `
                     Where-Object { (( $_.ResourceGroupName -eq $RGName ) -and ( !($_.ResourceType -imatch "availabilitySets" )))}
                 $attempts = 0
@@ -585,8 +585,7 @@ Function Delete-ResourceGroup([string]$RGName, [switch]$KeepDisks, [bool]$UseExi
                             if ($current_resource) {
                                 $null = Remove-AzResource -ResourceId $resource.ResourceId -Force -Verbose
                             }
-                        }
-                        catch {
+                        } catch {
                             Write-LogErr "Failed to delete resource $($resource.Name). We will try to remove it in next attempt."
                         }
                     }
@@ -596,21 +595,20 @@ Function Delete-ResourceGroup([string]$RGName, [switch]$KeepDisks, [bool]$UseExi
                 Write-LogInfo "Resources in $RGName are deleted."
                 $retValue = $true
             } else {
-                Write-LogWarn "Lock is in place for $RGName. Skipping RG delete!"
+                Write-LogInfo "Triggering delete operation for Resource Group ${RGName}"
+                $isRgDeleting = Start-DeleteResourceGroup -RGName $RGName
+                if ($isRgDeleting) {
+                    Write-LogInfo "Successfully triggered delete operation for Resource Group ${RGName}"
+                } else {
+                    Write-LogWarn "Failed to start delete operation for Resource Group ${RGName}"
+                }
+                $retValue = $isRgDeleting
             }
+        } else {
+            Write-LogWarn "Lock is in place for $RGName. Skipping RG delete!"
+            $retValue = $false
         }
-        else {
-            Write-LogInfo "Triggering delete operation for Resource Group ${RGName}"
-            $isRgDeleting = Start-DeleteResourceGroup -RGName $RGName
-            if ($isRgDeleting) {
-                Write-LogInfo "Successfully triggered delete operation for Resource Group ${RGName}"
-            } else {
-                Write-LogWarn "Failed to start delete operation for Resource Group ${RGName}"
-            }
-            $retValue = $isRgDeleting
-        }
-    }
-    else {
+    } else {
         Write-LogInfo "$RGName does not exists."
         $retValue = $true
     }


### PR DESCRIPTION
Check lock exists or not whenever set or not set UseExistingRG.

Run a test without set UseExistingRG, then add lock during testing. Test results - 
```
10/02/2019 14:06:51 : [INFO ] VERIFY-DEPLOYMENT-PROVISION ended running with status: PASS.
10/02/2019 14:06:51 : [INFO ] Try to delete resource group LISAv2-OneVM-lili-OF75-20191002140236...
10/02/2019 14:06:51 : [INFO ] Checking if LISAv2-OneVM-lili-OF75-20191002140236 exists...
10/02/2019 14:06:51 : [WARN ] Lock is in place for LISAv2-OneVM-lili-OF75-20191002140236. Skipping RG delete!
10/02/2019 14:06:51 : [INFO ] Failed to trigger delete resource group LISAv2-OneVM-lili-OF75-20191002140236.. Please delete it manually.
10/02/2019 14:06:52 : [INFO ] Test OF75 finished
```