### PR TITLE
Correct the result if no module version is verified

### DIFF
--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -30,135 +30,146 @@ UtilsInit
 # Check if version is greater than or equal to supported version
 function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
 
-# Check if vmbus string is recorded in dmesg
-hv_string=$(dmesg | grep "Vmbus version:")
-if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then
-    LogErr "Could not find the VMBus protocol string in dmesg. Test stopped here."
-    SetTestStateAborted
-    exit 0
-fi
+GetDistro
 
-skip_modules=()
-config_path="/boot/config-$(uname -r)"
-if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-    config_path="/usr/lib/kernel/config-$(uname -r)"
-fi
-LogMsg "Set the configuration path to $config_path"
-
-declare -A config_modulesDic
-config_modulesDic=(
-[CONFIG_HYPERV=y]="hv_vmbus"
-[CONFIG_HYPERV_STORAGE=y]="hv_storvsc"
-[CONFIG_HYPERV_NET=y]="hv_netvsc"
-[CONFIG_HYPERV_UTILS=y]="hv_utils"
-[CONFIG_HID_HYPERV_MOUSE=y]="hid_hyperv"
-[CONFIG_HYPERV_BALLOON=y]="hv_balloon"
-[CONFIG_HYPERV_KEYBOARD=y]="hyperv_keyboard"
-)
-for key in $(echo ${!config_modulesDic[*]})
-do
-    module_included=$(grep $key "$config_path")
-    if [ "$module_included" ]; then
-        skip_modules+=("${config_modulesDic[$key]}")
-        LogMsg "Skipping the built-in modules, ${config_modulesDic[$key]}"
-    fi
-done
-
-# Remove each module in HYPERV_MODULES from skip_modules
-for module in "${HYPERV_MODULES[@]}"; do
-    skip=""
-    for mod_skip in "${skip_modules[@]}"; do
-        [[ $module == $mod_skip ]] && { skip=1; break; }
-    done
-    [[ -n $skip ]] || tempList+=("$module")
-done
-HYPERV_MODULES=("${tempList[@]}")
-LogMsg "Target module names: ${HYPERV_MODULES[*]}"
-
-if [ ! $HYPERV_MODULES ]; then
-    LogErr "Target module is empty or null"
-    exit_code=$((exit_code+1))
-fi
-
-if which rpm 2>/dev/null;then
-    rpmAvailable=true
-    isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
-    LogMsg "The current LIS installation state: $isLISInstalled"
-else
-    rpmAvailable=false
-    isLISInstalled=''
-    LogMsg "The current LIS installation state: none"
-    LogErr "Test Skipped because of no LIS installation"
-    SetTestStateSkipped
-    exit 1
-fi
-LogMsg "RPM availability in the system: $rpmAvailable"
-
-if [ ! -z "$isLISInstalled" ]; then
-    expected_lis_version=$(dmesg | grep -i 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
-    if check_version_greater_equal $DISTRO_VERSION $min_supported_distro_version ; then
-        HYPERV_MODULES+=('pci_hyperv')
-        pci_module=$(lsmod | grep pci_hyperv)
-        if [ -z $pci_module ]; then
-            modprobe pci_hyperv
-            LogMsg "pci_hyperv module loaded"
-        fi
-    fi
-    if [[ $DISTRO_VERSION =~ 7\.3 ]] || [[ $DISTRO_VERSION =~ 7\.4 ]] ; then
-        if check_version_greater_equal $expected_lis_version $min_supported_LIS_version ; then
-            HYPERV_MODULES+=('mlx4_en')
-            mlx4_module=$(lsmod | grep mlx4_en)
-            if [ -z $mlx4_module ]; then
-                modprobe mlx4_en
-                LogMsg "mlx4_en module loaded"
-            fi
-        fi
-    fi
-fi
-
-# Verifies first if the modules are loaded
-for module in "${HYPERV_MODULES[@]}"; do
-    load_status=$(lsmod | grep "$module" 2>&1)
-
-    # Check to see if the module is loaded
-    if [[ $load_status =~ $module ]]; then
-        LogMsg "LIS module $module loaded successfully"
-        if [ "$rpmAvailable" = true ] && [ ! -z "$isLISInstalled" ]; then
-            version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
-            LogMsg "$module module version: ${version}"
-            if [ "$module" == "mlx4_en" && "$MLNX_VERSION" != "$version" ] ;then
-                LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
-                exit_code=$((exit_code+1))
-            else
-                continue
-            fi
-            if [ "$expected_lis_version" != "$version" ] ;then
-                LogErr "Status: $module $version did not match to the build one, $expected_lis_version"
-                exit_code=$((exit_code+1))
-            else
-                continue
-            fi
+case $DISTRO in
+    redhat_*|centos_*)
+        # Check if vmbus string is recorded in dmesg
+        hv_string=$(dmesg | grep "Vmbus version:")
+        if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then
+            LogErr "Could not find the VMBus protocol string in dmesg. Test stopped here."
+            SetTestStateAborted
+            exit 0
         fi
 
