### PR TITLE
Remove permission check/change for sgx device

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -35,11 +35,6 @@ if ! modinfo intel_sgx; then
     exit 1
 fi
 
-if [ "$(stat -c %a /dev/sgx)" == 600 ]; then
-    echo "/dev/sgx permission is incorrect: 0600, temporarily fix this issue by chmod 666"
-    sudo chmod 666 /dev/sgx
-fi
-
 function install_prereq_1804() {
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -


### PR DESCRIPTION
Canonical has fixed device permission. Remove the "permission check and change" code such that future regress in terms of wrong permission will be captured.

Passed tests:

1. .\Run-LisaV2.ps1 -TestPlatform Azure -TestLocation uksouth -ARMImageName 'Canonical UbuntuServer 18_04-lts-gen2 latest' -RGIdentifier xxx -TestNames 'VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM' -XMLSecretFile .\Secrets.xml
2. .\Run-LisaV2.ps1 -TestPlatform Azure -TestLocation uksouth -ARMImageName 'Canonical UbuntuServer 16_04-lts-gen2 latest' -RGIdentifier xxx -TestNames 'VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM' -XMLSecretFile .\Secrets.xml