### PR TITLE
Fix test issues against CentOS 8.0 and Redhat 8.0

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -24,7 +24,7 @@ UtilsInit
 Install_Kexec(){
     case $DISTRO in
         centos* | redhat* | fedora*)
-            if [[ $DISTRO != "redhat_8" ]]; then
+            if [[ $DISTRO != "redhat_8" ]] && [[ $DISTRO != "centos_8" ]]; then
                 yum_install "kexec-tools kdump-tools makedumpfile"
                 if [ $? -ne 0 ]; then
                     UpdateSummary "Warning: Kexec-tools failed to install."
@@ -347,7 +347,7 @@ sed -i "s/crashkernel=\S*//g" $boot_filepath
 sed -i "s/console=\S*//g" $boot_filepath
 
 # Add the crashkernel param
-if [[ $DISTRO != "redhat_8" ]]; then
+if [[ $DISTRO != "redhat_8" ]] && [[ $DISTRO != "centos_8" ]]; then
     sed -i "/vmlinuz-$(uname -r)/ s/$/ crashkernel=$crashkernel/" $boot_filepath
 else
     sed -i "/kernelopts=root/s/$/ crashkernel=$crashkernel/" $boot_filepath

--- a/Testscripts/Linux/KDUMP-Execute.sh
+++ b/Testscripts/Linux/KDUMP-Execute.sh
@@ -39,7 +39,7 @@ Exec_Rhel()
             UpdateSummary "Success: kdump service is active after reboot."
         fi
         ;;
-    "redhat_7" | "redhat_8" | "centos_7" | "fedora")
+    "redhat_7" | "redhat_8" | "centos_7" | "centos_8" | "fedora")
         #
         # RHEL7, kdump status has "Active: active" and "Active: inactive"
         # So, select "Active: active" to check active

--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -70,9 +70,8 @@ if [ "$os_GENERATION" -eq "1" ]; then
 fi
 
 # lsvmbus requires python
-if [[ $DISTRO == "redhat_8" ]]; then
-    which python || ln -s /usr/libexec/platform-python /sbin/python
-elif ! which python; then
+which python || [ -f /usr/libexec/platform-python ] && ln -s /usr/libexec/platform-python /sbin/python
+if ! which python; then
     update_repos
     install_package python
 fi

--- a/Testscripts/Linux/VERIFY-VHD-PREREQUISITES.py
+++ b/Testscripts/Linux/VERIFY-VHD-PREREQUISITES.py
@@ -47,7 +47,7 @@ def verify_grub(distro):
             return False
     if distro == "CENTOS" or distro == "ORACLELINUX" or distro == "REDHAT" or distro == "SLES" or distro == "FEDORA":
         version_release = 0
-        if distro == "REDHAT":
+        if distro == "REDHAT" or distro == "CENTOS":
             version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
         if float(version_release) == 8.0:
             RunLog.info("Getting Contents of /boot/grub2/grubenv")
@@ -277,13 +277,13 @@ if distro == "CENTOS":
     result = verify_udev_rules(distro)
     #Verify repositories
     r_out = Run("yum repolist")
-    if "base" in r_out and "updates" in r_out:
+    if "base" in r_out.lower() and "updates" in r_out.lower():
         RunLog.info("Expected repositories are present")
         print(distro+"_TEST_REPOSITORIES_AVAILABLE")
     else:
-        if "base" not in r_out:
+        if "base" not in r_out.lower():
             RunLog.error("Base repository not present")
-        if "updates" not in r_out:
+        if "updates" not in r_out.lower():
             RunLog.error("Updates repository not present")
         print(distro+"_TEST_REPOSITORIES_ERROR")
     #Verify etc/yum.conf

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -167,7 +167,15 @@ function Install_Dpdk () {
 			ssh "${1}" "yum -y groupinstall 'Infiniband Support' && dracut --add-drivers 'mlx4_en mlx4_ib mlx5_ib' -f && systemctl enable rdma"
 			check_exit_status "Install Infiniband Support on ${1}" "exit"
 			ssh "${1}" "grep 7.5 /etc/redhat-release && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo"
-			packages+=(kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel)
+			packages+=(kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel)
+			check_package "libmnl-devel"
+			if [ $? -eq 0 ]; then
+				packages+=("libmnl-devel")
+			fi
+			check_package "elfutils-libelf-devel"
+			if [ $? -eq 0 ]; then
+				packages+=("elfutils-libelf-devel")
+			fi
 			;;
 		ubuntu|debian)
 			ssh "${1}" "until dpkg --force-all --configure -a; sleep 10; do echo 'Trying again...'; done"

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -208,7 +208,7 @@ if [ $? -ne 0 ]; then
     exit 0
 fi
 
