### PR TITLE
Fix typo about bash file name "NET-Max-NICs.sh"

### DIFF
--- a/Testscripts/Windows/NET-HotAddRemove-Max-NIC.ps1
+++ b/Testscripts/Windows/NET-HotAddRemove-Max-NIC.ps1
@@ -25,7 +25,7 @@ function Main {
     )
 
     $switchName = "External"
-    $remoteScript = "NET-MAX-NICs.sh"
+    $remoteScript = "NET-Max-NICs.sh"
     $remoteScript2 = "NET-Verify-HotAdd-MultiNIC.sh"
     ########################################################################
     $params = $TestParams.Split(";")

--- a/XML/TestCases/FunctionalTests-Network.xml
+++ b/XML/TestCases/FunctionalTests-Network.xml
@@ -465,7 +465,7 @@
     <test>
         <testName>NET-HOT-ADD-REMOVE-MAXNIC</testName>
         <testScript>NET-HotAddRemove-Max-NIC.ps1</testScript>
-        <files>.\Testscripts\Linux\NET-MAX-NICs.sh,.\Testscripts\Linux\NET-Verify-HotAdd-MultiNIC.sh,.\Testscripts\Linux\utils.sh</files>
+        <files>.\Testscripts\Linux\NET-Max-NICs.sh,.\Testscripts\Linux\NET-Verify-HotAdd-MultiNIC.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
         <TestParameters>
             <param>TEST_TYPE=synthetic</param>


### PR DESCRIPTION
Because Linux bash/shell is case-sensitive, so fix the $remoteScript in ps1, change "NET-MAX-NICs.sh" to "NET-Max-NICs.sh" which is exactly same to the linux bash file name.

**Test error before fix:**
```
11/08/2019 01:50:57 : [ERROR] Failed to execute : echo '******' | sudo -S -s eval "export HOME=`pwd`;bash NET-MAX-NICs.sh  > NETMaxNICs.log". Retrying...
......
[sudo] password for rhel: bash: NET-MAX-NICs.sh: No such file or directory
```
**Test results after fix:**
```
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 01:57:21
VHD Under Test        : D:\RHEL-8.1.0-2019xxxx.0-x86_64-GEN2-A.vhdx
Initial Kernel Version: 4.18.0-xxx.el8.x86_64
Final Kernel Version  : 4.18.0-xxx.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-HOT-ADD-REMOVE-MAXNIC                                                         PASS                 1.83
```