### PR TITLE
Fix test issues found in latest gallery image pipeline

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -104,6 +104,7 @@ function Main() {
 			# install required packages regardless VM types.
 			LogMsg "Starting RDMA setup for RHEL/CentOS"
 			# required dependencies
+			grep 7.5 /etc/redhat-release || grep 7.6 /etc/redhat-release && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo
 			req_pkg="kernel-devel-$(uname -r) valgrind-devel redhat-rpm-config rpm-build gcc gcc-gfortran libdb-devel gcc-c++ glibc-devel zlib-devel numactl-devel libmnl-devel binutils-devel iptables-devel libstdc++-devel libselinux-devel elfutils-devel libtool libnl3-devel java libstdc++.i686 gtk2 atk cairo tcl tk createrepo byacc.x86_64 net-tools tcsh"
 			install_package $req_pkg
 			LogMsg "$?: Installed required packages $req_pkg"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -158,7 +158,7 @@ function Install_Dpdk () {
 	HOMEDIR=$(pwd)
 	export RTE_SDK="${HOMEDIR}/dpdk"
 	export RTE_TARGET="x86_64-native-linuxapp-gcc"
-
+	DPDK_DIR="dpdk"
 	SetTestStateRunning
 	LogMsg "Configuring ${1} ${DISTRO_NAME} ${DISTRO_VERSION} for DPDK test..."
 	packages=(gcc make git tar wget dos2unix psmisc make)
@@ -167,7 +167,7 @@ function Install_Dpdk () {
 			ssh "${1}" ". utils.sh && install_epel"
 			ssh "${1}" "yum -y groupinstall 'Infiniband Support' && dracut --add-drivers 'mlx4_en mlx4_ib mlx5_ib' -f && systemctl enable rdma"
 			check_exit_status "Install Infiniband Support on ${1}" "exit"
-			ssh "${1}" "grep 7.5 /etc/redhat-release && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo"
+			ssh "${1}" "(grep 7.5 /etc/redhat-release || grep 7.6 /etc/redhat-release) && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo"
 			packages+=(kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel)
 			check_package "libmnl-devel"
 			if [ $? -eq 0 ]; then
@@ -274,8 +274,6 @@ function Install_Dpdk () {
 		dpdkSrcDir="dpdk"
 		check_exit_status "Get DPDK sources from ppa on ${1}" "exit"
 	fi
-
-	DPDK_DIR="dpdk"
 
 	LogMsg "DPDK source directory: ${DPDK_DIR}"
 

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -59,6 +59,9 @@ function Start-Validation {
     #endregion
 
     #region lspci
+    Write-LogInfo "Install package pciutils to use lspci command."
+    Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $user -password $password `
+            -command "which lspci || (. ./utils.sh && install_package pciutils)" -runAsSudo -ignoreLinuxExitCode | Out-Null
     $lspci = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
         -username $superuser -password $password "lspci" -ignoreLinuxExitCode
 
@@ -217,6 +220,8 @@ function Main {
 
             if (-not $sts) {
                 # Download and install the latest LIS version
+                Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser -password $password `
+                    -command "which wget || (. ./utils.sh && install_package wget)" -runAsSudo -ignoreLinuxExitCode | Out-Null
                 Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $superuser `
                     -password $password -command "wget -q https://aka.ms/lis -O - | tar -xz" -ignoreLinuxExitCode | Out-Null
                 Write-Debug "Installed the latest LIS package"

--- a/Testscripts/Windows/VERIFY-ENABLE-DISABLE-SRIOV-ON-EXISTING-VM.ps1
+++ b/Testscripts/Windows/VERIFY-ENABLE-DISABLE-SRIOV-ON-EXISTING-VM.ps1
@@ -48,6 +48,12 @@ function Main {
     param( [object]$AllVmData, [object]$CurrentTestData )
     $currentTestResult = Create-TestResultObject
     try {
+        foreach ($vmData in $AllVMData) {
+            Write-LogInfo "Install package pciutils to use lspci command."
+            Copy-RemoteFiles -uploadTo $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password -file ".\Testscripts\Linux\utils.sh" -upload
+            Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username $user -password $password `
+                    -command "which lspci || (. ./utils.sh && install_package pciutils)" -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
+        }
         $resultArr = @()
         $Stage2Result = $true
         $FailureCount = 0


### PR DESCRIPTION
1. Fix lspci and wget not installed by default issue
2. Fix kernel-devel-$(uname -r) not exist in default repository in CentOS 76 (impact RDMA and DPDK cases)

Test results
```
[LISAv2 Test Results Summary]
Test Run On           : 02/15/2020 07:24:24
ARM Image Under Test  : RedHat : RHEL : 7-LVM : 7.7.2020020413
Initial Kernel Version: 3.10.0-1062.9.1.el7.x86_64
Final Kernel Version  : 3.10.0-1062.9.1.el7.x86_64
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:31

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                 15.2 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
    2 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                12.14 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 02/15/2020 07:35:02
ARM Image Under Test  : RedHat : RHEL : 7-LVM : 7.7.2020020413
Initial Kernel Version: 3.10.0-1062.9.1.el7.x86_64
Final Kernel Version  : 3.10.0-1062.9.1.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:37

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-DISABLE-ENABLE-AN                                                           PASS                35.68 
	EnableSRIOV : Test Iteration - 1 : PASS 
	DisableSRIOV : Test Iteration - 1 : PASS 
	EnableSRIOV : Test Iteration - 2 : PASS 
	DisableSRIOV : Test Iteration - 2 : PASS 
	EnableSRIOV : Test Iteration - 3 : PASS 
	DisableSRIOV : Test Iteration - 3 : PASS 
	EnableSRIOV : Test Iteration - 4 : PASS 
	DisableSRIOV : Test Iteration - 4 : PASS 
	EnableSRIOV : Test Iteration - 5 : PASS 
	DisableSRIOV : Test Iteration - 5 : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 02/15/2020 07:40:14
ARM Image Under Test  : OpenLogic : CentOS : 7.6 : 7.6.201909120
Initial Kernel Version: 3.10.0-957.27.2.el7.x86_64
Final Kernel Version  : 3.10.0-957.27.2.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                20.18 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 

Test Run On           : 02/14/2020 15:14:43
ARM Image Under Test  : RedHat : RHEL : 8 : 8.0.2019101800
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 6.92 
    2 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                  6.7 
```

Regression tests - 
```
[LISAv2 Test Results Summary]
Test Run On           : 02/15/2020 07:24:34
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1031-azure
Final Kernel Version  : 5.0.0-1031-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:42

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                19.44 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
    2 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                19.05 
	Using nVidia driver : GRID 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 02/15/2020 07:35:16
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1031-azure
Final Kernel Version  : 5.0.0-1031-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:47

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-DISABLE-ENABLE-AN                                                           PASS                44.26 
	EnableSRIOV : Test Iteration - 1 : PASS 
	DisableSRIOV : Test Iteration - 1 : PASS 
	EnableSRIOV : Test Iteration - 2 : PASS 
	DisableSRIOV : Test Iteration - 2 : PASS 
	EnableSRIOV : Test Iteration - 3 : PASS 
	DisableSRIOV : Test Iteration - 3 : PASS 
	EnableSRIOV : Test Iteration - 4 : PASS 
	DisableSRIOV : Test Iteration - 4 : PASS 
	EnableSRIOV : Test Iteration - 5 : PASS 
	DisableSRIOV : Test Iteration - 5 : PASS 
```

