### PR TITLE
Load modules for SLES 15 SP1.

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -69,7 +69,7 @@ function Modprobe_Setup() {
 	local modprobe_cmd="modprobe -a ib_uverbs"
 	# known issue on sles15 and ubuntu
 	local distro=$(detect_linux_distribution)$(detect_linux_distribution_version)
-	if [[ "${distro}" == "sles15" || ("${distro}" =~ "ubuntu") ]]; then
+	if [[ "${distro}" =~ "sles15" || ("${distro}" =~ "ubuntu") ]]; then
 		modprobe_cmd="${modprobe_cmd} mlx4_ib mlx5_ib || true"
 		LogMsg "Loading mlx4_ib and mlx5_ib modules with ib_uverbs module manually for distro: ${distro}"
 	fi


### PR DESCRIPTION
When test against SLES 15 SP1, all DPDK perf are not expected because mlx4_ib not loaded. Found this issue from the below log.

```
EAL:   probe driver: 15b3:1004 net_mlx4
net_mlx4: cannot access device, is mlx4_ib loaded?
```