### PR TITLE
Fix test issue in storage area.

### DIFF
--- a/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
@@ -15,10 +15,11 @@ function Main {
         $virtualMachine = Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName
         $diskCount = (Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}).MaxDataDiskCount
         $storageProfile = (Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName).StorageProfile
+        Write-Debug "Found max data disk $diskCount in the system"
         Write-LogInfo "Serial Addition and Removal of Data Disks"
+        $verifiedDiskCount = 0
         While ($count -lt $diskCount) {
             $count += 1
-            $verifiedDiskCount = 0
             $diskName = "disk"+ $count.ToString()
             if ($storageProfile.OsDisk.ManagedDisk) {
                 # Add managed data disks
@@ -41,17 +42,17 @@ function Main {
             }
             $updateVM1 = Update-AzVM -VM $virtualMachine -ResourceGroupName $AllVMData.ResourceGroupName
             if ($updateVM1.IsSuccessStatusCode) {
-                Write-LogInfo "Successfully attached an empty data disk of size $diskSizeinGB GB to VM"
+                Write-LogInfo "$count - Successfully attached an empty data disk of size $diskSizeinGB GB to VM"
             } else {
                 $testResult = $resultFail
-                throw "Fail to attachÂ an empty data disk of size $diskSizeinGB GB to VM"
+                throw "Fail to attach an empty data disk of size $diskSizeinGB GB to VM"
             }
             Write-LogInfo "Verifying if data disk is added to the VM: Running fdisk on remote VM"
             $fdiskOutput = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "/sbin/fdisk -l | grep /dev/sd" -runAsSudo
             foreach ($line in ($fdiskOutput.Split([Environment]::NewLine))) {
-                if($line -imatch "Disk /dev/sd[^ab]:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))) {
-                    Write-LogInfo "Data disk is successfully mounted to the VM: $line"
+                if($line -imatch "Disk /dev/sd[a-z][a-z]|sd[c-z]:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))) {
                     $verifiedDiskCount += 1
+                    Write-LogInfo "$verifiedDiskCount data disk is successfully attached to the VM: $line"
                 }
             }
             if ($verifiedDiskCount -eq 1) {
@@ -71,12 +72,13 @@ function Main {
             Write-LogInfo "Verifying if data disk is removed from the VM: Running fdisk on remote VM"
             $fdiskFinalOutput = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -command "/sbin/fdisk -l | grep /dev/sd" -runAsSudo
             foreach ($line in ($fdiskFinalOutput.Split([Environment]::NewLine))) {
-                if($line -imatch "Disk /dev/sd[^ab]:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))) {
+                if($line -imatch "Disk /dev/sd[a-z][a-z]|sd[c-z]:" -and [int64]($line.Split()[4]) -eq (([int64]($diskSizeinGB) * [int64]1073741824))) {
                     $testResult = $resultFail
                     throw "Data disk is NOT removed from the VM at $line"
                 }
             }
             Write-LogInfo "Successfully verified that data disk is removed from the VM"
+            $verifiedDiskCount-=1
             # Remove unmanaged data disks
             if (!$storageProfile.OsDisk.ManagedDisk) {
                 $osVhdStorageAccount | Remove-AzStorageBlob -Container $dataDiskVhdUri.Split('/')[-2] -Blob $dataDiskVhdUri.Split('/')[-1] -Verbose -Force

--- a/Testscripts/Windows/VERIFY-DISK-WITH-NOBARRIER.ps1
+++ b/Testscripts/Windows/VERIFY-DISK-WITH-NOBARRIER.ps1
@@ -12,7 +12,8 @@ function Main {
         $VirtualMachine = Get-AzVM -ResourceGroupName $VM.ResourceGroupName -Name $VM.RoleName
         $diskCount = (Get-AzVMSize -Location $allVMData.Location | Where-Object {$_.Name -eq $allVMData.InstanceSize}).MaxDataDiskCount
         $storageProfile = (Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName).StorageProfile
-
+        $allDiskNames = @()
+        $allUnmanagedDataDisks = @()
         Write-LogInfo "Max $diskCount Disks will be attached to VM"
         Write-LogInfo "--------------------------------------------------------"
         Write-LogInfo "Serial Addition of Data Disks"
@@ -22,6 +23,7 @@ function Main {
             $verifiedDiskCount = 0
             $diskName = "disk" + $count.ToString()
             $diskSizeinGB = "10"
+            $allDiskNames += $diskName
             if ($storageProfile.OsDisk.ManagedDisk) {
                 # Add managed data disks
                 $storageType = 'Standard_LRS'
@@ -37,14 +39,15 @@ function Main {
                 Write-LogInfo "#$count - Adding an unmanaged empty data disk of size $diskSizeinGB GB"
                 $Null = Add-AzVMDataDisk -VM $VirtualMachine -Name $diskName -DiskSizeInGB $diskSizeinGB -LUN $count -VhdUri $VHDuri.ToString() -CreateOption Empty
                 Write-LogInfo "#$count - Successfully created an unmanaged empty data disk of size $diskSizeinGB GB"
+                $allUnmanagedDataDisks += $VHDUri.ToString().Split('/')[-1]
             }
             $Null = Update-AzVM -VM $VirtualMachine -ResourceGroupName $ResourceGroupUnderTest
             Write-LogInfo "#$count - Successfully added an empty data disk to the VM of size $diskSizeinGB"
             Write-LogInfo "Verifying if data disk is added to the VM: Running fdisk on remote VM"
             $fdiskOutput = Run-LinuxCmd -username $user -password $password -ip $VM.PublicIP -port $VM.SSHPort -command "/sbin/fdisk -l | grep /dev/sd" -runAsSudo
             foreach ($line in ($fdiskOutput.Split([Environment]::NewLine))) {
-                if ($line -imatch "Disk /dev/sd[^ab]:" -and ([int]($line.Split()[2]) -ge [int]$diskSizeinGB)) {
-                    Write-LogInfo "Data disk is successfully mounted to the VM: $line"
+                if ($line -imatch "Disk /dev/sd[a-z][a-z]|sd[c-z]:" -and ([int]($line.Split()[2]) -ge [int]$diskSizeinGB)) {
+                    Write-LogInfo "Data disk is successfully attached to the VM: $line"
                     $verifiedDiskCount += 1
                 }
             }
@@ -69,6 +72,23 @@ function Main {
         elseif ( $finalStatus -imatch "TestCompleted") {
             Write-LogInfo "Test Completed."
             $testResult = "PASS"
+            Write-LogInfo "Parallel Removal of Data Disks from the VM"
+            Remove-AzVMDataDisk -VM $virtualMachine -DataDiskNames $allDiskNames | Out-Null
+            $updateVM2 = Update-AzVM -VM $virtualMachine -ResourceGroupName $AllVMData.ResourceGroupName
+            if ($updateVM2.IsSuccessStatusCode) {
+                Write-LogInfo "Successfully removed the data disk from the VM"
+                # Delete unmanaged data disks
+                if (!$storageProfile.OsDisk.ManagedDisk) {
+                    $osVhdStorageAccountName = $storageProfile.OsDisk.Vhd.Uri.Split(".").split("/")[2]
+                    $osVhdStorageAccount = Get-AzStorageAccount | where { $_.StorageAccountName -eq $osVhdStorageAccountName }
+                    foreach ($unmanagedDataDisk in $allUnmanagedDataDisks) {
+                        Write-LogInfo "Delete unmanaged data disks $unmanagedDataDisk"
+                        $osVhdStorageAccount | Remove-AzStorageBlob -Container $VHDUri.ToString().Split('/')[-2] -Blob $unmanagedDataDisk -Verbose -Force
+                    }
+                }
+            } else {
+                throw "Failed to remove the data disk from the VM"
+            }
         }
         $CurrentTestResult.TestSummary += New-ResultSummary -testResult $testResult -metaData "$($allVMData.InstanceSize) : Number of Disk Attached - $diskCount" `
             -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName


### PR DESCRIPTION
1 regex "Disk /dev/sd[^ab]:" will filter out sdaa, sdab etc.
2 DiskHotAddRemove-Parallel logic is messed up, it needs attached all disks in one command.
3 DiskHotAddRemove-Serial.ps1 needs to detach disks, otherwise, it will affect following cases.

Test results for unmanaged disk
```
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 01:25:23
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
Test Category         : Functional
Test Area             : STORAGE
Initial Kernel Version: 5.0.0-1023-azure
Final Kernel Version  : 5.0.0-1023-azure
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              VERIFY-DISK-WITH-NOBARRIER                                                        PASS                25.85 
	Standard_F16s_v2 : Number of Disk Attached - 32 : PASS 
    2 STORAGE              STORAGE-HOT-ADD-DISK-SERIAL                                                       PASS                36.64 
    3 STORAGE              STORAGE-HOT-ADD-DISK-PARALLEL                                                     PASS                  3.7 
```

Test results for managed disk 
```
[LISAv2 Test Results Summary]
Test Run On           : 11/07/2019 15:01:19
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-DAILY-LTS : latest
Test Category         : Functional
Test Area             : STORAGE
Initial Kernel Version: 5.0.0-1023-azure
Final Kernel Version  : 5.0.0-1023-azure
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              VERIFY-DISK-WITH-NOBARRIER                                                        PASS                25.29 
	Standard_F16s_v2 : Number of Disk Attached - 32 : PASS 
    2 STORAGE              STORAGE-HOT-ADD-DISK-SERIAL                                                       PASS                37.26 
    3 STORAGE              STORAGE-HOT-ADD-DISK-PARALLEL                                                     PASS                 3.22 
```