### PR TITLE
Fix VPP test case against Ubuntu.

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -71,11 +71,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>VPP_SOURCE_BRANCH</ReplaceThis>
-		<ReplaceWith>stable/1901</ReplaceWith>
-	</Parameter>
-	<Parameter>
-		<ReplaceThis>VPP_DPDK_VERSION</ReplaceThis>
-		<ReplaceWith>18.11</ReplaceWith>
+		<ReplaceWith>stable/2001</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_RDMA_CORE_SOURCE_URL</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -144,7 +144,6 @@
         </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkUtils.sh,.\Testscripts\Linux\build_test_vpp.sh</files>
         <TestParameters>
-            <param>dpdkVersion="VPP_DPDK_VERSION"</param>
             <param>vppSrcLink="VPP_SOURCE_URL"</param>
             <param>vppSrcBranch="VPP_SOURCE_BRANCH"</param>
         </TestParameters>


### PR DESCRIPTION
For CentOS/RHEL, there is one issue that is lack of python36 in epel repo which block this case, see https://bugzilla.redhat.com/show_bug.cgi?id=1739833.

For Ubuntu, I fix the issue and see below results.

Ubuntu 16.04
```
[LISAv2 Test Results Summary]
Test Run On           : 02/08/2020 06:45:09
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1067-azure
Final Kernel Version  : 4.15.0-1067-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-VPP                                                                   PASS                15.87 
```

Ubuntu 18.04
```
[LISAv2 Test Results Summary]
Test Run On           : 02/08/2020 07:15:01
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1029-azure
Final Kernel Version  : 5.0.0-1029-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-VPP                                                                   PASS                14.59 
```

Ubuntu 18.04 + proposed-edge
```
[LISAv2 Test Results Summary]
Test Run On           : 02/08/2020 06:44:28
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1029-azure
Final Kernel Version  : 5.3.0-1011-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:20

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-VPP                                                                   PASS                14.34 
```

Ubuntu 19.10
```
[LISAv2 Test Results Summary]
Test Run On           : 02/08/2020 06:46:14
ARM Image Under Test  : Canonical : UbuntuServer : 19.10-DAILY : latest
Initial Kernel Version: 5.3.0-1010-azure
Final Kernel Version  : 5.3.0-1010-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-VPP                                                                   PASS                20.64 
```