### PR TITLE
IMPI 2019 U6 refresh, Update dependencies, ofed driver in blob

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -69,8 +69,8 @@ function Main() {
 			# install required packages regardless VM types.
 			LogMsg "Starting RDMA setup for RHEL/CentOS"
 			# Due to redhat bug, 1787637, this workaround is required.
-			suppliment_pkg="dnf rpm"
-			install_package $suppliment_pkg
+			supplement_pkg="dnf rpm"
+			install_package $supplement_pkg
 			# required dependencies
 			req_pkg="kernel-devel-$(uname -r) valgrind-devel redhat-rpm-config rpm-build gcc gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel elfutils-devel libtool libnl3-devel java libstdc++.i686 gtk2 atk cairo tcl tk createrepo byacc.x86_64 net-tools kernel-rpm-macros tcsh"
 			install_package $req_pkg

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -140,8 +140,8 @@ function Run_IMB_MPI1() {
 				$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($mpi1_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			intel)
-				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params"
-				$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
+				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params"
+				$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_mpi1_path $extra_params > IMB-MPI1-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			mvapich)
 				LogMsg "$mpi_run_path -n $(($mpi1_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_mpi1_path $extra_params"
@@ -195,8 +195,8 @@ function Run_IMB_RMA() {
 				$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($rma_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			intel)
-				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params"
-				$mpi_run_path -hosts $master,$slaves -ppn $mpi1_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
+				LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params"
+				$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_rma_path $extra_params > IMB-RMA-AllNodes-output-Attempt-${attempt}.txt
 			;;
 			mvapich)
 				LogMsg "$mpi_run_path -n $(($rma_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_rma_path $extra_params"
@@ -250,8 +250,8 @@ function Run_IMB_NBC() {
 					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($nbc_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_nbc_path $extra_params > IMB-NBC-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
-					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $nbc_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params"
-					$mpi_run_path -hosts $master,$slaves -ppn $nbc_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params > IMB-NBC-AllNodes-output-Attempt-${attempt}.txt
+					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params"
+					$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_nbc_path $extra_params > IMB-NBC-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				mvapich)
 					LogMsg "$mpi_run_path -n $(($nbc_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_nbc_path $extra_params"
@@ -317,8 +317,8 @@ function Run_IMB_P2P() {
 					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($p2p_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
-					# LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
-					# $mpi_run_path -hosts $master,$slaves -ppn $p2p_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
+					# LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params"
+					# $mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_p2p_path $extra_params > IMB-P2P-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				mvapich)
 					LogMsg "$mpi_run_path -n $(($p2p_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_p2p_path $extra_params"
@@ -384,8 +384,8 @@ function Run_IMB_IO() {
 					$mpi_run_path --allow-run-as-root -x UCX_IB_PKEY=$UCX_IB_PKEY -n $(($io_ppn * $total_virtual_machines)) --H $master,$slaves $mpi_settings $imb_io_path $extra_params > IMB-IO-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				intel)
-					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $io_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params"
-					$mpi_run_path -hosts $master,$slaves -ppn $io_ppn -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params > IMB-IO-AllNodes-output-Attempt-${attempt}.txt
+					LogMsg "$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params"
+					$mpi_run_path -hosts $master,$slaves -ppn $(($VM_Size / $total_virtual_machines)) -n $(($VM_Size * $total_virtual_machines)) $mpi_settings $imb_io_path $extra_params > IMB-IO-AllNodes-output-Attempt-${attempt}.txt
 				;;
 				mvapich)
 					LogMsg "$mpi_run_path -n $(($io_ppn * $total_virtual_machines)) $master $slaves_array $mpi_settings $imb_io_path $extra_params"
@@ -496,9 +496,9 @@ function Main() {
 
 	# ############################################################################################################
 	# ib kernel modules verification
-	# mlx5_ib, rdma_cm, rdma_ucm, ib_ipoib shall be loaded in kernel
+	# mlx5_ib, rdma_cm, rdma_ucm, ib_ipoib, ib_umad shall be loaded in kernel
 	final_module_load_status=0
-	kernel_modules="mlx5_ib rdma_cm rdma_ucm ib_ipoib"
+	kernel_modules="mlx5_ib rdma_cm rdma_ucm ib_ipoib ib_umad"
 
 	for vm in $master $slaves_array; do
 	LogMsg "Checking kernel modules in $vm"
@@ -602,49 +602,72 @@ function Main() {
 	# ############################################################################################################
 	# Verify ibv_rc_pingpong, ibv_uc_pingpong and ibv_ud_pingpong and rping.
 	final_pingpong_state=0
+	found_ib0_interface=1
+
+	# Getting ib0 interface address and store in constants.sh
+	slaves_array=$(echo ${slaves} | tr ',' ' ')
+	for vm in $master $slaves_array; do
+		ib0=$(ssh root@${vm} ip addr show ib0 | awk -F ' *|:' '/inet /{print $3}' | cut -d / -f 1)
+		if [[ $? -eq 0 && $ib0 ]]; then
+			LogMsg "Successfully queried ib0 interface address, $ib0 from ${vm}."
+		else
+			LogErr "Failed to query ib0 interface address, $ib0 from ${vm}."
+			final_pingpong_state=$(($final_pingpong_state + 1))
+			found_ib0_interface=0
+		fi
+		LogMsg "Logging ib0_$vm value: $ib0"
+		vm_id=$(echo $vm | sed -r 's!/.*!!; s!.*\.!!')
+		echo ib0_$vm_id=$ib0 >> /root/constants.sh
+		export ib0_$vm_id=$ib0
+	done
 
 	# Define ibv_ pingpong commands in the array
 	declare -a ping_cmds=("ibv_rc_pingpong" "ibv_uc_pingpong" "ibv_ud_pingpong")
 
-	for ping_cmd in "${ping_cmds[@]}"; do
-		for vm1 in $master $slaves_array; do
-			for vm2 in $slaves_array $master; do
-				if [[ "$vm1" == "$vm2" ]]; then
-					# Skip self-ping test case
-					break
-				fi
-				# Define pingpong test log file name
-				log_file=IMB-"$ping_cmd"-output-$vm1-$vm2.txt
-				LogMsg "Run $ping_cmd from $vm2 to $vm1"
-				LogMsg "  Start $ping_cmd in server VM $vm1 first"
-				retries=0
-				while [ $retries -lt 3 ]; do
-					ssh root@${vm1} "$ping_cmd" &
-					sleep 1
-					LogMsg "  Start $ping_cmd in client VM $vm2"
-					ssh root@${vm2} "$ping_cmd $vm1 > /root/$log_file"
-					pingpong_state=$?
+	if [ $found_ib0_interface = 1 ]; then
+		for ping_cmd in "${ping_cmds[@]}"; do
+			for vm1 in $master $slaves_array; do
+				for vm2 in $slaves_array $master; do
+					if [[ "$vm1" == "$vm2" ]]; then
+						# Skip self-ping test case
+						break
+					fi
+					# Define pingpong test log file name
+					log_file=IMB-"$ping_cmd"-output-$vm1-$vm2.txt
+					LogMsg "Run $ping_cmd from $vm2 to $vm1"
+					LogMsg "  Start $ping_cmd in server VM $vm1 first"
+					retries=0
+					while [ $retries -lt 3 ]; do
+						ssh root@${vm1} "$ping_cmd" &
+						LogMsg "  $?"
+						sleep 1
+						vm1_id=ib0_$(echo $vm1 | sed -r 's!/.*!!; s!.*\.!!')
+						LogMsg "  Start $ping_cmd in client VM, $vm2 to ${!vm1_id}"
+						ssh root@${vm2} "$ping_cmd ${!vm1_id} > /root/$log_file"
+						pingpong_state=$?
+						LogMsg "  $pingpong_state"
 
-					sleep 1
-					scp root@${vm2}:/root/$log_file .
-					pingpong_result=$(cat $log_file | grep -i Mbit | cut -d ' ' -f7)
-					if [ $pingpong_state -eq 0 ] && [ $pingpong_result > 0 ]; then
-						LogMsg "$ping_cmd test execution successful"
-						LogMsg "$ping_cmd result $pingpong_result in $vm1-$vm2 - Succeeded."
-						retries=4
-					else
-						sleep 10
-						let retries=retries+1
+						sleep 1
+						scp root@${vm2}:/root/$log_file .
+						pingpong_result=$(cat $log_file | grep -i Mbit | cut -d ' ' -f7)
+						if [ $pingpong_state -eq 0 ] && [ $pingpong_result > 0 ]; then
+							LogMsg "$ping_cmd test execution successful"
+							LogMsg "$ping_cmd result $pingpong_result in $vm1-$vm2 - Succeeded."
+							retries=4
+						else
+							sleep 10
+							let retries=retries+1
+						fi
+					done
+					if [ $pingpong_state -ne 0 ] || (($(echo "$pingpong_result <= 0" | bc -l))); then
+						LogErr "$ping_cmd test execution failed"
+						LogErr "$ping_cmd result $pingpong_result in $vm1-$vm2 - Failed"
+						final_pingpong_state=$(($final_pingpong_state + 1))
 					fi
 				done
-				if [ $pingpong_state -ne 0 ] || (($(echo "$pingpong_result <= 0" | bc -l))); then
-					LogErr "$ping_cmd test execution failed"
-					LogErr "$ping_cmd result $pingpong_result in $vm1-$vm2 - Failed"
-					final_pingpong_state=$(($final_pingpong_state + 1))
-				fi
 			done
 		done
-	done
+	fi
 
 	if [ $final_pingpong_state -ne 0 ]; then
 		LogErr "ibv_ping_pong test failed in some VMs. Aborting further tests."

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -115,7 +115,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INSTALL_OFED</ReplaceThis>
-		<ReplaceWith>yes</ReplaceWith>
+		<ReplaceWith>no</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INSTALL_OFED_FROM_EXTENSION</ReplaceThis>
@@ -147,7 +147,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_IB</ReplaceThis>
-		<ReplaceWith>-env I_MPI_FABRICS ofa -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env SECS_PER_SAMPLE=600</ReplaceWith>
+		<ReplaceWith>-env I_MPI_FABRICS ofi -env SECS_PER_SAMPLE=600</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_MPI_SETTINGS_TCP</ReplaceThis>
@@ -274,7 +274,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_NBC_TESTNAMES</ReplaceThis>
-		<ReplaceWith>allreduce</ReplaceWith>
+		<ReplaceWith></ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_NBC_TESTNAMES</ReplaceThis>
@@ -549,7 +549,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>MLX_OFED_PARTIAL_LINK</ReplaceThis>
-		<ReplaceWith>http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel</ReplaceWith>
+		<ReplaceWith>https://partnerpipelineshare.blob.core.windows.net/ofed/MLNX_OFED_LINUX-4.7-3.2.9.0-</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>HPCX_PARTIAL_LINK_OFED</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -50,6 +50,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_INTEL_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_INTEL_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -90,6 +92,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>1</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_OPEN_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_OPEN_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -129,6 +133,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_OPEN_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_OPEN_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -244,6 +250,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_IBM_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_IBM_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -283,6 +291,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_IBM_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_IBM_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -323,6 +333,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_MVAPICH_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_MVAPICH_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>
@@ -362,6 +374,8 @@
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
+			<param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+			<param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
 			<param>num_reboot="INFINIBAND_MVAPICH_TOTAL_REBOOT_COUNT"</param>
 			<param>mpi_settings="INFINIBAND_MVAPICH_MPI_SETTINGS_IB"</param>
 			<param>ib_nic="INFINIBAND_IB_NIC"</param>


### PR DESCRIPTION
Changed ofed driver location and its installation
- Switched to blob access for reliable access.
- Relocated the code out of case-statement
- MLX ofed driver name convention of SLES 15 SP1
- Removed 3 dependencies for ofed driver installation, librdmacm1 ibverbs-providers libibverbs-dec

Added the work around for redhat bug 1787637
- update dnf and rpm before rpm-build package installation

Added ib0 interface address to the constants.sh file
- Gave ib0 interface address in ibv_pingpong argument
- ib0 interface was not available before VM restart with its configuration.Move the code to TestRDMA
- Prevented the infinite loop if ib0 is not showing up or null

Added ib_umad kernel module in module verification lines

Updated missing params in other test definitions.

Set the default OFED driver installation to 'no'

IMPI param changes
- IMPI moved to libfabric starting from 2019 onwards (hence the change ofa to ofi). The default provider is verbs (FI_PROVIDER=verbs) on IB
- UCX_TLS=rc,sm,self is no-op since it is not using mlx provider (actually UCX)
- Removed the NBC param
- ppn rank update for Intel MPI
- No need DAPL Provider info
- Added FI_PROVIDER and UCX parameters