### PR TITLE
improve library and hyperV common module to avoid run into bugs

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -322,7 +322,7 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
             $vhdSuffix = [System.IO.Path]::GetExtension($OsVHD)
             $InterfaceAliasWithInternet = (Get-NetIPConfiguration -ComputerName $HyperVHost | Where-Object {$_.NetProfile.Name -ne 'Unidentified network'}).InterfaceAlias
             # using -like *$_.Name* to replace -match $_.Name, in order to avoid Switch's Name contains brackets '(' ')', which will be taken as regex syntax, matching failure
-            $VMSwitches = Get-VMSwitch -ComputerName $HyperVHost | Where-Object {$InterfaceAliasWithInternet -like "*" + $_.Name + "*"} | Select-Object -First 1
+            $VMSwitches = Get-VMSwitch -ComputerName $HyperVHost | Where-Object {$InterfaceAliasWithInternet -like "*" + $_.Name + "*" } | Select-Object -First 1
             if ( $VirtualMachine.RoleName) {
                 $CurrentVMName = $HyperVGroupName + "-" + $VirtualMachine.RoleName
                 $CurrentVMOsVHDPath = "$DestinationOsVHDPath\$HyperVGroupName-$CurrentVMName-diff-OSDisk${vhdSuffix}"

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -908,11 +908,8 @@ function Get-HostMemory($HvServer, [int]$RequestedMemory) {
     $totalMemory = [math]::Round((Get-WmiObject -Class Win32_ComputerSystem -Computer $HvServer).TotalPhysicalMemory/1MB)
     $bufferMemory = [int](0.1 * $totalMemory)
     # Get available memory and decrease the buffer from it
-    if ($HvServer -ne "localhost") {
-        $availableMemory = [int](Get-Counter -Counter "\Memory\Available MBytes" -ComputerName $HvServer).CounterSamples[0].CookedValue
-    } else {
-        $availableMemory = [int](Get-Counter -Counter "\Memory\Available MBytes").CounterSamples[0].CookedValue
-    }
+    # WORKAROUND: 'Get-Counter' will throw exception on Windows Client as Hyper-V host, so work around by Invoke-Command
+    $availableMemory = Invoke-Command -ComputerName $HvServer -ScriptBlock { [int](Get-Counter -Counter "\Memory\Available MBytes").CounterSamples[0].CookedValue }
     $availableMemory = $availableMemory - $bufferMemory
     # Check if there is enough memory to deploy the VM
     $availableMemoryAfterDeploy = $availableMemory - $RequestedMemory

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -316,7 +316,8 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
 
             $vhdSuffix = [System.IO.Path]::GetExtension($OsVHD)
             $InterfaceAliasWithInternet = (Get-NetIPConfiguration -ComputerName $HyperVHost | Where-Object {$_.NetProfile.Name -ne 'Unidentified network'}).InterfaceAlias
-            $VMSwitches = Get-VMSwitch -ComputerName $HyperVHost | Where-Object {$InterfaceAliasWithInternet -match $_.Name} | Select-Object -First 1
+            # using -like *$_.Name* to replace -match $_.Name, in order to avoid Switch's Name contains brackets '(' ')', which will be taken as regex syntax, matching failure
+            $VMSwitches = Get-VMSwitch -ComputerName $HyperVHost | Where-Object {$InterfaceAliasWithInternet -like "*" + $_.Name + "*"} | Select-Object -First 1
             if ( $VirtualMachine.RoleName) {
                 $CurrentVMName = $HyperVGroupName + "-" + $VirtualMachine.RoleName
                 $CurrentVMOsVHDPath = "$DestinationOsVHDPath\$HyperVGroupName-$CurrentVMName-diff-OSDisk${vhdSuffix}"

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -37,7 +37,12 @@ function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
         $HyperVHostArray = @()
         if ($deployOnDifferentHosts -eq "yes") {
             foreach ($HypervHost in $GlobalConfig.Global.HyperV.Hosts.ChildNodes) {
-                $HyperVHostArray += $HyperVHost.ServerName
+                if (!($HyperVHostArray -contains $HyperVHost.ServerName)) {
+                    $HyperVHostArray += $HyperVHost.ServerName
+                }
+                else {
+                    throw "Duplicate HyperVHost name '$($HyperVHost.ServerName)' detected, could not deploy VMs on different hosts"
+                }
             }
         } else {
             $HyperVHostArray += $GlobalConfig.Global.HyperV.Hosts.ChildNodes[$index].ServerName

--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -39,8 +39,7 @@ function Create-AllHyperVGroupDeployments($SetupTypeData, $GlobalConfig, $TestLo
             foreach ($HypervHost in $GlobalConfig.Global.HyperV.Hosts.ChildNodes) {
                 if (!($HyperVHostArray -contains $HyperVHost.ServerName)) {
                     $HyperVHostArray += $HyperVHost.ServerName
-                }
-                else {
+                } else {
                     throw "Duplicate HyperVHost name '$($HyperVHost.ServerName)' detected, could not deploy VMs on different hosts"
                 }
             }

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -115,7 +115,7 @@ Param(
 
 
 $CURRENT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module "${CURRENT_DIR}\LISAv2-Framework"
+Import-Module "${CURRENT_DIR}\LISAv2-Framework" -Force
 
 $params = @{}
 $MyInvocation.MyCommand.Parameters.Keys | ForEach-Object {

--- a/Testscripts/Linux/DetectLinuxDistro.sh
+++ b/Testscripts/Linux/DetectLinuxDistro.sh
@@ -75,9 +75,6 @@ DetectDistro()
                 elif [[ "$tmp" =~ "SUSE Linux Enterprise High Performance Computing" ]]; then
                     echo "SLE_HPC"
                     exitVal=0
-                elif [[ "$tmp" =~ "Reference Distro" ]]; then
-                    echo "GeneralDistro"
-                    exitVal=0
                 else
                     echo "Unknown"
                 fi

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -118,10 +118,7 @@ function UtilsInit() {
 	if [ -f "$__LIS_CONSTANTS_FILE" ]; then
 		. "$__LIS_CONSTANTS_FILE"
 	else
-		LogErr "Constants file $__LIS_CONSTANTS_FILE missing or not a regular file. Cannot source it!"
-		SetTestStateAborted
-		UpdateSummary "Error: constants file $__LIS_CONSTANTS_FILE missing or not a regular file. Cannot source it!"
-		return 1
+		LogMsg "Constants file $__LIS_CONSTANTS_FILE missing or not a regular file. Cannot source it!"
 	fi
 
 	GetDistro && LogMsg "Testscript running on $DISTRO" || LogMsg "Test running on unknown distro!"

--- a/Utilities/Get-LISAv2Statistics.ps1
+++ b/Utilities/Get-LISAv2Statistics.ps1
@@ -10,7 +10,9 @@ param (
     [ValidateSet("0", "1", "2", "3")]
     [string] $Priority,
     [string] $Category,
-    [string] $Area
+    [string] $Area,
+    [boolean] $ExportCSV = $false,
+    [string] $Path
 )
 
 # Hashtable for tag info collection
@@ -66,14 +68,28 @@ if ($Area) {
     $all_test_cases = @($all_test_cases | Where-Object {$_.Area -imatch $Area})
 }
 
+if ($ExportCSV -eq $true) {
+    if (!$Path){
+        $Path = "./LISAv2Statistics_" + (Get-Date).ToString("yyyyMMdd_hhmmss") + ".csv"
+    }
+    $all_test_cases | Select-Object -Property TestName,Platform,Category,Area,Tags,Priority | Export-Csv -Path $Path -NoTypeInformation
+    if ($?) {
+        Write-Output "Exported CSV file: $Path"
+    }
+}
+else {
+    if ($Path) {
+        Write-Output "`n[Warning]: '`$Path' has value '$Path', but `$ExportCSV -eq `$false, formating output as Table instead of exporting csv."
+        Start-Sleep -s 5
+    }
+    $all_test_cases | Format-Table TestName,Platform,Category,Area,Tags,Priority -AutoSize
+    Write-Output "TestCases Count: $($all_test_cases.count)"
 
-$all_test_cases | Format-Table TestName,Platform,Category,Area,Tags,Priority -AutoSize
-Write-Output "TestCases Count: $($all_test_cases.count)"
-
-if (!$Platform -and !$Priority -and !$Tags -and !$Category -and !$Area) {
-    Write-Output "===== Test Cases Number per platform ====="
-    $platform_info | Format-Table -hide
-    Write-Output "===== Tag Details ====="
-    #Show tag information
-    Write-Output ($numTags | Out-String)
+    if (!$Platform -and !$Priority -and !$Tags -and !$Category -and !$Area) {
+        Write-Output "===== Test Cases Number per platform ====="
+        $platform_info | Format-Table -hide
+        Write-Output "===== Tag Details ====="
+        #Show tag information
+        Write-Output ($numTags | Out-String)
+    }
 }

--- a/Utilities/Get-LISAv2Statistics.ps1
+++ b/Utilities/Get-LISAv2Statistics.ps1
@@ -11,7 +11,7 @@ param (
     [string] $Priority,
     [string] $Category,
     [string] $Area,
-    [boolean] $ExportCSV = $false,
+    [switch] $ExportCSV,
     [string] $Path
 )
 
@@ -68,18 +68,18 @@ if ($Area) {
     $all_test_cases = @($all_test_cases | Where-Object {$_.Area -imatch $Area})
 }
 
-if ($ExportCSV -eq $true) {
+if ($ExportCSV.IsPresent) {
     if (!$Path){
         $Path = "./LISAv2Statistics_" + (Get-Date).ToString("yyyyMMdd_hhmmss") + ".csv"
     }
-    $all_test_cases | Select-Object -Property TestName,Platform,Category,Area,Tags,Priority | Export-Csv -Path $Path -NoTypeInformation
+    $all_test_cases | Select-Object -Property TestName,Platform,Category,Area,Tags,Priority | Export-Csv -Path $Path -NoTypeInformation -Force
     if ($?) {
         Write-Output "Exported CSV file: $Path"
     }
 }
 else {
     if ($Path) {
-        Write-Output "`n[Warning]: '`$Path' has value '$Path', but `$ExportCSV -eq `$false, formating output as Table instead of exporting csv."
+        Write-Output "`n[Warning]: '-Path' has value '$Path', but '-ExportCSV' does NOT present as a parameter, hence formating output as Table instead of exporting csv."
         Start-Sleep -s 5
     }
     $all_test_cases | Format-Table TestName,Platform,Category,Area,Tags,Priority -AutoSize


### PR DESCRIPTION
1. fix a bug in HyperV matching SwitchName (if Name contains brackets, matching failure)
2. remove TestAborted state as interim test State if there's no constants file.  (without constants.sh should be fine, as many utility functions can work without sourcing constants.sh)
3. remove useless distro detection about "General Distro"
4. Import LISAv2-Framework with -Force parameter, and improve debugging efficiency.
5. Improve Get-LISAv2Statistics with exporting csv
6. Add workaround for 'Get-Counter' throw exception on Windows Client as HyperV host