### PR TITLE
Fix ibname rename issue.

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -206,6 +206,9 @@ function Main() {
 			LogMsg "$?: Set hpcx version, $hpcx_ver"
 			;;
 		ubuntu*)
+			LogMsg "Disable rename ib0 on Ubuntu by adding net.ifnames=0 biosdevname=0 into kernel parameter."
+			sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 biosdevname=0"/' /etc/default/grub
+			update-grub
 			LogMsg "Starting RDMA setup for Ubuntu"
 			hpcx_ver="ubuntu"$VERSION_ID
 			LogMsg "Installing required packages ..."


### PR DESCRIPTION
We have to work around to disable consistent network device naming, since in waagent it uses hardcode name ib0.
Gen2
```
[LISAv2 Test Results Summary]
Test Run On           : 04/15/2020 12:58:36
ARM Image Under Test  : Canonical : UbuntuServer : 19_10-daily-gen2 : latest
Initial Kernel Version: 5.3.0-1016-azure
Final Kernel Version  : 5.3.0-1019-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:53

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                48.36 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
```

Gen1
```
[LISAv2 Test Results Summary]
Test Run On           : 04/15/2020 08:07:39
ARM Image Under Test  : Canonical : UbuntuServer : 19.10-DAILY : latest
Initial Kernel Version: 5.3.0-1016-azure
Final Kernel Version  : 5.3.0-1019-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:26

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                20.33 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 04/15/2020 11:23:38
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.0.0-1035-azure
Final Kernel Version  : 5.0.0-1036-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:29

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                21.51 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 

[LISAv2 Test Results Summary]
Test Run On           : 04/15/2020 12:30:07
ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
Initial Kernel Version: 4.15.0-1075-azure
Final Kernel Version  : 4.15.0-1077-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                18.22 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot : PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot : PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
```