### PR TITLE
Fix issue Run-LinuxCmd counts cpu.

### DIFF
--- a/Testscripts/Windows/Max-vCPU.ps1
+++ b/Testscripts/Windows/Max-vCPU.ps1
@@ -97,7 +97,7 @@ function Main {
 
     # Determine how many cores the VM has detected
     $vCPU = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
-            -command "cat /proc/cpuinfo | grep processor | wc -l" -RunAsSudo
+            -command "cat /proc/cpuinfo | grep ^processor | wc -l" -RunAsSudo
     if ($vCPU -eq $guestMaxCPUs) {
         Write-LogInfo "CPU count inside VM is $guestMaxCPUs"
         Write-LogInfo "VM $VMName successfully started with $guestMaxCPUs cores."


### PR DESCRIPTION
This is a synchronous change. Refer to PR#628.
Add "^"  to match the lines that start with string "processor". This can avoid mistakes of more than one string in one line.