### PR TITLE
Hyper-V: minor update LIS-Mount-CD to support run remotely and clean iso file

### DIFF
--- a/Testscripts/Windows/LIS-Mount-CD.ps1
+++ b/Testscripts/Windows/LIS-Mount-CD.ps1
@@ -98,7 +98,11 @@ function Main {
     if (-not $defaultVhdPath.EndsWith("\")) {
         $defaultVhdPath += "\"
     }
-    $isoPath = $defaultVhdPath + "${vmName}_CDtest.iso"
+
+    # Get remote iso file path
+    $isoPath_default = $defaultVhdPath + "${vmName}_CDtest.iso"
+    $isoPath = $isoPath_default.Replace(':','$')
+    $isoPath = "\\" + $HvServer + "\" + $isoPath
 
     $WebClient = New-Object System.Net.WebClient
     $WebClient.DownloadFile("$url", "$isoPath")
@@ -110,15 +114,16 @@ function Main {
         Write-LogErr "The .iso file $isoPath could not be found!"
         return $False
     }
-
     #
     # Insert the .iso file into the VMs DVD drive
     #
     if ($vmGen -eq 1) {
-        Add-VMDvdDrive -VMName $VMName -Path $isoPath -ControllerNumber 1 -ControllerLocation 1 -ComputerName $HvServer -Confirm:$False
+        Invoke-Command -ComputerName $HvServer { Add-VMDvdDrive -VMName $Using:VMName -Path $Using:isoPath_default `
+             -ControllerNumber 1 -ControllerLocation 1 -Confirm:$False }
     }
     else {
-        Add-VMDvdDrive -VMName $VMName -Path $isoPath -ControllerNumber 0 -ControllerLocation 1 -ComputerName $HvServer -Confirm:$False
+        Invoke-Command -ComputerName $HvServer { Add-VMDvdDrive -VMName $Using:VMName -Path $Using:isoPath_default `
+            -ControllerNumber 0 -ControllerLocation 1 -Confirm:$False }
     }
 
     if ($? -ne "True") {

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -436,6 +436,7 @@
         <setupScript>.\TestScripts\Windows\LIS-Mount-CD.ps1</setupScript>
         <testScript>LIS-Mount-CD.sh</testScript>
         <files>.\Testscripts\Linux\LIS-Mount-CD.sh,.\Testscripts\Linux\check_traces.sh,.\Testscripts\Linux\utils.sh</files>
+        <cleanUpScript>.\TestScripts\Windows\SETUP-RemoveIsoFromDvd.ps1</cleanUpScript>
         <setupType>OneVM</setupType>
         <Platform>HyperV</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Update LIS-Mount-CD and SETUP-RemoveIsoFromDvd.ps1 files
1) In LIS-Mount-CD, change downloading the iso file to test server directly. When use "Add-VMDvdDrive -VMName $VMName -Path $isoPath" to mount remote iso file to vm, it will fail by "Unable to mount the ISO file", so use invoke-command.
2) Add cleanupScript SETUP-RemoveIsoFromDvd.ps1 to Function.xml. If the test case is pass, the vm will be removed, but the iso file still on the server, meanwhile, removeISOFromDvd also can check remove dvd successfully or not.

Thank you so much.

Before fix:
```
10/22/2019 10:55:48 : [INFO ] MOUNT-CD started running ...
10/22/2019 10:55:49 : [INFO ] Run test case against the target machine ...
10/24/2019 05:26:01 : [INFO ] MOUNT-CD ended running with status: FAIL.
```

After fix:
```
   ID TestArea             TestCaseName                                            TestResult 
------------------------------------------------------------------------------------------------------------------------

    1 CORE                 MOUNT-CD                                                   PASS
```
