### PR TITLE
P2 and P3 cases - Update size for support both gen1 and gen2 images on Azure.

### DIFF
--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -80,7 +80,7 @@
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
-        <OverrideVMSize>Standard_D16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D16s_v3</OverrideVMSize>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\ovs_setup.sh,.\Testscripts\Linux\dpdkUtils.sh</files>
         <TestParameters>
             <param>dpdkSrcLink="DPDK_SOURCE_URL"</param>
@@ -117,7 +117,7 @@
         <testName>VERIFY-DPDK-NFF-GO</testName>
         <testScript>VERIFY-DPDK-NFF-GO.ps1</testScript>
         <setupType>OneVM3NIC</setupType>
-        <OverrideVMSize>Standard_D16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D16s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
@@ -138,7 +138,7 @@
         <testName>VERIFY-DPDK-VPP</testName>
         <testScript>VERIFY-DPDK-VPP.ps1</testScript>
         <setupType>OneVM3NIC</setupType>
-        <OverrideVMSize>Standard_D16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D16s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
@@ -157,7 +157,7 @@
         <testName>VERIFY-DPDK-PRIMARY-SECONDARY-PROCESSES</testName>
         <testScript>VERIFY-DPDK-PRIMARY-SECONDARY-PROCESSES.ps1</testScript>
         <setupType>OneVM3NIC</setupType>
-        <OverrideVMSize>Standard_D16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_D16s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -24,7 +24,7 @@
         <testScript>NESTED-KVM-NTTTCP-PRIVATE-BRIDGE.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_ntttcp_private_bridge.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\perf_ntttcp.sh</files>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_E16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_E16s_v3</OverrideVMSize>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>
@@ -294,7 +294,7 @@
         <testScript>NESTED-KVM-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_ntttcp_different_l1_nat.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\perf_ntttcp.sh,.\Testscripts\Linux\nat_qemu_ifup.sh,</files>
         <setupType>TwoVM2NIC</setupType>
-        <OverrideVMSize>Standard_E16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_E16s_v3</OverrideVMSize>
         <AdditionalHWConfig>
             <DiskType>Managed</DiskType>
         </AdditionalHWConfig>
@@ -492,7 +492,7 @@
         <testScript>NESTED-KVM-NETPERF-PPS.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_netperf_pps_nat.sh,.\Testscripts\Linux\enableRoot.sh,.\Testscripts\Linux\enablePasswordLessRoot.sh,.\Testscripts\Linux\perf_netperf.sh,.\Testscripts\Linux\nat_qemu_ifup.sh</files>
         <setupType>TwoVM2NIC</setupType>
-        <OverrideVMSize>Standard_E16_v3</OverrideVMSize>
+        <OverrideVMSize>Standard_E16s_v3</OverrideVMSize>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -629,7 +629,7 @@
         <testName>PERF-GOLANG-BENCHMARK</testName>
         <TestScript>PERF-GOLANG-BENCHMARK.ps1</TestScript>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_D13_v2</OverrideVMSize>
+        <OverrideVMSize>Standard_DS13_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\golang-benchmark.sh</files>
         <Platform>Azure,HyperV,WSL</Platform>
         <TestParameters>
@@ -646,7 +646,7 @@
         <preTestScript>GPU-DRIVER-INSTALL.ps1</preTestScript>
         <testScript>GPU-TENSORFLOW.ps1</testScript>
         <setupType>OneVM</setupType>
-        <OverrideVMSize>Standard_NC6</OverrideVMSize>
+        <OverrideVMSize>Standard_NC6s_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\gpu-driver-install.sh,.\Testscripts\Linux\gpu-tensorflow.sh</files>
         <TestParameters>
             <param>CUDADriverVersion="CUDA_DRIVER"</param>

--- a/XML/VMConfigurations/TwoVMs.xml
+++ b/XML/VMConfigurations/TwoVMs.xml
@@ -34,7 +34,7 @@
         <isDeployed>NO</isDeployed>
         <ResourceGroup>
             <VirtualMachine>
-                <ARMInstanceSize>Standard_E16_v3</ARMInstanceSize>
+                <ARMInstanceSize>Standard_E16s_v3</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>RDP</Name>
@@ -58,7 +58,7 @@
                 <ExtraNICs>1</ExtraNICs>
             </VirtualMachine>
             <VirtualMachine>
-                <ARMInstanceSize>Standard_E16_v3</ARMInstanceSize>
+                <ARMInstanceSize>Standard_E16s_v3</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>RDP</Name>
@@ -179,8 +179,8 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <InstanceSize>Standard_D12_v2</InstanceSize>
-                <ARMInstanceSize>Standard_D12_v2</ARMInstanceSize>
+                <InstanceSize>Standard_DS12_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS12_v2</ARMInstanceSize>
                 <RoleName></RoleName>
                 <EndPoints>
                     <Name>SSH</Name>
@@ -194,8 +194,8 @@
             <VirtualMachine>
                 <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
                 <state></state>
-                <InstanceSize>Standard_D12_v2</InstanceSize>
-                <ARMInstanceSize>Standard_D12_v2</ARMInstanceSize>
+                <InstanceSize>Standard_DS12_v2</InstanceSize>
+                <ARMInstanceSize>Standard_DS12_v2</ARMInstanceSize>
                 <RoleName>dependency-vm</RoleName>
                 <EndPoints>
                     <Name>SSH</Name>


### PR DESCRIPTION
Test results -
VERIFY-DPDK-NFF-GO and VERIFY-DPDK-PRIMARY-SECONDARY-PROCESSES abort for other reason, not related with deployment error.

```
[LISAv2 Test Results Summary]
Test Run On           : 04/07/2020 09:24:43
ARM Image Under Test  : canonical : ubuntuserver : 18_04-lts-gen2 : latest
Initial Kernel Version: 5.0.0-1035-azure
Final Kernel Version  : 5.0.0-1035-azure
Total Test Cases      : 9 (7 Passed, 0 Failed, 2 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:50

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-NTTTCP-PRIVATE-BRIDGE                                                  PASS                26.09 
    2 DPDK                 VERIFY-DPDK-OVS                                                                   PASS                11.53 
    3 NESTED               AZURE-NESTED-KVM-NTTTCP-DIFFERENT-L1-NAT                                          PASS                27.23
    4 NESTED               AZURE-NESTED-KVM-NETPERF-PPS                                                      PASS                12.57
    5 STRESS               STRESSTEST-WEB-PARALLEL-ACCESS                                                    PASS                 11.6 
    6 DPDK                 VERIFY-DPDK-NFF-GO                                                             ABORTED                 7.91 
    7 DPDK                 VERIFY-DPDK-VPP                                                                   PASS                15.39 
    8 DPDK                 VERIFY-DPDK-PRIMARY-SECONDARY-PROCESSES                                        ABORTED                13.56 
    9 GOLANG               PERF-GOLANG-BENCHMARK                                                             PASS                 7.37 

[LISAv2 Test Results Summary]
Test Run On           : 04/07/2020 12:47:03
VHD Under Test        : ubuntu_18.04.1_gen1_gen2.vhdx
Initial Kernel Version: 4.15.0-38-generic
Final Kernel Version  : 5.0.0-1036-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:32

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STRESS               STRESSTEST-WEB-PARALLEL-ACCESS                                                    PASS                16.29 
    2 GOLANG               PERF-GOLANG-BENCHMARK                                                             PASS                 2.78 
```