### PR TITLE
Fixed the path management of tar command up on the case of internet download

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -301,8 +301,9 @@ function Main() {
 			LogMsg "Downloading Intel MPI source code, $intel_mpi"
 			wget $intel_mpi
 
-			tar xvzf $(echo $intel_mpi | cut -d'/' -f5)
-			cd $(echo "${intel_mpi%.*}" | cut -d'/' -f5)
+			tar_filename=$(echo $intel_mpi | rev | cut -d'/' -f1 | rev)
+			tar xvzf $tar_filename
+			cd ${tar_filename%.*}
 
 			LogMsg "Executing silent installation"
 			sed -i -e 's/ACCEPT_EULA=decline/ACCEPT_EULA=accept/g' silent.cfg
@@ -333,8 +334,9 @@ function Main() {
 		wget $open_mpi
 		Verify_Result
 
-		tar xvzf $(echo $open_mpi | cut -d'/' -f5)
-		cd $(echo "${open_mpi%.*}" | cut -d'/' -f5 | sed -n '/\.tar$/s///p')
+		tar_filename=$(echo $open_mpi | rev | cut -d'/' -f1 | rev)
+		tar xvzf $tar_filename
+		cd ${tar_filename%.*.*}
 
 		LogMsg "Running configuration"
 		./configure --enable-mpirun-prefix-by-default
@@ -405,8 +407,9 @@ function Main() {
 			madh_location=$(find / -name "mad.h" | tail -1)
 			cp $madh_location /usr/include/infiniband/
 		fi
-		tar xvzf $(echo $mvapich_mpi | cut -d'/' -f5)
-		cd $(echo "${mvapich_mpi%.*}" | cut -d'/' -f5 | sed -n '/\.tar$/s///p')
+		tar_filename=$(echo $mvapich_mpi | rev | cut -d'/' -f1 | rev)
+		tar xvzf $tar_filename
+		cd ${tar_filename%.*.*}
 
 		LogMsg "Running configuration"
 		if [[ $DISTRO == "ubuntu"* ]]; then


### PR DESCRIPTION
If the MPI package is downloaded from the internet not blob, its path should be managed differently.

<Test results>
**MVAPICH MPI**

[OpenLogic CentOS 7.7 latest] [LISAv2 Test Results Summary]
[OpenLogic CentOS 7.7 latest] Test Run On           : 10/03/2019 23:54:32
[OpenLogic CentOS 7.7 latest] ARM Image Under Test  : OpenLogic : CentOS : 7.7 : latest
[OpenLogic CentOS 7.7 latest] Initial Kernel Version: 3.10.0-1062.1.1.el7.x86_64
[OpenLogic CentOS 7.7 latest] Final Kernel Version  : 3.10.0-1062.1.1.el7.x86_64
[OpenLogic CentOS 7.7 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[OpenLogic CentOS 7.7 latest] Total Time (dd:hh:mm) : 0:4:15
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[OpenLogic CentOS 7.7 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[OpenLogic CentOS 7.7 latest]     1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS               249.44 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-IO : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-IO : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-RMA : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] Logs can be found at C:\LISAv2\AY29\TestResults\2019-03-10-23-54-28-3284
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:13 : [INFO ] Creating 'C:\LISAv2\AY29\Azure-AY29-TestLogs.zip' from 'C:\LISAv2\AY29\TestResults\2019-03-10-23-54-28-3284'
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:16 : [INFO ] C:\LISAv2\AY29\Azure-AY29-TestLogs.zip created successfully.
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:16 : [INFO ] Analyzing results..
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:16 : [INFO ] Copying all files back to original working directory: C:\jenkins-slave-executor-2\workspace\Azure\pipeline-cloudtest-manual@2.
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:20 : [INFO ] Cleaning up C:\LISAv2\AY29
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:21 : [INFO ] Setting workspace back to original location: C:\jenkins-slave-executor-2\workspace\Azure\pipeline-cloudtest-manual@2
[OpenLogic CentOS 7.7 latest] 10/04/2019 04:10:21 : [INFO ] LISAv2 exit code: 0

**Intel MPI**
[OpenLogic CentOS 7.7 latest] [LISAv2 Test Results Summary]
[OpenLogic CentOS 7.7 latest] Test Run On           : 10/03/2019 23:54:06
[OpenLogic CentOS 7.7 latest] ARM Image Under Test  : OpenLogic : CentOS : 7.7 : latest
[OpenLogic CentOS 7.7 latest] Initial Kernel Version: 3.10.0-1062.1.1.el7.x86_64
[OpenLogic CentOS 7.7 latest] Final Kernel Version  : 3.10.0-1062.1.1.el7.x86_64
[OpenLogic CentOS 7.7 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[OpenLogic CentOS 7.7 latest] Total Time (dd:hh:mm) : 0:2:41
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[OpenLogic CentOS 7.7 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[OpenLogic CentOS 7.7 latest]     1 INFINIBAND           INFINIBAND-INTEL-MPI-2VM                                                          PASS                157.4 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-IO : SKIPPED 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-RMA : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-IO : SKIPPED 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-RMA : PASS 
[OpenLogic CentOS 7.7 latest] 	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] Logs can be found at C:\LISAv2\AT80\TestResults\2019-03-10-23-53-59-6062
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:47 : [INFO ] Creating 'C:\LISAv2\AT80\Azure-AT80-TestLogs.zip' from 'C:\LISAv2\AT80\TestResults\2019-03-10-23-53-59-6062'
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:47 : [INFO ] C:\LISAv2\AT80\Azure-AT80-TestLogs.zip created successfully.
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:47 : [INFO ] Analyzing results..
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:47 : [INFO ] Copying all files back to original working directory: C:\jenkins-slave-executor-3\workspace\Azure\pipeline-cloudtest-manual.
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:51 : [INFO ] Cleaning up C:\LISAv2\AT80
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:51 : [INFO ] Setting workspace back to original location: C:\jenkins-slave-executor-3\workspace\Azure\pipeline-cloudtest-manual
[OpenLogic CentOS 7.7 latest] 10/04/2019 02:35:51 : [INFO ] LISAv2 exit code: 0