### PR TITLE
Fix issue in RHEL 8 about missing install package kernel-modules-extra

### DIFF
--- a/Testscripts/Linux/NET-Corruption.sh
+++ b/Testscripts/Linux/NET-Corruption.sh
@@ -12,6 +12,10 @@ function InstallNetcat {
     [[ "$os_VENDOR" == "Fedora" ]] || \
     [[ "$os_VENDOR" == "CentOS" ]]; then
         package_name="nc"
+        # In RHEL 8 qdiscs are shipped as kernel modules in package named kernel-modules-extra
+        if [[ $os_RELEASE =~ 8.* ]]; then
+            install_package "kernel-modules-extra"
+        fi
     else
         package_name="netcat"
     fi


### PR DESCRIPTION
In RHEL_8 qdiscs are shipped as kernel modules in package named kernel-modules-extra, so need to install package kernel-modules-extra.

Test results after fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 11/05/2019 08:33:45
VHD Under Test        : D:\RHEL-8.1.0-2019xxxx-x86_64-GEN2-A.vhdx
Initial Kernel Version: 4.18.0-xxx.el8.x86_64
Final Kernel Version  : 4.18.0-xxx.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-TCP-CORRUPTION                                                                PASS                 3.02
```