### PR TITLE
Use DPDK version into dpdk-19.08.tar.xz

### DIFF
--- a/Testscripts/Linux/dpdkSetupAndRunTest.sh
+++ b/Testscripts/Linux/dpdkSetupAndRunTest.sh
@@ -87,7 +87,7 @@ fi
 LogMsg "Starting DPDK Setup"
 # when available update to dpdk latest
 if [ -z "${dpdkSrcLink}" ]; then
-	dpdkSrcLink="https://fast.dpdk.org/rel/dpdk-18.08.tar.xz"
+	dpdkSrcLink="https://fast.dpdk.org/rel/dpdk-19.08.tar.xz"
 	LogMsg "dpdkSrcLink missing from environment; using ${dpdkSrcLink}"
 fi
 

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -39,7 +39,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 <ReplaceableTestParameters>
 	<Parameter>
 		<ReplaceThis>DPDK_SOURCE_URL</ReplaceThis>
-		<ReplaceWith>https://fast.dpdk.org/rel/dpdk-18.11.tar.xz</ReplaceWith>
+		<ReplaceWith>https://fast.dpdk.org/rel/dpdk-19.08.tar.xz</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_PERF_CORES</ReplaceThis>


### PR DESCRIPTION
Kernel 5.3 and CentOS 8, RHEL 8 not work against version 18.11
Test results -
```
Ubuntu 19.10
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 05:53:12
ARM Image Under Test  : Canonical : UbuntuServer : 19.10-DAILY : latest
Initial Kernel Version: 5.3.0-1004-azure
Final Kernel Version  : 5.3.0-1006-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:32

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                21.34 

CentOS 8
Test Run On           : 11/08/2019 07:25:15
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : latest
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:27

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                22.08 


RHEL8
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 07:25:59
ARM Image Under Test  : RedHat : RHEL : 8 : latest
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                22.77 

Ubuntu 16.04
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 07:27:38
ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
Initial Kernel Version: 4.15.0-1061-azure
Final Kernel Version  : 4.15.0-1061-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:25

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                19.86 

RHEL 7.5
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 07:28:05
ARM Image Under Test  : RedHat : RHEL : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.43.1.el7.x86_64
Final Kernel Version  : 3.10.0-862.43.1.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:31

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                26.04 


SLES15
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 07:28:34
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                22.44 


CentOS7.5
[LISAv2 Test Results Summary]
Test Run On           : 11/08/2019 07:36:40
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : Latest
Initial Kernel Version: 3.10.0-862.11.6.el7.x86_64
Final Kernel Version  : 3.10.0-862.11.6.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:29

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                24.39 
```
