### PR TITLE
Minor update FunctionalTests-Power.xml to remove HyperV support

### DIFF
--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -5,7 +5,7 @@
 	Perform a simple VM hibernation in Azure or Hyper-V
 
 .Description
-	This test can be performed in Azure and Hyper-V both.
+	This test can be performed in Azure and Hyper-V both. But this script only covers Azure.
 	1. Prepare swap space for hibernation
 	2. Compile a new kernel (optional)
 	3. Update the grup.cfg with resume=UUID=xxxx where is from blkid swap disk

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -12,7 +12,7 @@
 		<AdditionalHWConfig>
 			<DiskType>Managed</DiskType>
 		</AdditionalHWConfig>
-		<Platform>Azure,HyperV</Platform>
+		<Platform>Azure</Platform>
 		<Category>Functional</Category>
 		<Area>POWER</Area>
 		<Tags>power</Tags>


### PR DESCRIPTION
Notice that adding the Hyper-V support in the commit https://github.com/LIS/LISAv2/commit/7e1e2402be99e7ae5704d28175966ebe9e876b66#diff-dcbe3953e67d7d52d7877c20ef074614 , and this Power Hibernation is new feature in the upstream kernel, it is so great that LISAv2 has auto case about this feature.

Looks that Power-Hibernate.ps1 does not support Hyper-V yet, vm operations are AZVM related. So suggest to remove Hyper-V support in case xml until updating Power-Hibernate.ps1 to support Hyper-V or add new case for Hyper-V later.   Thank you.

Test Result in Hyper-V with RHEL 8 VM：
03/05/2020 02:36:43 : [INFO ] Test script: Power-Hibernate.ps1 started.
03/05/2020 02:36:43 : [INFO ] C:\Users\xuli\LISAv2\Testscripts\Windows\Power-Hibernate.ps1 -TestParams ;hb_branch=next-20200210;hb_url=git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git -AllVmData @{HyperVHost=xxx; HyperVGroupName=LISAv2-OneVMhb-20190225-EM84-637190012970; PublicIP=xxx; InternalIP=xxx; RoleName=LISAv2-OneVMhb-20190225-EM84-637190012970-role-0; VMGeneration=2; SSHPort=22} -TestProvider HyperVProvider -CurrentTestData System.Xml.XmlElement
03/05/2020 02:36:43 : [DEBUG] Prepare swap space for VM LISAv2-OneVMhb-20190225-EM84-637190012970-role-0 in RG .
03/05/2020 02:36:43 : [INFO ] Generating constants.sh ...
03/05/2020 02:36:43 : [INFO ] hb_url=git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git added to constants.sh
03/05/2020 02:36:43 : [INFO ] hb_branch=next-20200210 added to constants.sh
03/05/2020 02:36:43 : [INFO ] constants.sh created successfully...
03/05/2020 02:36:44 : [ERROR] EXCEPTION : Cannot bind argument to parameter 'ResourceGroupName' because it is null. at line: 48
03/05/2020 02:36:44 : [INFO ] ==> Upload test results to database.
03/05/2020 02:36:44 : [INFO ] ==> Check if the test target machines are still running.
03/05/2020 02:36:44 : [INFO ] Trying to connect to deployed VMs. 

  ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 POWER                Power-hibernate                                                                   FAIL                 0.81 


   