### PR TITLE
Enable platform specific step of checking system logs

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -42,7 +42,8 @@ Function Get-FinalResultHeader($resultArr) {
 	return $result
 }
 
-function Create-TestResultObject() {
+function Create-TestResultObject()
+{
 	$objNode = New-Object -TypeName PSObject
 	Add-Member -InputObject $objNode -MemberType NoteProperty -Name TestResult -Value $null -Force
 	Add-Member -InputObject $objNode -MemberType NoteProperty -Name TestSummary -Value $null -Force

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -163,8 +163,8 @@ function Collect-CustomLogFile {
 Function Compare-OsLogs($InitialLogFilePath, $FinalLogFilePath, $LogStatusFilePath, $ErrorMatchPatten) {
 	$ret = $true
 	try {
-		$fileDiff = Compare-Object -ReferenceObject (Get-Content $FinalLogFilePath) `
-			-DifferenceObject (Get-Content $InitialLogFilePath)
+		$fileDiff = Compare-Object -ReferenceObject (Get-Content $InitialLogFilePath) `
+			-DifferenceObject (Get-Content $FinalLogFilePath)
 
 		if (!$fileDiff) {
 			$msg = "Initial and Final Logs have same content"
@@ -177,14 +177,16 @@ Function Compare-OsLogs($InitialLogFilePath, $FinalLogFilePath, $LogStatusFilePa
 			Set-Content -Value $msg -Path $LogStatusFilePath
 			Add-Content -Value "-------------------------------START----------------------------------" -Path $LogStatusFilePath
 			foreach ($line in $fileDiff) {
-				Add-Content -Value $line.InputObject -Path $LogStatusFilePath
-				if ($line.InputObject -imatch $ErrorMatchPatten) {
-					$errorCount += 1
-					if ($errorCount -eq 1) {
-						$warnMsg = "Following $patternStr messages were added in the logs during execution of test:"
-						Write-LogWarn $warnMsg
+				if ($line.SideIndicator -eq "=>") {
+					Add-Content -Value $line.InputObject -Path $LogStatusFilePath
+					if ($line.InputObject -imatch $ErrorMatchPatten) {
+						$errorCount += 1
+						if ($errorCount -eq 1) {
+							$warnMsg = "Following $patternStr messages were added in the logs during execution of test:"
+							Write-LogWarn $warnMsg
+						}
+						Write-LogWarn $line.InputObject
 					}
-					Write-LogWarn $line.InputObject
 				}
 			}
 			Add-Content -Value "--------------------------------EOF-----------------------------------" -Path $LogStatusFilePath

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -143,170 +143,74 @@ function Collect-CustomLogFile {
 	<#
 	.Synopsis
 		Checks if log file is present in VM and downloads it if so.
-    #>
-    param (
-        [string]$LogsDestination,
+	#>
+	param (
+		[string]$LogsDestination,
 		[string]$PublicIP,
 		[string]$SSHPort,
 		[string]$Username,
 		[string]$Password,
-        [string]$FileName
-    )
-    if (Check-FileInLinuxGuest -ipv4 $PublicIP -vmPassword $Password -vmPort $SSHPort -vmUserName $Username -fileName $FileName) {
-        Copy-RemoteFiles -download -downloadFrom $PublicIP -files $FileName `
-            -downloadTo $LogsDestination -port $SSHPort -username $Username -password $Password
-    } else {
-        Write-LogWarn "${fileName} does not exist on VM."
-    }
+		[string]$FileName
+	)
+	if (Check-FileInLinuxGuest -ipv4 $PublicIP -vmPassword $Password -vmPort $SSHPort -vmUserName $Username -fileName $FileName) {
+		Copy-RemoteFiles -download -downloadFrom $PublicIP -files $FileName `
+			-downloadTo $LogsDestination -port $SSHPort -username $Username -password $Password
+	} else {
+		Write-LogWarn "${fileName} does not exist on VM."
+	}
 }
 
-Function GetAndCheck-KernelLogs($allDeployedVMs, $status, $vmUser, $vmPassword, $EnableCodeCoverage) {
-	try	{
-		if (!($status -imatch "Initial" -or $status -imatch "Final")) {
-			Write-LogInfo "Status value should be either final or initial"
-			return $false
-		}
+Function Compare-OsLogs($InitialLogFilePath, $FinalLogFilePath, $LogStatusFilePath, $ErrorMatchPatten) {
+	$ret = $true
+	try {
+		$fileDiff = Compare-Object -ReferenceObject (Get-Content $FinalLogFilePath) `
+			-DifferenceObject (Get-Content $InitialLogFilePath)
 
-		if (!$vmUser) {
-			$vmUser = $user
-		}
-		if (!$vmPassword) {
-			$vmPassword = $password
-		}
-
-		$retValue = $false
-		foreach ($VM in $allDeployedVMs) {
-			Write-LogInfo "Collecting $($VM.RoleName) VM Kernel $status Logs ..."
-
-			$bootLogDir = "$Logdir\$($VM.RoleName)"
-			mkdir $bootLogDir -Force | Out-Null
-			$initialBootLogFile = "InitialBootLogs.txt"
-			$finalBootLogFile = "FinalBootLogs.txt"
-			$initialBootLog = Join-Path $BootLogDir $initialBootLogFile
-			$finalBootLog = Join-Path $BootLogDir $finalBootLogFile
-			$currenBootLogFile = $initialBootLogFile
-			$currenBootLog = $initialBootLog
-			$kernelLogStatus = Join-Path $BootLogDir "KernelLogStatus.txt"
-
-			if ($status -imatch "Final") {
-				$currenBootLogFile = $finalBootLogFile
-				$currenBootLog = $finalBootLog
-			}
-
-			if ($status -imatch "Initial") {
-				$checkConnectivityFile = Join-Path $LogDir ([System.IO.Path]::GetRandomFileName())
-				Set-Content -Value "Test connectivity." -Path $checkConnectivityFile
-				Copy-RemoteFiles -uploadTo $VM.PublicIP -port $VM.SSHPort -files $checkConnectivityFile `
-					-username $vmUser -password $vmPassword -upload | Out-Null
-				Remove-Item -Path $checkConnectivityFile -Force
-			}
-
-			if ($EnableCodeCoverage -and ($status -imatch "Final")) {
-				Write-LogInfo "Collecting coverage debug files from VM $($VM.RoleName)"
-
-				$gcovCollected = Collect-GcovData -ip $VM.PublicIP -port $VM.SSHPort `
-					-username $vmUser -password $vmPassword -logDir $LogDir
-
-				if ($gcovCollected) {
-					Write-LogInfo "GCOV data collected successfully"
-				} else {
-					Write-LogErr "Failed to collect GCOV data from VM: $($VM.RoleName)"
-				}
-			}
-			Run-LinuxCmd -ip $VM.PublicIP -port $VM.SSHPort -runAsSudo `
-				-username $vmUser -password $vmPassword `
-				-command "dmesg > ./${currenBootLogFile}" | Out-Null
-			Copy-RemoteFiles -download -downloadFrom $VM.PublicIP -port $VM.SSHPort -files "./${currenBootLogFile}" `
-				-downloadTo $BootLogDir -username $vmUser -password $vmPassword | Out-Null
-			Write-LogInfo "$($VM.RoleName): $status Kernel logs collected successfully to ${currenBootLogFile} file."
-
-			Write-LogInfo "Checking for call traces in kernel logs.."
-			$KernelLogs = Get-Content $currenBootLog
-			$callTraceFound  = $false
-			foreach ($line in $KernelLogs) {
-				if (( $line -imatch "Call Trace" ) -and ($line -inotmatch "initcall ")) {
-					Write-LogErr $line
-					$callTraceFound = $true
-				}
-				if ($callTraceFound) {
-					if ($line -imatch "\[<") {
-						Write-LogErr $line
+		if (!$fileDiff) {
+			$msg = "Initial and Final Logs have same content"
+			Write-LogInfo $msg
+			Set-Content -Value $msg -Path $LogStatusFilePath
+		} else {
+			$errorCount = 0
+			$msg = "Following lines were added in the logs during execution of test."
+			$patternStr = $ErrorMatchPatten.Replace('|','/')
+			Set-Content -Value $msg -Path $LogStatusFilePath
+			Add-Content -Value "-------------------------------START----------------------------------" -Path $LogStatusFilePath
+			foreach ($line in $fileDiff) {
+				Add-Content -Value $line.InputObject -Path $LogStatusFilePath
+				if ($line.InputObject -imatch $ErrorMatchPatten) {
+					$errorCount += 1
+					if ($errorCount -eq 1) {
+						$warnMsg = "Following $patternStr messages were added in the logs during execution of test:"
+						Write-LogWarn $warnMsg
 					}
+					Write-LogWarn $line.InputObject
 				}
 			}
-			if (!$callTraceFound) {
-				Write-LogInfo "No kernel call traces found in the kernel log"
-			}
-
-			if ($status -imatch "Initial") {
-				if (!$global:detectedDistro) {
-					$detectedDistro = Detect-LinuxDistro -VIP $VM.PublicIP -SSHport $VM.SSHPort `
-						-testVMUser $vmUser -testVMPassword $vmPassword
-				}
-				Set-DistroSpecificVariables -detectedDistro $detectedDistro
-				$retValue = $true
-			}
-
-			if($status -imatch "Final") {
-				$KernelDiff = Compare-Object -ReferenceObject (Get-Content $FinalBootLog) `
-					-DifferenceObject (Get-Content $InitialBootLog)
-
-				# Removing final dmesg file from logs to reduce the size of logs.
-				# We can always see complete Final Logs as: Initial Kernel Logs + Difference in Kernel Logs
-				Remove-Item -Path $FinalBootLog -Force | Out-Null
-
-				if (!$KernelDiff) {
-					$msg = "Initial and Final Kernel Logs have same content"
-					Write-LogInfo $msg
-					Set-Content -Value $msg -Path $KernelLogStatus
-					$retValue = $true
-				} else {
-					$errorCount = 0
-					$msg = "Following lines were added in the kernel log during execution of test."
-					Set-Content -Value $msg -Path $KernelLogStatus
-					Add-Content -Value "-------------------------------START----------------------------------" -Path $KernelLogStatus
-					foreach ($line in $KernelDiff) {
-						Add-Content -Value $line.InputObject -Path $KernelLogStatus
-						if ( ($line.InputObject -imatch "fail") -or ($line.InputObject -imatch "error") `
-								-or ($line.InputObject -imatch "warning")) {
-							$errorCount += 1
-							if ($errorCount -eq 1) {
-								$warnMsg = "Following fail/error/warning messages were added in the kernel log during execution of test:"
-								Write-LogWarn $warnMsg
-							}
-							Write-LogWarn $line.InputObject
-						}
-					}
-					Add-Content -Value "--------------------------------EOF-----------------------------------" -Path $KernelLogStatus
-					if ($errorCount -gt 0) {
-						Write-LogWarn "Found $errorCount fail/error/warning messages in kernel logs during execution."
-						$retValue = $false
-					}
-					Write-LogInfo "$($VM.RoleName): $status Kernel logs collected and compared successfully"
-				}
-
-				if ($callTraceFound) {
-					Write-LogInfo "Preserving the Resource Group(s) $($VM.ResourceGroupName)"
-					Add-ResourceGroupTag -ResourceGroup $VM.ResourceGroupName -TagName $preserveKeyword -TagValue "yes"
-					Add-ResourceGroupTag -ResourceGroup $VM.ResourceGroupName -TagName "calltrace" -TagValue "yes"
-					Write-LogInfo "Setting tags : calltrace = yes; testName = $testName"
-					$hash = @{}
-					$hash.Add("calltrace","yes")
-					$hash.Add("testName","$testName")
-					$Null = Set-AzResourceGroup -Name $($VM.ResourceGroupName) -Tag $hash
-				}
+			Add-Content -Value "--------------------------------EOF-----------------------------------" -Path $LogStatusFilePath
+			if ($errorCount -gt 0) {
+				Write-LogWarn "Found $errorCount $patternStr messages in the logs during execution."
+				$retValue = $false
 			}
 		}
-	} catch {
-		Write-LogInfo $_
-		$retValue = $false
 	}
-
+	catch
+	{
+		$line = $_.InvocationInfo.ScriptLineNumber
+		$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD,".")
+		$ErrorMessage =  $_.Exception.Message
+		Write-LogErr "EXCEPTION: $ErrorMessage"
+		Write-LogErr "Calling function - $($MyInvocation.MyCommand)."
+		Write-LogErr "Source: Line $line in script $script_name."
+	}
 	return $retValue
 }
 
-Function Check-KernelLogs($allVMData, $vmUser, $vmPassword) {
-	try {
+
+Function Check-KernelLogs($allVMData, $vmUser, $vmPassword)
+{
+	try
+	{
 		$errorLines = @()
 		$errorLines += "Call Trace"
 		$errorLines += "rcu_sched self-detected stall on CPU"

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -161,7 +161,7 @@ function Collect-CustomLogFile {
 }
 
 Function Compare-OsLogs($InitialLogFilePath, $FinalLogFilePath, $LogStatusFilePath, $ErrorMatchPatten) {
-	$ret = $true
+	$retValue = $true
 	try {
 		$fileDiff = Compare-Object -ReferenceObject (Get-Content $InitialLogFilePath) `
 			-DifferenceObject (Get-Content $FinalLogFilePath)

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -252,6 +252,19 @@ Class JUnitReportGenerator
 	}
 }
 
+Class TestResult
+{
+	[string] $TestResult
+	[string] $TestSummary
+	[array] $TestResultData
+
+	TestResult() {
+		$TestResult = $null
+		$TestSummary = $null
+		$TestResultData = @()
+	}
+}
+
 Class TestSummary
 {
 	[string] $TextSummary

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -252,19 +252,6 @@ Class JUnitReportGenerator
 	}
 }
 
-Class TestResult
-{
-	[string] $TestResult
-	[string] $TestSummary
-	[array] $TestResultData
-
-	TestResult() {
-		$this.TestResult = $null
-		$this.TestSummary = $null
-		$this.TestResultData = @()
-	}
-}
-
 Class TestSummary
 {
 	[string] $TextSummary

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -259,9 +259,9 @@ Class TestResult
 	[array] $TestResultData
 
 	TestResult() {
-		$TestResult = $null
-		$TestSummary = $null
-		$TestResultData = @()
+		$this.TestResult = $null
+		$this.TestSummary = $null
+		$this.TestResultData = @()
 	}
 }
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -503,7 +503,7 @@ Class TestController
 			$isVmAlive = Is-VmAlive -AllVMDataObject $VMData -MaxRetryCount 10
 			if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True" ) {
 				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
-				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false -and $currentTestResult.TestResult -eq $global:ResultPass) {
+				if (($testParameters["FailForLogCheck"] -eq "True") -and ($ret -eq $false) -and ($currentTestResult.TestResult -eq $global:ResultPass)) {
 					$currentTestResult.TestResult = $global:ResultFail
 					Write-LogErr "Test $($CurrentTestData.TestName) fails for log check"
 					$currentTestResult.testSummary += New-ResultSummary -testResult "Test fails for log check"
@@ -769,7 +769,7 @@ Class TestController
 		$retValue = $true
 		try	{
 			if (!($status -imatch "Initial" -or $status -imatch "Final")) {
-				Write-LogInfo "Status value should be either final or initial"
+				Write-LogErr "Status value should be either final or initial"
 				return $false
 			}
 			foreach ($VM in $AllVMData) {
@@ -804,7 +804,7 @@ Class TestController
 					-command "dmesg > ./${currentBootLogFile}" | Out-Null
 				Copy-RemoteFiles -download -downloadFrom $VM.PublicIP -port $VM.SSHPort -files "./${currentBootLogFile}" `
 					-downloadTo $BootLogDir -username $global:user -password $global:password | Out-Null
-				Write-LogInfo "$($VM.RoleName): $status Kernel logs collected successfully to ${currentBootLogFile} file."
+				Write-LogInfo "$($VM.RoleName): $status kernel log, ${currentBootLogFile}, collected successfully."
 
 				Write-LogInfo "Checking for call traces in kernel logs.."
 				$KernelLogs = Get-Content $currentBootLog

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -488,7 +488,7 @@ Class TestController
 		}
 
 		# Sometimes test scripts may return an array, the last one is the result object
-		if ($currentTestResult.GetType().Name -match "[]") {
+		if ($currentTestResult.count) {
 			$currentTestResult = $currentTestResult[-1]
 		}
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -503,7 +503,7 @@ Class TestController
 			$isVmAlive = Is-VmAlive -AllVMDataObject $VMData -MaxRetryCount 10
 			if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True" ) {
 				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
-				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false) {
+				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false -and $currentTestResult.TestResult -eq $global:ResultPass) {
 					$currentTestResult.TestResult = $global:ResultFail
 					Write-LogErr "Test $($CurrentTestData.TestName) fails log check"
 				}

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -488,7 +488,7 @@ Class TestController
 		}
 
 		# Sometimes test scripts may return an array, the last one is the result object
-		if ($currentTestResult.GetType().Name -ne "TestResult") {
+		if ($currentTestResult.GetType().Name -match "[]") {
 			$currentTestResult = $currentTestResult[-1]
 		}
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -435,7 +435,7 @@ Class TestController
 
 			if (!$global:IsWindowsImage) {
 				if (!$global:detectedDistro) {
-					$detectedDistro = Detect-LinuxDistro -VIP $VM.PublicIP -SSHport $VM.SSHPort `
+					$detectedDistro = Detect-LinuxDistro -VIP $VmData[0].PublicIP -SSHport $VmData[0].SSHPort `
 						-testVMUser $global:user -testVMPassword $global:password
 				}
 				Set-DistroSpecificVariables -detectedDistro $detectedDistro

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -505,7 +505,8 @@ Class TestController
 				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
 				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false -and $currentTestResult.TestResult -eq $global:ResultPass) {
 					$currentTestResult.TestResult = $global:ResultFail
-					Write-LogErr "Test $($CurrentTestData.TestName) fails log check"
+					Write-LogErr "Test $($CurrentTestData.TestName) fails for log check"
+					$currentTestResult.testSummary += New-ResultSummary -testResult "Test fails for log check"
 				}
 				$this.GetSystemBasicLogs($VmData, $global:user, $global:password, $CurrentTestData, $currentTestResult, $this.EnableTelemetry) | Out-Null
 			}

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -434,8 +434,14 @@ Class TestController
 			$this.TestProvider.RunSetup($VmData, $CurrentTestData, $testParameters, $ApplyCheckpoint)
 
 			if (!$global:IsWindowsImage) {
+				if (!$global:detectedDistro) {
+					$detectedDistro = Detect-LinuxDistro -VIP $VM.PublicIP -SSHport $VM.SSHPort `
+						-testVMUser $global:user -testVMPassword $global:password
+				}
+				Set-DistroSpecificVariables -detectedDistro $detectedDistro
+
 				Write-LogInfo "==> Check the target machine kernel log."
-				GetAndCheck-KernelLogs -allDeployedVMs $VmData -status "Initial" | Out-Null
+				$this.GetAndCompareOsLogs($VmData, "Initial")
 			}
 
 			# Upload test files to VMs
@@ -491,7 +497,10 @@ Class TestController
 			Write-LogInfo "==> Check if the test target machines are still running."
 			$isVmAlive = Is-VmAlive -AllVMDataObject $VMData -MaxRetryCount 10
 			if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True" ) {
-				GetAndCheck-KernelLogs -allDeployedVMs $VmData -status "Final" -EnableCodeCoverage $this.EnableCodeCoverage | Out-Null
+				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
+				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false) {
+					$currentTestResult.TestResult = $global:ResultFail
+				}
 				$this.GetSystemBasicLogs($VmData, $global:user, $global:password, $CurrentTestData, $currentTestResult, $this.EnableTelemetry) | Out-Null
 			}
 
@@ -747,5 +756,96 @@ Class TestController
 			Write-LogErr "Calling function - $($MyInvocation.MyCommand)."
 			Write-LogErr "Source: Line $line in script $script_name."
 		}
+	}
+
+	[bool] GetAndCompareOsLogs($AllVMData, $Status) {
+		$retValue = $true
+		try	{
+			if (!($status -imatch "Initial" -or $status -imatch "Final")) {
+				Write-LogInfo "Status value should be either final or initial"
+				return $false
+			}
+			foreach ($VM in $AllVMData) {
+				Write-LogInfo "Collecting $($VM.RoleName) VM Kernel $status Logs ..."
+
+				$bootLogDir = "$global:Logdir\$($VM.RoleName)"
+				mkdir $bootLogDir -Force | Out-Null
+
+				$currentBootLogFile = "${status}BootLogs.txt"
+				$currentBootLog = Join-Path $BootLogDir $currentBootLogFile
+
+				$initialBootLogFile = "InitialBootLogs.txt"
+				$initialBootLog = Join-Path $BootLogDir $initialBootLogFile
+
+				$kernelLogStatus = Join-Path $BootLogDir "KernelLogStatus.txt"
+
+				if ($this.EnableCodeCoverage -and ($status -imatch "Final")) {
+					Write-LogInfo "Collecting coverage debug files from VM $($VM.RoleName)"
+
+					$gcovCollected = Collect-GcovData -ip $VM.PublicIP -port $VM.SSHPort `
+						-username $global:user -password $global:password -logDir $global:LogDir
+
+					if ($gcovCollected) {
+						Write-LogInfo "GCOV data collected successfully"
+					} else {
+						Write-LogErr "Failed to collect GCOV data from VM: $($VM.RoleName)"
+					}
+				}
+
+				Run-LinuxCmd -ip $VM.PublicIP -port $VM.SSHPort -runAsSudo `
+					-username $global:user -password $global:password `
+					-command "dmesg > ./${currentBootLogFile}" | Out-Null
+				Copy-RemoteFiles -download -downloadFrom $VM.PublicIP -port $VM.SSHPort -files "./${currentBootLogFile}" `
+					-downloadTo $BootLogDir -username $global:user -password $global:password | Out-Null
+				Write-LogInfo "$($VM.RoleName): $status Kernel logs collected successfully to ${currentBootLogFile} file."
+
+				Write-LogInfo "Checking for call traces in kernel logs.."
+				$KernelLogs = Get-Content $currentBootLog
+				$callTraceFound  = $false
+				foreach ($line in $KernelLogs) {
+					if (( $line -imatch "Call Trace" ) -and ($line -inotmatch "initcall ")) {
+						Write-LogErr $line
+						$callTraceFound = $true
+					}
+					if ($callTraceFound) {
+						if ($line -imatch "\[<") {
+							Write-LogErr $line
+						}
+					}
+				}
+				if (!$callTraceFound) {
+					Write-LogInfo "No kernel call traces found in the kernel log"
+				}
+
+				if($status -imatch "Final") {
+					$ret = Compare-OsLogs -InitialLogFilePath $InitialBootLog -FinalLogFilePath $currentBootLog -LogStatusFilePath $KernelLogStatus `
+						-ErrorMatchPatten "fail|error|warning"
+
+					if ($ret -eq $false) {
+						$retValue = $false
+					}
+
+					# Removing final dmesg file from logs to reduce the size of logs.
+					# We can always see complete Final Logs as: Initial Kernel Logs + Difference in Kernel Logs
+					Remove-Item -Path $currentBootLog -Force | Out-Null
+
+					Write-LogInfo "$($VM.RoleName): $status Kernel logs collected and compared successfully"
+
+					if ($callTraceFound -and $global:TestPlatform -imatch "Azure") {
+						Write-LogInfo "Preserving the Resource Group(s) $($VM.ResourceGroupName). Setting tags : calltrace = yes"
+						Add-ResourceGroupTag -ResourceGroup $VM.ResourceGroupName -TagName "calltrace" -TagValue "yes"
+					}
+				}
+			}
+		} catch {
+			$line = $_.InvocationInfo.ScriptLineNumber
+			$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD,".")
+			$ErrorMessage =  $_.Exception.Message
+			Write-LogErr "EXCEPTION: $ErrorMessage"
+			Write-LogErr "Calling function - $($MyInvocation.MyCommand)."
+			Write-LogErr "Source: Line $line in script $script_name."
+		}
+
+		return $retValue
 	}
 }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -487,6 +487,11 @@ Class TestController
 			$currentTestResult.testSummary += Trim-ErrorLogMessage $errorMessage
 		}
 
+		# Sometimes test scripts may return an array, the last one is the result object
+		if ($currentTestResult.GetType().Name -ne "TestResult") {
+			$currentTestResult = $currentTestResult[-1]
+		}
+
 		# Upload results to database
 		Write-LogInfo "==> Upload test results to database."
 		if ($currentTestResult.TestResultData) {
@@ -500,6 +505,7 @@ Class TestController
 				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
 				if ($testParameters["FailForLogCheck"] -eq "True" -and $ret -eq $false) {
 					$currentTestResult.TestResult = $global:ResultFail
+					Write-LogErr "Test $($CurrentTestData.TestName) fails log check"
 				}
 				$this.GetSystemBasicLogs($VmData, $global:user, $global:password, $CurrentTestData, $currentTestResult, $this.EnableTelemetry) | Out-Null
 			}


### PR DESCRIPTION
1. For each case, the current test controller collects the dmesg before and after the case run, and compare the results. This PR changes the step to be platform specific, so that it can be overwritten by each platform.
2. enable FailForLogCheck TestParameter, if one case set FailForLogCheck to True, then it will fail if log check fails
3. Test pass on Azure