### PR TITLE
Add checking publisher when sed grub configration

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -347,11 +347,18 @@ function InstallKernel() {
         eval "apt install -f -y >> $LOG_FILE 2>&1"
         kernelInstallStatus=$?
 
+        release_publisher=$(cat /etc/issue | head -n 1 | awk '{print $1}')
+        if [ "${release_publisher}"x == "Debian"x ]; then
+            publisher_string="Debian GNU\/Linux"
+        else
+            publisher_string="Ubuntu"
+        fi
+		
         LogMsg "Configuring the correct kernel boot order"
         if [[ $kernelInstallStatus -eq 0 && "${image_file}" != '' ]]; then
             kernel_identifier=$(dpkg-deb --info "${image_file}" | grep 'Package: ' | grep -o "image.*")
             kernel_identifier=${kernel_identifier#image-}
-            sed -i.bak 's/GRUB_DEFAULT=.*/GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux '$kernel_identifier'"/g' /etc/default/grub
+            sed -i.bak "s/GRUB_DEFAULT=.*/GRUB_DEFAULT='Advanced options for $publisher_string>$publisher_string, with Linux $kernel_identifier'/g" /etc/default/grub
             update-grub
         else
             msg="Kernel correct boot order could not be set."


### PR DESCRIPTION
When install custom kernel, the last step is apt remove old kernel. if this old kernel is 4.19.0-0.bpo.5-cloud-amd64, when apt remove, it will install kernel 4.19.0-0.bpo.6-cloud-amd64. If we don't set GRUB_DEFAULT, the system will restart with the newest kernel 4.19.0-0.bpo.6 instead of custom kernel.

Before fix, we set GRUB_DEFAULT with "xx Ubuntu>Ubuntu xx", which can't match grub.cfg. This setting won't work.