### PR TITLE
Update CreateServicePrincipal.ps1 with required permission level information

### DIFF
--- a/Utilities/CreateServicePrincipal.ps1
+++ b/Utilities/CreateServicePrincipal.ps1
@@ -13,6 +13,8 @@ function New-SWRandomPassword {
         Generates one or more complex passwords designed to fulfill the requirements for Active Directory
     .DESCRIPTION
         Generates one or more complex passwords designed to fulfill the requirements for Active Directory
+        Strongly recommend the subscription owner executes the script. Non-owner may see warning message
+        such as "don't have enough permission to assign a role" in New-AzRoleAssignment
     .EXAMPLE
         New-SWRandomPassword
         C&3SX6Kn


### PR DESCRIPTION
Updated the comment with potential privilege level conflict warning message. This script should be run by subscription owner not contributor or lower level.