### PR TITLE
Adding clear logging including debug info (GPU)

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ########################################################################
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -29,24 +28,30 @@ grid_driver="https://go.microsoft.com/fwlink/?linkid=874272"
 
 #######################################################################
 function InstallCUDADrivers() {
+    LogMsg "Starting CUDA driver installation"
     case $DISTRO in
     redhat_7|centos_7)
-        CUDA_REPO_PKG="cuda-repo-rhel7-${CUDADriverVersion}.x86_64.rpm"
-        LogMsg "Using ${CUDA_REPO_PKG}"
+        CUDA_REPO_PKG="cuda-repo-rhel7-$CUDADriverVersion.x86_64.rpm"
+        LogMsg "Using $CUDA_REPO_PKG"
 
         wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/"${CUDA_REPO_PKG}" -O /tmp/"${CUDA_REPO_PKG}"
         if [ $? -ne 0 ]; then
-            LogErr "Failed to download ${CUDA_REPO_PKG}"
+            LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
             return 1
+        else
+            LogMsg "Successfully downloaded the $CUDA_REPO_PKG file in /tmp directory"
         fi
 
-        rpm -ivh /tmp/"${CUDA_REPO_PKG}"
+        rpm -ivh /tmp/"$CUDA_REPO_PKG"
+        LogMsg "Installed the rpm package, $CUDA_REPO_PKG"
         yum --nogpgcheck -y install cuda-drivers > ${HOME}/install_drivers.log 2>&1
         if [ $? -ne 0 ]; then
             LogErr "Failed to install the cuda-drivers!"
             SetTestStateAborted
             return 1
+        else
+            LogMsg "Successfully installed cuda-drivers"
         fi
     ;;
 
