### PR TITLE
Adding Gen2 VM support for SR-IOV tests

### DIFF
--- a/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
+++ b/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
@@ -191,7 +191,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ip link show ${synthetic_interface_vm_1} | grep ether | awk '{print $2}')
         vf_interface_vm_1=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface_vm_1 | sed 's/\// /g' | awk '{print $4}')
     else
-        vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+        else
+        # VM gen 1 case
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
     LogMsg "Virtual function found: $vf_interface_vm_1"
 
@@ -259,7 +265,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ip link show ${synthetic_interface_vm_1} | grep ether | awk '{print $2}')
         vf_interface_vm_1=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface_vm_1 | sed 's/\// /g' | awk '{print $4}')
     else
-        vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+        else
+        # VM gen 1 case
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
     LogMsg "Virtual function found: $vf_interface_vm_1"
 
@@ -282,7 +294,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ip link show ${synthetic_interface_vm_1} | grep ether | awk '{print $2}')
         vf_interface_vm_1=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface_vm_1 | sed 's/\// /g' | awk '{print $4}')
     else
-        vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+        else
+        # VM gen 1 case
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
     LogMsg "Virtual function found: $vf_interface_vm_1"
 
@@ -307,7 +325,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ip link show ${synthetic_interface_vm_1} | grep ether | awk '{print $2}')
         vf_interface_vm_1=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface_vm_1 | sed 's/\// /g' | awk '{print $4}')
     else
-        vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+        else
+        # VM gen 1 case
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
     LogMsg "Virtual function found: $vf_interface_vm_1"
 

--- a/Testscripts/Linux/SR-IOV-Utils.sh
+++ b/Testscripts/Linux/SR-IOV-Utils.sh
@@ -80,7 +80,13 @@ VerifyVF()
             synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
             vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
         else
-            vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+            if [[ -d /sys/firmware/efi ]]; then
+            # This is the case of VM gen 2
+                vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+            else
+            # VM gen 1 case
+                vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+            fi
         fi
     fi
 

--- a/Testscripts/Linux/SRIOV-DisableVF.sh
+++ b/Testscripts/Linux/SRIOV-DisableVF.sh
@@ -50,7 +50,13 @@ if [[ $DISTRO_VERSION =~ ^6\. ]]; then
     synthetic_MAC=$(ip link show ${synthetic_interface} | grep ether | awk '{print $2}')
     vf_interface=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface | sed 's/\// /g' | awk '{print $4}')
 else
-    vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}*" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+    if [[ -d /sys/firmware/efi ]]; then
+    # This is the case of VM gen 2
+        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+    else
+    # VM gen 1 case
+        vf_interface=$(find /sys/devices/* -name "*${synthetic_interface}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+    fi
 fi
 LogMsg "Virtual function found: $vf_interface"
 

--- a/Testscripts/Linux/SRIOV-VerifyVF-Connection.sh
+++ b/Testscripts/Linux/SRIOV-VerifyVF-Connection.sh
@@ -129,7 +129,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ip link show ${synthetic_interface_vm_1} | grep ether | awk '{print $2}')
         vf_interface_vm_1=$(grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v $synthetic_interface_vm_1 | sed 's/\// /g' | awk '{print $4}')
     else
-        vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep "pci" | sed 's/\// /g' | awk '{print $12}')
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $11}')
+        else
+        # VM gen 1 case
+            vf_interface_vm_1=$(find /sys/devices/* -name "*${synthetic_interface_vm_1}" | grep pci | sed 's/\// /g' | awk '{print $12}')
+        fi
     fi
     LogMsg "Virtual function found: $vf_interface_vm_1"
 
@@ -182,7 +188,13 @@ while [ $__iterator -le "$vf_count" ]; do
         synthetic_MAC=$(ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$static_IP_2" "$synthetic_MAC_command")
         cmd_to_send="grep -il ${synthetic_MAC} /sys/class/net/*/address | grep -v "${synthetic_interface_vm_2}" | sed 's/\// /g' | awk '{print \$4}'"
     else
-        cmd_to_send="find /sys/devices/* -name "*${synthetic_interface_vm_2}" | grep pci | sed 's/\// /g' | awk '{print \$12}'"
+        if [[ -d /sys/firmware/efi ]]; then
+        # This is the case of VM gen 2
+            cmd_to_send="find /sys/devices/* -name "*${synthetic_interface_vm_2}" | grep pci | sed 's/\// /g' | awk '{print $11}'"
+        else
+        # VM gen 1 case
+            cmd_to_send="find /sys/devices/* -name "*${synthetic_interface_vm_2}" | grep pci | sed 's/\// /g' | awk '{print $12}'"
+        fi
     fi
     vf_interface_vm_2=$(ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$static_IP_2" "$cmd_to_send")
 


### PR DESCRIPTION
New mlx5_core depends on mlx5_ib not mlx5_en. It depends on the ib device availability also. 
Fixed the VF name fetch steps with another way.

### TEST RESULTS

```
[LISAv2 Test Results Summary] with Gen2 VM
Test Run On           : 10/25/2019 17:34:56
VHD Under Test        : XXXXXXXXXXXXXXXXXXXXXXRHEL76-GEN2-1014-Upgrade.vhd
Initial Kernel Version: 3.10.0-957.36.1.el7.x86_64
Final Kernel Version  : 3.10.0-957.36.1.el7.x86_64
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:30

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-DISABLEVF-ON-GUEST                                                          PASS                  5.5 
    2 SRIOV                SRIOV-RELOAD-MODULE                                                               PASS                 5.66 
    3 SRIOV                SRIOV-DISABLE-ENABLE-PCI                                                          PASS                 7.12 


Logs can be found at C:\LISAv2\ZR88\TestResults\2019-25-10-10-34-47-5363

[LISAv2 Test Results Summary] with Gen1 VM
Test Run On           : 10/25/2019 18:21:08
ARM Image Under Test  : RedHat : RHEL : 7.6 : latest
Initial Kernel Version: 3.10.0-957.21.3.el7.x86_64
Final Kernel Version  : 3.10.0-957.21.3.el7.x86_64
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-DISABLEVF-ON-GUEST                                                          PASS                 3.07
    2 SRIOV                SRIOV-RELOAD-MODULE                                                               PASS                 2.83
    3 SRIOV                SRIOV-DISABLE-ENABLE-PCI                                                          PASS                  7.3


Logs can be found at C:\LISAv2\RZ83\TestResults\2019-25-10-11-21-03-5834
```