### PR TITLE
Update DM_HotAdd_Verify_udev.sh udev rule search item for RHEL

### DIFF
--- a/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
+++ b/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
@@ -13,6 +13,15 @@
 # Source constants file and initialize most common variables
 UtilsInit
 items=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
+
+case $DISTRO in
+    redhat_7|centos_7|redhat_8|centos_8)
+        items=(SUBSYSTEM!=\"memory\", GOTO=\"memory_hotplug_end\")
+    ;;
+    *)
+    ;;
+esac
+
 #######################################################################
 #
 # Main script body


### PR DESCRIPTION
Update DM_HotAdd_Verify_udev.sh search item since udev rule for memory hotadd is changed. So do minor change for fixing the case failure DYNAMIC-MEMORY-VERIFY-UDEV.

Original udev rule for memory hotadd is:
"SUBSYSTEM=="memory", ACTION=="add", ATTR{state}="online"

Latest udev rule for balloon is changed as below:
cat /lib/udev/rules.d/40-redhat.rules 
Memory hotadd request
SUBSYSTEM!="memory", GOTO="memory_hotplug_end"
ACTION!="add", GOTO="memory_hotplug_end"
PROGRAM="/bin/uname -p", RESULT=="s390*", GOTO="memory_hotplug_end"

ENV{.state}="online"
PROGRAM="/bin/systemd-detect-virt", RESULT=="none", ENV{.state}="online_movable"
ATTR{state}=="offline", ATTR{state}="$env{.state}"

LABEL="memory_hotplug_end"
Test result after change:
```
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DYNAMIC_MEMORY       DYNAMIC-MEMORY-VERIFY-UDEV                                                        PASS                 2.73
```
Test result before change:
```
03/02/2020 12:00:29 : [ERROR] EXCEPTION: Calling function - Run-LinuxCmd. Failed to execute : bash DM_HotAdd_Verify_udev.sh > DYNAMIC-MEMORY-VERIFY-UDEV_summary.log 2>&1.
03/02/2020 12:00:29 : [ERROR] Source: Line 569 in script .\Libraries\TestHelpers.psm1.
03/02/2020 12:00:29 : [INFO ] ==> Upload test results to database.

03/02/2020 12:01:14 : [INFO ] Checkpoint DYNAMIC-MEMORY-VERIFY-UDEV-FAIL created for VM LISAv2-OneVM-20190225-ZN36-637187757794-role-0.
03/02/2020 12:01:14 : [INFO ] End of testing: DYNAMIC-MEMORY-VERIFY-UDEV , result: FAIL
```