### PR TITLE
Fix issue hit against Debian 9-backports image

### DIFF
--- a/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
+++ b/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
@@ -26,6 +26,9 @@ fi
     exit 0
 }
 
+# Check if ethtool exist and install it if not
+VerifyIsEthtool
+
 # check_feature_status
 # $1: eth device name
 # $2: feature name

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -27,6 +27,20 @@
 grid_driver="https://go.microsoft.com/fwlink/?linkid=874272"
 
 #######################################################################
+function skip_test() {
+    if [[ "$driver" == "CUDA" ]] && ([[ $DISTRO == *"suse"* ]] || [[ $DISTRO == "redhat_8" ]] || [[ $DISTRO == *"debian"* ]]); then
+        LogMsg "$DISTRO not supported. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    fi
+
+    if [[ "$driver" == "GRID" ]] && ([[ $DISTRO == "redhat_8" ]] || [[ $DISTRO == *"debian"* ]]); then
+        LogMsg "$DISTRO not supported. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    fi
+}
+
 function InstallCUDADrivers() {
     LogMsg "Starting CUDA driver installation"
     case $DISTRO in
@@ -89,11 +103,6 @@ function InstallCUDADrivers() {
             LogMsg "Successfully installed cuda-drivers package"
         fi
     ;;
-    suse*|redhat_8)
-        LogMsg "$DISTRO not supported. Skip the test."
-        SetTestStateSkipped
-        exit 0
-    ;;
     esac
 
     find /var/lib/dkms/nvidia* -name make.log -exec cp {} $HOME/nvidia_dkms_make.log \;
@@ -155,7 +164,7 @@ UtilsInit
 
 GetDistro
 update_repos
-
+skip_test
 # Install dependencies
 install_gpu_requirements
 

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -74,7 +74,7 @@ function Main {
 		}
 
 		#Skip test case against distro CLEARLINUX and COREOS based here https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-hpc
-		if (@("CLEARLINUX", "COREOS").contains($global:detectedDistro)) {
+		if (@("CLEARLINUX", "COREOS", "DEBIAN").contains($global:detectedDistro)) {
 			Write-LogInfo "$($global:detectedDistro) is not supported! Test skipped!"
 			return "SKIPPED"
 		}

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -30,7 +30,7 @@
 		<Tags>stress,boot,network,sriov</Tags>
 		<Priority>2</Priority>
 	</test>
-		<test>
+	<test>
 		<testName>STRESSTEST-RELOAD-LIS-MODULES</testName>
 		<testScript>RELOAD-MODULES.ps1</testScript>
 		<files>.\TestScripts\Linux\RELOAD-MODULES.sh,.\TestScripts\Linux\utils.sh</files>
@@ -151,7 +151,7 @@
 		<Area>STRESS</Area>
 		<Tags>stress,nvme,storage</Tags>
 		<Priority>2</Priority>
-  </test>
+	</test>
 	<test>
 		<testName>STRESS-STORAGE-4K-IO-WITHVERIFY</testName>
 		<testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>


### PR DESCRIPTION
Install ethtool and lsvmbus.
Skip GPU CUDA and RDMA testing on Debian.

Test results - 
NVIDIA-GRID-DRIVER-VALIDATION-MAX-GPU failed for lack of one patch.
```
[LISAv2 Test Results Summary]
Test Run On           : 12/03/2019 08:52:36
ARM Image Under Test  : credativ : Debian : 9-backports : 9.20191118.0
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                 5.75 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 


[LISAv2 Test Results Summary]
Test Run On           : 12/03/2019 07:21:40
ARM Image Under Test  : credativ : Debian : 9-backports : 9.20191118.0
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 4 (0 Passed, 1 Failed, 0 Aborted, 3 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION-MAX-GPU                                             FAIL                 4.21 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 4, count inside the VM: 0 : FAIL 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 4, found inside the VM: 1 : FAIL 
	lshw: Expected Display adapters: 4, total adapters found in VM: 1 : FAIL 
	nvidia-smi: Expected GPU count: 4, found inside the VM: 1 : FAIL 
    2 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU                                          SKIPPED                 1.55 
	Using nVidia driver : CUDA 
    3 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                  SKIPPED                 2.06 
	Using nVidia driver : CUDA 
    4 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                        SKIPPED                 0.58 


[LISAv2 Test Results Summary]
Test Run On           : 12/03/2019 09:09:37
ARM Image Under Test  : credativ : Debian : 9-backports : 9.20191118.0
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                     SKIPPED                 1.03 
```