### PR TITLE
Modeprobe_Setup: Ubuntu needs manual loading for mlx4 driver

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -71,6 +71,7 @@ function Modprobe_Setup() {
 	local distro=$(detect_linux_distribution)$(detect_linux_distribution_version)
 	if [[ "${distro}" == "sles15" || ("${distro}" =~ "ubuntu") ]]; then
 		modprobe_cmd="${modprobe_cmd} mlx4_ib mlx5_ib || true"
+		LogMsg "Loading mlx4_ib and mlx5_ib modules with ib_uverbs module manually for distro: ${distro}"
 	fi
 
 	ssh ${1} "${modprobe_cmd}"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -67,9 +67,9 @@ function Modprobe_Setup() {
 	fi
 
 	local modprobe_cmd="modprobe -a ib_uverbs"
-	# known issue on sles15
+	# known issue on sles15 and ubuntu
 	local distro=$(detect_linux_distribution)$(detect_linux_distribution_version)
-	if [[ "${distro}" == "sles15" ]]; then
+	if [[ "${distro}" == "sles15" || ("${distro}" =~ "ubuntu") ]]; then
 		modprobe_cmd="${modprobe_cmd} mlx4_ib mlx5_ib || true"
 	fi
 


### PR DESCRIPTION
This is known issue for Ubuntu and being reported to Ubuntu.

Before DPDK performance testcases were failing for Ubuntu
```
DPDK_SOURCE_URL=https://git.dpdk.org/dpdk/snapshot/dpdk-v19.08.tar.gz
Test Run On           : 08/12/2019 01:52:29
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
Test Tag              : dpdk
Initial Kernel Version: 4.18.0-1025-azure
Final Kernel Version  : 4.18.0-1025-azure
Total Test Cases      : 11 (5 Passed, 6 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:3:48

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS4                                                     FAIL                12.98 
    2 DPDK                 VERIFY-DPDK-OVS                                                                   PASS                14.63 
    3 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                19.16 
    4 DPDK                 VERIFY-SRIOV-FAILSAFE-FOR-DPDK                                                    PASS                 40.5 
	DPDK-TESTPMD : Initial SRIOV : DPDK 19.08.0 : TxPPS : 11214907 : RxPPS : 11189292 
	DPDK-TESTPMD : Synthetic : DPDK 19.08.0 : TxPPS : 543530 : RxPPS : 0 
	DPDK-TESTPMD : Re-Enable SRIOV : DPDK 19.08.0 : TxPps : 10967208 : RxPps : 10949857 
	DPDK RxPPS : Difference between Initial and Re-Enabled SRIOV : 11189292 : 10949857 : 2.14 % 
    5 DPDK                 PERF-DPDK-MULTICORE-PPS-F32                                                       FAIL                24.86 
    6 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                               FAIL                16.18 
    7 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            FAIL                15.99 
    8 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS15                                                    FAIL                11.98 
    9 DPDK                 PERF-DPDK-MULTICORE-PPS-DS15                                                      FAIL                   21 
   10 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 4.99 
   11 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                 7.44 
```
Now:

```
[LISAv2 Test Results Summary]
Test Run On           : 11/07/2019 00:21:17
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1061-azure
Final Kernel Version  : 4.15.0-1061-azure
Total Test Cases      : 11 (10 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:3:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS4                                                     PASS                 12.4 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.3-rc2  rxonly    1    11493160   11361839   11135682   0             44010651619 43080644048 0          
18.11.3-rc2  io        1    11441819   11360210   10903313   10847216      44263789628 42531846733 42290364043 
    2 DPDK                 VERIFY-DPDK-OVS                                                                   PASS                13.79 
    3 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                17.04 
    4 DPDK                 VERIFY-SRIOV-FAILSAFE-FOR-DPDK                                                    PASS                   33 
	DPDK-TESTPMD : Initial SRIOV : DPDK 18.11.3-rc2 : TxPPS : 10714183 : RxPPS : 10668730 
	DPDK-TESTPMD : Synthetic : DPDK 18.11.3-rc2 : TxPPS : 520587 : RxPPS : 118205 
	DPDK-TESTPMD : Re-Enable SRIOV : DPDK 18.11.3-rc2 : TxPps : 11256109 : RxPps : 10547996 
	DPDK RxPPS : Difference between Initial and Re-Enabled SRIOV : 10668730 : 10547996 : 1.13 % 
    5 DPDK                 PERF-DPDK-MULTICORE-PPS-F32                                                       FAIL                23.26 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.3-rc2  rxonly    2    13234457   24855131   12664131   0             96561046567 48819656105 0          
18.11.3-rc2  io        2    12761979   24196633   12210011   12209786      94080814469 47336933632 47336774568
18.11.3-rc2  rxonly    4    13259732   18115862   12788800   0             69817746178 49487004256 0          
18.11.3-rc2  io        4    12698884   18102465   12170395   12170395      70544387553 46663744071 46663743596
18.11.3-rc2  rxonly    8    13324631   20808559   12732885   0             80509795459 49152370308 0          
18.11.3-rc2  io        8    12739964   20555585   12265996   12265996      79968590750 47513794391 47513794135
18.11.3-rc2  rxonly    16   13377287   21877004   12830137   0             85417740472 49570276139 0          
18.11.3-rc2  io        16   18047427   21965796   17129267   16398554      85708317410 66262506452 63421337441 
    6 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                               PASS                13.74 
dpdk_version test_mode phase   fwdrx_pps_avg fwdtx_pps_avg
------------ --------- -----   ------------- -------------
18.11.3-rc2  txonly    after   3545576       3545576      
18.11.3-rc2  txonly    before  3517242       3517241      
18.11.3-rc2  txonly    during  192442        192442       
18.11.3-rc2  txonly    overall 2558077       2558077 
    7 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            PASS                11.16 
dpdk_version core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg
------------ ---- ---------- ------------- ------------- ----------
18.11.3-rc2  2    17185872   10190877      10190877      9868889   
18.11.3-rc2  4    17912981   10635949      10635949      10247428  
18.11.3-rc2  8    18540471   10882403      10882382      10273042 
    8 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS15                                                    PASS                 8.94 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.3-rc2  rxonly    1    13104615   12817885   12255293   0             50124768068 47619265238 0          
18.11.3-rc2  io        1    9425792    12723582   7754022    7754021       49671247437 29973064367 29973062856 
    9 DPDK                 PERF-DPDK-MULTICORE-PPS-DS15                                                      PASS                17.98 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes    rx_bytes    fwd_bytes  
------------ --------- ---- ---------- ---------- ---------- ------------- --------    --------    ---------  
18.11.3-rc2  rxonly    2    18563017   18454388   17172560   0             72269167544 67245553697 0          
18.11.3-rc2  io        2    11716875   18039117   10400225   10398925      70412843235 40051277178 40046059861
18.11.3-rc2  rxonly    4    18780360   18172076   17477067   0             70522575311 66590284020 0          
18.11.3-rc2  io        4    15786637   17695682   12650569   12229998      68021994319 48590349655 47192963103
18.11.3-rc2  rxonly    8    19099889   18814282   18099752   0             73367270700 69446041908 0          
18.11.3-rc2  io        8    17439730   18378003   16583310   13584564      71844219574 64489416184 52708499098 
   10 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 7.47 
   11 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                  4.9 
```


