### PR TITLE
P1 cases - Update size for support both gen1 and gen2 images on Azure.

### DIFF
--- a/XML/AzureVMSizeToHyperVMapping.xml
+++ b/XML/AzureVMSizeToHyperVMapping.xml
@@ -245,6 +245,12 @@
         <NumberOfCores>4</NumberOfCores>
         <MemoryInMB>16384</MemoryInMB>
     </Standard_B4ms>
+    <Standard_B16ms>
+        <!-- Azure flavor Core: 16 -->
+        <NumberOfCores>8</NumberOfCores>
+        <!-- Azure flavor RAM size: 65536 -->
+        <MemoryInMB>16384</MemoryInMB>
+    </Standard_B16ms>
     <Standard_B8ms>
         <NumberOfCores>8</NumberOfCores>
         <MemoryInMB>32768</MemoryInMB>
@@ -317,8 +323,10 @@
         <MemoryInMB>8192</MemoryInMB>
     </Standard_DS14_v2>
     <Standard_DS15_v2>
-        <NumberOfCores>20</NumberOfCores>
-        <MemoryInMB>143360</MemoryInMB>
+        <!-- Azure flavor Core: 20 -->
+        <NumberOfCores>8</NumberOfCores>
+        <!-- Azure flavor RAM size: 143360 -->
+        <MemoryInMB>8192</MemoryInMB>
     </Standard_DS15_v2>
     <Standard_DS2_v2_Promo>
         <NumberOfCores>2</NumberOfCores>
@@ -397,8 +405,10 @@
         <MemoryInMB>8192</MemoryInMB>
     </Standard_D64_v3>
     <Standard_D64s_v3>
-        <NumberOfCores>64</NumberOfCores>
-        <MemoryInMB>262144</MemoryInMB>
+        <!-- Azure flavor Core: 64 -->
+        <NumberOfCores>8</NumberOfCores>
+        <!-- Azure flavor RAM size: 262144 -->
+        <MemoryInMB>8192</MemoryInMB>
     </Standard_D64s_v3>
     <Standard_E2_v3>
         <NumberOfCores>2</NumberOfCores>

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -57,7 +57,7 @@
         <testName>GPU-PCI-RESCIND</testName>
         <testScript>GPU-DRIVER-INSTALL.ps1</testScript>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_NC6</OverrideVMSize>
+        <OverrideVMSize>Standard_NC6s_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\utils.sh</files>
         <TestParameters>
             <param>CUDADriverVersion="CUDA_DRIVER"</param>

--- a/XML/TestCases/FunctionalTests-Network.xml
+++ b/XML/TestCases/FunctionalTests-Network.xml
@@ -408,7 +408,7 @@
     <test>
         <testName>VERIFY-RESTART-INTERFACE-RELOAD-NETVSC</testName>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D2_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS2_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>Synthetic</Networking>
         </AdditionalHWConfig>
@@ -685,7 +685,7 @@
         <testName>NETWORK-ADD-MAX-SYNTHETIC-NICS-DURING-PROVISION</testName>
         <setupScript>.\Testscripts\Windows\SETUP-NET-Add-Max-NIC.ps1</setupScript>
         <setupType>OneVM8NIC</setupType>
-        <OverrideVMSize>Standard_A8_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_B16ms</OverrideVMSize>
         <TestParameters>
             <param>network_interface_count=8</param>
             <param>TEST_TYPE=synthetic</param>
@@ -706,7 +706,7 @@
         <testScript>NET-Add-NIC-After-Provision.ps1</testScript>
         <files></files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_A8_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_B16ms</OverrideVMSize>
         <TestParameters>
             <param>EXTRA_NICS=7</param>
         </TestParameters>

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -70,7 +70,7 @@
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\Testscripts\Windows\SETUP-SR-IOV-Configure.ps1</setupScript>
         <testScript>SRIOV-RUN-COMMON-TEST.ps1</testScript>
         <setupType>TwoVM2Host1Dep</setupType>
-        <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
@@ -97,7 +97,7 @@
         <setupScript>.\Testscripts\Windows\SETUP-SR-IOV-Configure.ps1</setupScript>
         <testScript>SRIOV-RUN-COMMON-TEST.ps1</testScript>
         <setupType>TwoVM8NIC</setupType>
-        <OverrideVMSize>Standard_D14_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS14_v2</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
@@ -122,7 +122,7 @@
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\Testscripts\Windows\SETUP-SR-IOV-Configure.ps1</setupScript>
         <testScript>SRIOV-RUN-COMMON-TEST.ps1</testScript>
         <setupType>TwoVM8NIC</setupType>
