### PR TITLE
Fix issue for running in economy mode for xfstests.

### DIFF
--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -72,6 +72,7 @@ ConfigureXFSTestTools() {
     modprobe btrfs
     LogMsg "Packages installation complete."
     # Install dbench
+    rm -rf $dbench_folder
     git clone $dbench_git_url $dbench_folder
     pushd $dbench_folder
     ./autogen.sh
@@ -80,6 +81,7 @@ ConfigureXFSTestTools() {
     make install
     popd
     # Install xfstests
+    rm -rf $xfs_folder
     git clone $xfs_git_url $xfs_folder
     pushd $xfs_folder
     ./configure

--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -72,6 +72,7 @@ ConfigureXFSTestTools() {
     modprobe btrfs
     LogMsg "Packages installation complete."
     # Install dbench
+    LogMsg "Remove folder $dbench_folder if exists."
     rm -rf $dbench_folder
     git clone $dbench_git_url $dbench_folder
     pushd $dbench_folder
@@ -81,6 +82,7 @@ ConfigureXFSTestTools() {
     make install
     popd
     # Install xfstests
+    LogMsg "Remove folder $xfs_folder if exists."
     rm -rf $xfs_folder
     git clone $xfs_git_url $xfs_folder
     pushd $xfs_folder

--- a/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
+++ b/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
@@ -146,7 +146,7 @@ function Main {
                 }
                 Write-LogInfo "xfstesting.sh is still running!"
             } else {
-                throw "VM is not responsible during testing."
+                throw "VM is not responding during testing."
             }
         }
 

--- a/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
+++ b/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
@@ -127,8 +127,8 @@ function Main {
         $sw = [diagnostics.stopwatch]::StartNew()
         while ($sw.elapsed -lt $timeout) {
             Start-Sleep -Seconds 60
-            $tcpTestResult = (Test-NetConnection -ComputerName $allVMData.PublicIP -Port $allVMData.SSHPort).TcpTestSucceeded
-            if ($tcpTestResult) {
+            $isVmAlive = Is-VmAlive -AllVMDataObject $allVMData -MaxRetryCount 10
+            if ($isVmAlive -eq "True") {
                 $state = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
                 -username $superuser -password $password "cat state.txt"
                 if ($state -eq "TestCompleted") {
@@ -146,7 +146,7 @@ function Main {
                 }
                 Write-LogInfo "xfstesting.sh is still running!"
             } else {
-                continue
+                throw "VM is not responsible during testing."
             }
         }
 


### PR DESCRIPTION
When run case in economy mode, always run in the same VM when case pass and use the same setup type, the previous configuration file is not clean up, it will cause unexpected behavior.

When there is kernel panic hit, previous design will wait till 4 hours time out.

Test results -
```
[LISAv2 Test Results Summary]
Test Run On           : 03/22/2020 10:42:50
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Test Category         : Functional
Test Area             : NVME
Initial Kernel Version: 5.0.0-1032-azure
Final Kernel Version  : 5.0.0-1032-azure
Total Test Cases      : 11 (11 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:50

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-DISK-OPERATIONS                                                              PASS                 1.37 
    2 NVME                 NVME-CHECK-EXPECTED-FAILURES                                                      PASS                 0.75 
    3 NVME                 NVME-FSTRIM                                                                       PASS                 4.88 
    4 NVME                 NVME-BLKDISCARD                                                                   PASS                 0.97 
    5 NVME                 NVME-FILE-SYSTEM-VERIFICATION-GENERIC                                             PASS                46.66 
    6 NVME                 NVME-FILE-SYSTEM-VERIFICATION-XFS                                                 PASS                 26.2 
    7 NVME                 NVME-FILE-SYSTEM-VERIFICATION-EXT4                                                PASS                 7.53 
    8 NVME                 NVME-FILE-SYSTEM-VERIFICATION-BTRFS                                               PASS                 7.73 
    9 NVME                 NVME-PCI-RESCIND                                                                  PASS                 0.99 
   10 NVME                 NVME-DISK-VALIDATION                                                              PASS                 1.11 
   11 NVME                 NVME-MAX-DISK-VALIDATION                                                          PASS                 1.19 
```

```
[LISAv2 Test Results Summary]
Test Run On           : 03/22/2020 12:36:05
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Test Category         : Community
Initial Kernel Version: 5.0.0-1032-azure
Final Kernel Version  : 5.0.0-1032-azure
Total Test Cases      : 8 (8 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:9:40

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-AZURE-FILES                                        PASS                42.42 
    2 LKS                  LINUX-KERNEL-SELFTESTS                                                            PASS                11.12 
	total test cases : 93 
	total passed : 75 
	total failed : 0 
	total skipped : 18 
    3 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-GENERIC                                            PASS               184.23 
    4 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-XFS                                                PASS               102.17 
    5 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-EXT4                                               PASS                22.62 
    6 STORAGE              FILE-SYSTEM-VERIFICATION-TESTS-BTRFS                                              PASS                15.68 
    7 LTP                  LINUX-TEST-PROJECT-TESTS                                                          PASS                51.87 
	proc01 : FAIL 
	quota_remount_test01 : FAIL 
	binfmt_misc02 : FAIL 
    8 LTP                  LINUX-TEST-PROJECT-TESTS-FULL-RUN                                                 PASS               139.21 
	quotactl01 : FAIL 
	proc01 : FAIL 
	quota_remount_test01 : FAIL 
	binfmt_misc02 : FAIL 
	memcg_max_usage_in_bytes : FAIL 
	memcg_stat : FAIL 
	memcg_use_hierarchy : FAIL 
	memcg_usage_in_bytes : FAIL 
	cpuset_hotplug : FAIL 
	ext4-nsec-timestamps : FAIL 
	ext4-uninit-groups : FAIL 
	ext4-persist-prealloc : FAIL 
	ext4-subdir-limit : FAIL 
	cpuhotplug02 : FAIL 
	cpuhotplug03 : FAIL 
	cpuhotplug04 : FAIL 
	cpuhotplug06 : FAIL 
	getaddrinfo_01 : FAIL 
	crypto_user02 : FAIL 
```