### PR TITLE
Update Hyper-V test cases.

### DIFF
--- a/Testscripts/Linux/STOR_VHDXResize_PartitionDisk.sh
+++ b/Testscripts/Linux/STOR_VHDXResize_PartitionDisk.sh
@@ -19,7 +19,7 @@
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
-    echo "TestAborted" >state.txt
+    echo "TestAborted" > state.txt
     exit 1
 }
 

--- a/Testscripts/Windows/AddVhdxHardDisk.ps1
+++ b/Testscripts/Windows/AddVhdxHardDisk.ps1
@@ -30,10 +30,10 @@ $global:MinDiskSize = 1GB
 $global:DefaultDynamicSize = 127GB
 $SCSICount = 0
 $IDECount = 0
-$diskCount=$null
-$lun=$null
-$vmGeneration=$null
-$clusterVm=$null
+$diskCount = $null
+$lun = $null
+$vmGeneration = $null
+$clusterVm = $null
 
 ############################################################################
 #
@@ -83,7 +83,7 @@ function Create-HardDrive( [string] $vmName, [string] $server, [System.Boolean] 
     $drive = Get-VMHardDiskDrive -VMName $vmName -ControllerNumber $controllerID -ControllerLocation $Lun `
                 -ControllerType $controllerType -ComputerName $server
     if ($drive) {
-        if ( $controllerID -eq 0 -and $Lun -eq 0 ) {
+        if ($controllerID -eq 0 -and $Lun -eq 0) {
             Write-LogErr "Drive $controllerType $controllerID $Lun already exists"
             return $retVal
         } else {
@@ -125,24 +125,19 @@ function Create-HardDrive( [string] $vmName, [string] $server, [System.Boolean] 
 
     $fileInfo = Get-RemoteFileInfo -filename $vhdName -server $server
     if (-not $fileInfo) {
-      $nv = $null
-      switch ($vhdType)
-      {
-          "Dynamic"
-              {
-                  $nv = New-Vhd -Path $vhdName -size $global:MinDiskSize -Dynamic -LogicalSectorSizeBytes ([int] $sectorSize) -ComputerName $server
-              }
-          "Fixed"
-              {
-                  $nv = New-Vhd -Path $vhdName -size $global:MinDiskSize -Fixed -LogicalSectorSizeBytes ([int] $sectorSize) -ComputerName $server
-              }
-
-          default
-              {
+        $nv = $null
+        switch ($vhdType) {
+            "Dynamic" {
+                $nv = New-Vhd -Path $vhdName -size $global:MinDiskSize -Dynamic -LogicalSectorSizeBytes ([int] $sectorSize) -ComputerName $server
+            }
+            "Fixed" {
+                $nv = New-Vhd -Path $vhdName -size $global:MinDiskSize -Fixed -LogicalSectorSizeBytes ([int] $sectorSize) -ComputerName $server
+            }
+            default {
                 Write-LogErr "Unknown VHD type ${vhdType}"
-                  return $False
-              }
-       }
+                return $False
+            }
+        }
         if ($null -eq $nv) {
             Write-LogErr "New-VHD failed to create the new .vhd file: $($vhdName)"
             return $False
@@ -151,15 +146,13 @@ function Create-HardDrive( [string] $vmName, [string] $server, [System.Boolean] 
 
     $error.Clear()
     Add-VMHardDiskDrive -VMName $vmName -Path $vhdName -ControllerNumber $controllerID `
-     -ControllerLocation $Lun -ControllerType $controllerType -ComputerName $server
+        -ControllerLocation $Lun -ControllerType $controllerType -ComputerName $server
     if ($error.Count -gt 0) {
         Write-LogErr "Add-VMHardDiskDrive failed to add drive on ${controllerType} ${controllerID} ${Lun}s"
         $exception = $error[0].Exception.Message
         Write-LogErr "$exception"
         return $retVal
     }
-
-    "Success"
     $retVal = $True
     return $retVal
 }
@@ -201,17 +194,15 @@ function Main {
         $var = $fields[0].Trim()
         if ($var -match "SCSI_") {
             $var = "SCSI"
-        }
-        elseif ($var -match "IDE_") {
+        } elseif ($var -match "IDE_") {
             $var = "IDE"
         }
-        switch ($var)
-        {
-        "rootDIR"   { $rootDir = $fields[1].Trim() }
-        "diskCount"   { $diskCount = $fields[1].Trim() }
-        "SCSI"  { $SCSICount = $SCSICount +1 }
-        "IDE"  { $IDECount = $IDECount +1 }
-        default     {}  # unknown param - just ignore it
+        switch ($var) {
+            "rootDIR" { $rootDir = $fields[1].Trim() }
+            "diskCount" { $diskCount = $fields[1].Trim() }
+            "SCSI" { $SCSICount = $SCSICount +1 }
+            "IDE" { $IDECount = $IDECount +1 }
+            default {}  # unknown param - just ignore it
         }
     }
 
@@ -236,8 +227,7 @@ function Main {
         }
     }
 
