### PR TITLE
Remove targetpw check in SLES.

### DIFF
--- a/Testscripts/Windows/VERIFY-VHD-PREREQUISITES.ps1
+++ b/Testscripts/Windows/VERIFY-VHD-PREREQUISITES.ps1
@@ -33,7 +33,7 @@ function Main {
             $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_NETWORK_MANAGER_NOT_INSTALLED","_TEST_NETWORK_FILE_SUCCESS", "_TEST_IFCFG_ETH0_FILE_SUCCESS", "_TEST_UDEV_RULES_SUCCESS", "_TEST_GRUB_VERIFICATION_SUCCESS")
         }
         elseif ($global:detectedDistro -imatch "SLES") {
-            $matchstrings = @("_TEST_SUDOERS_VERIFICATION_SUCCESS","_TEST_GRUB_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
+            $matchstrings = @("_TEST_GRUB_VERIFICATION_SUCCESS", "_TEST_REPOSITORIES_AVAILABLE")
             # to avoid extra blank space
             $global:detectedDistro="SLES"
         }


### PR DESCRIPTION
#544 
Before 
```
[LISAv2 Test Results Summary]
Test Run On           : 12/16/2019 02:01:59
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-VHD-PREREQUISITES                                                          FAIL                 1.74 
```
After
```
[LISAv2 Test Results Summary]
Test Run On           : 12/16/2019 12:31:24
ARM Image Under Test  : SUSE : SLES : 15 : Latest
Initial Kernel Version: 4.12.14-5.30-azure
Final Kernel Version  : 4.12.14-5.30-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-VHD-PREREQUISITES                                                          PASS                 1.31 
```