### PR TITLE
Correct data disk lun number

### DIFF
--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -27,7 +27,7 @@ function Main {
                 $storageType = 'Premium_LRS'
                 $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeGB $diskSizeinGB
                 $dataDisk = New-AzDisk -DiskName $diskName -Disk $diskConfig -ResourceGroupName $AllVMData.ResourceGroupName
-                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun $count | Out-Null
+                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun ($count-1) | Out-Null
             } else {
                 # Add unmanaged data disks
                 $osVhdStorageAccountName = $storageProfile.OsDisk.Vhd.Uri.Split(".").split("/")[2]
@@ -40,7 +40,7 @@ function Main {
                     continue
                 }
                 $allUnmanagedDataDisks += $dataDiskVhdUri.Split('/')[-1]
-                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -VhdUri $dataDiskVhdUri -Caching None -DiskSizeInGB $diskSizeinGB -Lun $count -CreateOption Empty | Out-Null
+                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -VhdUri $dataDiskVhdUri -Caching None -DiskSizeInGB $diskSizeinGB -Lun ($count-1) -CreateOption Empty | Out-Null
             }
             Write-LogInfo "$count - Successfully create an empty data disks of size $diskSizeinGB GB"
         }

--- a/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
@@ -26,7 +26,7 @@ function Main {
                 $storageType = 'Premium_LRS'
                 $diskConfig = New-AzDiskConfig -SkuName $storageType -Location $AllVMData.Location -CreateOption Empty -DiskSizeGB $diskSizeinGB
                 $dataDisk = New-AzDisk -DiskName $diskName -Disk $diskConfig -ResourceGroupName $AllVMData.ResourceGroupName
-                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun $count | Out-Null
+                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -CreateOption Attach -ManagedDiskId $dataDisk.Id -Lun ($count-1) | Out-Null
             } else {
                 # Add unmanaged data disks
                 $osVhdStorageAccountName = $storageProfile.OsDisk.Vhd.Uri.Split(".").split("/")[2]
@@ -38,7 +38,7 @@ function Main {
                     $count -= 1
                     continue
                 }
-                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -VhdUri $dataDiskVhdUri -Caching None -DiskSizeInGB $diskSizeinGB -Lun $count -CreateOption Empty | Out-Null
+                Add-AzVMDataDisk -VM $virtualMachine -Name $diskName -VhdUri $dataDiskVhdUri -Caching None -DiskSizeInGB $diskSizeinGB -Lun ($count-1) -CreateOption Empty | Out-Null
             }
             $updateVM1 = Update-AzVM -VM $virtualMachine -ResourceGroupName $AllVMData.ResourceGroupName
             if ($updateVM1.IsSuccessStatusCode) {


### PR DESCRIPTION
When overwrite with 64 disks VM size(e.g. GS5), the case STORAGE-HOT-ADD-DISK-PARALLEL hits error:
```
01/23/2020 04:46:25 : [INFO ] 63 - Successfully create an empty data disks of size 30 GB
01/23/2020 04:46:39 : [INFO ] 64 - Successfully create an empty data disks of size 30 GB
01/23/2020 04:46:39 : [INFO ] Number of data disks added to the VM 64
01/23/2020 04:46:45 : [ERROR] The value '64' of parameter 'dataDisk.lun' is out of range. Value '64' must be between '0' and '63' inclusive.
ErrorCode: InvalidParameter
ErrorMessage: The value '64' of parameter 'dataDisk.lun' is out of range. Value '64' must be between '0' and '63' inclusive.
ErrorTarget: dataDisk.lun
StatusCode: 400
ReasonPhrase: Bad Request
OperationID : 1595d494-f450-4ba5-b94c-812088a1e54a at line: 48 
```
The data disk lun number should start with 0 and not bigger than 63.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>