### PR TITLE
Startup memory 512M is too low, cause VM enter into OOM status, increase it into 1024M

### DIFF
--- a/Testscripts/Linux/customKernelInstall.sh
+++ b/Testscripts/Linux/customKernelInstall.sh
@@ -353,7 +353,7 @@ function InstallKernel() {
         else
             publisher_string="Ubuntu"
         fi
-		
+
         LogMsg "Configuring the correct kernel boot order"
         if [[ $kernelInstallStatus -eq 0 && "${image_file}" != '' ]]; then
             kernel_identifier=$(dpkg-deb --info "${image_file}" | grep 'Package: ' | grep -o "image.*")
@@ -372,6 +372,7 @@ function InstallKernel() {
         else
             LogMsg "CUSTOM_KERNEL_SUCCESS"
             DEBIAN_FRONTEND=noninteractive apt -y remove linux-image-$(uname -r)
+            rm -rf *.deb
             SetTestStateCompleted
         fi
     elif [[ $CustomKernel == *.rpm ]]; then
@@ -426,6 +427,7 @@ function InstallKernel() {
             SetTestStateCompleted
             rpm -e kernel-$(uname -r)
             grub2-set-default 0
+            rm -rf *.rpm
         fi
     fi
     if [[ ${CustomKernel} == "linuxnext" ]] || [[ ${CustomKernel} == "netnext" ]] || \

--- a/XML/TestCases/FunctionalTests-DynamicMemory.xml
+++ b/XML/TestCases/FunctionalTests-DynamicMemory.xml
@@ -228,7 +228,7 @@
             <param>appGitTag=APP_GIT_TAG</param>
             <param>minMem1=512MB</param>
             <param>maxMem1=40%</param>
-            <param>startupMem1=512MB</param>
+            <param>startupMem1=1024MB</param>
             <param>memWeight1=100</param>
             <param>staticMem=1024MB</param>
             <param>maxMem2=85%</param>


### PR DESCRIPTION
Delete uploaded build kernel packages when build successfully, to reduce it occupy VM's space.
Test results, run 4/4 pass

```
[LISAv2 Test Results Summary]
Test Run On           : 11/26/2019 07:01:00
VHD Under Test        : ubuntu_18.04.1_gen1_gen2.vhdx
Initial Kernel Version: 4.15.0-38-generic
Final Kernel Version  : 5.0.0-1026-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:26

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC_MEMORY       DYNAMIC-MEMORY-HOT-REMOVE                                                         PASS                19.41 
```