-        version=$(modinfo "$module" | grep vermagic: | awk '{print $2}')
-        if [[ "$version" == "$(uname -r)" ]]; then
-            LogMsg "Found the matching kernel version of $module module: ${version}"
-        else
-            LogErr "LIS module $module did not match the kernel build version!"
+        skip_modules=()
+        config_path="/boot/config-$(uname -r)"
+        if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
+            config_path="/usr/lib/kernel/config-$(uname -r)"
+        fi
+        LogMsg "Set the configuration path to $config_path"
+
+        declare -A config_modulesDic
+        config_modulesDic=(
+        [CONFIG_HYPERV=y]="hv_vmbus"
+        [CONFIG_HYPERV_STORAGE=y]="hv_storvsc"
+        [CONFIG_HYPERV_NET=y]="hv_netvsc"
+        [CONFIG_HYPERV_UTILS=y]="hv_utils"
+        [CONFIG_HID_HYPERV_MOUSE=y]="hid_hyperv"
+        [CONFIG_HYPERV_BALLOON=y]="hv_balloon"
+        [CONFIG_HYPERV_KEYBOARD=y]="hyperv_keyboard"
+        )
+        for key in $(echo ${!config_modulesDic[*]})
+        do
+            module_included=$(grep $key "$config_path")
+            if [ "$module_included" ]; then
+                skip_modules+=("${config_modulesDic[$key]}")
+                LogMsg "Skipping the built-in modules, ${config_modulesDic[$key]}"
+            fi
+        done
+
+        # Remove each module in HYPERV_MODULES from skip_modules
+        for module in "${HYPERV_MODULES[@]}"; do
+            skip=""
+            for mod_skip in "${skip_modules[@]}"; do
+                [[ $module == $mod_skip ]] && { skip=1; break; }
+            done
+            [[ -n $skip ]] || tempList+=("$module")
+        done
+        HYPERV_MODULES=("${tempList[@]}")
+        LogMsg "Target module names: ${HYPERV_MODULES[*]}"
+
+        if [ ! $HYPERV_MODULES ]; then
+            LogErr "Target module is empty or null"
             exit_code=$((exit_code+1))
         fi
-    else
-        LogErr "LIS module $module was not loaded"
-        exit_code=$((exit_code+1))
-    fi
-done
 
-if [ 0 -eq $exit_code ]; then
-    LogMsg "Exiting with state: $__LIS_TESTCOMPLETED."
-    SetTestStateCompleted
-    exit 0
-else
-    LogMsg "Exiting with state: $__LIS_TESTABORTED."
-    SetTestStateAborted
-    exit 1
-fi
+        if which rpm 2>/dev/null;then
+            rpmAvailable=true
+            isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
+            LogMsg "The current LIS installation state: $isLISInstalled"
+        else
+            rpmAvailable=false
+            isLISInstalled=''
+            LogMsg "The current LIS installation state: none"
+            LogErr "Test Skipped because of no LIS installation"
+            SetTestStateSkipped
+            exit 1
+        fi
+        LogMsg "RPM availability in the system: $rpmAvailable"
+
+        if [ ! -z "$isLISInstalled" ]; then
+            expected_lis_version=$(dmesg | grep -i 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
+            if check_version_greater_equal $DISTRO_VERSION $min_supported_distro_version ; then
+                HYPERV_MODULES+=('pci_hyperv')
+                pci_module=$(lsmod | grep pci_hyperv)
+                if [ -z $pci_module ]; then
+                    modprobe pci_hyperv
+                    LogMsg "pci_hyperv module loaded"
+                fi
+            fi
+            if [[ $DISTRO_VERSION =~ 7\.3 ]] || [[ $DISTRO_VERSION =~ 7\.4 ]] ; then
+                if check_version_greater_equal $expected_lis_version $min_supported_LIS_version ; then
+                    HYPERV_MODULES+=('mlx4_en')
+                    mlx4_module=$(lsmod | grep mlx4_en)
+                    if [ -z $mlx4_module ]; then
+                        modprobe mlx4_en
+                        LogMsg "mlx4_en module loaded"
+                    fi
+                fi
+            fi
+        fi
+
+        # Verifies first if the modules are loaded
+        for module in "${HYPERV_MODULES[@]}"; do
+            load_status=$(lsmod | grep "$module" 2>&1)
+
+            # Check to see if the module is loaded
+            if [[ $load_status =~ $module ]]; then
+                LogMsg "LIS module $module loaded successfully"
+                if [ "$rpmAvailable" = true ] && [ ! -z "$isLISInstalled" ]; then
+                    version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
+                    LogMsg "$module module version: ${version}"
+                    if [ "$module" == "mlx4_en" && "$MLNX_VERSION" != "$version" ] ;then
+                        LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
+                        exit_code=$((exit_code+1))
+                    else
+                        continue
+                    fi
+                    if [ "$expected_lis_version" != "$version" ] ;then
+                        LogErr "Status: $module $version did not match to the build one, $expected_lis_version"
+                        exit_code=$((exit_code+1))
+                    else
+                        continue
+                    fi
+                fi
+
+                version=$(modinfo "$module" | grep vermagic: | awk '{print $2}')
+                if [[ "$version" == "$(uname -r)" ]]; then
+                    LogMsg "Found the matching kernel version of $module module: ${version}"
+                else
+                    LogErr "LIS module $module did not match the kernel build version!"
+                    exit_code=$((exit_code+1))
+                fi
+            else
+                LogErr "LIS module $module was not loaded"
+                exit_code=$((exit_code+1))
+            fi
+        done
+
+        if [ 0 -eq $exit_code ]; then
+            LogMsg "Exiting with state: $__LIS_TESTCOMPLETED."
+            SetTestStateCompleted
+            exit 0
+        else
+            LogMsg "Exiting with state: $__LIS_TESTABORTED."
+            SetTestStateAborted
+            exit 1
+        fi
+    ;;
+    *)
+        LogErr "$DISTRO is not supported in this test"
+        SetTestStateSkipped
+        exit 1
+    ;;
+esac

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -12,7 +12,7 @@
 #
 ########################################################################
 
