### PR TITLE
P0 cases - Update size for support both gen1 and gen2 images on Azure.

### DIFF
--- a/XML/AzureVMSizeToHyperVMapping.xml
+++ b/XML/AzureVMSizeToHyperVMapping.xml
@@ -287,8 +287,10 @@
         <MemoryInMB>28672</MemoryInMB>
     </Standard_DS12-2_v2>
     <Standard_DS12_v2>
-        <NumberOfCores>4</NumberOfCores>
-        <MemoryInMB>28672</MemoryInMB>
+        <!-- Azure flavor Core: 4 -->
+        <NumberOfCores>8</NumberOfCores>
+        <!-- Azure flavor RAM size: 28672 -->
+        <MemoryInMB>4096</MemoryInMB>
     </Standard_DS12_v2>
     <Standard_DS13-2_v2>
         <NumberOfCores>8</NumberOfCores>

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -3,7 +3,7 @@
         <testName>NVIDIA-CUDA-DRIVER-VALIDATION</testName>
         <testScript>GPU-DRIVER-INSTALL.ps1</testScript>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_NC6</OverrideVMSize>
+        <OverrideVMSize>Standard_NC6s_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\utils.sh</files>
         <TestParameters>
             <param>CUDADriverVersion="CUDA_DRIVER"</param>

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -2,7 +2,7 @@
     <test>
         <testName>SRIOV-VERIFY-LSPCI</testName>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D15_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -35,7 +35,7 @@
         <testScript>VERIFY-DEPLOYMENT-PROVISION.ps1</testScript>
         <files></files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D13_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS13_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -4,7 +4,7 @@
         <testScript>nested_kvm_basic_test.sh</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_basic_test.sh</files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_E4_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_E4s_v3</OverrideVMSize>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -101,7 +101,7 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <ARMInstanceSize>Standard_D5_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS5_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>

--- a/XML/VMConfigurations/TwoVMs.xml
+++ b/XML/VMConfigurations/TwoVMs.xml
@@ -147,8 +147,8 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <InstanceSize>Standard_D12_v2</InstanceSize>
-                <ARMInstanceSize>Standard_D12_v2</ARMInstanceSize>
+                <InstanceSize>Standard_DS12_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS12_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -161,8 +161,8 @@
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
                 <state></state>
-                <InstanceSize>Standard_D12_v2</InstanceSize>
-                <ARMInstanceSize>Standard_D12_v2</ARMInstanceSize>
+                <InstanceSize>Standard_DS12_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS12_v2</ARMInstanceSize>
                 <RoleName>dependency-vm</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>


### PR DESCRIPTION
- Azure NVIDIA-CUDA-DRIVER-VALIDATION Standard_NC6 => Standard_NC6s_v2
- Azure, HyperV SRIOV-VERIFY-LSPCI Standard_D15_v2 => Standard_DS4_v2
- Azure NESTED-KVM-BASIC-VERIFICATION Standard_E4_v3 => Standard_E4s_v3
- SetupType OneVM3NIC  Standard_D5_v2 => Standard_DS5_v2
```
Affected cases Azure, VERIFY-DPDK-COMPLIANCE,VERIFY-DPDK-RING-LATENCY
```
- TwoVM2Host1Dep Standard_D12_v2 => Standard_DS12_v2
```
Affected cases 
Azure and HyperV - ETHTOOL-OFFLOADING-SETTING,SRIOV-VERIFY-SINGLE-VF-CONNECTION,SRIOV-DISABLEVF-ON-GUEST,SRIOV-RELOAD-MODULE,SRIOV-DISABLE-ENABLE-PCI
HyperV only - ETHTOOL-OFFLOADING-SETTING-3NICS,SRIOV-VERIFY-SINGLE-VF-CONNECTION-ONE-VCPU,SRIOV-DISABLEVF-PING,SRIOV-DISABLEVF-IPERF,SRIOV-DETACH-NIC,SRIOV-DISABLEVF-ONHOST,SRIOV-DISABLE-NIC,SRIOV-DISABLE-VMQ,SRIOV-CHANGE-RSS,SRIOV-MULTICAST,SRIOV-BROADCAST,SRIOV-REBOOT-VM,SRIOV-STRESS-SAVE,SRIOV-STRESS-PAUSE,SRIOV-IPERF-STRESS,SRIOV-MOVE-VHD
```