### PR TITLE
Update for MVAPICH MPI refresh

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -81,6 +81,11 @@ function Upgrade_waagent {
 }
 
 function Main() {
+	# another rhel 8.0 repo bug workaround, https://bugzilla.redhat.com/show_bug.cgi?id=1787637
+	if [ $DISTRO == 'redhat_8' ]; then
+		echo 8 > /etc/yum/vars/releasever
+		LogMsg "$?: Applied a mitigation to /etc/yum/vars/releasever"
+	fi
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
 	# Install common packages
@@ -98,11 +103,8 @@ function Main() {
 		redhat_7|centos_7|redhat_8|centos_8)
 			# install required packages regardless VM types.
 			LogMsg "Starting RDMA setup for RHEL/CentOS"
-			# Due to redhat bug, 1787637, this workaround is required.
-			supplement_pkg="dnf rpm"
-			install_package $supplement_pkg
 			# required dependencies
-			req_pkg="kernel-devel-$(uname -r) valgrind-devel redhat-rpm-config rpm-build gcc gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel elfutils-devel libtool libnl3-devel java libstdc++.i686 gtk2 atk cairo tcl tk createrepo byacc.x86_64 net-tools kernel-rpm-macros tcsh"
+			req_pkg="kernel-devel-$(uname -r) valgrind-devel redhat-rpm-config rpm-build gcc gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel elfutils-devel libtool libnl3-devel java libstdc++.i686 gtk2 atk cairo tcl tk createrepo byacc.x86_64 net-tools tcsh"
 			install_package $req_pkg
 			LogMsg "$?: Installed required packages $req_pkg"
 			# libibverbs-devel and libibmad-devel have broken dependencies on Centos 7.6
@@ -118,6 +120,9 @@ function Main() {
 					LogMsg "$?: Installed $req_pkg"
 				;;
 				redhat_8|centos_8)
+					# Due to redhat bug, 1787637, this workaround is required.
+					supplement_pkg="dnf rpm kernel-rpm-macros"
+					install_package $supplement_pkg
 					req_pkg="python3-devel python2-devel python2-setuptools"
 					install_package $req_pkg
 					LogMsg "$?: Installed $req_pkg"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -120,9 +120,6 @@ function Main() {
 					LogMsg "$?: Installed $req_pkg"
 				;;
 				redhat_8|centos_8)
-					# Due to redhat bug, 1787637, this workaround is required.
-					supplement_pkg="dnf rpm kernel-rpm-macros"
-					install_package $supplement_pkg
 					req_pkg="python3-devel python2-devel python2-setuptools"
 					install_package $req_pkg
 					LogMsg "$?: Installed $req_pkg"

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -568,7 +568,7 @@ function Main() {
 	# IF completed successfully, constants.sh has setup_completed=0
 	setup_state_cnt=0
 	for vm in $master $slaves_array; do
-		setup_result=$(ssh root@${vm} "cat /root/constants.sh | grep -i setup_completed")
+		setup_result=$(ssh root@${vm} "cat /root/constants.sh | grep -i setup_completed" | head -1)
 		setup_result=$(echo $setup_result | cut -d '=' -f 2)
 		if [ "$setup_result" == "0" ]; then
 			LogMsg "$vm RDMA setup - Succeeded; $setup_result"

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -278,7 +278,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_NBC_TESTNAMES</ReplaceThis>
-		<ReplaceWith>allreduce</ReplaceWith>
+		<ReplaceWith></ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<!-- 11/02/2019 - 'Iallgather' & 'Iallgatherv' not working - removing them for now -->
@@ -287,11 +287,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_HPCX_NBC_TESTNAMES</ReplaceThis>
-		<ReplaceWith>allreduce</ReplaceWith>
+		<ReplaceWith></ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_MVAPICH_NBC_TESTNAMES</ReplaceThis>
-		<ReplaceWith>allreduce</ReplaceWith>
+		<ReplaceWith></ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_NBC_TEST_COUNT</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -5,7 +5,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -46,7 +45,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -88,7 +86,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>1</Priority>
 		<TestParameters>
@@ -129,7 +126,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -165,13 +161,12 @@
 		<Area>INFINIBAND</Area>
 		<Tags>rdma</Tags>
 	</test>
-<!-- 	HPC-X MPI: Mellanox HPC-X links constantly changed, so can not support HPC-X. Leave the code, however. 
+<!-- 	HPC-X MPI: Mellanox HPC-X links constantly changed, so can not support HPC-X. Leave the code, however.
 	<test>
 		<testName>INFINIBAND-HPCX-MPI-2VM</testName>
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>1</Priority>
 		<TestParameters>
@@ -208,7 +203,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -246,7 +240,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -287,7 +280,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -329,7 +321,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>TwoVM1Dep</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
@@ -370,7 +361,6 @@
 		<testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
 		<setupType>RDMA32VMs</setupType>
 		<OverrideVMSize>Standard_HC44rs</OverrideVMSize>
-		<SubtestValues>SOME,TEXTS,NEEDS,TO,BE,PRESENT,HERE,FOR,PRINTING,TEST,SUMMARY</SubtestValues>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>


### PR DESCRIPTION
1. Removed NBC test case
  - No allreduce needed
2. For manual investigation, allow the multiple times execution.
3. Moved two required dependency inside rhel8 only case
  - kernel-rpm-macro and dnf turned out only available in rhel 8 repo.
4. Applied the bug's workaround
5. Removed SubtestValues tag