-exit_code="0"
+exit_code=0
 expected_lis_version=''
 min_supported_distro_version="7.3"
 min_supported_LIS_version="4.3.0"
@@ -33,7 +33,7 @@ function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort 
 # Check if vmbus string is recorded in dmesg
 hv_string=$(dmesg | grep "Vmbus version:")
 if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then
-    LogErr "Error! Could not find the VMBus protocol string in dmesg."
+    LogErr "Could not find the VMBus protocol string in dmesg. Test stopped here."
     SetTestStateAborted
     exit 0
 fi
@@ -42,6 +42,7 @@ skip_modules=()
 config_path="/boot/config-$(uname -r)"
 if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
     config_path="/usr/lib/kernel/config-$(uname -r)"
+    LogMsg "Set the configuration path to $config_path"
 fi
 
 declare -A config_modulesDic
@@ -59,7 +60,7 @@ do
     module_included=$(grep $key "$config_path")
     if [ "$module_included" ]; then
         skip_modules+=("${config_modulesDic[$key]}")
-        LogMsg "Info: Skiping ${config_modulesDic[$key]} module as it is built-in."
+        LogMsg "Skipping the built-in modules, ${config_modulesDic[$key]}"
     fi
 done
 
@@ -72,22 +73,32 @@ for module in "${HYPERV_MODULES[@]}"; do
     [[ -n $skip ]] || tempList+=("$module")
 done
 HYPERV_MODULES=("${tempList[@]}")
+LogMsg "Target module names: ${HYPERV_MODULES[*]}"
+
+if [ ! $HYPERV_MODULES ]; then
+    LogErr "Target module is empty or null"
+    exit_code=$((exit_code+1))
+fi
 
 if which rpm 2>/dev/null;then
     rpmAvailable=true
+    isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
+    LogMsg "The current LIS installation state: $isLISInstalled"
 else
     rpmAvailable=false
+    isLISInstalled=''
+    LogMsg "The current LIS installation state: none"
 fi
-
-isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
+LogMsg "RPM availability in the system: $rpmAvailable"
 
 if [ ! -z "$isLISInstalled" ]; then
