### PR TITLE
DPDK - Fix insert data into database error when test_mode is not set.

### DIFF
--- a/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
+++ b/Testscripts/Windows/DPDK-TESTCASE-DRIVER.ps1
@@ -304,7 +304,9 @@ collect_VM_properties
 					$resultMap["DataPath"] = "Synthetic"
 				}
 				$resultMap["DPDKVersion"] = $mode.dpdk_version
-				$resultMap["TestMode"] = $mode.test_mode
+				if ($mode.test_mode) {
+					$resultMap["TestMode"] = $mode.test_mode
+				}
 				$resultMap["Cores"] = [int32]($mode.core)
 				$resultMap["Max_Rxpps"] = [int64]($mode.max_rx_pps)
 				$resultMap["Txpps"] = [int64]($mode.tx_pps_avg)


### PR DESCRIPTION
For PERF-DPDK-FWD-PPS-DS15 case, there is no test mode value.

Test results 

```
02/28/2020 09:23:48 : [INFO ] ==> Upload test results to database.
02/28/2020 09:23:48 : [INFO ] SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txpps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdbytes,DataPath,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) VALUES (10023559,'20.02.0',0,'Azure',0,'2020-02-28',19060221,0,10321634,0,0,'TCP','Linux',2,'Azure',0,'Standard_DS15_v2',0,0,'westus2','14393-10.0-0-0.305',0,'SRIOV','PERF-DPDK-FWD-PPS-DS15','Inbuilt','rhel 7.7','3.10.0-1062.1.1.el7.x86_64','IPv4')
02/28/2020 09:23:48 : [INFO ] SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txpps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdbytes,DataPath,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) VALUES (10025859,'20.02.0',0,'Azure',0,'2020-02-28',16820893,0,10383284,0,0,'TCP','Linux',4,'Azure',0,'Standard_DS15_v2',0,0,'westus2','14393-10.0-0-0.305',0,'SRIOV','PERF-DPDK-FWD-PPS-DS15','Inbuilt','rhel 7.7','3.10.0-1062.1.1.el7.x86_64','IPv4')
02/28/2020 09:23:48 : [INFO ] SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txpps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdbytes,DataPath,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) VALUES (10027122,'20.02.0',0,'Azure',0,'2020-02-28',16616871,0,10617910,0,0,'TCP','Linux',8,'Azure',0,'Standard_DS15_v2',0,0,'westus2','14393-10.0-0-0.305',0,'SRIOV','PERF-DPDK-FWD-PPS-DS15','Inbuilt','rhel 7.7','3.10.0-1062.1.1.el7.x86_64','IPv4')
02/28/2020 09:23:48 : [INFO ] Succeed to upload test results to database
[LISAv2 Test Results Summary]
Test Run On           : 02/28/2020 09:01:48
ARM Image Under Test  : RedHat : RHEL : 7-RAW : latest
Initial Kernel Version: 3.10.0-1062.1.1.el7.x86_64
Final Kernel Version  : 3.10.0-1062.1.1.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            PASS                18.14 
dpdk_version core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg
------------ ---- ---------- ------------- ------------- ----------
20.02.0      2    19060221   10321634      10321634      10023559  
20.02.0      4    16820893   10383284      10383284      10025859  
20.02.0      8    16616871   10617958      10617910      10027122 
```

Regression test results - 
```
02/28/2020 09:21:01 : [INFO ] SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txpps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdbytes,DataPath,TestMode,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) VALUES (10308244,'20.02.0',633231580,'Azure',61,'2020-02-28',14541392,11075009,0,39180019965,61,'TCP','Linux',1,'Azure',886150100,'Standard_DS15_v2',0,54884585572,'westus2','14393-10.0-0-0.305',0,'SRIOV','rxonly','PERF-DPDK-SINGLE-CORE-PPS-DS15','Inbuilt','rhel 7.7','3.10.0-1062.1.1.el7.x86_64','IPv4')
02/28/2020 09:21:01 : [INFO ] SQLQuery:  INSERT INTO Perf_DPDK_TestPmd (Rxpps,DPDKVersion,Rxpackets,TestPlatFrom,Tx_PacketSize_KBytes,TestDate,Txpps,Max_Rxpps,Fwdpps,Rxbytes,Rx_PacketSize_KBytes,ProtocolType,GuestOSType,Cores,HostType,Txpackets,GuestSize,Fwdpackets,Txbytes,HostBy,HostOS,Fwdbytes,DataPath,TestMode,TestCaseName,LISVersion,GuestDistro,KernelVersion,IPVersion) VALUES (8060958,'20.02.0',496860225,'Azure',61,'2020-02-28',14473010,9058635,8060958,30739939581,61,'TCP','Linux',1,'Azure',874814691,'Standard_DS15_v2',496860209,54144781630,'westus2','14393-10.0-0-0.305',30739938236,'SRIOV','io','PERF-DPDK-SINGLE-CORE-PPS-DS15','Inbuilt','rhel 7.7','3.10.0-1062.1.1.el7.x86_64','IPv4')
02/28/2020 09:21:01 : [INFO ] Succeed to upload test results to database
[LISAv2 Test Results Summary]
Test Run On           : 02/28/2020 09:02:05
ARM Image Under Test  : RedHat : RHEL : 7-RAW : latest
Initial Kernel Version: 3.10.0-1062.1.1.el7.x86_64
Final Kernel Version  : 3.10.0-1062.1.1.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS15                                                    PASS                14.93 
dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_b
                                                                           ytes
------------ --------- ---- ---------- ---------- ---------- ------------- ----
20.02.0      rxonly    1    11075009   14541392   10308244   0             5...
20.02.0      io        1    9058635    14473010   8060958    8060958       5... 
```