-    foreach ($p in $params)
-    {
+    foreach ($p in $params) {
         if ($p.Trim().Length -eq 0) {
             continue
         }
@@ -318,16 +308,14 @@ function Main {
                 $endLun = $diskCount-2
             }
         } else {
-        $startLun = $lun
-        $endLun = $lun
+            $startLun = $lun
+            $endLun = $lun
         }
-        for ($lun=$startLun; $lun -le $endLun; $lun++) {
-            "Create-HardDrive $vmName $hvServer $scsi $controllerID $Lun $vhdType $sectorSize"
+        for ($lun = $startLun; $lun -le $endLun; $lun++) {
             $sts = Create-HardDrive -vmName $vmName -server $hvServer -SCSI:$SCSI -ControllerID $controllerID `
-            -Lun $Lun -vhdType $vhdType -sectorSize $sectorSize
+                    -Lun $Lun -vhdType $vhdType -sectorSize $sectorSize
             if (-not $sts[$sts.Length-1]) {
                 Write-LogErr "Failed to create hard drive!"
-                $sts
                 $retVal = $false
                 continue
             }

--- a/Testscripts/Windows/CLEANUP-Backup-DISK.ps1
+++ b/Testscripts/Windows/CLEANUP-Backup-DISK.ps1
@@ -18,7 +18,7 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
+        $HvServer = $captureVMData.HyperVhost
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $backupdiskpath = (Get-VMHost).VirtualHardDiskPath + "\" + $VMName + "_VSS_DISK.vhdx"

--- a/Testscripts/Windows/CORE-VerifyHeartBeat.ps1
+++ b/Testscripts/Windows/CORE-VerifyHeartBeat.ps1
@@ -6,8 +6,8 @@
 
 .Description
     Use the PowerShell cmdlet to verify the heartbeat
-	provided by the test VM is detected by the Hyper-V
-	server.
+    provided by the test VM is detected by the Hyper-V
+    server.
 #>
 
 param([String] $TestParams,
@@ -67,7 +67,7 @@ function Main {
     }
 
     if ($heartbeatTimeout -eq 0) {
-        Write-LogErr "Test case timed out for VM to enter in the Running state"
+        Write-LogErr "Test case timed out for VM enter into the running state"
         return "FAIL"
     }
 
@@ -77,7 +77,7 @@ function Main {
         Write-LogInfo "Heartbeat detected"
     } else {
         Write-LogErr "Test Failed: VM heartbeat not detected!"
-        Write-LogErr "Heartbeat not detected while the Heartbeat service is enabled"
+        Write-LogErr "Heartbeat not detected while the Heartbeat service is enabled, Heartbeat - $($vm.Heartbeat)"
         return "FAIL"
     }
 
@@ -85,9 +85,9 @@ function Main {
     Disable-VMIntegrationService -ComputerName $HvServer -VMName $VMName -Name "Heartbeat"
     $status = Get-VMIntegrationService -VMName $VMName -ComputerName $HvServer -Name "Heartbeat"
     if ($status.Enabled -eq $False -And $vm.Heartbeat -eq "Disabled") {
-        Write-LogErr "Heartbeat disabled successfully"
+        Write-LogInfo "Heartbeat disabled successfully"
     } else {
-        Write-LogErr "Unable to disable the Heartbeat service"
+        Write-LogErr "Unable to disable the Heartbeat service, Heartbeat - $($vm.Heartbeat)"
         return "FAIL"
     }
 
@@ -99,7 +99,7 @@ function Main {
         return "PASS"
     } else {
         Write-LogErr "Test Failed: VM heartbeat not detected again!"
-        Write-LogErr "Heartbeat not detected after re-enabling the Heartbeat service"
+        Write-LogErr "Heartbeat not detected after re-enabling the Heartbeat service, Heartbeat - $($vm.Heartbeat)"
         return "FAIL"
     }
 }

--- a/Testscripts/Windows/CORE-VerifyShutdown.ps1
+++ b/Testscripts/Windows/CORE-VerifyShutdown.ps1
@@ -22,7 +22,7 @@ function Main {
         [String] $RootDir
     )
 
-    if (-not (Test-Path $RootDir) ) {
+    if (-not (Test-Path $RootDir)) {
         Write-LogErr "The test root directory '${RootDir}' does not exist"
         return "FAIL"
     } else {
@@ -71,7 +71,7 @@ function Main {
 
     # Now do a shutdown to ensure the Shutdown Service is still functioning
     Write-LogInfo "Shutting down the VM"
-    $ShutdownTimeout = 600
+    $shutdownTimeout = 600
     Stop-VM -Name $VMName -ComputerName $HvServer -Force
     while ($shutdownTimeout -gt 0) {
         if ((Check-VMState $VMName $HvServer) -eq "Off") {

--- a/Testscripts/Windows/CORE-VerifyTimeSync.ps1
+++ b/Testscripts/Windows/CORE-VerifyTimeSync.ps1
@@ -7,7 +7,6 @@
 .Description
     Disable, then re-enable the LIS Time Sync service. Then also save the VM and
     verify that after these operations a Time Sync request still works.
-    The XML test case definition for this test would look similar to:
 #>
 
 param([String] $TestParams,
@@ -54,7 +53,7 @@ function Main {
     }
 
     $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
-        -command "bash ./CORE-ConfigTimeSync.sh" -runAsSudo
+                -command "bash CORE-ConfigTimeSync.sh" -runAsSudo
     if (-not $retVal) {
         Write-LogErr "Failed to config time sync."
         return "FAIL"
@@ -88,14 +87,12 @@ function Main {
 
     # Enable the Time Sync service
     Write-LogInfo "Enabling the Integrated Services Time Sync Service"
-
     Enable-VMIntegrationService -ComputerName $HvServer -VMName $VMName -Name $service
     $status = Get-VMIntegrationService -ComputerName $HvServer -VMName $VMName -Name $service
     if ($status.Enabled -ne $True) {
         Write-LogErr "Integrated Time Sync Service could not be enabled"
         return "FAIL"
     }
-
     if ($status.PrimaryOperationalStatus -ne "Ok") {
         Write-LogErr "Incorrect Operational Status for Time Sync Service: $($status.PrimaryOperationalStatus)"
         return "FAIL"
@@ -121,7 +118,7 @@ function Main {
         $startTimeout -= 5
     }
     if ($startTimeout -eq 0) {
-        Write-LogErr "Test case timed out for VM to enter in the Running state"
+        Write-LogErr "Test case timed out for VM enter into the running state"
         return "FAIL"
     }
     Write-LogInfo "VM successfully started"

--- a/Testscripts/Windows/LIS-Mount-CD.ps1
+++ b/Testscripts/Windows/LIS-Mount-CD.ps1
@@ -31,12 +31,12 @@ function Main {
     #######################################################################
     # Check arguments
     if (-not $VMName) {
-       Write-LogErr "Missing vmName argument"
+        Write-LogErr "Missing vmName argument"
         return $False
     }
 
     if (-not $HvServer) {
-       Write-LogErr  "Missing hvServer argument"
+        Write-LogErr  "Missing hvServer argument"
         return $False
     }
     #
@@ -65,8 +65,8 @@ function Main {
     $error.Clear()
 
     $vmGen = Get-VMGeneration  -vmName  $VMName -hvServer $HvServer
-    if ( $hotAdd -eq "True" -and $vmGen -eq 1) {
-       Write-LogInfo " Generation 1 VM does not support hot add DVD, please skip this case in the test script"
+    if ($hotAdd -eq "True" -and $vmGen -eq 1) {
+        Write-LogInfo "Generation 1 VM does not support hot add DVD, please skip this case in the test script"
         return $True
     }
 
@@ -110,8 +110,7 @@ function Main {
 
     try {
         Get-RemoteFileInfo -filename $isoPath  -server $HvServer
-    }
-    catch {
+    } catch {
         Write-LogErr "The .iso file $isoPath could not be found!"
         return $False
     }

--- a/Testscripts/Windows/LIS-Mount-FloppyDisk.ps1
+++ b/Testscripts/Windows/LIS-Mount-FloppyDisk.ps1
@@ -109,6 +109,11 @@ function Main {
         return "FAIL"
     } else {
         Write-LogInfo "Test PASSED, Floppy Mounted on VM!"
+        Write-LogDbg "Disassociate floppy file from VM $VMName."
+        Set-VMFloppyDiskDrive -Path $null -VMName $VMName -ComputerName $HvServer
+        Write-LogDbg "Remove file - $vfdPath."
+        Remove-Item $vfdPath -Force
+        return "PASS"
     }
 
 }

--- a/Testscripts/Windows/NUMA-Test.ps1
+++ b/Testscripts/Windows/NUMA-Test.ps1
@@ -54,7 +54,7 @@ function Main {
 
     $numaVal = Get-NumaSupportStatus $kernel
     if (-not $numaVal) {
-        Write-LogWarn "NUMA not suported for kernel:`n $kernel"
+        Write-LogWarn "NUMA not supported for kernel:`n $kernel"
         return "ABORTED"
     }
 
@@ -73,7 +73,7 @@ function Main {
     Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port `
         $VMPort -command $cmdAddConstants -runAsSudo
     if (-not $?) {
-        Write-LogErr "Unable to submit command ${cmd} to VM!"
+        Write-LogErr "Unable to submit command ${cmdAddConstants} to VM!"
         return "FAIL"
     }
 

--- a/Testscripts/Windows/RUNTIME_MEM_HOTADD_REBOOT.ps1
+++ b/Testscripts/Windows/RUNTIME_MEM_HOTADD_REBOOT.ps1
@@ -25,9 +25,9 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $vmName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $Ipv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
+        $HvServer = $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
         Write-LogInfo "Test VM details :"
         Write-LogInfo "RoleName : $($captureVMData.RoleName)"
         Write-LogInfo "Public IP : $($captureVMData.PublicIP)"
@@ -37,8 +37,7 @@ function Main {
         Write-LogInfo "startup memory : $($testParams.startupMem)"
         # Parse the TestParams string, then process each parameter
         $startupMem = Convert-ToMemSize $testParams.startupMem $captureVMData.HyperVhost
-        if ( $startupMem -le 0 )
-        {
+        if ($startupMem -le 0) {
             Throw "Unable to convert startupMem to int64."
         }
         Write-LogInfo "startupMem: $startupMem"
@@ -48,15 +47,14 @@ function Main {
         # Skip the test if host is lower than WS2016
         $BuildNumber = Get-HostBuildNumber $HvServer
         Write-LogInfo "BuildNumber: '$BuildNumber'"
-        if ( $BuildNumber -eq 0 ) {
+        if ($BuildNumber -eq 0) {
             Throw "Feature is not supported"
-        }
-        elseif ( $BuildNumber -lt 10500 ) {
+        } elseif ($BuildNumber -lt 10500) {
             $testResult = "ABORTED"
             Throw "Feature supported only on WS2016 and newer"
         }
         $VmInfo = Get-VM -Name $vmName -ComputerName $HvServer -ErrorAction SilentlyContinue
-        if ( -not $VmInfo) {
+        if (-not $VmInfo) {
             Throw "VM $vmName does not exist"
         }
         # Get memory stats from vm1
@@ -65,7 +63,7 @@ function Main {
         [int64]$vm1BeforeAssigned = ($VmInfo.MemoryAssigned/1MB)
         [int64]$vm1BeforeDemand = ($VmInfo.MemoryDemand/1MB)
         $lisDriversCmd = "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
-        [int64]$vm1BeforeIncrease =Run-LinuxCmd -username $user -password $password -ip $Ipv4 -port $VMPort -command $lisDriversCmd -runAsSudo
+        [int64]$vm1BeforeIncrease = Run-LinuxCmd -username $user -password $password -ip $Ipv4 -port $VMPort -command $lisDriversCmd -runAsSudo
         Write-LogInfo "Free memory reported by guest VM before increase: $vm1BeforeIncrease"
         # Check memory values
         if (($vm1BeforeAssigned -le 0) -or ($vm1BeforeDemand -le 0) -or ($vm1BeforeIncrease -le 0)) {
@@ -76,19 +74,19 @@ function Main {
         # Change 1 - Increase memory by 1000MB(1048576000)
         $testMem = $startupMem + 1048576000
         # Set new memory value for 3 iterations
-        for ($i=0; $i -lt 3; $i++) {
-            Set-VMMemory -VMName $vmName  -ComputerName $HvServer -DynamicMemoryEnabled $false -StartupBytes $testMem
+        for ($i = 0; $i -lt 3; $i++) {
+            Set-VMMemory -VMName $vmName -ComputerName $HvServer -DynamicMemoryEnabled $false -StartupBytes $testMem
             Start-Sleep -Seconds 5
-            if ( $VmInfo.MemoryAssigned -eq $testMem ) {
+            if ($VmInfo.MemoryAssigned -eq $testMem) {
                 [int64]$vm1AfterAssigned = ($VmInfo.MemoryAssigned/1MB)
                 [int64]$vm1AfterDemand = ($VmInfo.MemoryDemand/1MB)
                 $lisDriversCmd = "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
-                [int64]$vm1AfterIncrease =Run-LinuxCmd -username $user -password $password -ip $Ipv4 -port $VMPort -command $lisDriversCmd -runAsSudo
+                [int64]$vm1AfterIncrease = Run-LinuxCmd -username $user -password $password -ip $Ipv4 -port $VMPort -command $lisDriversCmd -runAsSudo
                 Write-LogInfo "Free memory reported by guest VM after first 1000MB increase: $vm1AfterIncrease KB"
                 break
             }
         }
-        if ( $i -eq 3 ) {
+        if ($i -eq 3) {
             $testResult = $resultFail
             Throw "VM failed to change memory. LIS 4.1 or kernel version 4.4 required"
         }
@@ -101,17 +99,17 @@ function Main {
         Write-LogInfo "Memory stats after $vmName memory was changed"
         Write-LogInfo "${vmName}: Initial Memory - $vm1BeforeIncrease KB :: After setting new value - $vm1AfterIncrease"
         #checking the value increased is less than 700000
-        if ( ($vm1AfterIncrease - $vm1BeforeIncrease ) -le 700000) {
+        if (($vm1AfterIncrease - $vm1BeforeIncrease) -le 700000) {
             $testResult = $resultFail
             Throw "Guest reports that memory value hasn't increased enough!"
         }
         Write-LogInfo "Memory stats after $vmName memory was increased by 1000MB"
         Write-LogInfo "${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
         # Restart VM
-        $timeout=120
+        $timeout = 120
         Restart-VM -VMName $vmName -ComputerName $HvServer -Force
-        $sts=Wait-ForVMToStartKVP $vmName $HvServer $timeout
-        if( -not $sts[-1]) {
+        $sts = Wait-ForVMToStartKVP $vmName $HvServer $timeout
+        if (-not $sts[-1]) {
             $testResult = $resultFail
             Throw "VM $vmName has not booted after the restart" `
                     | Tee-Object -Append -file $summaryLog
@@ -120,10 +118,10 @@ function Main {
         Start-Sleep -Seconds 60
         $testMem = $testMem + 1048576000
         # Set new memory value trying for 3 iterations
-        for ($i=0; $i -lt 3; $i++) {
+        for ($i = 0; $i -lt 3; $i++) {
             Set-VMMemory -VMName $vmName -ComputerName $HvServer -DynamicMemoryEnabled $false -StartupBytes $testMem
             Start-Sleep -Seconds 5
-            if ( $VmInfo.MemoryAssigned -eq $testMem ) {
+            if ($VmInfo.MemoryAssigned -eq $testMem) {
                 [int64]$vm1AfterAssigned = ($VmInfo.MemoryAssigned/1MB)
                 [int64]$vm1AfterDemand = ($VmInfo.MemoryDemand/1MB)
                 $lisDriversCmd = "cat /proc/meminfo | grep -i MemFree | awk '{ print `$2 }'"
@@ -132,7 +130,7 @@ function Main {
                 break
             }
         }
-        if ( $i -eq 3 ) {
+        if ($i -eq 3) {
             $lisDriversCmd="dmesg | grep hot_add"
             Run-LinuxCmd -username $user -password $password -ip $Ipv4 -port $VMPort -command $lisDriversCmd -runAsSudo
             $testResult = $resultFail
@@ -142,19 +140,17 @@ function Main {
         Write-LogInfo "${vmName}: assigned - $vm1AfterAssigned | demand - $vm1AfterDemand"
         Write-LogInfo "VM memory changed successfully!"
         $testResult = $resultPass
-    }
-    catch {
-        $ErrorMessage =  $_.Exception.Message
+    } catch {
+        $ErrorMessage = $_.Exception.Message
         $ErrorLine = $_.InvocationInfo.ScriptLineNumber
         Write-LogErr "$ErrorMessage at line: $ErrorLine"
-    }
-    finally{
+    } finally {
         if (!$testResult) {
             $testResult = "ABORTED"
         }
         $resultArr += $testResult
     }
-	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
-	return $currentTestResult.TestResult
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+    return $currentTestResult.TestResult
 }
 Main -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n")) -allVMData $AllVmData

--- a/Testscripts/Windows/Reboot-Diff-Memory-Settings.ps1
+++ b/Testscripts/Windows/Reboot-Diff-Memory-Settings.ps1
@@ -33,7 +33,7 @@ function Main {
     $osInfo = Get-WmiObject Win32_OperatingSystem -ComputerName $HvServer
     $freeMem = [int]$($OSInfo.FreePhysicalMemory) / 1MB
 
-    # Array of memory size to boot( total available memory, 70% of available memory, 40% of available memory)
+    # Array of memory size to boot (total available memory, 70% of available memory, 40% of available memory)
     $mem100 = "{0:N0}" -f $($freeMem - 2)
     $mem70 = "{0:N0}" -f $($freeMem * 0.7)
     $mem40 = "{0:N0}" -f $($freeMem * 0.4)
@@ -45,17 +45,17 @@ function Main {
         if ($vm.State -ne "Off") {
             Stop-VM -Name $VMName -ComputerName $HvServer -Force
             if (-not $?) {
-               Write-LogErr "Unable to Shut Down VM"
-               $retVal = "FAIL"
-               break
+                Write-LogErr "Unable to Shut Down VM"
+                $retVal = "FAIL"
+                break
             }
 
             $timeout = 180
             $sts = Wait-ForVMToStop $VMName $HvServer $timeout
             if (-not $sts) {
-               Write-LogErr "Wait-ForVMToStop fail"
-               $retVal = "FAIL"
-               break
+                Write-LogErr "Wait-ForVMToStop fail"
+                $retVal = "FAIL"
+                break
             }
         }
 
@@ -85,7 +85,7 @@ function Main {
             Write-LogInfo "${VMName} IP Address after reboot: ${new_ipv4}"
             Set-Variable -Name "Ipv4" -Value $new_ipv4 -Scope Global
         } else {
-            Write-LogErr "VM $VMName failed to start after setting $numCPUs vCPUs"
+            Write-LogErr "VM $VMName failed to start after setting $memory GB RAM."
             $retVal = "FAIL"
             break
         }

--- a/Testscripts/Windows/SET-SECUREBOOT.ps1
+++ b/Testscripts/Windows/SET-SECUREBOOT.ps1
@@ -13,19 +13,19 @@ $ErrorActionPreference = "Stop"
 function Main {
     $currentTestResult = Create-TestResultObject
     $resultArr = @()
-    try
-    {
+    try {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
+        $HvServer = $captureVMData.HyperVhost
         # Check if the VM VHD in not on the same drive as the backup destination
         $vm = Get-VM -Name $VMName -ComputerName $HvServer
         #
         # Check if it's a Generation 2 VM
         #
         if ($vm.Generation -ne 2) {
-            throw "VM ${VMName} is not a Generation 2 VM"
+            Write-LogWarn "VM ${VMName} is not a Generation 2 VM, Skip test case."
+            return "SKIPPED"
         }
         #
         # Check if Secure Boot is enabled

--- a/Testscripts/Windows/SETUP-Backup-DISK.ps1
+++ b/Testscripts/Windows/SETUP-Backup-DISK.ps1
@@ -28,7 +28,7 @@ function Main {
         if ([string]::IsNullOrEmpty($driveletter)) {
             throw "Setup: The driveletter variable is empty!"
         }
-        $maxRetryCount=2
+        $maxRetryCount = 2
         $currentRetryCount = 0
         while ($currentRetryCount -lt $maxRetryCount){
             if (Test-Path ($backupdiskpath)) {
@@ -58,9 +58,9 @@ function Main {
             Remove-Item $filePath
         }
         Write-Output "$originaldriveletter" >> $filePath
-        $testResult=$resultPass
+        $testResult = $resultPass
     } catch {
-        $ErrorMessage =  $_.Exception.Message
+        $ErrorMessage = $_.Exception.Message
         $ErrorLine = $_.InvocationInfo.ScriptLineNumber
         Write-LogErr "$ErrorMessage at line: $ErrorLine"
     } finally {

--- a/Testscripts/Windows/SETUP-RemoveIsoFromDvd.ps1
+++ b/Testscripts/Windows/SETUP-RemoveIsoFromDvd.ps1
@@ -20,7 +20,7 @@ function Main {
         $TestParams
     )
 
-    $controllerNumber=$null
+    $controllerNumber = $null
 
     # Check arguments
     if (-not $vmName) {
@@ -40,13 +40,13 @@ function Main {
 
     # Make sure the DVD drive exists on the VM
     if ($vmGeneration -eq 1) {
-        $controllerNumber=1
+        $controllerNumber = 1
     } else {
-        $controllerNumber=0
+        $controllerNumber = 0
     }
 
     $dvdcount = $(Get-VMDvdDrive -VMName $vmName -ComputerName $hvServer).ControllerLocation.count
-    for ($i=0; $i -le $dvdcount; $i++) {
+    for ($i = 0; $i -le $dvdcount; $i++) {
         $dvd = Get-VMDvdDrive -VMName $vmName -ComputerName $hvServer `
             -ControllerNumber $controllerNumber -ControllerLocation $i
         if ($dvd) {

--- a/Testscripts/Windows/SETUP-STOR-TakeRevert-Snapshot.ps1
+++ b/Testscripts/Windows/SETUP-STOR-TakeRevert-Snapshot.ps1
@@ -43,7 +43,7 @@ function Main {
     }
 
     if (-not $snapshotname) {
-       Write-LogErr "Missing testParam snapshotname value"
+        Write-LogErr "Missing testParam snapshotname value"
         return "FAIL"
     }
 
@@ -65,7 +65,7 @@ function Main {
     #
     $stateFile = "${LogDir}\state.txt"
     $LISDisk = "echo '${VMPassword}' | sudo -S -s eval `"export HOME=``pwd``;bash ${remoteScript} > LISDisk.log`""
-    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $LISDisk -runAsSudo
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $LISDisk -runAsSudo | Out-Null
     Copy-RemoteFiles -download -downloadFrom $Ipv4 -files "/home/${VMUserName}/state.txt" `
         -downloadTo $LogDir -port $VMPort -username $VMUserName -password $VMPassword
     Copy-RemoteFiles -download -downloadFrom $Ipv4 -files "/home/${VMUserName}/LISDisk.log" `
@@ -91,16 +91,15 @@ function Main {
     #
     # Take a snapshot then restore the VM to the snapshot
     #
-    Write-LogInfo "Taking Snapshot operation on VM"
-
     $Snapshot = "TestSnapshot_$random"
+    Write-LogInfo "Taking Snapshot operation on VM, snapshot name - $Snapshot"
     Checkpoint-VM -Name $VMName -SnapshotName $Snapshot -ComputerName $HvServer
     if (-not $?) {
         Write-LogErr "Could not create VM snapshot!"
         return "FAIL"
     }
 
-    Write-LogInfo "Restoring Snapshot operation on VM"
+    Write-LogInfo "Restoring Snapshot operation on VM, snapshot name - $snapshotname"
     Restore-VMSnapshot -VMName $VMName -Name $snapshotname -ComputerName $HvServer -Confirm:$false
     if (-not $?) {
         Write-LogErr "Could not restore VM snapshot!"
@@ -114,9 +113,9 @@ function Main {
     Start-VM $VMName -ComputerName $HvServer
 
     $newIpv4 = Get-Ipv4AndWaitForSSHStart -VmName $VMName -HvServer $HvServer -Vmport $VMPort -User $VMUserName `
-              -Password $VMPassword -StepTimeout 30
+                  -Password $VMPassword -StepTimeout 30
     if (-not $newIpv4) {
-        Write-LogErr "Failed to retrive $VMName IP after snasphot restore"
+        Write-LogErr "Failed to retrieve $VMName IP after snapshot restore"
         return "FAIL"
     }
     #
@@ -124,11 +123,11 @@ function Main {
     #
     Write-LogInfo "Waiting for VM to boot ..."
     $null = Wait-VMHeartbeatOK -VMName $VMName -HvServer $HvServer `
-                         -RetryCount 60 -RetryInterval 4
+                -RetryCount 60 -RetryInterval 4
     Write-LogInfo "Checking if the test file is still present..."
     $sts = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $newIpv4 -port $VMPort `
-           -ignoreLinuxExitCode -command  "stat /home/$VMUserName/PostSnapData.txt 2>/dev/null"
-    if ( $sts) {
+                -ignoreLinuxExitCode -command  "stat /home/$VMUserName/PostSnapData.txt 2> /dev/null"
+    if ($sts) {
         Write-LogErr "File still present in VM"
         return "FAIL"
     }
@@ -138,7 +137,7 @@ function Main {
     #
     Write-LogInfo "Deleting snapshot ${Snapshot} of VM ${vmName}"
     Remove-VMSnapshot -VMName $VMName -Name $Snapshot -ComputerName $HvServer
-    if ( -not $?) {
+    if (-not $?) {
         Write-LogErr "Could not delete temporary VM snapshot!"
         return "FAIL"
     }

--- a/Testscripts/Windows/STOR-ExportImportVM.ps1
+++ b/Testscripts/Windows/STOR-ExportImportVM.ps1
@@ -61,7 +61,7 @@ function Main {
     while ($testCaseTimeout -gt 0) {
         $null = Stop-VM -Name $VMName -ComputerName $HvServer -Force -Verbose
 
-        if ( (Check-VMState -vmName $VMName -hvServer $HvServer ("Off"))) {
+        if ((Check-VMState -vmName $VMName -hvServer $HvServer ("Off"))) {
             break
         }
 
@@ -105,7 +105,7 @@ function Main {
     Write-LogInfo "VM ${vmName} exported successfully"
 
     #
-    # Before importing the VM from exported folder, Delete the created snapshot from the orignal VM.
+    # Before importing the VM from exported folder, Delete the created snapshot from the original VM.
     #
     $null = Get-VMSnapshot -VMName $VMName -ComputerName $HvServer -Name "TestExport" | Remove-VMSnapshot -Confirm:$False
 
@@ -128,7 +128,7 @@ function Main {
     switch ($BuildNum) {
         {$_ -lt 10000} {
             # Server 2012 R2, 20012 and 2008R2
-            $vmConfig = Invoke-Command -ComputerName $HvServer {Get-Item "$Using:vmPath\Virtual Machines\*.xml"}
+            $vmConfig = Invoke-Command -ComputerName $HvServer { Get-Item "$Using:vmPath\Virtual Machines\*.xml" }
         }
         {$_ -ge 10000} {
             # Server 2016 or newer
@@ -144,7 +144,7 @@ function Main {
     Write-LogInfo $vmConfig.fullname
 
     $null = Import-VM -Path $vmConfig -ComputerName $HvServer -Copy "${vmPath}\Virtual Hard Disks" `
-        -Verbose -Confirm:$False -GenerateNewId
+                -Verbose -Confirm:$False -GenerateNewId
     if ($? -ne "True") {
         Write-LogErr "Error while importing the VM"
         return "FAIL"
@@ -217,16 +217,15 @@ function Main {
         if ($? -ne "True") {
             Write-LogErr "Error while removing the Imported VM"
             return "FAIL"
-        }
-        else {
+        } else {
             Write-LogInfo "Imported VM removed, test completed"
             return "PASS"
         }
 
-        $null = Invoke-Command -ComputerName $HvServer {Remove-Item -Path "$Using:vmPath" -Recurse -Force}
+        $null = Invoke-Command -ComputerName $HvServer { Remove-Item -Path "$Using:vmPath" -Recurse -Force }
         if ($? -ne "True") {
             Write-LogErr "Error while deleting the export folder, trying again..."
-            $null = Invoke-Command -ComputerName $HvServer {Remove-Item -Recurse -Path "$Using:vmPath" -Force }
+            $null = Invoke-Command -ComputerName $HvServer { Remove-Item -Recurse -Path "$Using:vmPath" -Force }
         }
 
         return "FAIL"

--- a/Testscripts/Windows/STOR-VHDX-RESIZE-GROWFS.ps1
+++ b/Testscripts/Windows/STOR-VHDX-RESIZE-GROWFS.ps1
@@ -77,7 +77,7 @@ Function Set-HardDiskSize
 	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "echo 'rerun=yes' >> constants.sh" -runAsSudo
 	$ret = Run-LinuxCmd -ip $ip -port $port -username $user -password $password -command "./$guestScript" -runAsSudo
 	if (-not $ret) {
-		Throw "Running '${guestScript}'script failed on VM. check VM logs , exiting test case execution"
+		Throw "Running '${guestScript}' script failed on VM. check VM logs, exiting test case execution"
 	}
 	Write-LogInfo "The guest detects the new size after resizing ($diskSize)"
 } # End function

--- a/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-DISKSTRESS.ps1
+++ b/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-DISKSTRESS.ps1
@@ -17,10 +17,10 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $Ipv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
-        $HypervGroupName=$captureVMData.HyperVGroupName
+        $HvServer = $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
+        $HypervGroupName = $captureVMData.HyperVGroupName
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $sts = New-BackupSetup $VMName $HvServer
@@ -39,7 +39,7 @@ function Main {
             $testResult = $resultFail
             throw "Backup driveletter is not specified."
         }
-        $remoteScript="STOR_VSS_Disk_Stress.sh"
+        $remoteScript = "STOR_VSS_Disk_Stress.sh"
         $retval = Invoke-RemoteScriptAndCheckStateFile $remoteScript $user $password $Ipv4 $VMPort
         if ($retval -eq $False) {
             throw "Running $remoteScript script failed on VM!"

--- a/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-PARTITION.ps1
+++ b/Testscripts/Windows/STOR-VSS-BACKUP-RESTORE-PARTITION.ps1
@@ -65,7 +65,7 @@ function Main {
         }
         # Run the Partition Disk script
         if (-not $TestParams.secureBootVM) {
-            $remoteScript="PartitionMultipleDisks.sh"
+            $remoteScript = "PartitionMultipleDisks.sh"
             $retval = Invoke-RemoteScriptAndCheckStateFile $remoteScript $user $password $Ipv4 $VMPort
             if ($retval -eq $False) {
                 throw "Running $remoteScript script failed on VM!"
@@ -95,7 +95,7 @@ function Main {
         }
         $null = Remove-Backup $backupLocation
         if ($testResult -ne $resultFail) {
-            $testResult=$resultPass
+            $testResult = $resultPass
         }
     } catch {
         $ErrorMessage =  $_.Exception.Message

--- a/Testscripts/Windows/STOR-VSS-Backup-Change-Hypervvssd.ps1
+++ b/Testscripts/Windows/STOR-VSS-Backup-Change-Hypervvssd.ps1
@@ -57,10 +57,10 @@ function Main {
             throw "Backup driveletter is not specified."
         }
         # set the backup type array, if stop hypervvssd, it executes offline backup, if start hypervvssd, it executes online backup
-        $backupTypes = @("offline","online")
+        $backupTypes = @("offline", "online")
         # set hypervvssd status, firstly stop, then start
-        $setAction= @("stop","start")
-        for ($i = 0; $i -le 1; $i++ ) {
+        $setAction = @("stop", "start")
+        for ($i = 0; $i -le 1; $i++) {
             $serviceAction = $setAction[$i]
             $serviceCommand = "echo serviceAction=$serviceAction  >> constants.sh"
             Run-LinuxCmd -username $user -password $password -ip $VMIpv4 -port $VMPort $serviceCommand -runAsSudo | Out-Null
@@ -76,18 +76,18 @@ function Main {
             Start-Sleep -Seconds 3
             $stsBackUp = New-Backup $VMName $driveLetter $HvServer $VMIpv4 $VMPort
             # when stop hypervvssd, backup offline backup
-            if ( -not $stsBackUp[-1]) {
+            if (-not $stsBackUp[-1]) {
                 throw "Failed in start Backup"
             } else {
                 $backupLocation = $stsBackUp[-1]
                 # if stop hypervvssd, vm does offline backup
                 $bkType = Get-BackupType
                 $temp = $backupTypes[$i]
-                if ( $bkType -ne $temp ) {
+                if ($bkType -ne $temp) {
                     $testResult = "FAIL"
                     throw "Failed: Not get expected backup type as $temp"
                 } else {
-                     Write-LogInfo "Got expected backup type $temp"
+                    Write-LogInfo "Got expected backup type $temp"
                 }
                 $null = Remove-Backup $backupLocation
             }
@@ -97,8 +97,7 @@ function Main {
         $ErrorMessage =  $_.Exception.Message
         $ErrorLine = $_.InvocationInfo.ScriptLineNumber
         Write-LogErr "$ErrorMessage at line: $ErrorLine"
-    }
-    finally {
+    } finally {
         if (!$testResult) {
             $testResult = "Aborted"
         }

--- a/Testscripts/Windows/STOR-VSS-Backup-Disable-Enable-VSS.ps1
+++ b/Testscripts/Windows/STOR-VSS-Backup-Disable-Enable-VSS.ps1
@@ -16,25 +16,25 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $Ipv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
+        $HvServer = $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         # set the backup type array, if set Integration Service VSS
         # as disabled/unchecked, it executes offline backup, if VSS is
         # enabled/checked and hypervvssd is running, it executes online backup.
-        $backupTypes = @("offline","online")
+        $backupTypes = @("offline", "online")
         # checkVSSD uses to set integration service,
         # also uses to define whether need to check
         # hypervvssd running status during runSetup
-        $checkVSSD= @($false,$true)
+        $checkVSSD = @($false, $true)
         # If the kernel version is smaller than 3.10.0-383,
         # it does not take effect after un-check then
         # check VSS service unless restart VM.
         $supportkernel = "3.10.0.383"
         $supportStatus = Get-VMFeatureSupportStatus $Ipv4 $VMPort $user $password $supportkernel
-        for ($i = 0; $i -le 1; $i++ ) {
+        for ($i = 0; $i -le 1; $i++) {
             # stop vm then set integration service
             if (-not $supportStatus[-1]) {
                 # need to stop-vm to set integration service
@@ -50,7 +50,7 @@ function Main {
             if (-not $supportStatus[-1]) {
                 $timeout = 300
                 $sts = Start-VM -Name $VMName -ComputerName $HvServer
-                if (-not (Wait-ForVMToStartKVP $VMName $HvServer $timeout )) {
+                if (-not (Wait-ForVMToStartKVP $VMName $HvServer $timeout)) {
                     throw "${VMName} failed to start"
                 }
                 Start-Sleep -Seconds 3
@@ -59,7 +59,7 @@ function Main {
             if (-not $sts[-1]) {
                 throw "Run setup failed"
             }
-            if($checkVSSD[$i]) {
+            if ($checkVSSD[$i]) {
                 # Check VSS Demon is running
                 $sts = Check-VSSDemon $VMName $HvServer $Ipv4 $VMPort
                 if (-not $sts){
@@ -82,7 +82,7 @@ function Main {
             # it executes offline backup, otherwise, it executes online backup.
             $sts = Get-BackupType
             $temp = $backupTypes[$i]
-            if  ($sts -ne $temp) {
+            if ($sts -ne $temp) {
                 $testResult = $resultFail
                 throw "Didn't get expected backup type"
             } else {
@@ -91,7 +91,7 @@ function Main {
             $null = Remove-Backup $backupLocation
         }
         if ($testResult -ne $resultFail) {
-            $testResult=$resultPass
+            $testResult = $resultPass
         }
     } catch {
         $ErrorMessage =  $_.Exception.Message

--- a/Testscripts/Windows/STOR-VSS-BackupRestore-Fail.ps1
+++ b/Testscripts/Windows/STOR-VSS-BackupRestore-Fail.ps1
@@ -18,9 +18,9 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $Ipv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
+        $HvServer = $captureVMData.HyperVhost
+        $Ipv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $sts = New-BackupSetup $VMName $HvServer
@@ -29,7 +29,7 @@ function Main {
         }
         # Check VSS Demon is running
         $sts = Check-VSSDemon $VMName $HvServer $Ipv4 $VMPort
-        if (-not $sts){
+        if (-not $sts) {
             throw "VSS Daemon is not running"
         }
         # Create a file on the VM before backup
@@ -70,10 +70,9 @@ function Main {
         }
         $null = Remove-Backup $backupLocation
         if ($testResult -ne $resultFail) {
-            $testResult=$resultPass
+            $testResult = $resultPass
         }
-    }
-    catch {
+    } catch {
         $ErrorMessage =  $_.Exception.Message
         $ErrorLine = $_.InvocationInfo.ScriptLineNumber
         Write-LogErr "$ErrorMessage at line: $ErrorLine"

--- a/Testscripts/Windows/STOR-VSS-BackupRestore-ISO-NoNetwork.ps1
+++ b/Testscripts/Windows/STOR-VSS-BackupRestore-ISO-NoNetwork.ps1
@@ -20,7 +20,7 @@ $remoteScript = "STOR_VSS_StopNetwork.sh"
 #######################################################################
 function Main {
     param (
-       $TestParams, $AllVMData
+        $TestParams, $AllVMData
     )
     $currentTestResult = Create-TestResultObject
     try {
@@ -113,6 +113,18 @@ function Main {
         $sts = Check-VMStateAndFileStatus $VMName $HvServer $VMIpv4 $VMPort
         if (-not $sts) {
             throw "Backup evaluation failed"
+        }
+        $dvdDrive = Get-VMDvdDrive -VMName $VMName -ComputerName $hvServer
+        if ($dvdDrive) {
+            if ($dvdDrive.Path -ne $isoPath) {
+                Write-LogErr "DVD path changed into $($dvdDrive.Path) after restore backup."
+                $testResult = $resultFail
+            } else {
+                Write-LogInfo "DVD path is $($dvdDrive.Path) after restore backup."
+            }
+        } else {
+            Write-LogErr "DVD is missing after restore backup."
+            $testResult = $resultFail
         }
         $null = Remove-Backup $backupLocation
         if ($testResult -ne $resultFail) {

--- a/Testscripts/Windows/STOR-VSS-BackupRestore-Mount-Multi-Paths.ps1
+++ b/Testscripts/Windows/STOR-VSS-BackupRestore-Mount-Multi-Paths.ps1
@@ -20,10 +20,10 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $VMIpv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
-        $HypervGroupName=$captureVMData.HyperVGroupName
+        $HvServer = $captureVMData.HyperVhost
+        $VMIpv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
+        $HypervGroupName = $captureVMData.HyperVGroupName
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $sts = New-BackupSetup $VMName $HvServer
@@ -45,7 +45,7 @@ function Main {
             $testResult = $resultFail
             throw "Backup driveletter is not specified."
         }
-        $remoteScript="STOR_VSS_Disk_Mount_Multi_Paths.sh"
+        $remoteScript = "STOR_VSS_Disk_Mount_Multi_Paths.sh"
         $retval = Invoke-RemoteScriptAndCheckStateFile $remoteScript $user $password $VMIpv4 $VMPort
         if ($retval -eq $False) {
             throw "Running $remoteScript script failed on VM!"
@@ -64,9 +64,14 @@ function Main {
         if (-not $sts) {
             throw "Backup evaluation failed"
         }
+        $disks = Get-VMHardDiskDrive -VMName $VMName -ComputerName $HvServer | Where-Object {$_.ControllerType -like "IDE"}
+        if ($disks.Count -ne 2) {
+            Write-LogErr "IDE 1 1 doesn't exist after restore backup."
+            $testResult = $resultFail
+        }
         Remove-Backup $backupLocation | Out-Null
-        if( $testResult -ne $resultFail) {
-            $testResult=$resultPass
+        if ($testResult -ne $resultFail) {
+            $testResult = $resultPass
         }
     } catch {
         $ErrorMessage =  $_.Exception.Message

--- a/Testscripts/Windows/STOR-VSS-BackupRestore-Mount-Squashfs.ps1
+++ b/Testscripts/Windows/STOR-VSS-BackupRestore-Mount-Squashfs.ps1
@@ -17,10 +17,10 @@ function Main {
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $VMIpv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
-        $HypervGroupName=$captureVMData.HyperVGroupName
+        $HvServer = $captureVMData.HyperVhost
+        $VMIpv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
+        $HypervGroupName = $captureVMData.HyperVGroupName
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
         $sts = New-BackupSetup $VMName $HvServer
@@ -42,7 +42,7 @@ function Main {
             $testResult = $resultFail
             throw "Backup driveletter is not specified."
         }
-        $remoteScript="STOR_VSS_Disk_Mount_Squashfs.sh"
+        $remoteScript = "STOR_VSS_Disk_Mount_Squashfs.sh"
         $retval = Invoke-RemoteScriptAndCheckStateFile $remoteScript $user $password $VMIpv4 $VMPort
         if ($retval -eq $False) {
             throw "Running $remoteScript script failed on VM!"

--- a/Testscripts/Windows/STOR-VSS-BackupRestore-State.ps1
+++ b/Testscripts/Windows/STOR-VSS-BackupRestore-State.ps1
@@ -20,22 +20,19 @@ $ErrorActionPreference = "Stop"
 #######################################################################
 # Channge the VM state
 #######################################################################
-function Change-VMState($vmState,$vmName,$hvServer)
+function Change-VMState($vmState, $vmName, $hvServer)
 {
     $vm = Get-VM -Name $vmName -ComputerName $hvServer
     if ($vmState -eq "Off") {
         Stop-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
         return $vm.state
-    }
-    elseif ($vmState -eq "Saved") {
+    } elseif ($vmState -eq "Saved") {
         Save-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
         return $vm.state
-    }
-    elseif ($vmState -eq "Paused") {
+    } elseif ($vmState -eq "Paused") {
         Suspend-VM -Name $vmName -ComputerName $hvServer -ErrorAction SilentlyContinue
         return $vm.state
-    }
-    else {
+    } else {
         return $false
     }
 }
@@ -54,20 +51,20 @@ function Main
         $testResult = $null
         $captureVMData = $allVMData
         $VMName = $captureVMData.RoleName
-        $HvServer= $captureVMData.HyperVhost
-        $VMIpv4=$captureVMData.PublicIP
-        $VMPort=$captureVMData.SSHPort
-        $vmState=$TestParams.vmState
-        $HypervGroupName=$captureVMData.HyperVGroupName
+        $HvServer = $captureVMData.HyperVhost
+        $VMIpv4 = $captureVMData.PublicIP
+        $VMPort = $captureVMData.SSHPort
+        $vmState = $TestParams.vmState
+        $HypervGroupName = $captureVMData.HyperVGroupName
         Write-LogInfo "Test VM details :"
         Write-LogInfo "  RoleName : $($captureVMData.RoleName)"
         Write-LogInfo "  Public IP : $($captureVMData.PublicIP)"
         Write-LogInfo "  SSH Port : $($captureVMData.SSHPort)"
         Write-LogInfo "  HostName : $($captureVMData.HyperVhost)"
-        Write-LogInfo "vmstate from params  is $vmState"
+        Write-LogInfo "vmstate from params is $vmState"
         # Change the working directory to where we need to be
         Set-Location $WorkingDirectory
-        Write-LogInfo "WorkingDirectory"
+        Write-LogInfo "$WorkingDirectory"
         $sts = New-BackupSetup $VMName $HvServer
         if (-not $sts[-1]) {
             throw "Failed to create a Backup Setup"
@@ -88,19 +85,18 @@ function Main
         }
         Write-LogInfo "Driveletter is $driveletter"
         # Check if VM is Started
-        $vm = Get-VM -Name $VMName
-        $currentState=$vm.state
-        Write-LogInfo "current vm state is $currentState "
-        if ( $currentState -ne "Running" ) {
+        $vm = Get-VM -Name $VMName -ComputerName $hvServer
+        $currentState = $vm.state
+        Write-LogInfo "Current vm state is $currentState "
+        if ($currentState -ne "Running") {
             Write-LogErr "$vmName is not started."
         }
         # Change the VM state
         $sts = Change-VMState $vmState $VMName $HvServer
-        Write-LogInfo "VM state changed to $vmstate :  $sts"
+        Write-LogInfo "VM state changed to $vmstate : $sts"
         if (-not $sts[-1]) {
             throw "vmState param: $vmState is wrong. Available options are `'Off`', `'Saved`'' and `'Paused`'."
-        }
-        elseif ( $sts -ne $vmState ) {
+        } elseif ($sts -ne $vmState) {
             throw "Failed to put $vmName in $vmState state $sts."
         }
         Write-LogInfo "State change of $vmName to $vmState : Success."
@@ -119,16 +115,14 @@ function Main
             throw "Backup evaluation failed"
         }
         Remove-Backup $backupLocation | Out-Null
-        if( $testResult -ne $resultFail) {
-            $testResult=$resultPass
+        if ($testResult -ne $resultFail) {
+            $testResult = $resultPass
         }
-    }
-    catch {
-        $ErrorMessage =  $_.Exception.Message
+    } catch {
+        $ErrorMessage = $_.Exception.Message
         $ErrorLine = $_.InvocationInfo.ScriptLineNumber
         Write-LogErr "$ErrorMessage at line: $ErrorLine"
-    }
-    finally {
+    } finally {
         if (!$testResult) {
             $testResult = $resultAborted
         }

--- a/Testscripts/Windows/STORAGE-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/STORAGE-DiffDiskGrowth.ps1
@@ -104,7 +104,7 @@ function Main {
     }
 
     $vmGeneration = Get-VMGeneration $vmName $hvServer
-    if (( $controllerType -eq "IDE" -or $vhdFormat -eq "vhd" ) -and $vmGeneration -eq 2 ) {
+    if (($controllerType -eq "IDE" -or $vhdFormat -eq "vhd") -and $vmGeneration -eq 2) {
         Write-LogInfo "Generation 2 VM does not support IDE or vhd disk, skip test"
         return "SKIPPED"
     }
@@ -143,7 +143,7 @@ function Main {
     if ($vmGeneration -eq 1) {
         $lun = [int]($diskArgs[1].Trim())
     } else {
-        $lun = [int]($diskArgs[1].Trim()) +1
+        $lun = [int]($diskArgs[1].Trim()) + 1
     }
 
     $vhdName = ("{0}{1}-{2}-{3}-{4}-Diff.{5}" `
@@ -239,13 +239,11 @@ function Main {
         Write-LogInfo "The parent .vhd file did not change in size"
     }
 
-    if ($vhdFinalSize -gt $vhdInitialSize)
-    {
+    if ($vhdFinalSize -gt $vhdInitialSize) {
         Write-LogInfo "The differencing disk grew in size from ${vhdInitialSize} to ${vhdFinalSize}"
     }
 
     Write-LogInfo "Test finished with result: PASS"
-
     return "PASS"
 }
 

--- a/Testscripts/Windows/STORAGE-HotUnplug.ps1
+++ b/Testscripts/Windows/STORAGE-HotUnplug.ps1
@@ -74,8 +74,8 @@ function Main {
         $TestParams
     )
 
-    $scsi=$true
-    $REMOTE_SCRIPT="STORAGE-HotRemove.sh"
+    $scsi = $true
+    $REMOTE_SCRIPT = "STORAGE-HotRemove.sh"
 
     if ($null -eq $testParams -or $testParams.Length -lt 3) {
         Write-LogErr "setupScript requires test params"
@@ -111,28 +111,28 @@ function Main {
             continue
         }
 
-        $controllerType=$controller
+        $controllerType = $controller
         $diskArgs = $fields[1].Trim().Split(',')
         if ($diskArgs.Length -lt 3 -or $diskArgs.Length -gt 5) {
             Write-LogErr "Incorrect number of arguments: $p"
             return "FAIL"
         }
         $vmGeneration = Get-VMGeneration $vmName $hvServer
-        if($scsi){
+        if ($scsi) {
             $controllerID1 = $diskArgs[0].Trim()
             if ($vmGeneration -eq 1) {
                 $lun1 = [int]($diskArgs[1].Trim())
             } else {
-                $lun1 = [int]($diskArgs[1].Trim()) +1
+                $lun1 = [int]($diskArgs[1].Trim()) + 1
             }
-            $scsi=$false
+            $scsi = $false
         }
     }
 
-    $path1=(Get-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerLocation $lun1 `
+    $path1 = (Get-VMHardDiskDrive -VMName $vmName -ComputerName $hvServer -ControllerLocation $lun1 `
                 -ControllerNumber $controllerID1 -ControllerType $controllerType).Path
 
-    for ($i=0; $i -lt $loopCount; $i++) {
+    for ($i = 0; $i -lt $loopCount; $i++) {
         #Remove the 1st VHDx
         Write-LogInfo "Current loop number is $i."
         $retVal = Remove-VHDxDiskDrive $vmName $hvServer $controllerType $controllerID1 $lun1
@@ -142,7 +142,7 @@ function Main {
         }
         Write-LogInfo "Removed first VHDx with path $path1"
 
-        #verify if vm sees that disks were dettached
+        #verify if vm sees that disks were detached
         $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -command "bash ${REMOTE_SCRIPT}" -RunAsSudo
 
@@ -157,8 +157,8 @@ function Main {
         Start-Sleep -Seconds 5
         $diskNumber = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -command "fdisk -l | grep 'Disk /dev/sd*' | grep -v 'Disk /dev/sda' | wc -l" -RunAsSudo
-        if ( $diskNumber -ne 2) {
-            Write-LogErr "Failed to attach VHDx "
+        if ($diskNumber -ne 2) {
+            Write-LogErr "Failed to attach VHDx"
             return "FAIL"
         }
     }

--- a/Testscripts/Windows/Set-VM-Memory.ps1
+++ b/Testscripts/Windows/Set-VM-Memory.ps1
@@ -63,6 +63,8 @@ function Main {
         $vm = Get-VM -VMName $vmName -ComputerName $hvServer
         if ($vm.DynamicMemoryEnabled) {
             Set-VMMemory -VMName $vmName -ComputerName $hvServer -StartupBytes $startupMemory -MaximumBytes $startupMemory -MinimumBytes $startupMemory -Confirm:$False -Priority $memWeight
+        } else {
+            Set-VMMemory -VMName $vmName -ComputerName $hvServer -StartupBytes $startupMemory
         }
     }
 


### PR DESCRIPTION
Fix below scrips mainly
LIS-Mount-FloppyDisk.ps1 - case MOUNT-FLOPPYDISK, before fix, it doesn't return PASS and cleanup vfd file
STOR-VSS-BackupRestore-ISO-NoNetwork.ps1 - case VSS-BACKUPRESTORE-ISO-NONETWORK, add validation part
STOR-VSS-BackupRestore-Mount-Multi-Paths.ps1 - case VSS-BACKUP-RESTORE-MOUNT-MULTI-PATHS, add validation part
Reboot-Diff-Memory-Settings.ps1 - case REBOOT-DIFFERENT-MEMORY-SETTINGS, before fix, the update memory doesn't update it really.

For remains changed files - update the code format only.

Test results -
```
[LISAv2 Test Results Summary]
Test Run On           : 01/31/2020 06:28:01
VHD Under Test        : \\redmond\wsscfs\OSTC\LIS\VHD\Cloudbase\CentOS\CentOS_7.5\CentOS_7.5.vhdx
Initial Kernel Version: 3.10.0-862.el7.x86_64
Final Kernel Version  : 3.10.0-862.el7.x86_64
Total Test Cases      : 4 (4 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:35

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 BACKUP               VSS-BACKUPRESTORE-ISO-NONETWORK                                                   PASS                10.23 
    2 BACKUP               VSS-BACKUP-RESTORE-MOUNT-MULTI-PATHS                                              PASS                10.41 
    3 CORE                 REBOOT-DIFFERENT-MEMORY-SETTINGS                                                  PASS                 5.28 
    4 CORE                 MOUNT-FLOPPYDISK                                                                  PASS                  1.2 
```