### PR TITLE
GPU count calculation correction

### DIFF
--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -255,7 +255,11 @@ function Main {
             return $currentTestResult
         }
 
-        # The expected ratio is 1 GPU adapter for every 6 CPU cores
+        # The expected GPU ratio is different from VM sizes
+        # NC, NC_v2, NC_v3, NV, NV_v2, and ND: 6
+        # NV_v3: 12
+        # ND_v2: 5
+        # Due to hyperthreading option, NV12s_v3 has 1GPU, 24s_v3 has 2 and 48s_v3 has 4 GPUs
         $vmCPUCount = Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP `
             -port $allVMData.SSHPort -command "nproc" -ignoreLinuxExitCode
 

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -260,6 +260,7 @@ function Main {
         # NV_v3: 12
         # ND_v2: 5
         # Due to hyperthreading option, NV12s_v3 has 1GPU, 24s_v3 has 2 and 48s_v3 has 4 GPUs
+        # Source: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-gpu
         $vmCPUCount = Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP `
             -port $allVMData.SSHPort -command "nproc" -ignoreLinuxExitCode
 

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -200,19 +200,6 @@ function Main {
             }
         }
 
-        # Install required packages
-        # ---> Ubuntu case
-        if (@("UBUNTU").contains($global:detectedDistro)) {
-        Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
-            -password $password -command "install_package libglvnd-dev ubuntu-desktop" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null
-        }
-
-        # -----> SUSE
-        if (@("SUSE").contains($global:detectedDistro)) {
-            Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
-                -password $password -command "install_package xorg-x11-driver-video libglvnd-devel" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null
-        }
-
         # Start the test script
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "/$superuser/${testScript}" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -261,7 +261,7 @@ function Main {
         
         if ($allVMData.InstanceSize -match "Standard_NDv2") {
             [int]$expectedGPUCount = $($vmCPUCount/5)
-        } elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NVS") -and $allVMData.InstanceSize -imatch "v3") {
+        } elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NV") -and $allVMData.InstanceSize -imatch "v3") {
             [int]$expectedGPUCount = $($vmCPUCount/12)
         } else {
             [int]$expectedGPUCount = $($vmCPUCount/6)

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -206,11 +206,12 @@ function Main {
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "install_package libglvnd-dev ubuntu-desktop" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null
         }
+
         # -----> SUSE
         if (@("SUSE").contains($global:detectedDistro)) {
             Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
                 -password $password -command "install_package xorg-x11-driver-video libglvnd-devel" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null
-            }
+        }
 
         # Start the test script
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
@@ -260,7 +261,7 @@ function Main {
         
         if ($allVMData.InstanceSize -match "Standard_NDv2") {
             [int]$expectedGPUCount = $($vmCPUCount/5)
-        elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NVS") -and $allVMData.InstanceSize -imatch "v3") {
+        } elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NVS") -and $allVMData.InstanceSize -imatch "v3") {
             [int]$expectedGPUCount = $($vmCPUCount/12)
         } else {
             [int]$expectedGPUCount = $($vmCPUCount/6)

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -258,7 +258,7 @@ function Main {
         # The expected ratio is 1 GPU adapter for every 6 CPU cores
         $vmCPUCount = Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP `
             -port $allVMData.SSHPort -command "nproc" -ignoreLinuxExitCode
-        
+
         if ($allVMData.InstanceSize -match "Standard_NDv2") {
             [int]$expectedGPUCount = $($vmCPUCount/5)
         } elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NV") -and $allVMData.InstanceSize -imatch "v3") {

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -260,7 +260,7 @@ function Main {
         
         if ($allVMData.InstanceSize -match "Standard_NDv2") {
             [int]$expectedGPUCount = $($vmCPUCount/5)
-        elseif ($allVMData.InstanceSize -imatch "Standard_ND" -and $allVMData.InstanceSize -imatch "v3") {
+        elseif (($allVMData.InstanceSize -imatch "Standard_ND" -or $allVMData.InstanceSize -imatch "Standard_NVS") -and $allVMData.InstanceSize -imatch "v3") {
             [int]$expectedGPUCount = $($vmCPUCount/12)
         } else {
             [int]$expectedGPUCount = $($vmCPUCount/6)


### PR DESCRIPTION
VM size NVSv3 should be ratio 12.

NV12s_v3: the expected GPU device count is 1
NV24s_v3: the expected GPU device count is 2
NV48s_v3: the expected GPU device count is 4

TEST RESULT
```
[LISAv2 Test Results Summary]
Test Run On           : 11/06/2019 01:38:33
ARM Image Under Test  : Canonical : UbuntuServer : 16.04.0-LTS : latest
Initial Kernel Version: 4.15.0-1061-azure
Final Kernel Version  : 4.15.0-1061-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION-MAX-GPU                                             PASS                 5.08
        Using nVidia driver : GRID
        lsvmbus: Expected "PCI Express pass-through" count: 4, count inside the VM: 4 : PASS
        lspci: Expected "3D controller: NVIDIA Corporation" count: 4, found inside the VM: 4 : PASS
        lshw: Expected Display adapters: 4, total adapters found in VM: 4 : PASS
        nvidia-smi: Expected GPU count: 4, found inside the VM: 4 : PASS


Logs can be found at C:\LISAv2\ZC12\TestResults\2019-05-11-17-38-28-0754
```