### PR TITLE
Added a new Hibernation test

### DIFF
--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -21,34 +21,7 @@ GetDistro
 source ~/constants.sh
 
 function Main() {
-	LogMsg "Starting Hibernation required packages and kernel build in the VM"
-	update_repos
-
-	# Install common packages
-	req_pkg="gcc make flex bison git"
-	install_package $req_pkg
-	LogMsg "$?: Installed the common required packages; $req_pkg"
-
-	source /etc/os-release
-
-	case $DISTRO in
-		redhat_7|centos_7|redhat_8|centos_8)
-			req_pkg="elfutils-libelf-devel ncurses-devel bc elfutils-libelf-devel openssl-devel grub2"
-			;;
-		suse*|sles*)
-			req_pkg="ncurses-devel libelf-dev"
-			;;
-		ubuntu*)
-			req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache"
-			;;
-		*)
-			LogErr "$DISTRO does not support hibernation"
-			SetTestStateFailed
-			exit 0
-			;;
-	esac
-	install_package $req_pkg
-	LogMsg "$?: Installed required packages, $req_pkg"
+	
 
 	# Prepare swap space
 	for key in n p 1 2048 '' t 82 p w
@@ -80,30 +53,63 @@ function Main() {
 	ret=$(cat /etc/fstab)
 	LogMsg "$?: Displayed the contents in /etc/fstab"
 
-	# Start kernel compilation
-	LogMsg "Clone and compile new kernel from $hb_url to /usr/src/linux"
-	git clone $hb_url /usr/src/linux
-	LogMsg "$?: Cloned the kernel source repo in /usr/src/linux"
+	if [[$hb_url != ""]]; then
+		LogMsg "Starting Hibernation required packages and kernel build in the VM"
+		update_repos
 
-	cd /usr/src/linux/
+		# Install common packages
+		req_pkg="gcc make flex bison git"
+		install_package $req_pkg
+		LogMsg "$?: Installed the common required packages; $req_pkg"
 
-	git checkout $hb_branch
-	LogMsg "$?: Changed to $hb_branch"
+		source /etc/os-release
 
-	cp /boot/config*-azure /usr/src/linux/.config
-	LogMsg "$?: Copied the default config file from /boot"
+		case $DISTRO in
+			redhat_7|centos_7|redhat_8|centos_8)
+				req_pkg="elfutils-libelf-devel ncurses-devel bc elfutils-libelf-devel openssl-devel grub2"
+				;;
+			suse*|sles*)
+				req_pkg="ncurses-devel libelf-dev"
+				;;
+			ubuntu*)
+				req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache"
+				;;
+			*)
+				LogErr "$DISTRO does not support hibernation"
+				SetTestStateFailed
+				exit 0
+				;;
+		esac
+		install_package $req_pkg
+		LogMsg "$?: Installed required packages, $req_pkg"
 
-	yes '' | make oldconfig
-	LogMsg "$?: Did oldconfig make file"
+		# Start kernel compilation
+		LogMsg "Clone and compile new kernel from $hb_url to /usr/src/linux"
+		git clone $hb_url /usr/src/linux
+		LogMsg "$?: Cloned the kernel source repo in /usr/src/linux"
 
-	make -j $(getconf _NPROCESSORS_ONLN)
-	LogMsg "$?: Compiled the source codes"
+		cd /usr/src/linux/
 
-	make modules_install
-	LogMsg "$?: Installed new kernel modules"
+		git checkout $hb_branch
+		LogMsg "$?: Changed to $hb_branch"
 
-	make install
-	LogMsg "$?: Install new kernel"
+		cp /boot/config*-azure /usr/src/linux/.config
+		LogMsg "$?: Copied the default config file from /boot"
+
+		yes '' | make oldconfig
+		LogMsg "$?: Did oldconfig make file"
+
+		make -j $(getconf _NPROCESSORS_ONLN)
+		LogMsg "$?: Compiled the source codes"
+
+		make modules_install
+		LogMsg "$?: Installed new kernel modules"
+
+		make install
+		LogMsg "$?: Install new kernel"
+		cd
+
+	fi
 
 	sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub.d/50-cloudimg-settings.cfg
 	LogMsg "$?: Updated the 50-cloudimg-settings.cfg with resume=$sw_uuid"
@@ -117,7 +123,6 @@ function Main() {
 	update-grub2
 	LogMsg "$?: Ran update-grub2"
 
-	cd
 
 	# Append the test log to the main log files.
 	cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -120,8 +120,10 @@ function Main() {
 }
 
 # main body
+LogMsg "Start time: $date"
 Main
 cp ~/TestExecution.log ~/Setup-TestExecution.log
 cp ~/TestExecutionError.log ~/Setup-TestExecutionError.log
 SetTestStateCompleted
+LogMsg "End time: $date"
 exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -33,7 +33,7 @@ function Main() {
 
 	case $DISTRO in
 		redhat_7|centos_7|redhat_8|centos_8)
-			req_pkg="elfutils-libelf-devel"	
+			req_pkg="elfutils-libelf-devel ncurses-devel bc elfutils-libelf-devel openssl-devel grub2"
 			;;
 		suse*|sles*)
 			req_pkg="ncurses-devel libelf-dev"

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -14,13 +14,11 @@
 UtilsInit
 
 # Constants/Globals
-# Due to fdisk and hibernate command later, it needs to be running by root.
-HOMEDIR="/root"
 # Get distro information
 GetDistro
 
 # Load the global variables
