### PR TITLE
Update for "SkipVerifyKernelLogs" not blocking reporting telemetry data

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -523,12 +523,14 @@ Class TestController
 		try {
 			Write-LogInfo "==> Check if the test target machines are still running."
 			$isVmAlive = Is-VmAlive -AllVMDataObject $VMData -MaxRetryCount 10
-			if (!$global:IsWindowsImage -and $testParameters["SkipVerifyKernelLogs"] -ne "True" -and $isVmAlive -eq "True" ) {
-				$ret = $this.GetAndCompareOsLogs($VmData, "Final")
-				if (($testParameters["FailForLogCheck"] -eq "True") -and ($ret -eq $false) -and ($currentTestResult.TestResult -eq $global:ResultPass)) {
-					$currentTestResult.TestResult = $global:ResultFail
-					Write-LogErr "Test $($CurrentTestData.TestName) fails for log check"
-					$currentTestResult.testSummary += New-ResultSummary -testResult "Test fails for log check"
+			if (!$global:IsWindowsImage -and $isVmAlive -eq "True" ) {
+				if ($testParameters["SkipVerifyKernelLogs"] -ne "True") {
+					$ret = $this.GetAndCompareOsLogs($VmData, "Final")
+					if (($testParameters["FailForLogCheck"] -eq "True") -and ($ret -eq $false) -and ($currentTestResult.TestResult -eq $global:ResultPass)) {
+						$currentTestResult.TestResult = $global:ResultFail
+						Write-LogErr "Test $($CurrentTestData.TestName) fails for log check"
+						$currentTestResult.testSummary += New-ResultSummary -testResult "Test fails for log check"
+					}
 				}
 				$this.GetSystemBasicLogs($VmData, $global:user, $global:password, $CurrentTestData, $currentTestResult, $this.EnableTelemetry) | Out-Null
 			}


### PR DESCRIPTION
The SkipVerifyKernelLogs configuration of test cases should not block reporting telemetry data