### PR TITLE
No wait for start VM.

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2339,10 +2339,10 @@ Function Set-SRIOVinAzureVMs {
                     Write-LogErr "Start-AzVM command executes failed."
                 }
                 $vm = Get-AzVM -ResourceGroupName $ResourceGroup -Name $VMName -Status
-                $MaxAttempts = 20
+                $MaxAttempts = 30
                 while (($vm.Statuses[-1].Code -ne "PowerState/running") -and ($MaxAttempts -gt 0)) {
-                    Write-LogInfo "Attempt $(21 - $MaxAttempts) - VM $($VMName) is in $($vm.Statuses[-1].Code) state, still not in running state, wait for 10 seconds..."
-                    Start-Sleep -Seconds 10
+                    Write-LogInfo "Attempt $(31 - $MaxAttempts) - VM $($VMName) is in $($vm.Statuses[-1].Code) state, still not in running state, wait for 20 seconds..."
+                    Start-Sleep -Seconds 20
                     $MaxAttempts -= 1
                     $vm = Get-AzVM -ResourceGroupName $ResourceGroup -Name $VMName -Status
                 }


### PR DESCRIPTION
Test results
```
[LISAv2 Test Results Summary]
Test Run On           : 12/11/2019 07:41:16
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1027-azure
Final Kernel Version  : 5.0.0-1027-azure
Total Test Cases      : 6 (6 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:57

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION-1                                  PASS                 6.24 
    2 NETWORK              NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION-2                                  PASS                 6.75 
    3 NETWORK              NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION-3                                  PASS                 7.77 
    4 SRIOV                SRIOV-ADD-MAX-NICS-AFTER-PROVISION-1                                              PASS                 6.71 
    5 SRIOV                SRIOV-ADD-MAX-NICS-AFTER-PROVISION-2                                              PASS                  6.1 
    6 SRIOV                SRIOV-ADD-MAX-NICS-AFTER-PROVISION-3                                              PASS                 6.29 
```