### PR TITLE
SGX - Delete state.txt file before testing.

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -14,9 +14,10 @@
 set -e
 set -x
 
+sudo rm -rf state.txt
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
-    echo "TestAborted" >state.txt
+    echo "TestAborted" > state.txt
     exit 1
 }
 

--- a/XML/TestCases/FunctionalTests-SGX.xml
+++ b/XML/TestCases/FunctionalTests-SGX.xml
@@ -12,6 +12,6 @@
         <Category>Functional</Category>
         <Area>SGX</Area>
         <Tags>sgx</Tags>
-        <Priority>0</Priority>
+        <Priority></Priority>
     </test>
 </TestCases>


### PR DESCRIPTION
Found issue during test this case against ubuntu + proposed kernel, the state.txt file generated during install custom kernel under sudo, it has root privilege, but in SGX case, it ran under a normal user, then case will hit permission denied issue.

```
[LISAv2 Test Results Summary]
Test Run On           : 03/08/2020 05:58:02
ARM Image Under Test  : Canonical : UbuntuServer : 18_04-lts-gen2 : latest
Initial Kernel Version: 5.0.0-1032-azure
Final Kernel Version  : 5.0.0-1034-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 4.28 

[LISAv2 Test Results Summary]
Test Run On           : 03/08/2020 06:40:25
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Initial Kernel Version: 4.15.0-1071-azure
Final Kernel Version  : 4.15.0-1074-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 3.64 
```