### PR TITLE
Change data disk sku from Premium_LRS to Standard_LRS

### DIFF
--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -24,7 +24,7 @@ function Main {
             $allDiskNames += $diskName
             if ($storageProfile.OsDisk.ManagedDisk) {
                 # Add managed data disks
-                $storageType = 'Premium_LRS'
+                $storageType = $TestParams.DiskSku
                 $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeGB $diskSizeinGB
                 $dataDisk = New-AzDisk -DiskName $diskName -Disk $diskConfig -ResourceGroupName $AllVMData.ResourceGroupName
                 Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun $count | Out-Null

--- a/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
@@ -23,7 +23,7 @@ function Main {
             $diskName = "disk"+ $count.ToString()
             if ($storageProfile.OsDisk.ManagedDisk) {
                 # Add managed data disks
-                $storageType = 'Premium_LRS'
+                $storageType = $TestParams.DiskSku
                 $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeGB $diskSizeinGB
                 $dataDisk = New-AzDisk -DiskName $diskName -Disk $diskConfig -ResourceGroupName $AllVMData.ResourceGroupName
                 Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun $count | Out-Null

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -612,4 +612,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>LAGSCOPE_VERSION</ReplaceThis>
 		<ReplaceWith>v0.2.0</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>DATA_DISK_SKU</ReplaceThis>
+		<ReplaceWith>Premium_LRS</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests-Storage.xml
+++ b/XML/TestCases/FunctionalTests-Storage.xml
@@ -752,6 +752,7 @@
         <setupType>OneVM</setupType>
         <testParameters>
             <param>DiskSize=30</param>
+            <param>DiskSku=DATA_DISK_SKU</param>
         </testParameters>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
@@ -769,6 +770,7 @@
         <setupType>OneVM</setupType>
         <testParameters>
             <param>DiskSize=30</param>
+            <param>DiskSku=DATA_DISK_SKU</param>
         </testParameters>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

If overwrite VM size with premium unsupported sizes(like Standard_D1_v2) this case will be failed due to "[ERROR] Requested operation cannot be performed because the VM size Standard_D1_v2 does not support the storage account type Premium_LRS of disk 'disk1'."
So please consider to change it to Standard_LRS to support all VM sizes.
Thanks!