-if [[ $DISTRO == "redhat_8" ]]; then
+if [ -f /usr/libexec/platform-python ]; then
     ln -s /usr/libexec/platform-python /sbin/python
     wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
     chmod +x lsvmbus

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -271,6 +271,9 @@ GetDistro()
 		*CentOS*release*7\.*\.*)
 			DISTRO=centos_7
 			;;
+		*CentOS*release*8\.*\.*)
+			DISTRO=centos_8
+			;;
 		*CentOS*)
 			DISTRO=centos_x
 			;;

--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -35,12 +35,8 @@ ConfigureXFSTestTools() {
         ;;
 
         redhat*|centos*|fedora*)
-            pack_list=(libacl-devel libaio-devel libattr-devel libuuid-devel sqlite uuid-devel xfsdump xfsprogs-devel xfsprogs-qa-devel zlib-devel)
-            if [[ $DISTRO != "redhat_8" ]]; then
-                pack_list+=(btrfs-progs-devel llvm-ocaml-devel)
-            else
-                which python || ln -s /usr/libexec/platform-python /sbin/python
-            fi
+            pack_list=(libacl-devel libaio-devel libattr-devel libuuid-devel sqlite xfsdump xfsprogs-devel xfsprogs-qa-devel zlib-devel btrfs-progs-devel llvm-ocaml-devel uuid-devel)
+            which python || [ -f /usr/libexec/platform-python ] && ln -s /usr/libexec/platform-python /sbin/python
         ;;
 
         suse*|sles*)
@@ -55,11 +51,13 @@ ConfigureXFSTestTools() {
     # Install common & specific dependencies
     update_repos
     install_fio
-    pack_list+=(acl attr automake bc cifs-utils dos2unix dump e2fsprogs gawk gcc git libtool lvm2 make parted quota sed xfsdump xfsprogs)
-    if [[ $DISTRO != "redhat_8" ]]; then
-        pack_list+=(indent python)
-    fi
-    install_package ${pack_list[@]}
+    pack_list+=(acl attr automake bc cifs-utils dos2unix dump e2fsprogs gawk gcc git libtool lvm2 make parted quota sed xfsdump xfsprogs indent python)
+    for package in "${pack_list[@]}"; do
+        check_package "$package"
+        if [ $? -eq 0 ]; then
+            install_package "$package"
+        fi
+    done
     if [ -n "${NVME}" ]; then
         install_nvme_cli
     fi


### PR DESCRIPTION
Fix #620 
OpenLogic CentOS 8.0 8.0.20191030
For DPDK, if use default version 18.11 will hit build error, this build issue got fixed in version DPDK_SOURCE_URL=https://github.com/DPDK/dpdk/archive/v19.11-rc1.tar.gz

```
[LISAv2 Test Results Summary]
Test Run On           : 11/02/2019 14:05:30
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 LSVMBUS                                                                           PASS                 0.76 


[LISAv2 Test Results Summary]
Test Run On           : 11/02/2019 15:44:48
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.68 
    2 CORE                 TIME-CLOCKEVENT-UP                                                                PASS                 0.54 
    3 CORE                 TIME-CLOCKEVENT-SMP                                                               PASS                 0.43 

[LISAv2 Test Results Summary]
Test Run On           : 11/04/2019 06:25:32
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                               PASS                15.41 
dpdk_version test_mode phase   fwdrx_pps_avg fwdtx_pps_avg
------------ --------- -----   ------------- -------------
19.11.0-rc1  txonly    after   5688134       5688135      
19.11.0-rc1  txonly    before  5581744       5581744      
19.11.0-rc1  txonly    during  6380          6380         
19.11.0-rc1  txonly    overall 2327500       2327500 

[LISAv2 Test Results Summary]
Test Run On           : 11/04/2019 06:53:23
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 6.21 
    2 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                 4.93 

[LISAv2 Test Results Summary]
Test Run On           : 11/04/2019 06:59:05
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Test Area             : KDUMP
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 5 (4 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-SINGLE-CORE                                                           PASS                 2.93 
    2 KDUMP                KDUMP-CRASH-SMP                                                                   PASS                 2.89 
    3 KDUMP                KDUMP-CRASH-AUTO-SIZE                                                          SKIPPED                 0.44 
    4 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU                                                        PASS                 2.85 
    5 KDUMP                KDUMP-CRASH-16-CORES                                                              PASS                 2.93 

[LISAv2 Test Results Summary]
Test Run On           : 11/04/2019 07:41:02
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:48

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-FILE-SYSTEM-VERIFICATION-GENERIC                                             PASS                45.68

[LISAv2 Test Results Summary]
Test Run On           : 11/04/2019 12:37:59
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : 8.0.20191030
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 4.82  
```