### PR TITLE
Fix avoid interactive when install package.

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2473,7 +2473,7 @@ function install_lagscope () {
 
 		ubuntu|debian)
 			dpkg_configure
-			apt-get -y install libaio1 sysstat git bc make gcc cmake
+			install_package "libaio1 sysstat git bc make gcc cmake"
 			build_lagscope "${1}"
 			;;
 
@@ -2546,7 +2546,7 @@ function install_ntttcp () {
 
 		ubuntu|debian)
 			dpkg_configure
-			apt-get -y install wget libaio1 sysstat git bc make gcc dstat psmisc lshw cmake
+			install_package "wget libaio1 sysstat git bc make gcc dstat psmisc lshw cmake"
 			build_ntttcp "${1}"
 			build_lagscope "${2}"
 			;;


### PR DESCRIPTION
Using install_package to avoid that test hung when need human interaction during install package.

```
[LISAv2 Test Results Summary]
Test Run On           : 01/19/2020 03:39:42
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1066-azure
Final Kernel Version  : 4.15.0-1067-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:26

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               AZURE-NESTED-KVM-NTTTCP-DIFFERENT-L1-NAT                                          PASS                17.28 
```