### PR TITLE
Minor update timesync_config.sh to skip ntp for rhel 8 and support heartbeat case on remote host.

### DIFF
--- a/Testscripts/Linux/timesync_config.sh
+++ b/Testscripts/Linux/timesync_config.sh
@@ -31,7 +31,11 @@ case $DISTRO in
         else
             chrony_config_path="/etc/chrony.conf"
             chrony_service_name="chronyd"
-            ntp_service_name="ntpd"
+            if [[ $os_RELEASE =~ 8.* ]]; then
+                LogMsg "Info: $os_VENDOR $os_RELEASE does not support NTP. Skip define ntp_service_name."
+            else
+                ntp_service_name="ntpd"
+            fi
         fi
     ;;
     ubuntu* | debian*)
@@ -75,11 +79,14 @@ if [[ $Chrony == "off" ]]; then
         SetTestStateFailed
         exit 1
     fi
-    service $ntp_service_name stop
-    if [ $? -ne 0 ]; then
-        LogMsg "ERROR: Unable to stop NTPD"
-        SetTestStateFailed
-        exit 1
+
+    if [[ -n $ntp_service_name ]]; then
+        service $ntp_service_name stop
+        if [ $? -ne 0 ]; then
+            LogMsg "ERROR: Unable to stop NTPD"
+            SetTestStateFailed
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
Two updates here:
1.	TimeSync-SaveVM-ChronyOff
In RHEL 8, ntp service has been removed. In the timesync_config.sh file, it calls service ntpd stop, will make case fail. So change to ignore stopping ntpd for RHEL 8.
2.	Heartbeat-PausedCritical.ps1
Original New-VHD and xcopy lines cannot create partition and copy file on remote server, so use invoke-command to make them run on the remote server. Generally, we debug cases failure using remote server, if can support run in the remote, will be great. Thank you.

Before fix, test result:
```
10/18/2019 06:56:07 : [INFO ] PAUSED-CRITICAL-HEARTBEAT started running ...
10/18/2019 06:56:07 : [INFO ] Run test case against the target machine ...
10/18/2019 07:01:18 : [INFO ] PAUSED-CRITICAL-HEARTBEAT ended running with status: FAIL.

10/18/2019 07:39:52 : [INFO ] TIMESYNC-SAVEDVM-CHRONYOFF started running ...
10/18/2019 07:39:52 : [INFO ] Run test case against the target machine ...
10/18/2019 07:43:41 : [INFO ] TIMESYNC-SAVEDVM-CHRONYOFF ended running with status: FAIL.
```
After fix, test result:
```
  ID TestArea             TestCaseName                                                                TestResult 
------------------------------------------------------------------------------------------------------------------------

  1 CORE                 PAUSED-CRITICAL-HEARTBEAT                                                         PASS
    
  2 CORE                 TIMESYNC-SAVEDVM-CHRONYOFF                                                   PASS
```