### PR TITLE
Remove hardcode eth8 eth_name

### DIFF
--- a/Testscripts/Linux/NET-Max-NICs.sh
+++ b/Testscripts/Linux/NET-Max-NICs.sh
@@ -144,7 +144,6 @@ function main() {
     # Check if every interface has an IP assigned
     for eth_name in ${IFACES[@]}; do
         eth_ip=$(ip a | grep $eth_name | sed -n '2 p' | awk '{print $2}')
-        eth_name=eth8
         eth_number=$(echo $eth_name | sed 's/[^0-9]*//g')
         if [[ $eth_number -ge 8 ]]; then
             continue


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

With this line, it will skip IP address detection. So need to remove this line.

Before:
$ cat TestExecution.log 
```
Thu Oct 31 15:55:58 2019 : Testscript running on redhat_7
Thu Oct 31 15:55:58 2019 : Successfully initialized testscript!
Thu Oct 31 15:55:58 2019 : Array of NICs - eth0 eth1 eth2 eth3 eth4 eth5 eth6 eth7
```
After:
```
Thu Oct 31 15:24:34 2019 : Testscript running on redhat_7
Thu Oct 31 15:24:34 2019 : Successfully initialized testscript!
Thu Oct 31 15:24:34 2019 : Array of NICs - eth0 eth1 eth2 eth3 eth4 eth5 eth6 eth7
Thu Oct 31 15:24:34 2019 : IP for eth0 is 10.0.0.4/24
Thu Oct 31 15:24:34 2019 : IP for eth1 is 10.0.1.4/24
Thu Oct 31 15:24:34 2019 : IP for eth2 is 10.0.2.4/24
Thu Oct 31 15:24:34 2019 : IP for eth3 is 10.0.3.4/24
Thu Oct 31 15:24:34 2019 : IP for eth4 is 10.0.4.4/24
Thu Oct 31 15:24:34 2019 : IP for eth5 is 10.0.5.4/24
Thu Oct 31 15:24:34 2019 : IP for eth6 is 10.0.6.4/24
Thu Oct 31 15:24:34 2019 : IP for eth7 is 10.0.7.4/24
```