### PR TITLE
Fix the SLES repo URL and stop firewall for RHEL 8

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2207,25 +2207,13 @@ function install_sshpass () {
 
 # Add benchmark repo on SLES
 function add_sles_benchmark_repo () {
-	if [ $DISTRO_NAME == "sles" ]; then
-		case $DISTRO_VERSION in
-			12*)
-				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_12_SP5/benchmark.repo"
-				;;
-			15*)
-				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_15_SP1/benchmark.repo"
-				;;
-			*)
-				LogErr "Unsupported SLES version $DISTRO_VERSION for add_sles_benchmark_repo"
-				return 1
-		esac
-		zypper addrepo $repo_url
-		zypper --no-gpg-checks refresh
-		return 0
-	else
-		LogErr "Unsupported distribution for add_sles_benchmark_repo"
-		return 1
-	fi
+	source /etc/os-release
+	IFS='- ' read -r -a array <<< "$VERSION"
+	repo_url="https://download.opensuse.org/repositories/benchmark/SLE_${array[0]}_${array[1]}/benchmark.repo"
+	LogMsg "add_sles_benchmark_repo - $repo_url"
+	zypper addrepo $repo_url
+	zypper --no-gpg-checks refresh
+	return 0
 }
 
 # Add network utilities repo on SLES

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2209,11 +2209,8 @@ function install_sshpass () {
 function add_sles_benchmark_repo () {
 	if [ $DISTRO_NAME == "sles" ]; then
 		case $DISTRO_VERSION in
-			11*)
-				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_11_SP4/benchmark.repo"
-				;;
 			12*)
-				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_12_SP4/benchmark.repo"
+				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_12_SP5/benchmark.repo"
 				;;
 			15*)
 				repo_url="https://download.opensuse.org/repositories/benchmark/SLE_15_SP1/benchmark.repo"
@@ -2466,6 +2463,7 @@ function install_lagscope () {
 			yum -y --nogpgcheck install libaio sysstat git bc make gcc wget cmake
 			build_lagscope "${1}"
 			iptables -F
+			systemctl stop firewalld.service || service firewalld stop
 			;;
 
 		ubuntu|debian)


### PR DESCRIPTION
Test results - 
```
[LISAv2 Test Results Summary]
Test Run On           : 04/07/2020 06:52:17
ARM Image Under Test  : RedHat : RHEL : 8 : latest
Initial Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
Final Kernel Version  : 4.18.0-80.11.2.el8_0.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:20

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-LATENCY-Synthetic                                                PASS                17.58 
	Minimum Latency : 156.879 
	Maximum Latency : 19657.135 
	Average Latency : 539.174 

[LISAv2 Test Results Summary]
Test Run On           : 04/07/2020 06:39:41
ARM Image Under Test  : SUSE : sles-12-sp5 : gen1 : latest
Override VM size      : Standard_L80s_v2
Initial Kernel Version: 4.12.14-16.7-azure
Final Kernel Version  : 4.12.14-16.7-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:3:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 PERF-NVME-4K-IO                                                                   PASS               191.09 
	Mode=randread : block_size=4K q_depth=80 iops=630203.894590 
	Mode=randread : block_size=4K q_depth=160 iops=932367.073806 
	Mode=randread : block_size=4K q_depth=320 iops=1106325.642313 
	Mode=randread : block_size=4K q_depth=640 iops=1294433.489651 
	Mode=randread : block_size=4K q_depth=1280 iops=1508100.550289 
	Mode=randread : block_size=4K q_depth=2560 iops=1756692.336514 
	Mode=randread : block_size=4K q_depth=5120 iops=2010358.630196 
	Mode=randread : block_size=4K q_depth=10240 iops=1816123.269024 
	Mode=randread : block_size=4K q_depth=20480 iops=1558650.572167 
	Mode=randwrite : block_size=4K q_depth=80 iops=683493.599145 
	Mode=randwrite : block_size=4K q_depth=160 iops=949600.303496 
	Mode=randwrite : block_size=4K q_depth=320 iops=1112219.609258 
	Mode=randwrite : block_size=4K q_depth=640 iops=1289671.889125 
	Mode=randwrite : block_size=4K q_depth=1280 iops=1497885.224935 
	Mode=randwrite : block_size=4K q_depth=2560 iops=1745930.758017 
	Mode=randwrite : block_size=4K q_depth=5120 iops=1994110.226391 
	Mode=randwrite : block_size=4K q_depth=10240 iops=1607805.361130 
	Mode=randwrite : block_size=4K q_depth=20480 iops=1785252.833067 
	Mode=read : block_size=4K q_depth=80 iops=634702.105186 
	Mode=read : block_size=4K q_depth=160 iops=922489.195933 
	Mode=read : block_size=4K q_depth=320 iops=1105297.276102 
	Mode=read : block_size=4K q_depth=640 iops=1308059.868949 
	Mode=read : block_size=4K q_depth=1280 iops=1551081.852463 
	Mode=read : block_size=4K q_depth=2560 iops=1838789.867184 
	Mode=read : block_size=4K q_depth=5120 iops=2105799.665680 
	Mode=read : block_size=4K q_depth=10240 iops=2196101.296868 
	Mode=read : block_size=4K q_depth=20480 iops=2229919.335067 
	Mode=write : block_size=4K q_depth=80 iops=678678.371804 
	Mode=write : block_size=4K q_depth=160 iops=957696.461281 
	Mode=write : block_size=4K q_depth=320 iops=1110155.728400 
	Mode=write : block_size=4K q_depth=640 iops=1268581.964045 
	Mode=write : block_size=4K q_depth=1280 iops=1505791.045856 
	Mode=write : block_size=4K q_depth=2560 iops=1656710.166674 
	Mode=write : block_size=4K q_depth=5120 iops=1628814.699475 
	Mode=write : block_size=4K q_depth=10240 iops=1834884.078466 
	Mode=write : block_size=4K q_depth=20480 iops=1847304.598577 
```