@@ -54,6 +59,7 @@ function InstallCUDADrivers() {
         GetOSVersion
         # Temporary fix till driver for ubuntu19 series list under http://developer.download.nvidia.com/compute/cuda/repos/
         if [[ $os_RELEASE =~ 19.* ]]; then
+            LogMsg "There is no cuda driver for $os_RELEASE, used the one for 18.10"
             os_RELEASE="18.10"
         fi
         CUDA_REPO_PKG="cuda-repo-ubuntu${os_RELEASE//./}_${CUDADriverVersion}_amd64.deb"
@@ -61,13 +67,16 @@ function InstallCUDADrivers() {
 
         wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/"${CUDA_REPO_PKG}" -O /tmp/"${CUDA_REPO_PKG}"
         if [ $? -ne 0 ]; then
-            LogErr "Failed to download ${CUDA_REPO_PKG}"
+            LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
             return 1
+        else
+            LogMsg "Successfully downloaded $CUDA_REPO_PKG"
         fi
 
         apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/7fa2af80.pub
-        dpkg -i /tmp/"${CUDA_REPO_PKG}"
+        dpkg -i /tmp/"$CUDA_REPO_PKG"
+        LogMsg "Installed $CUDA_REPO_PKG"
         dpkg_configure
         apt update
 
@@ -76,6 +85,8 @@ function InstallCUDADrivers() {
             LogErr "Failed to install cuda-drivers package!"
             SetTestStateAborted
             return 1
+        else
+            LogMsg "Successfully installed cuda-drivers package"
         fi
     ;;
     suse*|redhat_8)
@@ -92,17 +103,21 @@ function InstallCUDADrivers() {
 }
 
 function InstallGRIDdrivers() {
+    LogMsg "Starting GRID driver installation"
     wget "$grid_driver" -O /tmp/NVIDIA-Linux-x86_64-grid.run
     if [ $? -ne 0 ]; then
         LogErr "Failed to download the GRID driver!"
         SetTestStateAborted
         return 1
+    else
+        LogMsg "Successfully downloaded the GRID driver"
     fi
 
     cat > /etc/modprobe.d/nouveau.conf<< EOF
     blacklist nouveau
     blacklist lbm-nouveau
 EOF
+    LogMsg "Updated nouveau.conf file with blacklist"
 
     pushd /tmp
     chmod +x NVIDIA-Linux-x86_64-grid.run
@@ -111,11 +126,14 @@ EOF
         LogErr "Failed to install the GRID driver!"
         SetTestStateAborted
         return 1
+    else
+        LogMsg "Successfully install the GRID driver"
     fi
     popd
 
     cp /etc/nvidia/gridd.conf.template /etc/nvidia/gridd.conf
     echo 'IgnoreSP=FALSE' >> /etc/nvidia/gridd.conf
+    LogMsg "Added IgnoreSP parameter in gridd.conf"
     find /var/log/* -name nvidia-installer.log -exec cp {} ${HOME}/nvidia-installer.log \;
     if [[ ! -f "${HOME}/nvidia-installer.log" ]]; then
         echo "File not found, nvidia-installer.log" > ${HOME}/nvidia-installer.log

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -62,10 +62,10 @@ function InstallCUDADrivers() {
             LogMsg "There is no cuda driver for $os_RELEASE, used the one for 18.10"
             os_RELEASE="18.10"
         fi
-        CUDA_REPO_PKG="cuda-repo-ubuntu$os_RELEASE//./_$CUDADriverVersion_amd64.deb"
-        LogMsg "Using $CUDA_REPO_PKG"
+        CUDA_REPO_PKG="cuda-repo-ubuntu${os_RELEASE//./}_${CUDADriverVersion}_amd64.deb"
+        LogMsg "Using ${CUDA_REPO_PKG}"
 
-        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/"$CUDA_REPO_PKG" -O /tmp/"$CUDA_REPO_PKG"
+        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/"${CUDA_REPO_PKG}" -O /tmp/"${CUDA_REPO_PKG}"
         if [ $? -ne 0 ]; then
             LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
@@ -74,7 +74,7 @@ function InstallCUDADrivers() {
             LogMsg "Successfully downloaded $CUDA_REPO_PKG"
         fi
 
-        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/7fa2af80.pub
+        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/7fa2af80.pub
         dpkg -i /tmp/"$CUDA_REPO_PKG"
         LogMsg "Installed $CUDA_REPO_PKG"
         dpkg_configure

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -34,7 +34,7 @@ function InstallCUDADrivers() {
         CUDA_REPO_PKG="cuda-repo-rhel7-$CUDADriverVersion.x86_64.rpm"
         LogMsg "Using $CUDA_REPO_PKG"
 
-        wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/"${CUDA_REPO_PKG}" -O /tmp/"${CUDA_REPO_PKG}"
+        wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/"$CUDA_REPO_PKG" -O /tmp/"$CUDA_REPO_PKG"
         if [ $? -ne 0 ]; then
             LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
@@ -45,7 +45,7 @@ function InstallCUDADrivers() {
 
         rpm -ivh /tmp/"$CUDA_REPO_PKG"
         LogMsg "Installed the rpm package, $CUDA_REPO_PKG"
-        yum --nogpgcheck -y install cuda-drivers > ${HOME}/install_drivers.log 2>&1
+        yum --nogpgcheck -y install cuda-drivers > $HOME/install_drivers.log 2>&1
         if [ $? -ne 0 ]; then
             LogErr "Failed to install the cuda-drivers!"
             SetTestStateAborted
@@ -62,10 +62,10 @@ function InstallCUDADrivers() {
             LogMsg "There is no cuda driver for $os_RELEASE, used the one for 18.10"
             os_RELEASE="18.10"
         fi
-        CUDA_REPO_PKG="cuda-repo-ubuntu${os_RELEASE//./}_${CUDADriverVersion}_amd64.deb"
-        LogMsg "Using ${CUDA_REPO_PKG}"
+        CUDA_REPO_PKG="cuda-repo-ubuntu$os_RELEASE//./_$CUDADriverVersion_amd64.deb"
+        LogMsg "Using $CUDA_REPO_PKG"
 
-        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/"${CUDA_REPO_PKG}" -O /tmp/"${CUDA_REPO_PKG}"
+        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/"$CUDA_REPO_PKG" -O /tmp/"$CUDA_REPO_PKG"
         if [ $? -ne 0 ]; then
             LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
@@ -74,13 +74,13 @@ function InstallCUDADrivers() {
             LogMsg "Successfully downloaded $CUDA_REPO_PKG"
         fi
 
-        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/7fa2af80.pub
+        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/7fa2af80.pub
         dpkg -i /tmp/"$CUDA_REPO_PKG"
         LogMsg "Installed $CUDA_REPO_PKG"
         dpkg_configure
         apt update
 
-        apt -y --allow-unauthenticated install cuda-drivers > ${HOME}/install_drivers.log 2>&1
+        apt -y --allow-unauthenticated install cuda-drivers > $HOME/install_drivers.log 2>&1
         if [ $? -ne 0 ]; then
             LogErr "Failed to install cuda-drivers package!"
             SetTestStateAborted
@@ -96,9 +96,9 @@ function InstallCUDADrivers() {
     ;;
     esac
 
-    find /var/lib/dkms/nvidia* -name make.log -exec cp {} ${HOME}/nvidia_dkms_make.log \;
-    if [[ ! -f "${HOME}/nvidia_dkms_make.log" ]]; then
-        echo "File not found, make.log" > ${HOME}/nvidia_dkms_make.log
+    find /var/lib/dkms/nvidia* -name make.log -exec cp {} $HOME/nvidia_dkms_make.log \;
+    if [[ ! -f "$HOME/nvidia_dkms_make.log" ]]; then
+        echo "File not found, make.log" > $HOME/nvidia_dkms_make.log
     fi
 }
 
@@ -134,9 +134,9 @@ EOF
     cp /etc/nvidia/gridd.conf.template /etc/nvidia/gridd.conf
     echo 'IgnoreSP=FALSE' >> /etc/nvidia/gridd.conf
     LogMsg "Added IgnoreSP parameter in gridd.conf"
-    find /var/log/* -name nvidia-installer.log -exec cp {} ${HOME}/nvidia-installer.log \;
-    if [[ ! -f "${HOME}/nvidia-installer.log" ]]; then
-        echo "File not found, nvidia-installer.log" > ${HOME}/nvidia-installer.log
+    find /var/log/* -name nvidia-installer.log -exec cp {} $HOME/nvidia-installer.log \;
+    if [[ ! -f "$HOME/nvidia-installer.log" ]]; then
+        echo "File not found, nvidia-installer.log" > $HOME/nvidia-installer.log
     fi
 }
 

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3415,7 +3415,10 @@ function DisableEnablePCI ()
         *)        LogErr "Unsupported device type for DisableEnablePCI." ; return 1 ;;
     esac
 
+	LogMsg "Disable and re-enable device: $1"
+
     if ! lspci --version > /dev/null 2>&1; then
+		LogMsg "This distro needs to get lspci. Installing pciutils"
         update_repos
         install_package "pciutils"
     fi
@@ -3430,19 +3433,22 @@ function DisableEnablePCI ()
         return 1
     else
         LogMsg "Found the following $vf_pci_type devices:"
-        # Remove the VF for each address
+        # Identify the PCI device for each address
         for addr in ${vf_pci_addresses[@]}; do
             LogMsg "$(lspci | grep $addr)"
         done
     fi
 
-    # Remove the VF for each address
+    # Verify and remove PCI device path for each address
     for addr in ${vf_pci_addresses[@]}; do
         vf_pci_remove_path="/sys/bus/pci/devices/${addr}/remove"
         if [ ! -f "$vf_pci_remove_path" ]; then
             LogErr "Could not to disable the PCI device, because the $vf_pci_remove_path doesn't exist."
             return 1
-        fi
+        else
+			LogMsg "Found the PCI device remove pathg: $vf_pci_remove_path"
+		fi
+		LogMsg "Removing $addr device"
         echo 1 > "$vf_pci_remove_path"
     done
 
@@ -3454,13 +3460,17 @@ function DisableEnablePCI ()
         if [ -d "$vf_pci_device_path" ] || [ "$(lspci | grep -ic $addr)" -ne 0 ]; then
             LogErr "Could not disable the PCI device: $addr"
             return 1
-        fi
+        else
+			LogMsg "Successfully verified the PCI device removal"
+		fi
     done
 
     # Check if all VFs has been re-enabled
     retry=1
     while [ $retry -le 5 ]; do
+	LogMsg "Trying count: $retry"
         # Enable the VF
+		LogMsg "Rescanning PCI devices in the system"
         echo 1 > /sys/bus/pci/rescan
         sleep 5
         #Search for all addresses and folder structures

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -39,14 +39,14 @@ function Start-Validation {
     # Scope to match GPUs only since there can be other pass-through devices
     $pciExpressCount = (Select-String -Path $LogDir\PCI-Express-passthrough.txt -Pattern "Device_ID.*47505500").Matches.Count
     if ( $pciExpressCount -gt 0 ) {
-        Write-Debug "Successfully fetched more than a PCI Expess device "
+        Write-Debug "Successfully found more than a PCI Expess device "
     } else {
-        Write-Error "Could not fetched the PCI Express device count"
+        Write-Error "Could not find the PCI Express device count"
     }
 
     if ($pciExpressCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
-        Write-Debug "Successfully verified PCI Express device count with the expected GPU counts: $pciExpressCount"
+        Write-Debug "Successfully verified PCI Express device count with the expected GPU count: $pciExpressCount"
     } else {
         $currentResult = $resultFail
         Write-Error "Failed to verify the PCI Express device count. Expected: $expectedGPUCount, but found: $pciExpressCount"

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -29,13 +29,27 @@ function Start-Validation {
     # region PCI Express pass-through in lsvmbus
     $PCIExpress = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
         -username $superuser -password $password "lsvmbus -vv" -ignoreLinuxExitCode
+    if ( $PCIExpress ) {
+        Write-Debug "Successfully fetched the PCIExpress result from lsvmbus"
+    } else {
+        Write-Error "Could not succeed to fetch out PCIExpress result from lsvmbus"
+    }
+
     Set-Content -Value $PCIExpress -Path $LogDir\PCI-Express-passthrough.txt -Force
     # Scope to match GPUs only since there can be other pass-through devices
     $pciExpressCount = (Select-String -Path $LogDir\PCI-Express-passthrough.txt -Pattern "Device_ID.*47505500").Matches.Count
+    if ( $pciExpressCount -gt 0 ) {
+        Write-Debug "Successfully fetched more than a PCI Expess device "
+    } else {
+        Write-Error "Could not fetched the PCI Express device count"
+    }
+
     if ($pciExpressCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
+        Write-Debug "Successfully verified PCI Express device count with the expected GPU counts: $pciExpressCount"
     } else {
         $currentResult = $resultFail
+        Write-Error "Failed to verify the PCI Express device count. Expected: $expectedGPUCount, but found: $pciExpressCount"
         $failureCount += 1
     }
     $metaData = "lsvmbus: Expected `"PCI Express pass-through`" count: $expectedGPUCount, count inside the VM: $pciExpressCount"
@@ -47,12 +61,20 @@ function Start-Validation {
     #region lspci
     $lspci = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
         -username $superuser -password $password "lspci" -ignoreLinuxExitCode
+
+    if ( $lspci ) {
+        Write-Debug "Successfully fetched the lspci command result"
+    } else {
+        Write-Error "Failed to fetch the lspci command result"
+    }
     Set-Content -Value $lspci -Path $LogDir\lspci.txt -Force
     $lspciCount = (Select-String -Path $LogDir\lspci.txt -Pattern "NVIDIA Corporation").Matches.Count
     if ($lspciCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
+        Write-Debug "Successfully verified PCI device count with lspci result: $lspciCount"
     } else {
         $currentResult = $resultFail
+        Write-Error "Failed to verify the PCI device count with lspci device result. Expected: $expectedGPUCount, found: $lspciCount"
         $failureCount += 1
     }
     $metaData = "lspci: Expected `"3D controller: NVIDIA Corporation`" count: $expectedGPUCount, found inside the VM: $lspciCount"
@@ -64,12 +86,19 @@ function Start-Validation {
     #region lshw -c video
     $lshw = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
         -username $superuser -password $password "lshw -c video" -ignoreLinuxExitCode
+    if ( $lshw ) {
+        Write-Debug "Successfully fetch the lshw command result"
+    } else {
+        Write-Error "Failed to fetch the lshw command result"
+    }
     Set-Content -Value $lshw -Path $LogDir\lshw-c-video.txt -Force
     $lshwCount = (Select-String -Path $LogDir\lshw-c-video.txt -Pattern "vendor: NVIDIA Corporation").Matches.Count
     if ($lshwCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
+        Write-Debug "Successfully verified lshw count: $lshwCount"
     } else {
         $currentResult = $resultFail
+        Write-Error "Failed to verify the lshw command result. Expected: $expectedGPUcount, found: $lshwCount"
         $failureCount += 1
     }
     $metaData = "lshw: Expected Display adapters: $expectedGPUCount, total adapters found in VM: $lshwCount"
@@ -81,12 +110,19 @@ function Start-Validation {
     #region nvidia-smi
     $nvidiasmi = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
         -username $superuser -password $password "nvidia-smi" -ignoreLinuxExitCode
+    if ( $nvdiasmi ) {
+        Write-Debug "Successfully fetched the nvidia-smi command result"
+    } else {
+        Write-Error "Failed to fetch the nvidia-smi command result"
+    }
     Set-Content -Value $nvidiasmi -Path $LogDir\nvidia-smi.txt -Force
     $nvidiasmiCount = (Select-String -Path $LogDir\nvidia-smi.txt -Pattern "Tesla").Matches.Count
     if ($nvidiasmiCount -eq $expectedGPUCount) {
         $currentResult = $resultPass
+        Write-Debug "Successfully verified nvidia-smi device count: $nvidiasmiCount"
     } else {
         $currentResult = $resultFail
+        Write-Error "Failed to verify nvidia-smi device count. Expected: $expectedGPUCount, found: $nvidiasmiCount"
         $failureCount += 1
     }
     $metaData = "nvidia-smi: Expected GPU count: $expectedGPUCount, found inside the VM: $nvidiasmiCount"
@@ -116,10 +152,12 @@ function Collect-Logs {
             -Username $user -Password $password -LogsDestination $LogDir -FileName "install_drivers.log"
         Collect-CustomLogFile -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort `
             -Username $user -Password $password -LogsDestination $LogDir -FileName "nvidia_dkms_make.log"
+        Write-Debug "Successfully collected the CUDA test log"
     }
     if ($driver -eq "GRID") {
         Collect-CustomLogFile -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort `
             -Username $user -Password $password -LogsDestination $LogDir -FileName "nvidia-installer.log"
+        Write-Debug "Successfully collected the GRID test log"
     }
 }
 
@@ -142,6 +180,7 @@ function Main {
         Provision-VMsForLisa -allVMData $allVMData -installPackagesOnRoleNames "none"
         Copy-RemoteFiles -uploadTo $allVMData.PublicIP -port $allVMData.SSHPort `
             -files $currentTestData.files -username $superuser -password $password -upload | Out-Null
+        Write-Debug "Copied all required files to the Guest OS system"
 
         #Skip test case against distro CLEARLINUX and COREOS based here https://docs.microsoft.com/en-us/azure/virtual-machines/linux/n-series-driver-setup
         if (@("CLEARLINUX", "COREOS").contains($global:detectedDistro)) {
@@ -152,9 +191,11 @@ function Main {
         # this covers both NV and NVv2 series
         if ($allVMData.InstanceSize -imatch "Standard_NV") {
             $driver = "GRID"
+            Write-Debug "Verfied this instance is with GRID device driver"
         # NC and ND series use CUDA
         } elseif ($allVMData.InstanceSize -imatch "Standard_NC" -or $allVMData.InstanceSize -imatch "Standard_ND") {
             $driver = "CUDA"
+            Write-Debug "Verified this instance is with CUDA device driver"
         } else {
             Write-LogErr "Azure VM size $($allVMData.InstanceSize) not supported in automation!"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "ABORTED"
@@ -165,20 +206,26 @@ function Main {
         $cmdAddConstants = "echo -e `"driver=$($driver)`" >> constants.sh"
         Run-LinuxCmd -username $superuser -password $password -ip $allVMData.PublicIP -port $allVMData.SSHPort `
             -command $cmdAddConstants | Out-Null
+        Write-Debug "Added GPU driver name to constants.sh file"
 
         # For CentOS and RedHat the requirement is to install LIS RPMs
         if (@("REDHAT", "CENTOS").contains($global:detectedDistro)) {
             # HPC images already have the LIS RPMs installed
             $sts = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $user -password $password `
                 -command "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v" -ignoreLinuxExitCode
+            Write-Debug "Checking if HPC image has rpm packages already. Here is query result: $sts"
+
             if (-not $sts) {
                 # Download and install the latest LIS version
                 Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
                     -password $password -command "wget -q https://aka.ms/lis -O - | tar -xz" -ignoreLinuxExitCode | Out-Null
+                Write-Debug "Installed the latest LIS package"
                 Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
                     -password $password -command "cd LISISO && ./install.sh > installLIS.log" -ignoreLinuxExitCode | Out-Null
                 $installLIS = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
                     -password $password -command "cat /$superuser/LISISO/installLIS.log" -ignoreLinuxExitCode
+                Write-Debug "Checking installLIS log: $installLIS"
+
                 if ($installLIS -imatch "Unsupported kernel version") {
                     Write-LogInfo "Unsupported kernel version!"
                     $currentTestResult.TestSummary += New-ResultSummary -testName $CurrentTestData.testName -testResult "Unsupported kernel version!"
@@ -203,8 +250,11 @@ function Main {
         # Start the test script
         Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "/$superuser/${testScript}" -runMaxAllowedTime 1800 -ignoreLinuxExitCode | Out-Null
+        Write-Debug "Ran test script $testscript in the Guest OS"
+
         $installState = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
             -password $password -command "cat /$superuser/state.txt"
+        Write-Debug "Found installState: $installState"
 
         if ($installState -eq "TestSkipped") {
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "SKIPPED"
@@ -212,14 +262,14 @@ function Main {
         }
 
         if ($installState -imatch "TestAborted") {
-            Write-LogErr "CUDA drivers installation aborted"
+            Write-LogErr "GPU drivers installation aborted"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "ABORTED"
             Collect-Logs
             return $currentTestResult
         }
 
         if ($installState -ne "TestCompleted") {
-            Write-LogErr "Unable to install the CUDA drivers!"
+            Write-LogErr "Unable to install the GPU drivers!"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "FAIL"
             Collect-Logs
             return $currentTestResult
@@ -236,7 +286,7 @@ function Main {
         $driverLoaded = Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP `
             -port $allVMData.SSHPort -command "lsmod | grep nvidia" -ignoreLinuxExitCode
         if ($null -eq $driverLoaded) {
-            Write-LogErr "nVidia driver is not loaded after VM restart!"
+            Write-LogErr "GPU driver is not loaded after VM restart!"
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "FAIL"
             Collect-Logs
             return $currentTestResult
@@ -250,6 +300,11 @@ function Main {
         # Source: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-gpu
         $vmCPUCount = Run-LinuxCmd -username $user -password $password -ip $allVMData.PublicIP `
             -port $allVMData.SSHPort -command "nproc" -ignoreLinuxExitCode
+        if ( $vmCPUCount ) {
+            Write-Debug "Successfully fetched nproc result: $vmCPUCount"
+        } else {
+            Write-Error "Could not fetch the nproc command result."
+        }
 
         if ($allVMData.InstanceSize -match "Standard_NDv2") {
             [int]$expectedGPUCount = $($vmCPUCount/5)
@@ -258,7 +313,6 @@ function Main {
         } else {
             [int]$expectedGPUCount = $($vmCPUCount/6)
         }
-
         Write-LogInfo "Azure VM Size: $($allVMData.InstanceSize), expected GPU Adapters total: $expectedGPUCount"
 
         # Disable and enable the PCI device first if the parameter is given

--- a/Testscripts/Windows/GPU-TENSORFLOW.ps1
+++ b/Testscripts/Windows/GPU-TENSORFLOW.ps1
@@ -84,7 +84,7 @@ function Main {
             foreach ($param in $currentTestData.TestParameters.param) {
                 if ($param -match "CUDADriverVersion") {
                     $CUDADriverVersion = $param.Replace("CUDADriverVersion=","").Replace('"',"")
-                    Write-Debug "CUDA driver version: $$CUDADRiverVersion"
+                    Write-Debug "CUDA driver version: $CUDADRiverVersion"
                 }
                 if ($param -match "CudaToolkitVersion") {
                     $CudaToolkitVersion = $param.Replace("CudaToolkitVersion=","").Replace('"',"")

--- a/Testscripts/Windows/GPU-TENSORFLOW.ps1
+++ b/Testscripts/Windows/GPU-TENSORFLOW.ps1
@@ -12,6 +12,7 @@ function Run-TestScript ($ip, $port, $testScript)
     Run-LinuxCmd -username $user -password $password -ip $ip -port $port -command "chmod a+x *.sh" -runAsSudo
     Write-LogInfo "Executing : ${testScript}"
     $cmd = "bash /home/$user/${testScript}"
+    Write-Debug "Commands: $cmd"
     $testJob = Run-LinuxCmd -username $user -password $password -ip $ip -port $port -command $cmd -runAsSudo -RunInBackground
     $timeCount = 0
     while ((Get-Job -Id $testJob).State -eq "Running") {
@@ -54,6 +55,7 @@ function Main {
             $currentTestResult.TestResult = Get-FinalResultHeader -resultarr "ABORTED"
             return $currentTestResult
         }
+        Write-Debug "Set GPU device driver: $driver"
 
         # Install CUDA/GRID driver
         $workDir = Get-Location
@@ -64,6 +66,7 @@ function Main {
         if ($result -match "PASS") {
             #Start the test script
             $testScript = "gpu-tensorflow.sh"
+            Write-Debug "Running test script, $testScript"
             Run-TestScript -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -testScript $testScript | Out-Null
             $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $currentTestData.files.Split('\')[3].Split('.')[0] `
                           -TestType "sh" -PublicIP $allVMData.PublicIP -SSHPort $allVMData.SSHPort -Username $user `
@@ -73,6 +76,7 @@ function Main {
             $remoteFiles = "*.csv,*.log"
             Copy-RemoteFiles -download -downloadFrom $allVMData.PublicIP -files $remoteFiles -downloadTo $LogDir `
                 -port $allVMData.SSHPort -username $user -password $password
+            Write-Debug "Collecting remote files like csv or log"
         }
 
         if ($testResult -match "PASS") {
@@ -80,15 +84,18 @@ function Main {
             foreach ($param in $currentTestData.TestParameters.param) {
                 if ($param -match "CUDADriverVersion") {
                     $CUDADriverVersion = $param.Replace("CUDADriverVersion=","").Replace('"',"")
+                    Write-Debug "CUDA driver version: $$CUDADRiverVersion"
                 }
                 if ($param -match "CudaToolkitVersion") {
                     $CudaToolkitVersion = $param.Replace("CudaToolkitVersion=","").Replace('"',"")
+                    Write-Debug "CUDA Tool kit version: $CudaToolkitVersion"
                 }
                 if ($param -match "TensorflowVersion") {
                     $TensorflowVersion = $param.Replace("TensorflowVersion=","").Replace('"',"")
                     if (-not $TensorflowVersion) {
                         $TensorflowVersion = "tf-nightly-gpu"
                     }
+                    Write-Debug "TensorFlow version: $TensorflowVersion"
                 }
             }
 


### PR DESCRIPTION
1. No functional change
2. Added more debug msg

Test results of CUDA driver
```
[Canonical UbuntuServer 18.04-LTS latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 18.04-LTS latest] Test Run On           : 11/12/2019 23:10:24
[Canonical UbuntuServer 18.04-LTS latest] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[Canonical UbuntuServer 18.04-LTS latest] Initial Kernel Version: 5.0.0-1023-azure
[Canonical UbuntuServer 18.04-LTS latest] Final Kernel Version  : 5.0.0-1023-azure
[Canonical UbuntuServer 18.04-LTS latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 18.04-LTS latest] Total Time (dd:hh:mm) : 0:0:22
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 18.04-LTS latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 18.04-LTS latest]     1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                19.83 
[Canonical UbuntuServer 18.04-LTS latest] 	Using nVidia driver : CUDA 
[Canonical UbuntuServer 18.04-LTS latest] 	lsvmbus: Expected "PCI Express pass-through" count: 4, count inside the VM: 4 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	lspci: Expected "3D controller: NVIDIA Corporation" count: 4, found inside the VM: 4 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	lshw: Expected Display adapters: 4, total adapters found in VM: 4 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	nvidia-smi: Expected GPU count: 4, found inside the VM: 4 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] Logs can be found at C:\LISAv2\GZ90\TestResults\2019-12-11-23-10-20-9773
```
Test result of GRID driver
```
[Canonical UbuntuServer 18.04-LTS latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 18.04-LTS latest] Test Run On           : 11/12/2019 23:10:02
[Canonical UbuntuServer 18.04-LTS latest] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[Canonical UbuntuServer 18.04-LTS latest] Initial Kernel Version: 5.0.0-1023-azure
[Canonical UbuntuServer 18.04-LTS latest] Final Kernel Version  : 5.0.0-1023-azure
[Canonical UbuntuServer 18.04-LTS latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 18.04-LTS latest] Total Time (dd:hh:mm) : 0:0:26
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 18.04-LTS latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 18.04-LTS latest]     1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                23.86 
[Canonical UbuntuServer 18.04-LTS latest] 	Using nVidia driver : GRID 
[Canonical UbuntuServer 18.04-LTS latest] 	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] Logs can be found at C:\LISAv2\NH54\TestResults\2019-12-11-23-09-58-9042
```