### PR TITLE
Change Azure VM size to Standard_DS3_v2 with 4 CPUs and fix issues

### DIFF
--- a/Testscripts/Linux/CORE-CPUVerifyOnline.sh
+++ b/Testscripts/Linux/CORE-CPUVerifyOnline.sh
@@ -17,13 +17,13 @@
 UtilsInit
 
 # Getting the CPUs count
-cpu_count=$(grep -i processor -o /proc/cpuinfo | wc -l)
+cpu_count=$(grep -i ^processor -o /proc/cpuinfo | wc -l)
 UpdateSummary "${cpu_count} CPU cores detected"
 
 #
 # Verifying all CPUs can't be offline except CPU0
 #
-for ((cpu=1 ; cpu<=$cpu_count ; cpu++)) ;do
+for ((cpu=1 ; cpu<$cpu_count ; cpu++)) ;do
     LogMsg "Checking the $cpu on /sys/device/...."
     __file_path="/sys/devices/system/cpu/cpu$cpu/online"
     if [ -e "$__file_path" ]; then

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -210,6 +210,7 @@
         <testScript>CORE-CPUVerifyOnline.sh</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\CORE-CPUVerifyOnline.sh</files>
         <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
         <TestParameters>
             <param>vCPU=4</param>
         </TestParameters>


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

1. Use Standard_DS3_v2 with 4 vCPUs in Azure. Before, the VM size is DS1_v2 with only 1 vCPU. The proposal of this case is to verify CPU offline when vCPU number > 1. If vCPU number is 1, this case actually does nothing.
2. If the VM uses AMD processor(such as L8s_v2), the "grep -i processor -o /proc/cpuinfo" will hit twice per CPU. So grep ^processor instead.
```
# grep -i processor /proc/cpuinfo 
processor	: 0
model name	: AMD EPYC 7551 32-Core Processor
processor	: 1
model name	: AMD EPYC 7551 32-Core Processor
processor	: 2
model name	: AMD EPYC 7551 32-Core Processor
processor	: 3
model name	: AMD EPYC 7551 32-Core Processor
processor	: 4
model name	: AMD EPYC 7551 32-Core Processor
processor	: 5
model name	: AMD EPYC 7551 32-Core Processor
processor	: 6
model name	: AMD EPYC 7551 32-Core Processor
processor	: 7
model name	: AMD EPYC 7551 32-Core Processor
```
Before:
```
# grep -i 'processor' -o /proc/cpuinfo 
processor
Processor
processor
Processor
processor
Processor
processor
Processor
processor
Processor
processor
Processor
processor
Processor
processor
Processor
```
After:
```
# grep -i ^processor -o /proc/cpuinfo 
processor
processor
processor
processor
processor
processor
processor
processor
```
3. 4 CPUs means cpu0,cpu1,cpu2,cpu3. If skip cpu0, we should offline only 3 cpus(cpu1,cpu2,cpu3). So the loop end condition should be '<$cpu_count' but not '<=$cpu_count'.
4. I'm not quite understand why we skip cpu0 in this case? 

Thanks!

Br,
Yuxin Sun