### PR TITLE
RDMA/IB test duration shortened

### DIFF
--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -118,7 +118,6 @@ function Run_IMB_Intranode() {
 
 function Run_IMB_MPI1() {
 	total_attempts=$(seq 1 1 $imb_mpi1_tests_iterations)
-	imb_mpi1_final_status=0
 	if [[ $imb_mpi1_tests == "all" ]]; then
 		extra_params=""
 	else
@@ -172,7 +171,6 @@ function Run_IMB_MPI1() {
 
 function Run_IMB_RMA() {
 	total_attempts=$(seq 1 1 $imb_rma_tests_iterations)
-	imb_rma_final_status=0
 	if [[ $imb_rma_tests == "all" ]]; then
 		extra_params=""
 	else
@@ -227,7 +225,6 @@ function Run_IMB_RMA() {
 
 function Run_IMB_NBC() {
 	total_attempts=$(seq 1 1 $imb_nbc_tests_iterations)
-	imb_nbc_final_status=0
 	if [[ $imb_nbc_tests == "all" ]]; then
 		extra_params=""
 	else
@@ -294,7 +291,6 @@ function Run_IMB_NBC() {
 
 function Run_IMB_P2P() {
 	total_attempts=$(seq 1 1 $imb_p2p_tests_iterations)
-	imb_p2p_final_status=0
 	if [[ $imb_p2p_tests == "all" ]]; then
 		extra_params=""
 	else
@@ -361,7 +357,6 @@ function Run_IMB_P2P() {
 
 function Run_IMB_IO() {
 	total_attempts=$(seq 1 1 $imb_io_tests_iterations)
-	imb_io_final_status=0
 	if [[ $imb_io_tests == "all" ]]; then
 		extra_params=""
 	else
@@ -739,18 +734,20 @@ function Main() {
 	# Run all benchmarks
 	Run_IMB_Intranode
 	Run_IMB_MPI1
-	Run_IMB_RMA
-	Run_IMB_NBC
-	# Sometimes IMB-P2P and IMB-IO aren't available, skip them if it's the case
-	if [ ! -z "$imb_p2p_path" ]; then
-		Run_IMB_P2P
-	else
-		LogMsg "INFINIBAND_VERIFICATION_SKIPPED_P2P_ALLNODES"
-	fi
-	if [ ! -z "$imb_io_path" ]; then
-		Run_IMB_IO
-	else
-		LogMsg "INFINIBAND_VERIFICATION_SKIPPED_IO_ALLNODES"
+	if [[ $quicktestonly == "no" ]]; then
+		Run_IMB_RMA
+		Run_IMB_NBC
+		# Sometimes IMB-P2P and IMB-IO aren't available, skip them if it's the case
+		if [ ! -z "$imb_p2p_path" ]; then
+			Run_IMB_P2P
+		else
+			LogMsg "INFINIBAND_VERIFICATION_SKIPPED_P2P_ALLNODES"
+		fi
+		if [ ! -z "$imb_io_path" ]; then
+			Run_IMB_IO
+		else
+			LogMsg "INFINIBAND_VERIFICATION_SKIPPED_IO_ALLNODES"
+		fi
 	fi
 
 	# Get all results and finish the test

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -148,6 +148,9 @@ function Main {
 					$installOFEDFromExtension = $false
 				}
 			}
+			if ($TestParam -imatch "quicktest_only") {
+				$QuickTestOnly = [string]($TestParam.Replace("quicktest_only=", "").Trim('"'))
+			}
 		}
 		Add-Content -Value "master=`"$($ServerVMData.InternalIP)`"" -Path $constantsFile
 		Write-LogInfo "master=$($ServerVMData.InternalIP) added to constants.sh"
@@ -155,6 +158,8 @@ function Main {
 		Write-LogInfo "slaves=$SlaveInternalIPs added to constants.sh"
 		Add-Content -Value "VM_Size=`"$VM_Size`"" -Path $constantsFile
 		Write-LogInfo "VM_Size=$VM_Size added to constants.sh"
+		Add-Content -Value "quicktestonly=`"$QuickTestOnly`"" -Path $constantsFile
+		Write-LogInfo "quicktestonly=$QuickTestOnly added to constants.sh"
 
 		Write-LogInfo "constants.sh created successfully..."
 		#endregion
@@ -397,7 +402,7 @@ function Main {
 					$SkippedLogs = Select-String -Path $logFileName -Pattern $patternSkipped
 					if ($SucessLogs.Count -eq 1) {
 						$currentResult = $resultPass
-					} elseif ($SkippedLogs.Count -eq 1) {
+					} elseif (($SkippedLogs.Count -eq 1) -or ($QuickTestOnly -eq "yes")) {
 						$currentResult = "SKIPPED"
 					} else {
 						$currentResult = $resultFail
@@ -419,7 +424,7 @@ function Main {
 					$SkippedLogs = Select-String -Path $logFileName -Pattern $patternSkipped
 					if ($SucessLogs.Count -eq 1) {
 						$currentResult = $resultPass
-					} elseif ($SkippedLogs.Count -eq 1) {
+					} elseif (($SkippedLogs.Count -eq 1) -or ($QuickTestOnly -eq "yes")) {
 						$currentResult = "SKIPPED"
 					} else {
 						$currentResult = $resultFail
@@ -439,6 +444,8 @@ function Main {
 					$SucessLogs = Select-String -Path $logFileName -Pattern $pattern
 					if ($SucessLogs.Count -eq 1) {
 						$currentResult = $resultPass
+					} elseif ($QuickTestOnly -eq "yes") {
+						$currentResult = "SKIPPED"
 					} else {
 						$currentResult = $resultFail
 					}
@@ -457,6 +464,8 @@ function Main {
 					$SucessLogs = Select-String -Path $logFileName -Pattern $pattern
 					if ($SucessLogs.Count -eq 1) {
 						$currentResult = $resultPass
+					} elseif ($QuickTestOnly -eq "yes") {
+						$currentResult = "SKIPPED"
 					} else {
 						$currentResult = $resultFail
 					}

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -612,4 +612,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>LAGSCOPE_VERSION</ReplaceThis>
 		<ReplaceWith>v0.2.0</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>QUICKTEST_ONLY</ReplaceThis>
+		<ReplaceWith>no</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -34,6 +34,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -74,6 +75,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -115,6 +117,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -155,6 +158,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -192,6 +196,7 @@
 			<param>hpcx_mpi_inbox=HPCX_PARTIAL_LINK_INBOX</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -228,6 +233,7 @@
 			<param>hpcx_mpi_inbox=HPCX_PARTIAL_LINK_INBOX</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -269,6 +275,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -309,6 +316,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -350,6 +358,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
@@ -390,6 +399,7 @@
 			<param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
 			<param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
 			<param>walaagent_repo=WALAAgent_REPO</param>
+			<param>quicktest_only=QUICKTEST_ONLY</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>


### PR DESCRIPTION
RDMA/IB tests took sometimes 12 ~ 17 hours due to driver or IO/P2P test status. It won't be a part of regression test or new kernel pipeline tests. Put P2P, NBC, RMA, IO in optional by controlling the test parameter QUICKTEST_ONLY=yes.

Added new param for quick test only mode
Applied the condition for the RMA, NBC, IO and P2P
Removed the duplicated definition
Set to Skip if QuickTestOnly == "yes"

<Test Results>
[LISAv2 Test Results Summary]
Test Run On           : 01/23/2020 01:06:20
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size      : Standard_HC44rs
Initial Kernel Version: 5.0.0-1028-azure
Final Kernel Version  : 5.0.0-1028-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:50

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                 44.4 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : SKIPPED 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-NBC : SKIPPED 


Logs can be found at C:\LISAv2\EF61\TestResults\2020-23-01-01-06-15-1024

[LISAv2 Test Results Summary]
Test Run On           : 01/23/2020 00:14:28
ARM Image Under Test  : RedHat : RHEL : 7.7 : latest
Override VM size      : Standard_HC44rs
Initial Kernel Version: 3.10.0-1062.el7.x86_64
Final Kernel Version  : 3.10.0-1062.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS                 16.6 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-IO : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-RMA : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : SKIPPED 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-IO : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-RMA : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-NBC : SKIPPED 


Logs can be found at C:\LISAv2\LU66\TestResults\2020-23-01-00-14-23-8006


[LISAv2 Test Results Summary]
Test Run On           : 01/23/2020 00:14:25
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size      : Standard_HC44rs
Initial Kernel Version: 5.0.0-1028-azure
Final Kernel Version  : 5.0.0-1028-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:51

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-MVAPICH-MPI-2VM                                                        PASS                42.99 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-IO : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-RMA : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : SKIPPED 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-IO : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-RMA : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-NBC : SKIPPED 


Logs can be found at C:\LISAv2\LZ35-20200123001419\TestResults\2020-23-01-00-14-21-3897


[LISAv2 Test Results Summary]
Test Run On           : 01/23/2020 01:06:20
ARM Image Under Test  : RedHat : RHEL : 7.7 : latest
Override VM size      : Standard_HC44rs
Initial Kernel Version: 3.10.0-1062.el7.x86_64
Final Kernel Version  : 3.10.0-1062.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                15.71 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : SKIPPED 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : SKIPPED 
	InfiniBand-Verification-2-Reboot : IMB-NBC : SKIPPED 


Logs can be found at C:\LISAv2\ME75-20200123010615\TestResults\2020-23-01-01-06-16-9245