-        <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
@@ -178,7 +178,7 @@
     <test>
         <testName>SRIOV-DISABLE-ENABLE-AN</testName>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D3_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
         <testScript>VERIFY-ENABLE-DISABLE-SRIOV-ON-EXISTING-VM.ps1</testScript>
         <files></files>
         <TestIterations>5</TestIterations>
@@ -193,7 +193,7 @@
         <setupScript>.\TestScripts\Windows\SETUP-Change-CPU.ps1,.\Testscripts\Windows\SETUP-SR-IOV-Configure.ps1</setupScript>
         <testScript>SRIOV-RUN-COMMON-TEST.ps1</testScript>
         <setupType>TwoVM2Host1Dep</setupType>
-        <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -477,7 +477,7 @@
         <testScript>verify_vmbus_interrupts.sh</testScript>
         <files>.\Testscripts\Linux\verify_vmbus_interrupts.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_A3</OverrideVMSize>
+        <OverrideVMSize>Standard_B4ms</OverrideVMSize>
         <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -490,7 +490,7 @@
         <testName>PERF-SYSCALL-BENCHMARK</testName>
         <testScript>PERF-SYSCALL-BENCHMARK.ps1</testScript>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D15_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS15_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_syscallbenchmark.sh</files>
         <TestParameters>
             <param>syscallurl="https://github.com/arkanis/syscall-benchmark.git"</param>

--- a/XML/VMConfigurations/MultiVMs.xml
+++ b/XML/VMConfigurations/MultiVMs.xml
@@ -91,7 +91,7 @@
         <isDeployed>NO</isDeployed>
         <ResourceGroup>
             <VirtualMachine>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>server</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -103,7 +103,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-1</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -115,7 +115,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-2</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -127,7 +127,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-3</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -139,7 +139,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-4</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -151,7 +151,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-5</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -163,7 +163,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-6</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -175,7 +175,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-7</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -187,7 +187,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName>client-vm-8</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -119,8 +119,8 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <InstanceSize>Standard_D14_v2</InstanceSize>
-                <ARMInstanceSize>Standard_D14_v2</ARMInstanceSize>
+                <InstanceSize>Standard_DS14_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS14_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>

--- a/XML/VMConfigurations/TwoVMs.xml
+++ b/XML/VMConfigurations/TwoVMs.xml
@@ -118,7 +118,7 @@
         <isDeployed>NO</isDeployed>
         <ResourceGroup>
             <VirtualMachine>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -130,7 +130,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
-                <ARMInstanceSize>Standard_D15_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS15_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -244,7 +244,7 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <ARMInstanceSize>Standard_D5_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS5_v2</ARMInstanceSize>
                 <RoleName>server-vm</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -257,7 +257,7 @@
             </VirtualMachine>
             <VirtualMachine>
                 <state></state>
-                <ARMInstanceSize>Standard_D5_v2</ARMInstanceSize>
+                <ARMInstanceSize>Standard_DS5_v2</ARMInstanceSize>
                 <RoleName>client-vm</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>


### PR DESCRIPTION
Azure platform - GPU-PCI-RESCIND, Standard_NC6 => Standard_NC6s_v2
Azure platform - VERIFY-RESTART-INTERFACE-RELOAD-NETVSC, Standard_D2_v2 => Standard_DS2_v2
Azure and HyperV platform - NETWORK-ADD-MAX-SYNTHETIC-NICS-DURING-PROVISION, Standard_A8_v2 => Standard_B16ms
Azure platform - NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION, Standard_A8_v2 => Standard_B16ms
Azure and HyperV platform - SRIOV-VERIFY-SINGLE-VF-CONNECTION-MAX-VCPU, Standard_D64_v3 => Standard_D64s_v3
Azure and HyperV platform - SRIOV-VERIFY-MAX-VF-CONNECTION, Standard_D14_v2 => Standard_DS14_v2
Azure and HyperV platform - SRIOV-VERIFY-MAX-VF-CONNECTION-MAX-VCPU, Standard_D64_v3 => Standard_D64s_v3
Azure and HyperV platform - VMBUS_VERIFY_INTERRUPTS, Standard_A3 => Standard_B4ms
Azure and HyperV platform - PERF-SYSCALL-BENCHMARK, Standard_D15_v2 => Standard_DS15_v2

NineVM,OneVM8NIC,TwoVM2Host,TwoVM3NIC changed