### PR TITLE
device name path changed, Issue #597

### DIFF
--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -80,7 +80,11 @@ VerifyVF()
             synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
             vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
         else
-            vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $11}')
+            if [[ $VMGen -eq 1 ]]l then
+                vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+            else
+                vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $11}')
+            fi
         fi
     fi
 

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -80,7 +80,7 @@ VerifyVF()
             synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
             vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
         else
-            if [[ $VMGen -eq 1 ]]l then
+            if [[ $VMGen -eq 1 ]]; then
                 vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
             else
                 vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $11}')

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -80,7 +80,7 @@ VerifyVF()
             synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
             vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
         else
-            vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+            vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $11}')
         fi
     fi
 

--- a/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
+++ b/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
@@ -45,6 +45,10 @@ function Main {
             Write-LogInfo "Will add VF_IP2=$($dependencyVmData.InternalIP) to constants"
             "VF_IP2=$($dependencyVmData.InternalIP)" | Out-File sriov_constants.sh -Append
 
+            # Pass VM Generation info to constants file
+            Write-LogInfo "Will add VMGen=$($testVmData.VMGeneration) to constants"
+            "VMGen=$($testVmData.VMGeneration)" | Out-File sriov_constants.sh
+
             # Extract IP addresses from both VMs
             $ipIndex = 3
             foreach ($nic in $testVmExtraNICs) {

--- a/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
+++ b/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
@@ -47,7 +47,7 @@ function Main {
 
             # Pass VM Generation info to constants file
             Write-LogInfo "Will add VMGen=$($testVmData.VMGeneration) to constants"
-            "VMGen=$($testVmData.VMGeneration)" | Out-File sriov_constants.sh
+            "VMGen=$($testVmData.VMGeneration)" | Out-File sriov_constants.sh -Append
 
             # Extract IP addresses from both VMs
             $ipIndex = 3


### PR DESCRIPTION
Below command returns two lines now.

find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g'| awk '{print $12}'

The actual path shows like below with the command, find /sys/devices/* -name "*eth0"
/sys/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/VMBUS:00/0ce8bfb4-39c0-4431-9830-49a806c94fad/pci9830:00/9830:00:02.0/net/**eth1**/upper_eth0
/sys/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/VMBUS:00/000d3aa2-81af-000d-3aa2-81af000d3aa2/net/eth0

This should be 'print $11'

The issue #597 