### PR TITLE
Fixed OMPI for SUSE images

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -52,6 +52,17 @@ function Verify_Result {
 	fi
 }
 
+function Upgrade_waagent {
+	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
+	wget https://github.com/Azure/WALinuxAgent/archive/v2.2.45.tar.gz
+	tar xvzf v2.2.45.tar.gz
+	cd WALinuxAgent-2.2.45
+	python3 setup.py install --force
+	service waagent restart
+	# Later, VM reboot completes the service upgrade
+	cd ..
+}
+
 function Main() {
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
@@ -64,6 +75,8 @@ function Main() {
 	LogMsg "$?: Set memlock values to unlimited for both soft and hard"
 	hpcx_ver=""
 	source /etc/os-release
+	# Place the temporary solution for waagent 2.2.45 upgrade.
+	Upgrade_waagent
 	case $DISTRO in
 		redhat_7|centos_7|redhat_8|centos_8)
 			# install required packages regardless VM types.

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -56,7 +56,7 @@ function Upgrade_waagent {
 	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
 	LogMsg "Starting waagent upgrade"
 	ln -s /usr/bin/python3 /usr/bin/python
-	if [ $DISTRO == suse* || $DISTRO == sles* ]; then
+	if [[ $DISTRO == suse* || $DISTRO == sles* ]]; then
 		install_package net-tools-deprecated
 	else
 		install_package net-tools
@@ -64,6 +64,8 @@ function Upgrade_waagent {
 	wget https://github.com/Azure/WALinuxAgent/archive/v2.2.45.tar.gz
 	tar xvzf v2.2.45.tar.gz
 	cd WALinuxAgent-2.2.45
+	sed -i -e 's/# OS.EnableRDMA=y/OS.EnableRDMA=y/g' /root/WALinuxAgent-2.2.45/config/waagent.conf
+	sed -i -e 's/# AutoUpdate.Enabled=y/AutoUpdate.Enabled=y/g' /root/WALinuxAgent-2.2.45/config/waagent.conf
 	python3 setup.py install --force
 	LogMsg "$?: Completed the waagent upgrade"
 	LogMsg "Restart waagent service"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -52,6 +52,34 @@ function Verify_Result {
 	fi
 }
 
+function Upgrade_waagent {
+	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
+	LogMsg "Starting waagent upgrade"
+	ln -s /usr/bin/python3 /usr/bin/python
+	if [[ $DISTRO == suse_15 ]]; then
+		install_package net-tools-deprecated
+	else
+		install_package net-tools
+	fi
+	wget https://github.com/Azure/WALinuxAgent/archive/v2.2.45.tar.gz
+	tar xvzf v2.2.45.tar.gz
+	cd WALinuxAgent-2.2.45
+	sed -i -e 's/# OS.EnableRDMA=y/OS.EnableRDMA=y/g' /root/WALinuxAgent-2.2.45/config/waagent.conf
+	sed -i -e 's/# AutoUpdate.Enabled=y/AutoUpdate.Enabled=y/g' /root/WALinuxAgent-2.2.45/config/waagent.conf
+	python3 setup.py install --force
+	LogMsg "$?: Completed the waagent upgrade"
+	LogMsg "Restart waagent service"
+	if [[ $DISTRO == "ubuntu"* ]]; then
+		service walinuxagent restart
+	else
+		service waagent restart
+	fi
+	Verify_Result
+	# Later, VM reboot completes the service upgrade
+	cd ..
+	LogMsg "Ended waagent upgrade"
+}
+
 function Main() {
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
@@ -64,6 +92,8 @@ function Main() {
 	LogMsg "$?: Set memlock values to unlimited for both soft and hard"
 	hpcx_ver=""
 	source /etc/os-release
+	# Place the temporary solution for waagent 2.2.45 upgrade.
+	Upgrade_waagent
 	case $DISTRO in
 		redhat_7|centos_7|redhat_8|centos_8)
 			# install required packages regardless VM types.

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -84,7 +84,7 @@ function Main() {
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
 	# Install common packages
-	install_package "gcc git make zip"
+	install_package "gcc git make zip python3"
 	LogMsg "Installed the common required packages, gcc git make zip"
 	# Change memory limits
 	echo "* soft memlock unlimited" >> /etc/security/limits.conf

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -56,8 +56,7 @@ function Upgrade_waagent {
 	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
 	LogMsg "Starting waagent upgrade"
 	ln -s /usr/bin/python3 /usr/bin/python
-	source /etc/os-release
-	if [[ $DISTRO == suse* || $DISTRO == sles* && $VERSION_ID != 12.4 ]]; then
+	if [[ $DISTRO == suse_15 ]]; then
 		install_package net-tools-deprecated
 	else
 		install_package net-tools

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -54,13 +54,28 @@ function Verify_Result {
 
 function Upgrade_waagent {
 	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
+	LogMsg "Starting waagent upgrade"
+	ln -s /usr/bin/python3 /usr/bin/python
+	if [ $DISTRO == suse* || $DISTRO == sles* ]; then
+		install_package net-tools-deprecated
+	else
+		install_package net-tools
+	fi
 	wget https://github.com/Azure/WALinuxAgent/archive/v2.2.45.tar.gz
 	tar xvzf v2.2.45.tar.gz
 	cd WALinuxAgent-2.2.45
 	python3 setup.py install --force
-	service waagent restart
+	LogMsg "$?: Completed the waagent upgrade"
+	LogMsg "Restart waagent service"
+	if [[ $DISTRO == "ubuntu"* ]]; then
+		service walinuxagent restart
+	else
+		service waagent restart
+	fi
+	Verify_Result
 	# Later, VM reboot completes the service upgrade
 	cd ..
+	LogMsg "Ended waagent upgrade"
 }
 
 function Main() {

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -56,7 +56,8 @@ function Upgrade_waagent {
 	# This is only temporary solution, WILL BE REMOVED as soon as 2.2.45 release in each image.
 	LogMsg "Starting waagent upgrade"
 	ln -s /usr/bin/python3 /usr/bin/python
-	if [[ $DISTRO == suse* || $DISTRO == sles* ]]; then
+	source /etc/os-release
+	if [[ $DISTRO == suse* || $DISTRO == sles* && $VERSION_ID != 12.4 ]]; then
 		install_package net-tools-deprecated
 	else
 		install_package net-tools

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -433,7 +433,6 @@ function Main() {
 	else
 		service waagent restart
 	fi
-	Verify_Result
 	sleep 2
 
 	LogMsg "Starting $mpi_type MPI tests..."

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -427,6 +427,14 @@ function Run_IMB_IO() {
 }
 
 function Main() {
+	LogMsg "Restarting waagent for ib0 device loading"
+	if [[ $DISTRO == "ubuntu"* ]]; then
+		service walinuxagent restart
+	else
+		service waagent restart
+	fi
+	sleep 2
+
 	LogMsg "Starting $mpi_type MPI tests..."
 
 	# ############################################################################################################

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -427,6 +427,15 @@ function Run_IMB_IO() {
 }
 
 function Main() {
+	LogMsg "Restarting waagent for ib0 device loading"
+	if [[ $DISTRO == "ubuntu"* ]]; then
+		service walinuxagent restart
+	else
+		service waagent restart
+	fi
+	Verify_Result
+	sleep 2
+
 	LogMsg "Starting $mpi_type MPI tests..."
 
 	# ############################################################################################################

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -167,7 +167,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_OPEN_MPI_SETTINGS_IB</ReplaceThis>
-		<ReplaceWith>--mca btl self,vader,openib --mca btl_openib_cq_size 4096</ReplaceWith>
+		<ReplaceWith>--mca btl self,vader,openib --mca btl_openib_cq_size 4096 --mca btl_openib_allow_ib 1 --mca btl_openib_warn_no_device_params_found 0</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_HPCX_MPI_SETTINGS_IB</ReplaceThis>


### PR DESCRIPTION
New OMPI 4.0.2 requires below parameter.

  --mca btl_openib_allow_ib 1 --mca btl_openib_warn_no_device_params_found 0

waagent 2.2.45 is the only version for successful ib device initialization