-    expected_lis_version=$(dmesg | grep 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
+    expected_lis_version=$(dmesg | grep -i 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
     if check_version_greater_equal $DISTRO_VERSION $min_supported_distro_version ; then
         HYPERV_MODULES+=('pci_hyperv')
         pci_module=$(lsmod | grep pci_hyperv)
         if [ -z $pci_module ]; then
             modprobe pci_hyperv
+            LogMsg "pci_hyperv module loaded"
         fi
     fi
     if [[ $DISTRO_VERSION =~ 7\.3 ]] || [[ $DISTRO_VERSION =~ 7\.4 ]] ; then
@@ -96,6 +107,7 @@ if [ ! -z "$isLISInstalled" ]; then
             mlx4_module=$(lsmod | grep mlx4_en)
             if [ -z $mlx4_module ]; then
                 modprobe mlx4_en
+                LogMsg "mlx4_en module loaded"
             fi
         fi
     fi
@@ -107,44 +119,43 @@ for module in "${HYPERV_MODULES[@]}"; do
 
     # Check to see if the module is loaded
     if [[ $load_status =~ $module ]]; then
-        if [ "$rpmAvailable" = true ] ; then
-            if [ ! -z "$isLISInstalled" ]; then
-                version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
-                LogMsg "$module module: ${version}"
-                if [ "$module" == "mlx4_en" ] ;then
-                    if [ "$MLNX_VERSION" != "$version" ] ;then
-                        LogErr "ERROR: Status: $module $version doesnot match with build version $MLNX_VERSION"
-                        exit_code="1"
-                    fi
-                    continue
-                fi
-                if [ "$expected_lis_version" != "$version" ] ;then
-                    LogErr "ERROR: Status: $module $version doesnot match with build version $expected_lis_version"
-                    exit_code="1"
+        LogMsg "LIS nmodule $module loaded successfully"
+        if [ "$rpmAvailable" = true ] && [ ! -z "$isLISInstalled" ]; then
+            version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
+            LogMsg "$module module version: ${version}"
+            if [ "$module" == "mlx4_en" ] ;then
+                if [ "$MLNX_VERSION" != "$version" ] ;then
+                    LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
+                    exit_code=$((exit_code+1))
                 fi
                 continue
             fi
+            if [ "$expected_lis_version" != "$version" ] ;then
+                LogErr "Status: $module $version did not match to the build one, $expected_lis_version"
+                exit_code=$((exit_code+1))
+            fi
+            continue
         fi
-        
+
         version=$(modinfo "$module" | grep vermagic: | awk '{print $2}')
         if [[ "$version" == "$(uname -r)" ]]; then
-            LogMsg "Found a kernel matching version for $module module: ${version}"
+            LogMsg "Found the matching kernel version of $module module: ${version}"
         else
-            LogErr "Error: LIS module $module doesn't match the kernel build version!"
-            exit_code="1"
+            LogErr "LIS module $module did not match the kernel build version!"
+            exit_code=$((exit_code+1))
         fi
     else
-         LogErr "Error: LIS module $module is not loaded"
-         exit_code="1"
+         LogErr "LIS module $module was not loaded"
+         exit_code=$((exit_code+1))
     fi
 done
 
-if [ "1" -eq "$exit_code" ]; then
-    LogMsg "Exiting with state: TestAborted."
-    SetTestStateAborted
-else
-    LogMsg "Exiting with state: TestCompleted."
+if [ 0 -eq $exit_code ]; then
+    LogMsg "Exiting with state: $__LIS_TESTCOMPLETED."
     SetTestStateCompleted
+    exit 0
+else
+    LogMsg "Exiting with state: $__LIS_TESTABORTED."
+    SetTestStateAborted
+    exit 1
 fi
-
-exit 0

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -41,7 +41,7 @@ fi
 skip_modules=()
 config_path="/boot/config-$(uname -r)"
 if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-	config_path="/usr/lib/kernel/config-$(uname -r)"
+    config_path="/usr/lib/kernel/config-$(uname -r)"
 fi
 LogMsg "Set the configuration path to $config_path"
 
@@ -88,6 +88,9 @@ else
     rpmAvailable=false
     isLISInstalled=''
     LogMsg "The current LIS installation state: none"
+    LogErr "Test Skipped because of no LIS installation"
+    SetTestStateSkipped
+    exit 1
 fi
 LogMsg "RPM availability in the system: $rpmAvailable"
 
@@ -124,8 +127,8 @@ for module in "${HYPERV_MODULES[@]}"; do
             version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
             LogMsg "$module module version: ${version}"
             if [ "$module" == "mlx4_en" && "$MLNX_VERSION" != "$version" ] ;then
-                    LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
-                    exit_code=$((exit_code+1))
+                LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
+                exit_code=$((exit_code+1))
             else
                 continue
             fi

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -41,9 +41,9 @@ fi
 skip_modules=()
 config_path="/boot/config-$(uname -r)"
 if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-    config_path="/usr/lib/kernel/config-$(uname -r)"
-    LogMsg "Set the configuration path to $config_path"
+	config_path="/usr/lib/kernel/config-$(uname -r)"
 fi
+LogMsg "Set the configuration path to $config_path"
 
 declare -A config_modulesDic
 config_modulesDic=(

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -148,8 +148,8 @@ for module in "${HYPERV_MODULES[@]}"; do
             exit_code=$((exit_code+1))
         fi
     else
-         LogErr "LIS module $module was not loaded"
-         exit_code=$((exit_code+1))
+        LogErr "LIS module $module was not loaded"
+        exit_code=$((exit_code+1))
     fi
 done
 

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -77,12 +77,6 @@ LogMsg "Target module names: $HYPERV_MODULES"
 
 if [ ! $HYPERV_MODULES ]; then
     LogErr "Target module is empty or null"
-    GetDistro
-    if [ $OS_FAMILY != "Rhel" ]; then
-    LogErr "Confirmed this VM is not RHEL Family, which this test does not support."
-        SetTestStateSkipped
-        exit 1
-    fi
 fi
 
 if which rpm 2>/dev/null;then
@@ -156,9 +150,9 @@ done
 if [ "1" -eq "$exit_code" ]; then
     LogMsg "Exiting with state: $__LIS_TESTABORTED."
     SetTestStateAborted
+    exit 1
 else
     LogMsg "Exiting with state: $__LIS_TESTCOMPLETED."
     SetTestStateCompleted
+    exit 0
 fi
-
-exit 0

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -75,6 +75,16 @@ done
 HYPERV_MODULES=("${tempList[@]}")
 LogMsg "Target module names: $HYPERV_MODULES"
 
+if [ ! $HYPERV_MODULES ]; then
+    LogErr "Target module is empty or null"
+    GetDistro
+    if [ $OS_FAMILY != "Rhel" ]; then
+    LogErr "Confirmed this VM is not RHEL Family, which this test does not support."
+        SetTestStateSkipped
+        exit 1
+    fi
+fi
+
 if which rpm 2>/dev/null;then
     rpmAvailable=true
 else

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -33,7 +33,7 @@ function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort 
 # Check if vmbus string is recorded in dmesg
 hv_string=$(dmesg | grep "Vmbus version:")
 if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then
-    LogErr "Error! Could not find the VMBus protocol string in dmesg."
+    LogErr "Could not find the VMBus protocol string in dmesg. Test stopped here."
     SetTestStateAborted
     exit 0
 fi
@@ -42,6 +42,7 @@ skip_modules=()
 config_path="/boot/config-$(uname -r)"
 if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
     config_path="/usr/lib/kernel/config-$(uname -r)"
+    LogMsg "Set the configuration path to $config_path"
 fi
 
 declare -A config_modulesDic
@@ -59,7 +60,7 @@ do
     module_included=$(grep $key "$config_path")
     if [ "$module_included" ]; then
         skip_modules+=("${config_modulesDic[$key]}")
-        LogMsg "Info: Skiping ${config_modulesDic[$key]} module as it is built-in."
+        LogMsg "Skipping the built-in modules, ${config_modulesDic[$key]}"
     fi
 done
 
@@ -72,22 +73,26 @@ for module in "${HYPERV_MODULES[@]}"; do
     [[ -n $skip ]] || tempList+=("$module")
 done
 HYPERV_MODULES=("${tempList[@]}")
+LogMsg "Target module names: $HYPERV_MODULES"
 
 if which rpm 2>/dev/null;then
     rpmAvailable=true
 else
     rpmAvailable=false
 fi
+LogMsg "RPM availability in the system: $rpmAvailable"
 
 isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
+LogMsg "The current LIS installation state: $isLISInstalled"
 
 if [ ! -z "$isLISInstalled" ]; then
-    expected_lis_version=$(dmesg | grep 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
+    expected_lis_version=$(dmesg | grep -i 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])
     if check_version_greater_equal $DISTRO_VERSION $min_supported_distro_version ; then
         HYPERV_MODULES+=('pci_hyperv')
         pci_module=$(lsmod | grep pci_hyperv)
         if [ -z $pci_module ]; then
             modprobe pci_hyperv
+            LogMsg "pci_hyperv module loaded"
         fi
     fi
     if [[ $DISTRO_VERSION =~ 7\.3 ]] || [[ $DISTRO_VERSION =~ 7\.4 ]] ; then
@@ -96,6 +101,7 @@ if [ ! -z "$isLISInstalled" ]; then
             mlx4_module=$(lsmod | grep mlx4_en)
             if [ -z $mlx4_module ]; then
                 modprobe mlx4_en
+                LogMsg "mlx4_en module loaded"
             fi
         fi
     fi
@@ -107,43 +113,41 @@ for module in "${HYPERV_MODULES[@]}"; do
 
     # Check to see if the module is loaded
     if [[ $load_status =~ $module ]]; then
-        if [ "$rpmAvailable" = true ] ; then
-            if [ ! -z "$isLISInstalled" ]; then
-                version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
-                LogMsg "$module module: ${version}"
-                if [ "$module" == "mlx4_en" ] ;then
-                    if [ "$MLNX_VERSION" != "$version" ] ;then
-                        LogErr "ERROR: Status: $module $version doesnot match with build version $MLNX_VERSION"
-                        exit_code="1"
-                    fi
-                    continue
-                fi
-                if [ "$expected_lis_version" != "$version" ] ;then
-                    LogErr "ERROR: Status: $module $version doesnot match with build version $expected_lis_version"
+        if [ "$rpmAvailable" = true ] && [ ! -z "$isLISInstalled" ]; then
+            version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
+            LogMsg "$module module version: ${version}"
+            if [ "$module" == "mlx4_en" ] ;then
+                if [ "$MLNX_VERSION" != "$version" ] ;then
+                    LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
                     exit_code="1"
                 fi
                 continue
             fi
+            if [ "$expected_lis_version" != "$version" ] ;then
+                LogErr "Status: $module $version did not match to the build one, $expected_lis_version"
+                exit_code="1"
+            fi
+            continue
         fi
-        
+
         version=$(modinfo "$module" | grep vermagic: | awk '{print $2}')
         if [[ "$version" == "$(uname -r)" ]]; then
-            LogMsg "Found a kernel matching version for $module module: ${version}"
+            LogMsg "Found the matching kernel version of $module module: ${version}"
         else
-            LogErr "Error: LIS module $module doesn't match the kernel build version!"
+            LogErr "LIS module $module did not match the kernel build version!"
             exit_code="1"
         fi
     else
-         LogErr "Error: LIS module $module is not loaded"
+         LogErr "LIS module $module was not loaded"
          exit_code="1"
     fi
 done
 
 if [ "1" -eq "$exit_code" ]; then
-    LogMsg "Exiting with state: TestAborted."
+    LogMsg "Exiting with state: $__LIS_TESTABORTED."
     SetTestStateAborted
 else
-    LogMsg "Exiting with state: TestCompleted."
+    LogMsg "Exiting with state: $__LIS_TESTCOMPLETED."
     SetTestStateCompleted
 fi
 

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -170,6 +170,6 @@ case $DISTRO in
     *)
         LogErr "$DISTRO is not supported in this test"
         SetTestStateSkipped
-        exit 1
+        exit 0
     ;;
 esac

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -119,22 +119,22 @@ for module in "${HYPERV_MODULES[@]}"; do
 
     # Check to see if the module is loaded
     if [[ $load_status =~ $module ]]; then
-        LogMsg "LIS nmodule $module loaded successfully"
+        LogMsg "LIS module $module loaded successfully"
         if [ "$rpmAvailable" = true ] && [ ! -z "$isLISInstalled" ]; then
             version=$(modinfo "$module" | grep version: | head -1 | awk '{print $2}')
             LogMsg "$module module version: ${version}"
-            if [ "$module" == "mlx4_en" ] ;then
-                if [ "$MLNX_VERSION" != "$version" ] ;then
+            if [ "$module" == "mlx4_en" && "$MLNX_VERSION" != "$version" ] ;then
                     LogErr "Status: $module $version did not match to the build one, $MLNX_VERSION"
                     exit_code=$((exit_code+1))
-                fi
+            else
                 continue
             fi
             if [ "$expected_lis_version" != "$version" ] ;then
                 LogErr "Status: $module $version did not match to the build one, $expected_lis_version"
                 exit_code=$((exit_code+1))
+            else
+                continue
             fi
-            continue
         fi
 
         version=$(modinfo "$module" | grep vermagic: | awk '{print $2}')

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -77,17 +77,19 @@ LogMsg "Target module names: ${HYPERV_MODULES[*]}"
 
 if [ ! $HYPERV_MODULES ]; then
     LogErr "Target module is empty or null"
+    exit_code=$((exit_code+1))
 fi
 
 if which rpm 2>/dev/null;then
     rpmAvailable=true
     isLISInstalled=$(rpm -qa | grep microsoft-hyper-v 2>/dev/null)
+    LogMsg "The current LIS installation state: $isLISInstalled"
 else
     rpmAvailable=false
     isLISInstalled=''
+    LogMsg "The current LIS installation state: none"
 fi
 LogMsg "RPM availability in the system: $rpmAvailable"
-LogMsg "The current LIS installation state: $isLISInstalled"
 
 if [ ! -z "$isLISInstalled" ]; then
     expected_lis_version=$(dmesg | grep -i 'Vmbus LIS version' | awk -F ':' '{print $3}' | tr -d [:blank:])

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -73,7 +73,7 @@ for module in "${HYPERV_MODULES[@]}"; do
     [[ -n $skip ]] || tempList+=("$module")
 done
 HYPERV_MODULES=("${tempList[@]}")
-LogMsg "Target module names: $HYPERV_MODULES"
+LogMsg "Target module names: ${HYPERV_MODULES[@]}"
 
 if [ ! $HYPERV_MODULES ]; then
     LogErr "Target module is empty or null"


### PR DESCRIPTION
Depending on the distro and its module loading state, the test result should be accurate. The old code shows 'passed' all the times regardless LIS module version check or not. 

The change will filter out no module version check case, and turn in 'failed' result, if not.

**Before changing**
```
[SUSE SLES 15 latest] [LISAv2 Test Results Summary]
[SUSE SLES 15 latest] Test Run On           : 12/06/2019 22:25:04
[SUSE SLES 15 latest] ARM Image Under Test  : SUSE : SLES : 15 : latest
[SUSE SLES 15 latest] Initial Kernel Version: 4.12.14-5.30-azure
[SUSE SLES 15 latest] Final Kernel Version  : 4.12.14-5.30-azure
[SUSE SLES 15 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[SUSE SLES 15 latest] Total Time (dd:hh:mm) : 0:0:4
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[SUSE SLES 15 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[SUSE SLES 15 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.46 
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest] Logs can be found at C:\LISAv2\CH93\TestResults\2019-06-12-22-25-00-9426
```
In side of TestExecution.log,
```
Fri Dec 06 22:29:00 2019 : Target module is empty or null
Fri Dec 06 22:29:00 2019 : RPM availability in the system: true
Fri Dec 06 22:29:00 2019 : The current LIS installation state: 
Fri Dec 06 22:29:00 2019 : Exiting with state: **TestCompleted**.
```
**After changing**
```
[SUSE SLES 15 latest] [LISAv2 Test Results Summary]
[SUSE SLES 15 latest] Test Run On           : 12/06/2019 22:50:55
[SUSE SLES 15 latest] ARM Image Under Test  : SUSE : SLES : 15 : latest
[SUSE SLES 15 latest] Initial Kernel Version: 4.12.14-5.30-azure
[SUSE SLES 15 latest] Final Kernel Version  : 4.12.14-5.30-azure
[SUSE SLES 15 latest] Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
[SUSE SLES 15 latest] Total Time (dd:hh:mm) : 0:0:4
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[SUSE SLES 15 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[SUSE SLES 15 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        **FAIL**                 1.47 
[SUSE SLES 15 latest] Calling function - Run-LinuxCmd. Failed to execute : bash VERIFY-LIS-MODULES-VERSION.sh > VERIFY-LIS-MODULES-VERSION_summary.log 2>&1.
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest] 
[SUSE SLES 15 latest] Logs can be found at C:\LISAv2\VO24\TestResults\2019-06-12-22-50-51-2120

[Canonical UbuntuServer 12.04.5-LTS latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 12.04.5-LTS latest] Test Run On           : 12/06/2019 22:36:12
[Canonical UbuntuServer 12.04.5-LTS latest] ARM Image Under Test  : Canonical : UbuntuServer : 12.04.5-LTS : latest
[Canonical UbuntuServer 12.04.5-LTS latest] Initial Kernel Version: 3.13.0-117-generic
[Canonical UbuntuServer 12.04.5-LTS latest] Final Kernel Version  : 3.13.0-117-generic
[Canonical UbuntuServer 12.04.5-LTS latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 12.04.5-LTS latest] Total Time (dd:hh:mm) : 0:0:2
[Canonical UbuntuServer 12.04.5-LTS latest] 
[Canonical UbuntuServer 12.04.5-LTS latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 12.04.5-LTS latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 12.04.5-LTS latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.42 
[Canonical UbuntuServer 12.04.5-LTS latest] 
[Canonical UbuntuServer 12.04.5-LTS latest] 
[Canonical UbuntuServer 12.04.5-LTS latest] Logs can be found at C:\LISAv2\OQ27\TestResults\2019-06-12-22-36-08-3330
```
They are also regression result with other distros
```
[OpenLogic CentOS 7.1 latest] [LISAv2 Test Results Summary]
[OpenLogic CentOS 7.1 latest] Test Run On           : 12/06/2019 22:36:46
[OpenLogic CentOS 7.1 latest] ARM Image Under Test  : OpenLogic : CentOS : 7.1 : latest
[OpenLogic CentOS 7.1 latest] Initial Kernel Version: 3.10.0-229.20.1.el7.x86_64
[OpenLogic CentOS 7.1 latest] Final Kernel Version  : 3.10.0-229.20.1.el7.x86_64
[OpenLogic CentOS 7.1 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[OpenLogic CentOS 7.1 latest] Total Time (dd:hh:mm) : 0:0:2
[OpenLogic CentOS 7.1 latest] 
[OpenLogic CentOS 7.1 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[OpenLogic CentOS 7.1 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[OpenLogic CentOS 7.1 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.48 
[OpenLogic CentOS 7.1 latest] 
[OpenLogic CentOS 7.1 latest] 
[OpenLogic CentOS 7.1 latest] Logs can be found at C:\LISAv2\AD45-20191206223639\TestResults\2019-06-12-22-36-42-2320

[RedHat RHEL 7.7 latest] [LISAv2 Test Results Summary]
[RedHat RHEL 7.7 latest] Test Run On           : 12/06/2019 22:36:40
[RedHat RHEL 7.7 latest] ARM Image Under Test  : RedHat : RHEL : 7.7 : latest
[RedHat RHEL 7.7 latest] Initial Kernel Version: 3.10.0-1062.el7.x86_64
[RedHat RHEL 7.7 latest] Final Kernel Version  : 3.10.0-1062.el7.x86_64
[RedHat RHEL 7.7 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[RedHat RHEL 7.7 latest] Total Time (dd:hh:mm) : 0:0:3
[RedHat RHEL 7.7 latest] 
[RedHat RHEL 7.7 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[RedHat RHEL 7.7 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[RedHat RHEL 7.7 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.82 
[RedHat RHEL 7.7 latest] 
[RedHat RHEL 7.7 latest] 
[RedHat RHEL 7.7 latest] Logs can be found at C:\LISAv2\DR49\TestResults\2019-06-12-22-36-34-0509


[Canonical UbuntuServer 19.04 latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 19.04 latest] Test Run On           : 12/06/2019 22:36:24
[Canonical UbuntuServer 19.04 latest] ARM Image Under Test  : Canonical : UbuntuServer : 19.04 : latest
[Canonical UbuntuServer 19.04 latest] Initial Kernel Version: 5.0.0-1025-azure
[Canonical UbuntuServer 19.04 latest] Final Kernel Version  : 5.0.0-1025-azure
[Canonical UbuntuServer 19.04 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 19.04 latest] Total Time (dd:hh:mm) : 0:0:3
[Canonical UbuntuServer 19.04 latest] 
[Canonical UbuntuServer 19.04 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 19.04 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 19.04 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.53 
[Canonical UbuntuServer 19.04 latest] 
[Canonical UbuntuServer 19.04 latest] 
[Canonical UbuntuServer 19.04 latest] Logs can be found at C:\LISAv2\QJ35\TestResults\2019-06-12-22-36-20-0458

[OpenLogic CentOS 7.6 latest] [LISAv2 Test Results Summary]
[OpenLogic CentOS 7.6 latest] Test Run On           : 12/06/2019 22:36:49
[OpenLogic CentOS 7.6 latest] ARM Image Under Test  : OpenLogic : CentOS : 7.6 : latest
[OpenLogic CentOS 7.6 latest] Initial Kernel Version: 3.10.0-957.27.2.el7.x86_64
[OpenLogic CentOS 7.6 latest] Final Kernel Version  : 3.10.0-957.27.2.el7.x86_64
[OpenLogic CentOS 7.6 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[OpenLogic CentOS 7.6 latest] Total Time (dd:hh:mm) : 0:0:3
[OpenLogic CentOS 7.6 latest] 
[OpenLogic CentOS 7.6 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[OpenLogic CentOS 7.6 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[OpenLogic CentOS 7.6 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                  0.8 
[OpenLogic CentOS 7.6 latest] 
[OpenLogic CentOS 7.6 latest] 
[OpenLogic CentOS 7.6 latest] Logs can be found at C:\LISAv2\YR26\TestResults\2019-06-12-22-36-45-3650

[Canonical UbuntuServer 18.04-LTS latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 18.04-LTS latest] Test Run On           : 12/06/2019 22:36:21
[Canonical UbuntuServer 18.04-LTS latest] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[Canonical UbuntuServer 18.04-LTS latest] Initial Kernel Version: 5.0.0-1027-azure
[Canonical UbuntuServer 18.04-LTS latest] Final Kernel Version  : 5.0.0-1027-azure
[Canonical UbuntuServer 18.04-LTS latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 18.04-LTS latest] Total Time (dd:hh:mm) : 0:0:3
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 18.04-LTS latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 18.04-LTS latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                  0.8 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] Logs can be found at C:\LISAv2\SJ22\TestResults\2019-06-12-22-36-15-8948

[RedHat RHEL 6.9 latest] [LISAv2 Test Results Summary]
[RedHat RHEL 6.9 latest] Test Run On           : 12/06/2019 22:36:34
[RedHat RHEL 6.9 latest] ARM Image Under Test  : RedHat : RHEL : 6.9 : latest
[RedHat RHEL 6.9 latest] Initial Kernel Version: 2.6.32-696.18.7.el6.x86_64
[RedHat RHEL 6.9 latest] Final Kernel Version  : 2.6.32-696.18.7.el6.x86_64
[RedHat RHEL 6.9 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[RedHat RHEL 6.9 latest] Total Time (dd:hh:mm) : 0:0:3
[RedHat RHEL 6.9 latest] 
[RedHat RHEL 6.9 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[RedHat RHEL 6.9 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[RedHat RHEL 6.9 latest]     1 CORE                 VERIFY-LIS-MODULES-VERSION                                                        PASS                 0.66 
[RedHat RHEL 6.9 latest] 
[RedHat RHEL 6.9 latest] 
[RedHat RHEL 6.9 latest] Logs can be found at C:\LISAv2\SO40-20191206223627\TestResults\2019-06-12-22-36-29-9279
```
