### PR TITLE
Updated ppa link with Canonical's feedback

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -191,8 +191,8 @@ function Main() {
 			LogMsg "Starting RDMA setup for Ubuntu"
 			hpcx_ver="ubuntu"$VERSION_ID
 			LogMsg "Installing required packages ..."
-			LogMsg "*** Adding Canonical ppa for temporary fix"
-			add-apt-repository -y ppa:ci-train-ppa-service/3760
+			# the old fix integrated to dpdk-18.11 repo
+			add-apt-repository ppa:canonical-server/dpdk-azure-18.11 -y
 
 			LogMsg "Required 32-bit java"
 			dpkg --add-architecture i386
@@ -227,8 +227,6 @@ function Main() {
 					LogMsg "Module $ex_module already loaded"
 				fi
 			done
-			LogMsg "*** Adding Canonical ppa for temporary fix"
-			add-apt-repository -y ppa:ci-train-ppa-service/3760
 			LogMsg "*** System updating with the customized ppa"
 			apt update
 			apt upgrade -y

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -193,6 +193,11 @@ function Main() {
 			LogMsg "Installing required packages ..."
 			# the old fix integrated to dpdk-18.11 repo
 			add-apt-repository ppa:canonical-server/dpdk-azure-18.11 -y
+			if [ $? -ne 0 ]; then
+				LogErr "Failed to add the required dpdk-azure-18.11 repo to apt source"
+			else
+				LogMsg "Successfully added the required dpdk-azure-18.11 repo"
+			fi
 
 			LogMsg "Required 32-bit java"
 			dpkg --add-architecture i386


### PR DESCRIPTION
The permanent location for the PPA is:
https://launchpad.net/~canonical-server/+archive/ubuntu/dpdk-azure-18.11
with updated libraries:
- rdma-core v24
- dpdk 18.11.2
- openvswitch 2.11.1


Azure-Functional-INFINIBAND.INFINIBAND-INTEL-MPI-2VM   - PASSED
Azure-Functional-INFINIBAND.INFINIBAND-MVAPICH-MPI-2VM   - PASSED
Azure-Functional-INFINIBAND.INFINIBAND-OPEN-MPI-2VM   - PASSED

