### PR TITLE
Fix Hyper-V TIME cases for RHEL 8 and AMD host

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKEVENT.sh
+++ b/Testscripts/Linux/TIME-CLOCKEVENT.sh
@@ -60,8 +60,10 @@ CheckTimerInfo()
 # unbind clockevent "Hyper-V clockevent"
 UnbindClockEvent()
 {
-    if [ "$VCPU" -gt "1" ]; then
-        LogMsg "SMP vcpus not support unbind clockevent"
+    # AMD cpu not support unbind clockevent
+    lscpu | grep -i amd
+    if [ $? -eq 0 ] || [ "$VCPU" -gt "1" ]; then
+        LogMsg "AMD cpu or SMP vcpus not support unbind clockevent"
     else
         clockevent_unbind_file="/sys/devices/system/clockevents/clockevent0/unbind_device"
         clockevent="Hyper-V clockevent"

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -28,7 +28,7 @@ CheckSource()
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
 	clocksource="hyperv_clocksource_tsc_page"
 	if ! [[ $(find $current_clocksource -type f -size +0M) ]]; then
-		LogMsg "Test Failed. No file was found current_clocksource greater than 0M."
+		LogErr "Test Failed. No file was found current_clocksource greater than 0M."
 		SetTestStateFailed
 		exit 0
 	else
@@ -36,18 +36,18 @@ CheckSource()
 		if [[ $__file_content == "$clocksource" ]]; then
 			LogMsg "Test successful. Proper file was found. Clocksource file content is $__file_content"
 		else
-			LogMsg "Test failed. Proper file was NOT found."
+			LogErr "Test failed. Proper file was NOT found."
 			SetTestStateFailed
 			exit 0
 		fi
 	fi
 
-	# check cpu with constant_tsc
-	if grep -q constant_tsc /proc/cpuinfo
+	# check cpu with tsc, for Intel CPU shows constant_tsc, for AMD cpu, only tsc
+	if grep -q tsc /proc/cpuinfo
 	then
-		LogMsg "Test successful. /proc/cpuinfo contains flag constant_tsc"
+		LogMsg "Test successful. /proc/cpuinfo contains flag tsc"
 	else
-		LogMsg "Test failed. /proc/cpuinfo does not contain flag constant_tsc"
+		LogErr "Test failed. /proc/cpuinfo does not contain flag tsc"
 		SetTestStateFailed
 		exit 0
 	fi
@@ -62,7 +62,7 @@ CheckSource()
 	then
 		LogMsg "Test successful. dmesg contains log - clocksource $__dmesg_output"
 	else
-		LogMsg "Test failed. dmesg does not contain log - clocksource $__dmesg_output"
+		LogErr "Test failed. dmesg does not contain log - clocksource $__dmesg_output"
 		SetTestStateFailed
 		exit 0
 	fi
@@ -90,12 +90,12 @@ function UnbindCurrentSource()
 		if [ -n "$val" ] && [ "$_clocksource" == "acpi_pm" ]; then
 			LogMsg "Test successful. After unbind, current clocksource is $_clocksource"
 		else
-			LogMsg "Test failed. After unbind, current clocksource is $_clocksource"
+			LogErr "Test failed. After unbind, current clocksource is $_clocksource"
 			SetTestStateFailed
 			exit 0
 		fi
 	else
-		LogMsg "Test failed. Can not unbind $clocksource"
+		LogErr "Test failed. Can not unbind $clocksource"
 		SetTestStateFailed
 		exit 0
 	fi

--- a/Testscripts/Linux/TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/TIMESYNC-NTP.sh
@@ -31,9 +31,9 @@ UtilsInit
 # Try to restart NTP. If it fails we try to install it.
 if is_fedora ; then
     # RHEL 8 does not support NTP, skip test
-    if [[ $os_RELEASE = 8.* ]]; then
+    if [[ $os_RELEASE =~ 8.* ]]; then
         LogMsg "Info: $os_VENDOR $os_RELEASE does not support NTP. Test skipped. "
-        SetTestStateAborted
+        SetTestStateSkipped
         exit 0
     fi
     # Check if ntpd is running


### PR DESCRIPTION
Three minor updates:
1. TIME-CLOCKEVENT
   when unblind the clockevent for AMD host, guest console will hang. Refer to bug https://bugzilla.redhat.com/show_bug.cgi?id=1762681, this is low priority bug since customer may not unbind it, but it will block lisav2 test.
2. TIME-CLOCKSOURCE
For intel cpu, it will show constant_tsc when grep /proc/cpuinfo, for AMD host, it will show tsc. In order to combine together, only check tsc here.
3. TIMESYNC-NTP
[[ $os_release = 8.* ]] is false when $os_release=8, also for rhel 8, skip NTP testing.

Test Result:
**Before Fix**
10/14/2019 02:31:10 : [INFO ] TIMESYNC-NTP ended running with status: ABORTED.
10/14/2019 02:31:10 : [INFO ] TIME-CLOCKSOURCE started running.
10/14/2019 02:35:45 : [INFO ] TIME-CLOCKSOURCE ended running with status: FAIL.
10/14/2019 02:35:45 : [INFO ] TIME-CLOCKEVENT-UP started running.  --> **Cannot connect with VM via ssh**


**After Fix**
```
  ID TestArea             TestCaseName                                                                TestResult TestDu
ation(in minutes)
-----------------------------------------------------------------------------------------------------------------------
------------------
   1 CORE                 TIMESYNC-NTP                                                                   SKIPPED
         1.06
   2 CORE                 TIME-CLOCKSOURCE                                                                  PASS
         1.84
   3 CORE                 TIME-CLOCKEVENT-UP                                                                PASS
```
