### PR TITLE
Fix issue when convert datetime.

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2833,12 +2833,22 @@ Function Upload-AzureBootAndDeploymentDataToDB ($DeploymentTime, $AllVMData, $Cu
             $waagentFile = "$LogDir\$($vmData.RoleName)-waagent.log.txt"
             $waagentStartLineNumber = (Select-String -Path $waagentFile -Pattern "$walaStartIdentifier")[-1].LineNumber
             $waagentStartLine = (Get-Content -Path $waagentFile)[$waagentStartLineNumber - 1]
-            $waagentStartTime = [datetime]($waagentStartLine.Split()[0] + " " + $waagentStartLine.Split()[1])
-
+            try {
+                $waagentStartTime = [datetime]($waagentStartLine.Split()[0] + " " + $waagentStartLine.Split()[1])
+            } catch {
+                if ($_.Exception.Message.Contains("String was not recognized as a valid DateTime")) {
+                    $waagentStartTime = [datetime]($waagentStartLine.Split()[0].Split('T')[0] + " " + $waagentStartLine.Split()[0].Split('T')[1].Split('Z')[0])
+                }
+            }
             $waagentFinishedLineNumber = (Select-String -Path $waagentFile -Pattern "$walaEndIdentifier")[-1].LineNumber
             $waagentFinishedLine = (Get-Content -Path $waagentFile)[$waagentFinishedLineNumber - 1]
-            $waagentFinishedTime = [datetime]($waagentFinishedLine.Split()[0] + " " + $waagentFinishedLine.Split()[1])
-
+            try {
+                $waagentFinishedTime = [datetime]($waagentFinishedLine.Split()[0] + " " + $waagentFinishedLine.Split()[1])
+            } catch {
+                if ($_.Exception.Message.Contains("String was not recognized as a valid DateTime")) {
+                    $waagentFinishedTime = [datetime]($waagentFinishedLine.Split()[0].Split('T')[0] + " " + $waagentFinishedLine.Split()[0].Split('T')[1].Split('Z')[0])
+                }
+            }
             $WALAProvisionTime = [int]($waagentFinishedTime - $waagentStartTime).TotalSeconds
             Write-LogInfo "$($vmData.RoleName) - WALA Provision Time = $WALAProvisionTime seconds"
             #endregion


### PR DESCRIPTION
Old WALA and new WALA time format is different - 
```
2020/02/14 10:21:07.250491 INFO Daemon Azure Linux Agent Version:2.2.32.2
...
2020-02-14T10:21:16.967899Z INFO ExtHandler [PERIODIC] Using host plugin as default channel.
```
Before fix 
```
02/10/2020 15:00:46 : [ERROR] EXCEPTION : Cannot convert value "2020-02-10T14:46:28.352919Z INFO" to type "System.DateTime". Error: "String was not recognized as a valid DateTime."
02/10/2020 15:00:46 : [ERROR] Source : Line 2840 in script .\Libraries\Azure.psm1.
```
After fix
```
02/10/2020 15:45:08 : [INFO ] LISAv2-OneVM-ubuntuAz-FM73-20200210233732-role-0 - WALA Version = 2.2.34
02/10/2020 15:45:08 : [INFO ] LISAv2-OneVM-ubuntuAz-FM73-20200210233732-role-0 - WALA Provision Time = -56622 seconds
02/10/2020 15:45:08 : [INFO ] LISAv2-OneVM-ubuntuAz-FM73-20200210233732-role-0 - Kernel Boot Time = 38.149792 seconds
02/10/2020 15:45:08 : [WARN ] Kernel log file is empty.
```
Run against various gallery images -
```
Oracle 7.6
02/14/2020 10:08:11 : [INFO ] WALA Start Identifier = Azure Linux Agent Version
02/14/2020 10:08:11 : [INFO ] WALA End Identifier = Start env monitor service
02/14/2020 10:08:11 : [INFO ] LISAv2-OneVM-lilirl76-IT82-20200214100619-role-0 - WALA Version = 2.2.35.1
02/14/2020 10:08:11 : [INFO ] LISAv2-OneVM-lilirl76-IT82-20200214100619-role-0 - WALA Provision Time = 17 seconds
02/14/2020 10:08:11 : [INFO ] LISAv2-OneVM-lilirl76-IT82-20200214100619-role-0 - Kernel Boot Time = 25.858385 seconds
02/14/2020 10:08:11 : [INFO ] LISAv2-OneVM-lilirl76-IT82-20200214100619-role-0 - Host Version = 14393-10.0-0-0.305

Debian 9
02/14/2020 10:07:14 : [INFO ] LISAv2-OneVM-lilidebian-VM52-20200214100539-role-0 - WALA Version = 2.2.34
02/14/2020 10:07:14 : [INFO ] LISAv2-OneVM-lilidebian-VM52-20200214100539-role-0 - WALA Provision Time = 1 seconds
02/14/2020 10:07:14 : [INFO ] LISAv2-OneVM-lilidebian-VM52-20200214100539-role-0 - Kernel Boot Time = 26.496396 seconds

CoreOS
02/14/2020 10:05:13 : [INFO ] LISAv2-OneVM-lilicoreos-RQ76-20200214100304-role-0 - WALA Version = 2.2.32.2
02/14/2020 10:05:13 : [INFO ] LISAv2-OneVM-lilicoreos-RQ76-20200214100304-role-0 - WALA Provision Time = 9 seconds
02/14/2020 10:05:13 : [INFO ] LISAv2-OneVM-lilicoreos-RQ76-20200214100304-role-0 - Kernel Boot Time = 47.872893 seconds
02/14/2020 10:05:13 : [INFO ] LISAv2-OneVM-lilicoreos-RQ76-20200214100304-role-0 - Host Version = 14393-10.0-0-0.305

Ubuntu 18.04
02/14/2020 10:07:45 : [INFO ] LISAv2-OneVM-liliu1804-ZY56-20200214100505-role-0 - WALA Version = 2.2.40
02/14/2020 10:07:45 : [INFO ] LISAv2-OneVM-liliu1804-ZY56-20200214100505-role-0 - WALA Provision Time = 4 seconds
02/14/2020 10:07:45 : [INFO ] LISAv2-OneVM-liliu1804-ZY56-20200214100505-role-0 - Kernel Boot Time = 58.21415 seconds
02/14/2020 10:07:45 : [INFO ] LISAv2-OneVM-liliu1804-ZY56-20200214100505-role-0 - Host Version = 14393-10.0-0-0.305

SLES 15 SP1
02/14/2020 09:52:37 : [INFO ] LISAv2-OneVM-lilisles15sp1-MH51-20200214094945-role-0 - WALA Version = 2.2.36
02/14/2020 09:52:37 : [INFO ] LISAv2-OneVM-lilisles15sp1-MH51-20200214094945-role-0 - WALA Provision Time = 27 seconds
02/14/2020 09:52:37 : [INFO ] LISAv2-OneVM-lilisles15sp1-MH51-20200214094945-role-0 - Kernel Boot Time = 63.947858 seconds
```
