### PR TITLE
DiskHotAddRemove failed with large size VM

### DIFF
--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -15,7 +15,7 @@ function Main {
         $allUnmanagedDataDisks = @()
         $virtualMachine = Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName
         $diskCount = (Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}).MaxDataDiskCount
-        Write-Debug "Found max data disk size $diskCount in the system0"
+        Write-Debug "Found max data disk size $diskCount in the system"
         $storageProfile = (Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName).StorageProfile
         Write-LogInfo "Parallel Addition of Data Disks to the VM "
         While ($count -lt $diskCount) {
@@ -25,7 +25,7 @@ function Main {
             if ($storageProfile.OsDisk.ManagedDisk) {
                 # Add managed data disks
                 $storageType = 'Premium_LRS'
-                $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeGB $diskSizeinGB
+                $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeInBytes $diskSizeinGB
                 $dataDisk = New-AzDisk -DiskName $diskName -Disk $diskConfig -ResourceGroupName $AllVMData.ResourceGroupName
                 Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun $count | Out-Null
             } else {

--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -53,7 +53,7 @@ function Main {
         Write-LogInfo "Verifying if data disk is added to the VM: Running fdisk on remote VM"
         $fdiskOutput = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "/sbin/fdisk -l | grep /dev/sd" -runAsSudo
         foreach ($line in ($fdiskOutput.Split([Environment]::NewLine))) {
-            if ($line -imatch "Disk /dev/sd[^ab]:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))){
+            if ($line -imatch "Disk /dev/sd[a-z]+:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))){
                 Write-LogInfo "Data disk is successfully mounted to the VM: $line"
                 $verifiedDiskCount += 1
             }

--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -57,7 +57,6 @@ function Main {
             if ($line -imatch "Disk /dev/sd[a-z]+:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))){
                 $verifiedDiskCount += 1
                 Write-LogInfo "$verifiedDiskCount data disk is successfully mounted to the VM: $line"
-                
             }
         }
         Write-LogInfo "Number of data disks verified inside VM $verifiedDiskCount"


### PR DESCRIPTION
Both DiskHotAddRemove tests are running with bigger size VM, it failed because it did not count after /dev/adz. Changing the regex to continue counting the /dev/adaa and so on.