### PR TITLE
Fix issue met in KDUMP area.

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -94,7 +94,7 @@ function Upload-RemoteFile($uploadTo, $port, $file, $username, $password, $usePr
 			Start-Sleep -Milliseconds 100
 			$uploadJobStatus = Get-Job -Id $uploadJob.Id
 			$uploadTimout = $false
-			$pscpStuckTimeout = 60
+			$pscpStuckTimeout = 90
 			while (( $uploadJobStatus.State -eq "Running" ) -and ( !$uploadTimout ))
 			{
 				$now = Get-Date


### PR DESCRIPTION
Fix the side effect of #536 
Before fix
```
[LISAv2 Test Results Summary]
Test Run On           : 11/01/2019 13:35:21
VHD Under Test        : EOSG-AUTOBUILT-Canonical-UbuntuServer-18.04-DAILY-LTS-latest-upstreamk-u-1980.vhd
Initial Kernel Version: 5.4.0-rc5-fdbc6c104f95
Final Kernel Version  : 5.4.0-rc5-fdbc6c104f95
Total Test Cases      : 6 (2 Passed, 4 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:54

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SMP-1                                                                 FAIL                 6.71 
.\Tools\pscp is stuck for 60 seconds. Aborting upload.
    2 KDUMP                KDUMP-CRASH-SMP-2                                                                 FAIL                 7.21 
.\Tools\pscp is stuck for 60 seconds. Aborting upload.
    3 KDUMP                KDUMP-CRASH-SMP-3                                                                 FAIL                 7.03 
.\Tools\pscp is stuck for 60 seconds. Aborting upload.
    4 KDUMP                KDUMP-CRASH-16-CORES-1                                                            FAIL                 6.98 
.\Tools\pscp is stuck for 60 seconds. Aborting upload.
    5 KDUMP                KDUMP-CRASH-16-CORES-2                                                            PASS                 6.26 
    6 KDUMP                KDUMP-CRASH-16-CORES-3                                                            PASS                 6.87 
```
After fix
```
[LISAv2 Test Results Summary]
Test Run On           : 11/01/2019 15:21:26
VHD Under Test        : EOSG-AUTOBUILT-Canonical-UbuntuServer-18.04-DAILY-LTS-latest-upstreamk-u-1980.vhd
Test Area             : KDUMP
Initial Kernel Version: 5.4.0-rc5-fdbc6c104f95
Final Kernel Version  : 5.4.0-rc5-fdbc6c104f95
Total Test Cases      : 15 (12 Passed, 0 Failed, 0 Aborted, 3 Skipped)
Total Time (dd:hh:mm) : 0:2:27

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SINGLE-CORE-1                                                         PASS                    6 
    2 KDUMP                KDUMP-CRASH-SINGLE-CORE-2                                                         PASS                 6.52 
    3 KDUMP                KDUMP-CRASH-SINGLE-CORE-3                                                         PASS                 6.33 
    4 KDUMP                KDUMP-CRASH-SMP-1                                                                 PASS                 6.83 
    5 KDUMP                KDUMP-CRASH-SMP-2                                                                 PASS                 6.91 
    6 KDUMP                KDUMP-CRASH-SMP-3                                                                 PASS                 6.98 
    7 KDUMP                KDUMP-CRASH-AUTO-SIZE-1                                                        SKIPPED                 2.05 
    8 KDUMP                KDUMP-CRASH-AUTO-SIZE-2                                                        SKIPPED                 2.23 
    9 KDUMP                KDUMP-CRASH-AUTO-SIZE-3                                                        SKIPPED                 2.21 
   10 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU-1                                                      PASS                 6.77 
   11 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU-2                                                      PASS                 6.24 
   12 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU-3                                                      PASS                 6.58 
   13 KDUMP                KDUMP-CRASH-16-CORES-1                                                            PASS                 6.86 
   14 KDUMP                KDUMP-CRASH-16-CORES-2                                                            PASS                 6.67 
   15 KDUMP                KDUMP-CRASH-16-CORES-3                                                            PASS                 6.61 
```