### PR TITLE
Fix DYNAMIC-MEMORY-VERIFY-UDEV

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -379,7 +379,7 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
 
             $Out = New-VHD -ParentPath $parentOsVHDPath -Path $CurrentVMOsVHDPath -ComputerName $HyperVHost
             if ($Out) {
-                Write-LogInfo "Prerequiste: Prepare OS Disk $CurrentVMOsVHDPath - Succeeded."
+                Write-LogInfo "Prerequisite: Prepare OS Disk $CurrentVMOsVHDPath - Succeeded."
                 Write-LogInfo "New-VM -Name $CurrentVMName -MemoryStartupBytes $CurrentVMMemory -BootDevice VHD -VHDPath $CurrentVMOsVHDPath -Generation $VMGeneration -Switch $($VMSwitches.Name) -ComputerName $HyperVHost"
                 $NewVM = New-VM -Name $CurrentVMName -MemoryStartupBytes $CurrentVMMemory -BootDevice VHD `
                     -VHDPath $CurrentVMOsVHDPath -Generation $VMGeneration -Switch $($VMSwitches.Name) -ComputerName $HyperVHost
@@ -423,7 +423,7 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
                     $ErrorCount += 1
                 }
             } else {
-                Write-LogInfo "Prerequiste: Prepare OS Disk $CurrentVMOsVHDPath - Failed."
+                Write-LogInfo "Prerequisite: Prepare OS Disk $CurrentVMOsVHDPath - Failed."
                 $ErrorCount += 1
             }
             if ($SetupTypeData.ClusteredVM) {

--- a/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
+++ b/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
@@ -6,13 +6,13 @@
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
-    echo "TestAborted" >state.txt
+    echo "TestAborted" > state.txt
     exit 2
 }
 
 # Source constants file and initialize most common variables
 UtilsInit
-
+items=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
 #######################################################################
 #
 # Main script body
@@ -21,8 +21,8 @@ UtilsInit
 # Create the state.txt file so ICA knows we are running
 
 # Cleanup any old summary.log files
-if [ -e ~/summary.log ]; then
-    rm -rf ~/summary.log
+if [ -e summary.log ]; then
+    rm -rf summary.log
 fi
 
 # Search in /etc/udev and /lib/udev folders

--- a/Testscripts/Windows/DM-CONFIGURE-MEMORY.ps1
+++ b/Testscripts/Windows/DM-CONFIGURE-MEMORY.ps1
@@ -54,8 +54,8 @@ param([String] $TestParams,
 
 function Main {
     param (
-         $TestParams, $AllVmData
-	  )
+        $TestParams, $AllVmData
+    )
     $resultArr = @()
     $currentTestResult = Create-TestResultObject
     try {
@@ -67,13 +67,13 @@ function Main {
         # Check input arguments
         #
         if (-not $VMName) {
-           throw "INFO: VM name is null. "
+            throw "INFO: VM name is null. "
         }
         if (-not $HvServer) {
             throw "Error: HvServer is null"
         }
         if (-not $TestParams) {
-          throw "Error: TestParams is null"
+            throw "Error: TestParams is null"
         }
         $vm_mem = (Get-VMMemory $VMName -ComputerName $HvServer).Startup
         Write-LogInfo "VM Memory $vm_mem"
@@ -109,18 +109,18 @@ function Main {
 
         $dmMemWeight = [Convert]::ToInt32($TestParams.memWeight)
         if (($dmMemWeight -lt 0) -or ($dmmemWeight -gt 100)) {
-           throw "Error: Memory weight needs to be between 0 and 100."
+            throw "Error: Memory weight needs to be between 0 and 100."
         }
         Write-LogInfo "dmmemWeight $dmMemWeight"
 
         if ($TestParams.bootLargeMem -ilike "yes") {
-           $bootLargeMem = $true
+            $bootLargeMem = $true
         }
         Write-LogInfo "BootLargeMemory: $bootLargeMem"
 
         $dmStaticMem = Convert-ToMemSize $TestParams.staticMem $HvServer
         if ($dmStaticMem -le 0) {
-           Write-LogWarn "Unable to convert staticMem to int64."
+            Write-LogWarn "Unable to convert staticMem to int64."
         }
         # check if we have all variables set
         if ($VMName -and ($tpEnabled -eq $false -or $tpEnabled -eq $true) -and $dmStartupMem -and ([int64]$dmMemWeight -ge [int64]0)) {
@@ -136,15 +136,15 @@ function Main {
                 # wait for VM to finish shutting down
                 Wait-ForHyperVVMShutdown $HvServer $VMName
             }
-	        if ($bootLargeMem) {
+            if ($bootLargeMem) {
                 $OSInfo = Get-CIMInstance Win32_OperatingSystem -ComputerName $HvServer
-		        $freeMem = $OSInfo.FreePhysicalMemory * 1KB
-		        if ($dmStartupMem -le $freeMem) {
-			        Set-VMMemory -VMName $VMName -ComputerName $HvServer -DynamicMemoryEnabled $false -StartupBytes $dmStartupMem
-		        } else {
-			        throw "Error: Insufficient memory to run test. Skipping test."
-		        }
-	        } elseif ($tpEnabled) {
+                $freeMem = $OSInfo.FreePhysicalMemory * 1KB
+                if ($dmStartupMem -le $freeMem) {
+                    Set-VMMemory -VMName $VMName -ComputerName $HvServer -DynamicMemoryEnabled $false -StartupBytes $dmStartupMem
+                } else {
+                    throw "Error: Insufficient memory to run test. Skipping test."
+                }
+            } elseif ($tpEnabled) {
                 if ($maxMem_xmlValue -eq $startupMem_xmlValue) {
                     $dmStartupMem = $dmMaxMem
                 }


### PR DESCRIPTION
Miss this https://github.com/LIS/lis-test/blob/master/WS2012R2/lisa/remote-scripts/ica/DM_HotAdd_Verify_udev.sh#L28 when move the case before, though the case will pass, but we didn't test it in real meaning, it means it will always pass.

Test results -
```
[LISAv2 Test Results Summary]
Test Run On           : 01/16/2020 09:28:49
VHD Under Test        : ubuntu_18.04.1_gen1_gen2.vhdx
Initial Kernel Version: 4.15.0-38-generic
Final Kernel Version  : 4.15.0-38-generic
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC_MEMORY       DYNAMIC-MEMORY-VERIFY-UDEV                                                        PASS                 1.37 

[LISAv2 Test Results Summary]
Test Run On           : 01/16/2020 09:19:21
VHD Under Test        : CentOS_7.5.vhdx
Initial Kernel Version: 3.10.0-862.el7.x86_64
Final Kernel Version  : 3.10.0-862.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC_MEMORY       DYNAMIC-MEMORY-VERIFY-UDEV                                                        PASS                 1.32 
```