### PR TITLE
Fix issue when minorVersion is not just number

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1791,6 +1791,10 @@ function GetOSVersion {
                 os_CODENAME=${ver#*|}
                 os_RELEASE=${ver%|*}
                 os_UPDATE=${os_RELEASE##*.}
+                # For the scenario "7.0 Beta (Maipo)", only need to keep the number part for transfering int type
+                if [[ $os_VENDOR == "Red Hat" || $os_UPDATE == "\d*\D*" ]]; then
+                    os_UPDATE=${os_UPDATE% *}
+                fi
                 os_RELEASE=${os_RELEASE%.*}
                 break
             fi

--- a/Testscripts/Windows/NET-Test-Vxlan.ps1
+++ b/Testscripts/Windows/NET-Test-Vxlan.ps1
@@ -51,8 +51,10 @@ function Main {
     # Make sure the VM supports vxlan before testing it
     [int]$majorVersion = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $vm2ipv4 `
         -port $VMPort -command ". utils.sh && GetOSVersion && echo `$os_RELEASE"
-    [int]$minorVersion = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $vm2ipv4 `
+    $minorVersion = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $vm2ipv4 `
         -port $VMPort -command ". utils.sh && GetOSVersion && echo `$os_UPDATE"
+    # In case minorVersion is not int, such as '1 Beta'
+    [int]$minorVersion = $minorVersion.split(' ')[0]
     if ((($majorVersion -le 6) -and ($minorVersion -le 4)) -or $majorVersion -le 5) {
         Write-LogWarn "RHEL ${majorVersion}.${minorVersion} doesn't support vxlan"
         return "ABORT"


### PR DESCRIPTION
Fix issue when minorVersion is not just number, such as "1 Beta" (for such scenarios that the OS version is like 8.1 Beta), which will cause error in [int]$minorVersion.

Test results after fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 11/07/2019 09:04:49
VHD Under Test        : D:\RHEL-8.1.0-xxxx-x86_64-GEN2-A.vhdx
Initial Kernel Version: 4.18.0-xxx.el8.x86_64
Final Kernel Version  : 4.18.0-xxx.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-VXLAN                                                                         PASS                 9.77
```