-source /root/constants.sh
+source ./constants.sh
 
 function Verify_File {
 	# Verify if the file exists or not.
@@ -79,29 +77,64 @@ function Main() {
 			;;
 	esac
 
-	cp /boot/config*-azure /root/linux/.config
-	cd /root/linux
+	# Prepare swap space
+	for key in n p 1 2048 2147483647 t 82 w
+	do
+		echo $key >> ./keys.txt
+	done
+
+	sudo cat ./keys.txt | sudo fdisk /dev/sdc
+
+	sudo mkswap /dev/sdc1
+
+	sudo swapon /dev/sdc1
+
+	sw_uuid=$(blkid | grep -i sw | awk '{print $2}' | tr -d " " | sed 's/"//g')
+
+	sudo chmod 766 /etc/fstab
+
+	sudo echo $sw_uuid none swap sw 0 0 >> /etc/fstab
+
+	# Start kernel compilation
+	git clone $hb_url
+	LogMsg "$?: Cloned the kernel source repo"
+
+	cp /boot/config*-azure ./linux/.config
+	LogMsg "$?: Copied the default config file from /boot"
+
+	cd ./linux
+	git branch $hb_branch
+	LogMsg "$?: Changed to $hb_branch"
+
 	yes '' | make oldconfig
+	LogMsg "$?: Did oldconfig make file"
+
 	make -j $(getconf _NPROCESSORS_ONLN)
+	LogMsg "$?: Compiled the source codes"
+
 	make modules_install
+	LogMsg "$?: Installed new kernel modules"
+
 	make install
+	LogMsg "$?: Install new kernel"
 
-	sed -i -e 's/rootdelay=300/rootdelay=300 resume=UUID=$uuid/g' /etc/default/grub.d/50-cloudimg-settings.cfg
-	Verify_Result
+	sed -i -e 's/rootdelay=300/rootdelay=300 resume=UUID=$sw_uuid/g' /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated the 50-cloudimg-settings.cfg with resume=UUID=$sw_uuid"
 
-	update-grud2
+	update-grub2
+	LogMsg "$?: Ran update-grub2"
 
-	echo 'echo disk > /sys/power/state' > /root/test.sh
-	chmod 766 /root/test.sh
+	LogMsg "Setting hibernate command to ./test.sh"
+	echo 'echo disk > /sys/power/state' > ./test.sh
+	chmod 766 ./test.sh
 
-	echo "setup_completed=0" >> /root/constants.sh
-	LogMsg "Completed SetupRDAM process"
+	echo "setup_completed=0" >> ./constants.sh
 	LogMsg "Main function completed"
 }
 
 # main body
 Main
-cp /root/TestExecution.log /root/Setup-TestExecution.log
-cp /root/TestExecutionError.log /root/Setup-TestExecutionError.log
+cp ./TestExecution.log ./Setup-TestExecution.log
+cp ./TestExecutionError.log ./Setup-TestExecutionError.log
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+# This script will set up hibernation configuration in the VM.
+########################################################################################################
+# Source utils.sh
+. utils.sh || {
+	echo "Error: unable to source utils.sh!"
+	echo "TestAborted" >state.txt
+	exit 0
+}
+# Source constants file and initialize most common variables
+UtilsInit
+
+# Constants/Globals
+# Get distro information
+GetDistro
+
+# Load the global variables
+source ~/constants.sh
+
+function Main() {
+	LogMsg "Starting Hibernation required packages and kernel build in the VM"
+	update_repos
+
+	# Install common packages
+	req_pkg="gcc make flex bison git"
+	install_package $req_pkg
+	LogMsg "$?: Installed the common required packages; $req_pkg"
+
+	source /etc/os-release
+
+	case $DISTRO in
+		redhat_7|centos_7|redhat_8|centos_8)
+			req_pkg="elfutils-libelf-devel ncurses-devel bc elfutils-libelf-devel openssl-devel grub2"
+			;;
+		suse*|sles*)
+			req_pkg="ncurses-devel libelf-dev"
+			;;
+		ubuntu*)
+			req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache"
+			;;
+		*)
+			LogErr "$DISTRO does not support hibernation"
+			SetTestStateFailed
+			exit 0
+			;;
+	esac
+	install_package $req_pkg
+	LogMsg "$?: Installed required packages, $req_pkg"
+
+	# Prepare swap space
+	for key in n p 1 2048 '' t 82 p w
+	do
+		echo $key >> ~/keys.txt
+	done
+	LogMsg "Generated the keys.txt file for fdisk commanding"
+
+	sudo cat ~/keys.txt | sudo fdisk /dev/sdc
+	LogMsg "$?: Executed fdisk command"
+	ret=$(sudo ls /dev/sd*)
+	LogMsg "$?: List out /dev/sd* - $ret"
+
+	sudo mkswap /dev/sdc1
+	LogMsg "$?: Set up the swap space"
+
+	sudo swapon /dev/sdc1
+	LogMsg "$?: Enabled the swap space"
+	ret=$(swapon -s)
+	LogMsg "$?: Show the swap on information - $ret"
+
+	sw_uuid=$(blkid | grep -i sw | awk '{print $2}' | tr -d " " | sed 's/"//g')
+	LogMsg "$?: Found the Swap space disk UUID: $sw_uuid"
+
+	sudo chmod 766 /etc/fstab
+
+	sudo echo $sw_uuid none swap sw 0 0 >> /etc/fstab
+	LogMsg "$?: Updated /etc/fstab file with swap uuid information"
+	ret=$(cat /etc/fstab)
+	LogMsg "$?: Displayed the contents in /etc/fstab"
+
+	# Start kernel compilation
+	LogMsg "Clone and compile new kernel from $hb_url to /usr/src/linux"
+	git clone $hb_url /usr/src/linux
+	LogMsg "$?: Cloned the kernel source repo in /usr/src/linux"
+
+	cd /usr/src/linux/
+
+	git checkout $hb_branch
+	LogMsg "$?: Changed to $hb_branch"
+
+	cp /boot/config*-azure /usr/src/linux/.config
+	LogMsg "$?: Copied the default config file from /boot"
+
+	yes '' | make oldconfig
+	LogMsg "$?: Did oldconfig make file"
+
+	make -j $(getconf _NPROCESSORS_ONLN)
+	LogMsg "$?: Compiled the source codes"
+
+	make modules_install
+	LogMsg "$?: Installed new kernel modules"
+
+	make install
+	LogMsg "$?: Install new kernel"
+
+	sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated the 50-cloudimg-settings.cfg with resume=$sw_uuid"
+
+	sed -i -e "s/GRUB_HIDDEN_TIMEOUT=*.*/GRUB_HIDDEN_TIMEOUT=30/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated GRUB_HIDDEN_TIMEOUT value with 30"
+
+	sed -i -e "s/GRUB_TIMEOUT=*.*/GRUB_TIMEOUT=30/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated GRUB_TIMEOUT value with 30"
+
+	update-grub2
+	LogMsg "$?: Ran update-grub2"
+
+	cd
+
+	# Append the test log to the main log files.
+	cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log
+	cat /usrsrc/linux/TestExecutionError.log >> ~/TestExecutionError.log
+
+	LogMsg "Setting hibernate command to test.sh"
+	echo 'echo disk > /sys/power/state' > ~/test.sh
+	chmod 766 ~/test.sh
+
+	echo "setup_completed=0" >> ~/constants.sh
+	LogMsg "Main function completed"
+}
+
+# main body
+LogMsg "Start time: $(date)"
+Main
+cp ~/TestExecution.log ~/Setup-TestExecution.log
+cp ~/TestExecutionError.log ~/Setup-TestExecutionError.log
+SetTestStateCompleted
+LogMsg "End time: $(date)"
+exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -21,8 +21,6 @@ GetDistro
 source ~/constants.sh
 
 function Main() {
-	
-
 	# Prepare swap space
 	for key in n p 1 2048 '' t 82 p w
 	do
@@ -107,8 +105,12 @@ function Main() {
 
 		make install
 		LogMsg "$?: Install new kernel"
+
 		cd
 
+		# Append the test log to the main log files.
+		cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log
+		cat /usrsrc/linux/TestExecutionError.log >> ~/TestExecutionError.log
 	fi
 
 	sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub.d/50-cloudimg-settings.cfg
@@ -122,11 +124,6 @@ function Main() {
 
 	update-grub2
 	LogMsg "$?: Ran update-grub2"
-
-
-	# Append the test log to the main log files.
-	cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log
-	cat /usrsrc/linux/TestExecutionError.log >> ~/TestExecutionError.log
 
 	LogMsg "Setting hibernate command to test.sh"
 	echo 'echo disk > /sys/power/state' > ~/test.sh

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -17,9 +17,6 @@ UtilsInit
 # Get distro information
 GetDistro
 
-# Load the global variables
-source ~/constants.sh
-
 function Main() {
 	# Prepare swap space
 	for key in n p 1 2048 '' t 82 p w
@@ -51,7 +48,7 @@ function Main() {
 	ret=$(cat /etc/fstab)
 	LogMsg "$?: Displayed the contents in /etc/fstab"
 
-	if [[$hb_url != ""]]; then
+	if [[ $hb_url != "" ]]; then
 		LogMsg "Starting Hibernation required packages and kernel build in the VM"
 		update_repos
 
@@ -59,8 +56,6 @@ function Main() {
 		req_pkg="gcc make flex bison git"
 		install_package $req_pkg
 		LogMsg "$?: Installed the common required packages; $req_pkg"
-
-		source /etc/os-release
 
 		case $DISTRO in
 			redhat_7|centos_7|redhat_8|centos_8)
@@ -110,7 +105,7 @@ function Main() {
 
 		# Append the test log to the main log files.
 		cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log
-		cat /usrsrc/linux/TestExecutionError.log >> ~/TestExecutionError.log
+		cat /usr/src/linux/TestExecutionError.log >> ~/TestExecutionError.log
 	fi
 
 	sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub.d/50-cloudimg-settings.cfg
@@ -134,10 +129,8 @@ function Main() {
 }
 
 # main body
-LogMsg "Start time: $(date)"
 Main
 cp ~/TestExecution.log ~/Setup-TestExecution.log
 cp ~/TestExecutionError.log ~/Setup-TestExecutionError.log
 SetTestStateCompleted
-LogMsg "End time: $(date)"
 exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -25,7 +25,7 @@ function Main() {
 	update_repos
 
 	# Install common packages
-	req_pkg="gcc make flex bison git libncurses5-dev libssl-dev ccache"
+	req_pkg="gcc make flex bison git"
 	install_package $req_pkg
 	LogMsg "$?: Installed the common required packages; $req_pkg"
 
@@ -39,7 +39,7 @@ function Main() {
 			req_pkg="ncurses-devel libelf-dev"
 			;;
 		ubuntu*)
-			req_pkg="build-essential fakeroot"
+			req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache"
 			;;
 		*)
 			LogErr "$DISTRO does not support hibernation"

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+# This script will set up hibernation configuration in the VM.
+########################################################################################################
+# Source utils.sh
+. utils.sh || {
+	echo "Error: unable to source utils.sh!"
+	echo "TestAborted" >state.txt
+	exit 0
+}
+# Source constants file and initialize most common variables
+UtilsInit
+
+# Constants/Globals
+# Due to fdisk and hibernate command later, it needs to be running by root.
+HOMEDIR="/root"
+# Get distro information
+GetDistro
+
+# Load the global variables
+source /root/constants.sh
+
+function Verify_File {
+	# Verify if the file exists or not.
+	# The first parameter is absolute path
+	if [ -e $1 ]; then
+		LogMsg "File found $1"
+	else
+		LogErr "File not found $1"
+	fi
+}
+
+function Found_File {
+	# The first parameter is file name, the second parameter is filtering
+	target_path=$(find / -name $1 | grep $2)
+	if [ -n $target_path ]; then
+		LogMsg "Verified $1 binary in $target_path successfully"
+	else
+		LogErr "Could not verify $1 binary in the system"
+	fi
+}
+
+function Verify_Result {
+	# Return OK string, if the latest result is 0
+	if [ $? -eq 0 ]; then
+		LogMsg "OK"
+	else
+		LogErr "FAIL"
+	fi
+}
+
+function Main() {
+	LogMsg "Starting Hibernation required packages and kernel build in the VM"
+	update_repos
+
+	# Install common packages
+	req_pkg="gcc make flex bison git build-essential fakeroot libncurses5-dev libssl-dev ccache"
+	install_package $req_pkg
+	LogMsg "$?: Installed the common required packages; $req_pkg"
+
+	source /etc/os-release
+
+	case $DISTRO in
+		redhat_7|centos_7|redhat_8|centos_8)
+			;;
+		suse*|sles*)
+			req_pkg="ncurses-devel libelf-dev"
+			install_package $req_pkg
+			LogMsg "$?: Installed required packages, $req_pkg"
+			;;
+		ubuntu*)
+			;;
+		*)
+			LogErr "$DISTRO does not support hibernation"
+			SetTestStateFailed
+			exit 0
+			;;
+	esac
+
+	cp /boot/config*-azure /root/linux/.config
+	cd /root/linux
+	yes '' | make oldconfig
+	make -j $(getconf _NPROCESSORS_ONLN)
+	make modules_install
+	make install
+
+	sed -i -e 's/rootdelay=300/rootdelay=300 resume=UUID=$uuid/g' /etc/default/grub.d/50-cloudimg-settings.cfg
+	Verify_Result
+
+	update-grud2
+
+	echo 'echo disk > /sys/power/state' > /root/test.sh
+	chmod 766 /root/test.sh
+
+	echo "setup_completed=0" >> /root/constants.sh
+	LogMsg "Completed SetupRDAM process"
+	LogMsg "Main function completed"
+}
+
+# main body
+Main
+cp /root/TestExecution.log /root/Setup-TestExecution.log
+cp /root/TestExecutionError.log /root/Setup-TestExecutionError.log
+SetTestStateCompleted
+exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -75,16 +75,16 @@ function Main() {
 	LogMsg "Updated /etc/fstab file with swap uuid information"
 
 	# Start kernel compilation
-	LogMsg "Clone and compile new kernel from $hb_url"
-	git clone $hb_url
-	LogMsg "$?: Cloned the kernel source repo"
+	LogMsg "Clone and compile new kernel from $hb_url to /usr/src"
+	git clone $hb_url /usr/src/
+	LogMsg "$?: Cloned the kernel source repo in /usr/src/"
 
-	cd linux
+	cd /usr/src/linux/
 
 	git checkout $hb_branch
 	LogMsg "$?: Changed to $hb_branch"
 
-	cp /boot/config*-azure ./.config
+	cp /boot/config*-azure /usr/src/linux/.config
 	LogMsg "$?: Copied the default config file from /boot"
 
 	yes '' | make oldconfig

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -18,36 +18,7 @@ UtilsInit
 GetDistro
 
 # Load the global variables
-source ./constants.sh
-
-function Verify_File {
-	# Verify if the file exists or not.
-	# The first parameter is absolute path
-	if [ -e $1 ]; then
-		LogMsg "File found $1"
-	else
-		LogErr "File not found $1"
-	fi
-}
-
-function Found_File {
-	# The first parameter is file name, the second parameter is filtering
-	target_path=$(find / -name $1 | grep $2)
-	if [ -n $target_path ]; then
-		LogMsg "Verified $1 binary in $target_path successfully"
-	else
-		LogErr "Could not verify $1 binary in the system"
-	fi
-}
-
-function Verify_Result {
-	# Return OK string, if the latest result is 0
-	if [ $? -eq 0 ]; then
-		LogMsg "OK"
-	else
-		LogErr "FAIL"
-	fi
-}
+source ~/constants.sh
 
 function Main() {
 	LogMsg "Starting Hibernation required packages and kernel build in the VM"
@@ -78,33 +49,41 @@ function Main() {
 	esac
 
 	# Prepare swap space
-	for key in n p 1 2048 2147483647 t 82 w
+	for key in n p 1 2048 '' t 82 p w
 	do
-		echo $key >> ./keys.txt
+		echo $key >> ~/keys.txt
 	done
+	LogMsg "Generated the keys.txt file for fdisk commanding"
 
-	sudo cat ./keys.txt | sudo fdisk /dev/sdc
+	sudo cat ~/keys.txt | sudo fdisk /dev/sdc
+	LogMsg "$?: Executed fdisk command"
 
 	sudo mkswap /dev/sdc1
+	LogMsg "Made the swap space"
 
 	sudo swapon /dev/sdc1
+	LogMsg "Enabled the swap space"
 
 	sw_uuid=$(blkid | grep -i sw | awk '{print $2}' | tr -d " " | sed 's/"//g')
+	LogMsg "Found the Swap space disk UUID: $sw_uuid"
 
 	sudo chmod 766 /etc/fstab
 
 	sudo echo $sw_uuid none swap sw 0 0 >> /etc/fstab
+	LogMsg "Updated /etc/fstab file with swap uuid information"
 
 	# Start kernel compilation
+	LogMsg "Clone and compile new kernel from $hb_url"
 	git clone $hb_url
 	LogMsg "$?: Cloned the kernel source repo"
 
-	cp /boot/config*-azure ./linux/.config
-	LogMsg "$?: Copied the default config file from /boot"
+	cd linux
 
-	cd ./linux
-	git branch $hb_branch
+	git checkout $hb_branch
 	LogMsg "$?: Changed to $hb_branch"
+
+	cp /boot/config*-azure ./.config
+	LogMsg "$?: Copied the default config file from /boot"
 
 	yes '' | make oldconfig
 	LogMsg "$?: Did oldconfig make file"
@@ -118,23 +97,31 @@ function Main() {
 	make install
 	LogMsg "$?: Install new kernel"
 
-	sed -i -e 's/rootdelay=300/rootdelay=300 resume=UUID=$sw_uuid/g' /etc/default/grub.d/50-cloudimg-settings.cfg
-	LogMsg "$?: Updated the 50-cloudimg-settings.cfg with resume=UUID=$sw_uuid"
+	sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated the 50-cloudimg-settings.cfg with resume=$sw_uuid"
+
+	sed -i -e "s/GRUB_HIDDEN_TIMEOUT=*.*/GRUB_HIDDEN_TIMEOUT=30/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated GRUB_HIDDEN_TIMEOUT value with 30"
+
+	sed -i -e "s/GRUB_TIMEOUT=*.*/GRUB_TIMEOUT=30/g" /etc/default/grub.d/50-cloudimg-settings.cfg
+	LogMsg "$?: Updated GRUB_TIMEOUT value with 30"
 
 	update-grub2
 	LogMsg "$?: Ran update-grub2"
 
-	LogMsg "Setting hibernate command to ./test.sh"
-	echo 'echo disk > /sys/power/state' > ./test.sh
-	chmod 766 ./test.sh
+	cd
 
-	echo "setup_completed=0" >> ./constants.sh
+	LogMsg "Setting hibernate command to test.sh"
+	echo 'echo disk > /sys/power/state' > ~/test.sh
+	chmod 766 ~/test.sh
+
+	echo "setup_completed=0" >> ~/constants.sh
 	LogMsg "Main function completed"
 }
 
 # main body
 Main
-cp ./TestExecution.log ./Setup-TestExecution.log
-cp ./TestExecutionError.log ./Setup-TestExecutionError.log
+cp ~/TestExecution.log ~/Setup-TestExecution.log
+cp ~/TestExecutionError.log ~/Setup-TestExecutionError.log
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -59,25 +59,31 @@ function Main() {
 
 	sudo cat ~/keys.txt | sudo fdisk /dev/sdc
 	LogMsg "$?: Executed fdisk command"
+	ret=$(sudo ls /dev/sd*)
+	LogMsg "$?: List out /dev/sd* - $ret"
 
 	sudo mkswap /dev/sdc1
-	LogMsg "Made the swap space"
+	LogMsg "$?: Set up the swap space"
 
 	sudo swapon /dev/sdc1
-	LogMsg "Enabled the swap space"
+	LogMsg "$?: Enabled the swap space"
+	ret=$(swapon -s)
+	LogMsg "$?: Show the swap on information - $ret"
 
 	sw_uuid=$(blkid | grep -i sw | awk '{print $2}' | tr -d " " | sed 's/"//g')
-	LogMsg "Found the Swap space disk UUID: $sw_uuid"
+	LogMsg "$?: Found the Swap space disk UUID: $sw_uuid"
 
 	sudo chmod 766 /etc/fstab
 
 	sudo echo $sw_uuid none swap sw 0 0 >> /etc/fstab
-	LogMsg "Updated /etc/fstab file with swap uuid information"
+	LogMsg "$?: Updated /etc/fstab file with swap uuid information"
+	ret=$(cat /etc/fstab)
+	LogMsg "$?: Displayed the contents in /etc/fstab"
 
 	# Start kernel compilation
-	LogMsg "Clone and compile new kernel from $hb_url to /usr/src"
-	git clone $hb_url /usr/src/
-	LogMsg "$?: Cloned the kernel source repo in /usr/src/"
+	LogMsg "Clone and compile new kernel from $hb_url to /usr/src/linux"
+	git clone $hb_url /usr/src/linux
+	LogMsg "$?: Cloned the kernel source repo in /usr/src/linux"
 
 	cd /usr/src/linux/
 
@@ -113,6 +119,10 @@ function Main() {
 
 	cd
 
+	# Append the test log to the main log files.
+	cat /usr/src/linux/TestExecution.log >> ~/TestExecution.log
+	cat /usrsrc/linux/TestExecutionError.log >> ~/TestExecutionError.log
+
 	LogMsg "Setting hibernate command to test.sh"
 	echo 'echo disk > /sys/power/state' > ~/test.sh
 	chmod 766 ~/test.sh
@@ -122,10 +132,10 @@ function Main() {
 }
 
 # main body
-LogMsg "Start time: $date"
+LogMsg "Start time: $(date)"
 Main
 cp ~/TestExecution.log ~/Setup-TestExecution.log
 cp ~/TestExecutionError.log ~/Setup-TestExecutionError.log
 SetTestStateCompleted
-LogMsg "End time: $date"
+LogMsg "End time: $(date)"
 exit 0

--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -25,7 +25,7 @@ function Main() {
 	update_repos
 
 	# Install common packages
-	req_pkg="gcc make flex bison git build-essential fakeroot libncurses5-dev libssl-dev ccache"
+	req_pkg="gcc make flex bison git libncurses5-dev libssl-dev ccache"
 	install_package $req_pkg
 	LogMsg "$?: Installed the common required packages; $req_pkg"
 
@@ -33,13 +33,13 @@ function Main() {
 
 	case $DISTRO in
 		redhat_7|centos_7|redhat_8|centos_8)
+			req_pkg="elfutils-libelf-devel"	
 			;;
 		suse*|sles*)
 			req_pkg="ncurses-devel libelf-dev"
-			install_package $req_pkg
-			LogMsg "$?: Installed required packages, $req_pkg"
 			;;
 		ubuntu*)
+			req_pkg="build-essential fakeroot"
 			;;
 		*)
 			LogErr "$DISTRO does not support hibernation"
@@ -47,6 +47,8 @@ function Main() {
 			exit 0
 			;;
 	esac
+	install_package $req_pkg
+	LogMsg "$?: Installed required packages, $req_pkg"
 
 	# Prepare swap space
 	for key in n p 1 2048 '' t 82 p w

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -137,8 +137,8 @@ function Main {
 
 		# Resume the VM
 		Start-AzVM -Name $vmName -ResourceGroupName $rgName -NoWait | Out-Null
-		Write-LogInfo "Waked up the VM $vmName in Resource Group $rgName and waiting 120 seconds"
-		Start-Sleep -s 120
+		Write-LogInfo "Waked up the VM $vmName in Resource Group $rgName and waiting 180 seconds"
+		Start-Sleep -s 180
 
 		#Verify the VM status after power on event
 		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -54,7 +54,7 @@ function Main {
 		Start-Sleep -s 30
 		$vm = Add-AzVMDataDisk -VM $vm -Name $dataDiskName -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
 		Start-Sleep -s 30
-		
+
 		Update-AzVM -VM $vm -ResourceGroupName $rgName
 		Write-LogInfo "Updated the VM with a new data disk"
 		Write-LogInfo "Waiting for 30 seconds for configuration sync"

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -1,0 +1,211 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+	Perform a simple VM hibernation in Azure or Hyper-V
+
+.Description
+	This test can be performend in Azure and Hyper-V both.
+	1. Prepare swap space for hibernation
+	2. Compile a new kernel (optional)
+	3. Update the grup.cfg with resume=UUID=xxxx where is from blkid swap disk
+	4. Hibernate the VM, and verify the VM status
+	5. Resume the VM and verify the VM status.
+	6. Verify no kernel panic or call trace
+#>
+
+param([object] $AllVmData, [string]$TestParams)
+
+function Main {
+	param($AllVMData, $TestParams)
+	$currentTestResult = Create-TestResultObject
+	try {
+		$testResult = "FAIL"
+		Write-LogDbg "Prepare swap space for VM $($AllVMData.RoleName) in RG $($AllVMData.ResourceGroupName)."
+		# Prepare the swap space in the target VM
+		$rgName = $(AllVMData.ResourceGroupName)
+		$vmName = $($AllVMData.RoleName)
+		$location = $($AllVMData.Location)
+		$storageType = 'StandardSSD_LRS'
+		$dataDiskName = $vmName + '_datadisk1'
+
+		#region Generate constants.sh
+		# We need to add extra parameters to constants.sh file apart from parameter properties defined in XML.
+		# Hence, we are generating constants.sh file again in test script.
+
+		Write-LogInfo "Generating constants.sh ..."
+		$constantsFile = "$LogDir\constants.sh"
+		foreach ($TestParam in $CurrentTestData.TestParameters.param) {
+			Add-Content -Value "$TestParam" -Path $constantsFile
+			Write-LogInfo "$TestParam added to constants.sh"
+			if ($TestParam -imatch "hb_url") {
+				$hb_url = [int]($TestParam.Replace("hb_url=", "").Trim('"'))
+			}
+			if ($TestParam -imatch "hb_branch") {
+				$hb_branch = [int]($TestParam.Replace("hb_branch=", "").Trim('"'))
+			}
+		}
+		Add-Content -Value "hb_url=$hb_url" -Path $constantsFile
+		Write-LogInfo "hb_url=$hb_url added to constants.sh"
+		Add-Content -Value "hb_branch=$hb_branch" -Path $constantsFile
+		Write-LogInfo "hb_branch=$hb_branch added to constants.sh"
+
+		Write-LogInfo "constants.sh created successfully..."
+		#endregion
+
+		#region Add a new swap disk to Azure VM
+		$diskConfig = New-AzDiskConfig -SkuName $storageType -Location $location -CreateOption Empty -DiskSizeGB 1024
+		$dataDisk1 = New-AzDisk -DiskName $dataDiskName -Disk $diskConfig -ResourceGroupName $rgName
+
+		$vm = Get-AzVM -Name $vmName -ResourceGroupName $rgName
+		$vm = Add-AzVMDataDisk -VM $vm -Name $dataDiskName -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
+
+		Update-AzVM -VM $vm -ResourceGroupName $rgName
+
+		# fdisk creates a new Linux swap space
+		"n p 1 2048 2147483647 t 82 w" | ForEach-Object {
+			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "echo ${_} >> /root/keys.txt" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+		}
+		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /root/keys.txt | fdisk /dev/sdc" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+		# mkswap creates the swap space
+		$mkswap_ret = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "mkswap /dev/sdc1" -ignoreLinuxExitCode:$true -runAsSudo
+		Write-LogDbg "mkswap result: $mkswap_ret"
+
+		# swapon enabled the path
+		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "swapon /dev/sdc1" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+		# Get the UUID from the blkid output
+		$blkid_ret = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "blkid" -ignoreLinuxExitCode:$true -runAsSudo
+		Write-LogDbg "blkid result: $blkid_ret"
+
+		$UUID_val = $mkswap_ret.Split(' ')
+		Write-LogMsg "UUID: $UUID_val[12]"
+
+		Add-Content -Value "uuid=$UUID_val[12]" -Path $constantsFile
+		Write-LogInfo "uuid=$UUID_val[12] added to constants.sh"
+
+		Write-LogInfo "constants.sh updated successfully..."
+
+		# Insert a new line in fstab file for permenent disk mounting
+		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "echo '${UUID_val[12]} none swap sw 0 0' >> /etc/fstab" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+		#endregion
+
+		#region Upload files to master VM
+		foreach ($VMData in $AllVMData) {
+			Copy-RemoteFiles -uploadTo $VMData.PublicIP -port $VMData.SSHPort `
+				-files "$constantsFile,$($CurrentTestData.files)" -username $user -password $password -upload -runAsSudo
+		}
+		#endregion
+
+		# Run kernel compilation if defined
+		# Configuration for the hibernation
+		if ($hb_url -ne "") {
+			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "/root/SetupHbKernel.sh" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+
+			# Wait for kernel compilation completion. 20 min timeout
+			$timeout = New-Timespan -Minutes 20
+			$sw = [diagnostics.stopwatch]::StartNew()
+			while ($sw.elapsed -lt $timeout){
+				$vmCount = $AllVMData.Count
+				foreach ($VMData in $AllVMData) {
+					Wait-Time -seconds 15
+					$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "cat /root/state.txt" -runAsSudo
+					if ($state -eq "TestCompleted") {
+						$kernelCompileCompleted = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "cat /root/constants.sh | grep setup_completed=0" -runAsSudo
+						if ($kernelCompileCompleted -ne "setup_completed=0") {
+							Throw "SetupHbKernel.sh run finished on $($VMData.RoleName) but setup was not successful!"
+						}
+						Write-LogInfo "SetupHbKernel.sh finished on $($VMData.RoleName)"
+						$vmCount--
+					}
+
+					if ($state -eq "TestSkipped") {
+						Write-LogInfo "SetupHbKernel.sh finished with SKIPPED state!"
+						$testResult = "SKIPPED"
+						return "SKIPPED"
+					}
+
+					if (($state -eq "TestFailed") -or ($state -eq "TestAborted")) {
+						Write-LogErr "SetupHbKernel.sh didn't finish successfully!"
+						$testResult = $resultAborted
+						return $resultAborted
+					}
+				}
+				if ($vmCount -eq 0){
+					break
+				}
+				Write-LogInfo "SetupHbKernel.sh is still running on $vmCount VM(s)!"
+			}
+			if ($vmCount -eq 0){
+				Write-LogInfo "SetupHbKernel.sh is done"
+			} else {
+				Throw "SetupHbKernel.sh didn't finish at least on one VM!"
+			}
+		}
+
+		# Reboot VM to apply swap setup changes
+		Write-LogInfo "Rebooting All VMs!"
+		$TestProvider.RestartAllDeployments($AllVMData)
+
+		# Check the VM status before hibernation
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified VM status is running before hibernation"
+		} else {
+			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status before hibernation"
+			throw "Can not identify VM status before hibernate"
+		}
+
+		# Hibernate the VM
+		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "source /root/test.sh" -ignoreLinuxExitCode:$true -runAsSudo | Out-Null
+		Write-LogInfo "Sent hibernate command to the system"
+		Start-Sleep -s 120
+
+		# Verify the VM status
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM stopped") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified VM status is running after hibernation command sent"
+		} else {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status after hibernation command sent"
+			throw "Can not identify VM ststus after hibernate"
+		}
+
+		# Resume the VM
+		Start-AzVM -Name $vmName -ResourceGroupName $rgName -NoWait | Out-Null
+		Write-LogInfo "Waked up the VM $vmName in Resource Group $rgName"
+		Start-Sleep -s 120
+
+		#Verify the VM status after power on event
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified VM status is running before resuming"
+		} else {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status before resuming"
+			throw "Can not identify VM status after resuming"
+		}
+
+		# Verify the kernel panic or call trace
+		$calltrace_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -i 'call trace'" -ignoreLinuxExitCode:$true -runAsSudo
+
+		if ($calltrace_filter -ne "") {
+			Write-LogInfo "Found Call Trace in dmesg"
+			throw "Call trace in dmesg"
+		} else {
+			Write-LogInfo "Not found call trace in dmesg"
+		}
+
+	} catch {
+		$ErrorMessage =  $_.Exception.Message
+		$ErrorLine = $_.InvocationInfo.ScriptLineNumber
+		Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+	} finally {
+		if (!$testResult) {
+			$testResult = $resultAborted
+		}
+		$resultArr = $testResult
+	}
+
+	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+	return $currentTestResult
+}
+
+Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -1,0 +1,190 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+	Perform a simple VM hibernation in Azure or Hyper-V
+
+.Description
+	This test can be performend in Azure and Hyper-V both.
+	1. Prepare swap space for hibernation
+	2. Compile a new kernel (optional)
+	3. Update the grup.cfg with resume=UUID=xxxx where is from blkid swap disk
+	4. Hibernate the VM, and verify the VM status
+	5. Resume the VM and verify the VM status.
+	6. Verify no kernel panic or call trace
+#>
+
+param([object] $AllVmData, [string]$TestParams)
+
+function Main {
+	param($AllVMData, $TestParams)
+	$currentTestResult = Create-TestResultObject
+	try {
+		$testResult = $resultFail
+		Write-LogDbg "Prepare swap space for VM $($AllVMData.RoleName) in RG $($AllVMData.ResourceGroupName)."
+		# Prepare the swap space in the target VM
+		$rgName = $AllVMData.ResourceGroupName
+		$vmName = $AllVMData.RoleName
+		$location = $AllVMData.Location
+		$storageType = 'StandardSSD_LRS'
+		$dataDiskName = $vmName + '_datadisk1'
+
+		#region Generate constants.sh
+		# We need to add extra parameters to constants.sh file apart from parameter properties defined in XML.
+		# Hence, we are generating constants.sh file again in test script.
+
+		Write-LogInfo "Generating constants.sh ..."
+		$constantsFile = "$LogDir\constants.sh"
+		foreach ($TestParam in $CurrentTestData.TestParameters.param) {
+			Add-Content -Value "$TestParam" -Path $constantsFile
+			Write-LogInfo "$TestParam added to constants.sh"
+			if ($TestParam -imatch "hb_url") {
+				$hb_url = $TestParam
+			}
+		}
+
+		Write-LogInfo "constants.sh created successfully..."
+		#endregion
+
+		#region Add a new swap disk to Azure VM
+		$diskConfig = New-AzDiskConfig -SkuName $storageType -Location $location -CreateOption Empty -DiskSizeGB 1024
+		$dataDisk1 = New-AzDisk -DiskName $dataDiskName -Disk $diskConfig -ResourceGroupName $rgName
+
+		$vm = Get-AzVM -Name $vmName -ResourceGroupName $rgName
+		Start-Sleep -s 30
+		$vm = Add-AzVMDataDisk -VM $vm -Name $dataDiskName -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
+		Start-Sleep -s 30
+
+		Update-AzVM -VM $vm -ResourceGroupName $rgName
+		Write-LogInfo "Updated the VM with a new data disk"
+		Write-LogInfo "Waiting for 30 seconds for configuration sync"
+		# Wait for disk sync with Azure host
+		Start-Sleep -s 30
+
+		#region Upload files to master VM
+		foreach ($VMData in $AllVMData) {
+			Copy-RemoteFiles -uploadTo $VMData.PublicIP -port $VMData.SSHPort -files "$constantsFile,$($CurrentTestData.files)" -username $user -password $password -upload
+				Write-LogInfo "Copied the script files to the VM"
+		}
+		#endregion
+
+		# Run kernel compilation if defined
+		# Configuration for the hibernation
+		if ($hb_url -ne "") {
+			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "./SetupHbKernel.sh" -RunInBackground -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
+			Write-LogInfo "Executed SetupHbKernel script inside VM"
+
+			# Wait for kernel compilation completion. 60 min timeout
+			$timeout = New-Timespan -Minutes 60
+			$sw = [diagnostics.stopwatch]::StartNew()
+			while ($sw.elapsed -lt $timeout){
+				$vmCount = $AllVMData.Count
+				Wait-Time -seconds 15
+				$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "cat ~/state.txt"
+				if ($state -eq "TestCompleted") {
+					$kernelCompileCompleted = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "cat ~/constants.sh | grep setup_completed=0"
+					if ($kernelCompileCompleted -ne "setup_completed=0") {
+						Write-LogErr "SetupHbKernel.sh run finished on $($VMData.RoleName) but setup was not successful!"
+					} else {
+						Write-LogInfo "SetupHbKernel.sh finished on $($VMData.RoleName)"
+						$vmCount--
+					}
+					break
+				} elseif ($state -eq "TestSkipped") {
+					Write-LogInfo "SetupHbKernel.sh finished with SKIPPED state!"
+					$testResult = $resultSkipped
+					return $testResult
+				} elseif (($state -eq "TestFailed") -or ($state -eq "TestAborted")) {
+					Write-LogErr "SetupHbKernel.sh didn't finish successfully!"
+					$testResult = $resultAborted
+					return $testResult
+				} else {
+					Write-LogInfo "SetupHbKernel.sh is still running in the VM!"
+				}
+			}
+			if ($vmCount -le 0){
+				Write-LogInfo "SetupHbKernel.sh is done"
+			} else {
+				Throw "SetupHbKernel.sh didn't finish in the VM!"
+			}
+		}
+
+		# Reboot VM to apply swap setup changes
+		Write-LogInfo "Rebooting All VMs!"
+		$TestProvider.RestartAllDeployments($AllVMData)
+
+		# Check the VM status before hibernation
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is running before hibernation"
+		} else {
+			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status before hibernation"
+			throw "Can not identify VM status before hibernate"
+		}
+
+		# Hibernate the VM
+		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "sudo ~/test.sh" -ignoreLinuxExitCode:$true | Out-Null
+		Write-LogInfo "Sent hibernate command to the VM"
+		Start-Sleep -s 120
+
+		# Verify the VM status
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM stopped") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is stopped after hibernation command sent"
+		} else {
+			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status after hibernation command sent"
+			throw "Can not identify VM ststus after hibernate"
+		}
+
+		# Resume the VM
+		Start-AzVM -Name $vmName -ResourceGroupName $rgName -NoWait | Out-Null
+		Write-LogInfo "Waked up the VM $vmName in Resource Group $rgName and waiting 180 seconds"
+		Start-Sleep -s 180
+
+		#Verify the VM status after power on event
+		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
+		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
+			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is running after resuming"
+		} else {
+			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status after resuming"
+			throw "Can not identify VM status after resuming"
+		}
+
+		# Verify the kernel panic or call trace
+		$calltrace_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -i 'call trace'" -ignoreLinuxExitCode:$true
+
+		if ($calltrace_filter -ne "") {
+			Write-LogErr "Found Call Trace in dmesg"
+			throw "Call trace in dmesg"
+		} else {
+			Write-LogInfo "Not found Call Trace in dmesg"
+		}
+
+		# Check the system log if it shows Power Management log
+		$pm_log_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -i 'PM: hibernation '" -ignoreLinuxExitCode:$true
+
+		if ($pm_log_filter -eq "") {
+			Write-LogErr "Could not find Power Management log in dmesg"
+			throw "Missing PM logging in dmesg"
+		} else {
+			Write-LogInfo "Successfully found Power Management log in dmesg"
+			Write-LogInfo $pm_log_filter
+		}
+
+		$testResult = $resultPass
+	} catch {
+		$ErrorMessage =  $_.Exception.Message
+		$ErrorLine = $_.InvocationInfo.ScriptLineNumber
+		Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+	} finally {
+		if (!$testResult) {
+			$testResult = $resultAborted
+		}
+		$resultArr = $testResult
+	}
+
+	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+	return $currentTestResult
+}
+
+Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -38,9 +38,6 @@ function Main {
 		foreach ($TestParam in $CurrentTestData.TestParameters.param) {
 			Add-Content -Value "$TestParam" -Path $constantsFile
 			Write-LogInfo "$TestParam added to constants.sh"
-			if ($TestParam -imatch "hb_url") {
-				$hb_url = $TestParam
-			}
 		}
 
 		Write-LogInfo "constants.sh created successfully..."

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -5,7 +5,7 @@
 	Perform a simple VM hibernation in Azure or Hyper-V
 
 .Description
-	This test can be performend in Azure and Hyper-V both.
+	This test can be performed in Azure and Hyper-V both.
 	1. Prepare swap space for hibernation
 	2. Compile a new kernel (optional)
 	3. Update the grup.cfg with resume=UUID=xxxx where is from blkid swap disk
@@ -61,7 +61,7 @@ function Main {
 		#region Upload files to master VM
 		foreach ($VMData in $AllVMData) {
 			Copy-RemoteFiles -uploadTo $VMData.PublicIP -port $VMData.SSHPort -files "$constantsFile,$($CurrentTestData.files)" -username $user -password $password -upload
-				Write-LogInfo "Copied the script files to the VM"
+			Write-LogInfo "Copied the script files to the VM"
 		}
 		#endregion
 
@@ -110,9 +110,9 @@ function Main {
 		# Check the VM status before hibernation
 		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
 		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
-			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is running before hibernation"
+			Write-LogInfo "$($vmStatus.Statuses[1].DisplayStatus): Verified successfully VM status is running before hibernation"
 		} else {
-			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status before hibernation"
+			Write-LogErr "$($vmStatus.Statuses[1].DisplayStatus): Could not find the VM status before hibernation"
 			throw "Can not identify VM status before hibernate"
 		}
 
@@ -124,11 +124,11 @@ function Main {
 		# Verify the VM status
 		# Can not find if VM hibernation completion or not as soon as it disconnects the network. Assume it is in timeout.
 		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
-		if ($vmStatus.Statuses[1].DisplayStatus = "VM stopped") {
-			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is stopped after hibernation command sent"
+		if ($vmStatus.Statuses[1].DisplayStatus -eq "VM stopped") {
+			Write-LogInfo "$($vmStatus.Statuses[1].DisplayStatus): Verified successfully VM status is stopped after hibernation command sent"
 		} else {
-			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status after hibernation command sent"
-			throw "Can not identify VM ststus after hibernate"
+			Write-LogErr "$($vmStatus.Statuses[1].DisplayStatus): Could not find the VM status after hibernation command sent"
+			throw "Can not identify VM status after hibernate"
 		}
 
 		# Resume the VM
@@ -163,10 +163,10 @@ function Main {
 
 		#Verify the VM status after power on event
 		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
-		if ($vmStatus.Statuses[1].DisplayStatus = "VM running") {
-			Write-LogInfo "$vmStatus.Statuses[1].DisplayStatus: Verified successfully VM status is running after resuming"
+		if ($vmStatus.Statuses[1].DisplayStatus -eq "VM running") {
+			Write-LogInfo "$($vmStatus.Statuses[1].DisplayStatus): Verified successfully VM status is running after resuming"
 		} else {
-			Write-LogErr "$vmStatus.Statuses[1].DisplayStatus: Could not find the VM status after resuming"
+			Write-LogErr "$($vmStatus.Statuses[1].DisplayStatus): Could not find the VM status after resuming"
 			throw "Can not identify VM status after resuming"
 		}
 

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -51,12 +51,15 @@ function Main {
 		$dataDisk1 = New-AzDisk -DiskName $dataDiskName -Disk $diskConfig -ResourceGroupName $rgName
 
 		$vm = Get-AzVM -Name $vmName -ResourceGroupName $rgName
+		Start-Sleep -s 30
 		$vm = Add-AzVMDataDisk -VM $vm -Name $dataDiskName -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
-
+		Start-Sleep -s 30
+		
 		Update-AzVM -VM $vm -ResourceGroupName $rgName
-
+		Write-LogInfo "Updated the VM with a new data disk"
+		Write-LogInfo "Waiting for 30 seconds for configuration sync"
 		# Wait for disk sync with Azure host
-		Start-Sleep -s 10
+		Start-Sleep -s 30
 
 		#region Upload files to master VM
 		foreach ($VMData in $AllVMData) {
@@ -69,11 +72,11 @@ function Main {
 		# Run kernel compilation if defined
 		# Configuration for the hibernation
 		if ($hb_url -ne "") {
-			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "~/SetupHbKernel.sh" -RunInBackground -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
+			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "./SetupHbKernel.sh" -RunInBackground -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
 			Write-LogInfo "Executed SetupHbKernel script inside VM"
 
-			# Wait for kernel compilation completion. 20 min timeout
-			$timeout = New-Timespan -Minutes 30
+			# Wait for kernel compilation completion. 60 min timeout
+			$timeout = New-Timespan -Minutes 60
 			$sw = [diagnostics.stopwatch]::StartNew()
 			while ($sw.elapsed -lt $timeout){
 				$vmCount = $AllVMData.Count

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -69,7 +69,7 @@ function Main {
 		# Run kernel compilation if defined
 		# Configuration for the hibernation
 		if ($hb_url -ne "") {
-			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "./SetupHbKernel.sh" -RunInBackground -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
+			Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "~/SetupHbKernel.sh" -RunInBackground -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
 			Write-LogInfo "Executed SetupHbKernel script inside VM"
 
 			# Wait for kernel compilation completion. 20 min timeout
@@ -77,7 +77,6 @@ function Main {
 			$sw = [diagnostics.stopwatch]::StartNew()
 			while ($sw.elapsed -lt $timeout){
 				$vmCount = $AllVMData.Count
-				
 				Wait-Time -seconds 15
 				$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "cat ~/state.txt"
 				if ($state -eq "TestCompleted") {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -613,15 +613,6 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>no</ReplaceWith>
 	</Parameter>
 	<Parameter>
-		<ReplaceThis>Hb_CustomKernelURL</ReplaceThis>
-		<ReplaceWith>https://github.com/dcui/linux.git</ReplaceWith>
-	</Parameter>
-		<Parameter>
-		<ReplaceThis>Hb_CustomKernelBranch</ReplaceThis>
-		<ReplaceWith>decui/hibernation/2020-0127/upstream-linus/v5.5</ReplaceWith>
-	</Parameter>
-
-	<Parameter>
 		<ReplaceThis>DATA_DISK_SKU</ReplaceThis>
 		<ReplaceWith>Premium_LRS</ReplaceWith>
 	</Parameter>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -616,4 +616,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>DATA_DISK_SKU</ReplaceThis>
 		<ReplaceWith>Premium_LRS</ReplaceWith>
 	</Parameter>
+		<ReplaceThis>Hb_CustomKernelURL</ReplaceThis>
+		<ReplaceWith>https://github.com/dcui/linux.git</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>Hb_CustomKernelBranch</ReplaceThis>
+		<ReplaceWith>decui/hibernation/2020-0127/upstream-linus/v5.5</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -617,10 +617,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>Premium_LRS</ReplaceWith>
 	</Parameter>
 		<ReplaceThis>Hb_CustomKernelURL</ReplaceThis>
-		<ReplaceWith>https://github.com/dcui/linux.git</ReplaceWith>
+		<ReplaceWith>git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>Hb_CustomKernelBranch</ReplaceThis>
-		<ReplaceWith>decui/hibernation/2020-0127/upstream-linus/v5.5</ReplaceWith>
+		<ReplaceWith>next-20200210</ReplaceWith>
 	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -616,4 +616,13 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>QUICKTEST_ONLY</ReplaceThis>
 		<ReplaceWith>no</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>Hb_CustomKernelURL</ReplaceThis>
+		<ReplaceWith>https://github.com/dcui/linux.git</ReplaceWith>
+	</Parameter>
+		<Parameter>
+		<ReplaceThis>Hb_CustomKernelBranch</ReplaceThis>
+		<ReplaceWith>decui/hibernation/2020-0127/upstream-linus/v5.5</ReplaceWith>
+	</Parameter>
+
 </ReplaceableTestParameters>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -616,6 +616,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>DATA_DISK_SKU</ReplaceThis>
 		<ReplaceWith>Premium_LRS</ReplaceWith>
 	</Parameter>
+	<Parameter>
 		<ReplaceThis>Hb_CustomKernelURL</ReplaceThis>
 		<ReplaceWith>git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -9,6 +9,9 @@
 			<param>hb_url=Hb_CustomKernelURL</param>
 			<param>hb_branch=Hb_CustomKernelBranch</param>
 		</TestParameters>
+		<AdditionalHWConfig>
+			<DiskType>Managed</DiskType>
+		</AdditionalHWConfig>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
 		<Area>POWER</Area>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -2,7 +2,7 @@
 	<test>
 		<testName>Power-hibernate</testName>
 		<testScript>Power-Hibernate.ps1</testScript>
-		<setupType>OneVM</setupType>
+		<setupType>OneVMhb</setupType>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -2,7 +2,7 @@
 	<test>
 		<testName>Power-hibernate</testName>
 		<testScript>Power-Hibernate.ps1</testScript>
-		<setupType>OneVM1Disk</setupType>
+		<setupType>OneVMhb</setupType>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -2,7 +2,7 @@
 	<test>
 		<testName>Power-hibernate</testName>
 		<testScript>Power-Hibernate.ps1</testScript>
-		<setupType>OneVMhb</setupType>
+		<setupType>OneVM</setupType>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -1,0 +1,17 @@
+<TestCases>
+	<test>
+		<testName>Power-hibernate</testName>
+		<testScript>Power-Hibernate.ps1</testScript>
+		<setupType>OneVM</setupType>
+		<files>.\Testscripts\Linux\utils.sh,\Testscripts\Linux\SetupHbKernel.sh</files>
+		<Priority>3</Priority>
+		<TestParameters>
+			<param>hb_url=Hb_CustomKernelURL</param>
+			<param>hb_branch=Hb_CustomKernelBranch</param>
+		</TestParameters>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>POWER</Area>
+		<Tags>power</Tags>
+	</test>
+</TestCases>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -12,7 +12,7 @@
 		<AdditionalHWConfig>
 			<DiskType>Managed</DiskType>
 		</AdditionalHWConfig>
-		<Platform>Azure</Platform>
+		<Platform>Azure,HyperV</Platform>
 		<Category>Functional</Category>
 		<Area>POWER</Area>
 		<Tags>power</Tags>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -2,8 +2,8 @@
 	<test>
 		<testName>Power-hibernate</testName>
 		<testScript>Power-Hibernate.ps1</testScript>
-		<setupType>OneVM</setupType>
-		<files>.\Testscripts\Linux\utils.sh,\Testscripts\Linux\SetupHbKernel.sh</files>
+		<setupType>OneVM1Disk</setupType>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
 		<Priority>3</Priority>
 		<TestParameters>
 			<param>hb_url=Hb_CustomKernelURL</param>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -1,0 +1,20 @@
+<TestCases>
+	<test>
+		<testName>Power-hibernate</testName>
+		<testScript>Power-Hibernate.ps1</testScript>
+		<setupType>OneVMhb</setupType>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
+		<Priority>3</Priority>
+		<TestParameters>
+			<param>hb_url=Hb_CustomKernelURL</param>
+			<param>hb_branch=Hb_CustomKernelBranch</param>
+		</TestParameters>
+		<AdditionalHWConfig>
+			<DiskType>Managed</DiskType>
+		</AdditionalHWConfig>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>POWER</Area>
+		<Tags>power</Tags>
+	</test>
+</TestCases>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -17,6 +17,24 @@
             </VirtualMachine>
         </ResourceGroup>
     </OneVM>
+    <OneVMhb>
+        <isDeployed>NO</isDeployed>
+        <ResourceGroup>
+            <VirtualMachine>
+                <state></state>
+                <InstanceSize>Standard_DS4_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS4_v2</ARMInstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>SSH</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>22</LocalPort>
+                    <PublicPort>22</PublicPort>
+                </EndPoints>
+                <DataDisk></DataDisk>
+            </VirtualMachine>
+        </ResourceGroup>
+    </OneVMhb>
     <OneVMWin>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>


### PR DESCRIPTION
Hibernation patches are all accepted in linux-next. 
TestParameter hb_Branch and hb_url can accept linux-next or developer's repo info
Ubuntu 18.04 passed the test, but RHEL 7.7 failed due to disk space full in the middle of git-cloning. RHEL has different disk layout from the OS installation. None of small space is available for linux-next or developer's linux repo cloning. SUSE has package repo access issue, so no test result.

Target kernel is 5.5.0+ or 5.6.0.

[LISAv2 Test Results Summary]
Test Run On           : 02/13/2020 23:01:25
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1031-azure
Final Kernel Version  : 5.5.0+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:43

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 POWER                Power-hibernate                                                                   PASS                40.02


Logs can be found at C:\LISAv2\TW37\TestResults\2020-13-02-15-01-20-4328