### PR TITLE
Added new test case of NVMe long-term stress test

### DIFF
--- a/Testscripts/Linux/nested_kvm_perf_fio.sh
+++ b/Testscripts/Linux/nested_kvm_perf_fio.sh
@@ -89,7 +89,7 @@ Run_Fio()
 		io=$startIO
 		while [ $io -le $maxIO ]
 		do
-			Thread=$startThread			
+			Thread=$startThread
 			while [ $Thread -le $maxThread ]
 			do
 				if [ $Thread -ge 8 ]
@@ -106,7 +106,7 @@ Run_Fio()
 				fio $FILEIO --readwrite=$testmode --bs=${io}K --runtime=$ioruntime --iodepth=$Thread --numjobs=$numjobs --output-format=json --output=$jsonfilename --name="iteration"${iteration} >> $LOGFILE
 				iostatPID=$(ps -ef | awk '/iostat/ && !/awk/ { print $2 }')
 				kill -9 $iostatPID
-				Thread=$(( Thread*2 ))		
+				Thread=$(( Thread*2 ))
 				iteration=$(( iteration+1 ))
 			done
 		io=$(( io * io_increment ))

--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -197,6 +197,7 @@ ConfigNVME()
 		echo 0 > /sys/block/${namespace}/queue/rq_affinity
 		sleep 1
 		nvme_namespaces="${nvme_namespaces}/dev/${namespace}:"
+		LogMsg "NMVe name space: $namespace"
 	done
 	# Deleting last char of string (:)
 	nvme_namespaces=${nvme_namespaces%?}
@@ -204,8 +205,10 @@ ConfigNVME()
 	# Set the remaining variables
 	# NVMe perf tests will have a starting qdepth equal to vCPU number
 	startQDepth=$(nproc)
+	LogMsg "Setting qdepth in the setting: $startQDepth"
 	# NVMe perf tests will have a max qdepth equal to vCPU number x 256
 	maxQDepth=$(($(nproc) * 256))
+	LogMsg "Setting maxQDepth in the setting: $maxQDepth"
 }
 
 CreateLVM()

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -99,7 +99,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_STRESS_RUNTIME</ReplaceThis>
-		<ReplaceWith>12h</ReplaceWith>
+		<ReplaceWith>720</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_TEST_DURATION_IN_SECONDS</ReplaceThis>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -98,6 +98,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>300</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>FIO_STRESS_RUNTIME</ReplaceThis>
+		<ReplaceWith>48h</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>DPDK_TEST_DURATION_IN_SECONDS</ReplaceThis>
 		<ReplaceWith>120</ReplaceWith>
 	</Parameter>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -99,7 +99,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_STRESS_RUNTIME</ReplaceThis>
-		<ReplaceWith>48h</ReplaceWith>
+		<ReplaceWith>12h</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_TEST_DURATION_IN_SECONDS</ReplaceThis>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -140,7 +140,7 @@
 			<param>maxQDepth=16384</param>
 			<param>startIO=4</param>
 			<param>ioruntime=FIO_STRESS_RUNTIME</param>
-			<param>maxIO=4</param>
+			<param>maxIO=1</param>
 			<param>PHYSICAL_NUMBER=1</param>
 			<param>parseTimeout=FIO_LOG_PARSE_TIMEOUT</param>
 			<param>nvme_version=NVME_VERSION</param>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -124,4 +124,32 @@
 		<Tags>stress,network,sriov</Tags>
 		<Priority>2</Priority>
 	</test>
+		<test>
+		<testName>STRESSTEST-NVME-4K-IO</testName>
+		<testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
+		<setupType>OneVM</setupType>
+		<OverrideVMSize>Standard_L64s_v2</OverrideVMSize>
+		<setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\TestScripts\Windows\SETUP-Config-VM.ps1,.\Testscripts\Windows\SETUP-Add-NVME-Disk.ps1</setupScript>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
+		<TestParameters>
+			<param>vmCpuNumber=8</param>
+			<param>vmMemory=8GB</param>
+			<param>NVME=yes</param>
+			<param>modes=PERF-STORAGE-4K-IO-MODES</param>
+			<param>startQDepth=64</param>
+			<param>maxQDepth=16384</param>
+			<param>startIO=4</param>
+			<param>ioruntime=FIO_STRESS_RUNTIME</param>
+			<param>maxIO=4</param>
+			<param>PHYSICAL_NUMBER=1</param>
+			<param>parseTimeout=FIO_LOG_PARSE_TIMEOUT</param>
+			<param>nvme_version=NVME_VERSION</param>
+		</TestParameters>
+		<cleanupScript>.\Testscripts\Windows\SETUP-Remove-NVME-Disk.ps1</cleanupScript>
+		<Platform>Azure,HyperV</Platform>
+		<Category>Stress</Category>
+		<Area>STRESS</Area>
+		<Tags>stress,nvme,storage</Tags>
+		<Priority>2</Priority>
+	</test>
 </TestCases>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -140,7 +140,7 @@
 			<param>maxQDepth=16384</param>
 			<param>startIO=4</param>
 			<param>ioruntime=FIO_STRESS_RUNTIME</param>
