### PR TITLE
Try more times when hit dpkg lock during install package on Ubuntu.

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2276,11 +2276,11 @@ function add_sles_network_utilities_repo () {
 }
 
 function dpkg_configure () {
-	retry=5
+	retry=100
 	until [ $retry -le 0 ]; do
 		sudo dpkg --force-all --configure -a && break
 		retry=$[$retry - 1]
-		sleep 5
+		sleep 6
 		LogMsg 'Trying again to run dpkg --configure ...'
 	done
 }


### PR DESCRIPTION
@harz566 Found that we have the logic to handle dpkg lock during install package, just the wait time is too short, I extend the wait time.