-			<param>maxIO=1</param>
+			<param>maxIO=4</param>
 			<param>PHYSICAL_NUMBER=1</param>
 			<param>parseTimeout=FIO_LOG_PARSE_TIMEOUT</param>
 			<param>nvme_version=NVME_VERSION</param>


### PR DESCRIPTION
A simple twick of NVMe performance test case to Stress one. Measured multiple times of the testing time. The key parameter would be 'FIO_STRESS_RUNTIME'. which users can control the execution time.

TEST RESULT with'FIO_STRESS_RUNTIME=720'

[LISAv2 Test Results Summary]
Test Run On           : 11/06/2019 02:22:29
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1023-azure
Final Kernel Version  : 5.0.0-1023-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:7:30

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STRESS               STRESSTEST-NVME-4K-IO                                                             PASS               443.64
        Mode=randread : block_size=4K q_depth=64 iops=998403.720554
        Mode=randread : block_size=4K q_depth=128 iops=1602833.672088
        Mode=randread : block_size=4K q_depth=256 iops=2347870.182987
        Mode=randread : block_size=4K q_depth=512 iops=2837763.994866
        Mode=randread : block_size=4K q_depth=1024 iops=2936709.315689
        Mode=randread : block_size=4K q_depth=2048 iops=2959925.452316
        Mode=randread : block_size=4K q_depth=4096 iops=2958421.601213
        Mode=randread : block_size=4K q_depth=8192 iops=2959127.796504
        Mode=randread : block_size=4K q_depth=16384 iops=2960391.000649
        Mode=randwrite : block_size=4K q_depth=64 iops=1130273.218037
        Mode=randwrite : block_size=4K q_depth=128 iops=1912386.740854
        Mode=randwrite : block_size=4K q_depth=256 iops=2318437.929198
        Mode=randwrite : block_size=4K q_depth=512 iops=2470136.201173
        Mode=randwrite : block_size=4K q_depth=1024 iops=2483698.263425
        Mode=randwrite : block_size=4K q_depth=2048 iops=2205233.195319
        Mode=randwrite : block_size=4K q_depth=4096 iops=2281327.683061
        Mode=randwrite : block_size=4K q_depth=8192 iops=2225102.752869
        Mode=randwrite : block_size=4K q_depth=16384 iops=2438168.399643
        Mode=read : block_size=4K q_depth=64 iops=828364.867922
        Mode=read : block_size=4K q_depth=128 iops=1428920.655052
        Mode=read : block_size=4K q_depth=256 iops=2250480.313791
        Mode=read : block_size=4K q_depth=512 iops=2867088.486120
        Mode=read : block_size=4K q_depth=1024 iops=2909384.708435
        Mode=read : block_size=4K q_depth=2048 iops=2933113.991344
        Mode=read : block_size=4K q_depth=4096 iops=2940695.149262
        Mode=read : block_size=4K q_depth=8192 iops=2937323.604771
        Mode=read : block_size=4K q_depth=16384 iops=2936471.737867
        Mode=write : block_size=4K q_depth=64 iops=1112600.639133
        Mode=write : block_size=4K q_depth=128 iops=1935590.568604
        Mode=write : block_size=4K q_depth=256 iops=2514642.866004
        Mode=write : block_size=4K q_depth=512 iops=2363649.028751
        Mode=write : block_size=4K q_depth=1024 iops=2365679.603555
        Mode=write : block_size=4K q_depth=2048 iops=2235795.103716
        Mode=write : block_size=4K q_depth=4096 iops=2378082.430258
        Mode=write : block_size=4K q_depth=8192 iops=2230193.164671
        Mode=write : block_size=4K q_depth=16384 iops=2462835.101398


Logs can be found at C:\LISAv2\GO85\TestResults\2019-05-11-18-22-25-1489

Also tested with other values. 
FIO_STRESS_RUNTIME=60: Execution time is 50 min
FIO_STRESS_RUNTIME=120: Execution time is 186 min