### PR TITLE
ethtool update for legacy OS

### DIFF
--- a/Documents/How-to-use.md
+++ b/Documents/How-to-use.md
@@ -207,6 +207,10 @@ Per Category, each XML file has VM name, Resource Group name, etc. We do not rec
             CentOS Linux release 7.3.1611 (Core)
             CentOS Linux release 7.4.1708 (Core)
             CentOS Linux release 7.5.1804 (Core)
+            CentOS Linux release 7.6
+            CentOS Linux release 7.7
+            CentOS Linux release 8.0
+            CentOS Linux release 8.1
             CentOS release 6.5 (Final)
             CentOS release 6.6 (Final)
             CentOS release 6.7 (Final)
@@ -214,33 +218,40 @@ Per Category, each XML file has VM name, Resource Group name, etc. We do not rec
             CentOS release 6.9 (Final)
             CentOS release 6.10 (Final)
         b. ClearLinux
-            Clear Linux OS for Intel Architecture 1
+            Clear Linux OS for Basic
+            Clear Linux OS for Containers
+            Clear Linux OS for Machine-Learning
         c. Debian
-            Debian GNU/Linux 7 (wheezy)
-            Debian GNU/Linux 8 (jessie)
-            Debian GNU/Linux 9 (stretch)
-        d. OpenSUSE
-            openSUSE Leap 42.3
-        e. Oracle
+            Debian GNU/Linux 10 (+backport)
+            Debian GNU/Linux 11
+        d. Oracle
             Oracle Linux Server 6.8
             Oracle Linux Server 6.9
             Oracle Linux Server 7.3
             Oracle Linux Server 7.4
-        f. RHEL
-            Red Hat Enterprise Linux Server release 6.7 (Santiago)
-            Red Hat Enterprise Linux Server release 6.8 (Santiago)
-            Red Hat Enterprise Linux Server release 6.9 (Santiago)
-            Red Hat Enterprise Linux Server release 6.10 (Santiago)
-            Red Hat Enterprise Linux Server release 7.2 (Maipo)
-            Red Hat Enterprise Linux Server release 7.3 (Maipo)
-            Red Hat Enterprise Linux Server release 7.4 (Maipo)
-            Red Hat Enterprise Linux Server release 7.5 (Maipo)
-        g. SLES
-            SUSE Linux Enterprise Server 11 SP4
-            SUSE Linux Enterprise Server 12 SP2
-            SUSE Linux Enterprise Server 12 SP3
-            SUSE Linux Enterprise Server 15
-        h. Ubuntu
+            Oracle Linux Server 7.5
+            Oracle Linux Server 7.6
+            Oracle Linux Server 7.7
+            Oracle Linux Server 8
+            Oracle Linux Server 8.1
+        e. RHEL
+            Red Hat Enterprise Linux Server release 6.7
+            Red Hat Enterprise Linux Server release 6.8
+            Red Hat Enterprise Linux Server release 6.9
+            Red Hat Enterprise Linux Server release 6.10
+            Red Hat Enterprise Linux Server release 7.2
+            Red Hat Enterprise Linux Server release 7.3
+            Red Hat Enterprise Linux Server release 7.4
+            Red Hat Enterprise Linux Server release 7.5
+            Red Hat Enterprise Linux Server release 7.6
+            Red Hat Enterprise Linux Server release 7.7
+            Red Hat Enterprise Linux Server release 8.0
+            Red Hat Enterprise Linux Server release 8.1
+        f. SLES
+            SUSE Linux Enterprise Server 12 SP4
+            SUSE Linux Enterprise Server 12 SP5
+            SUSE Linux Enterprise Server 15 SP1
+        g. Ubuntu
             Ubuntu 12.04.5 LTS, Precise Pangolin
             Ubuntu 14.04.5 LTS, Trusty Tahr
             Ubuntu 16.04.4 LTS (Xenial Xerus)
@@ -248,7 +259,9 @@ Per Category, each XML file has VM name, Resource Group name, etc. We do not rec
             Ubuntu 17.10 (Artful Aardvark)
             Ubuntu 18.04 LTS (Bionic Beaver)
             Ubuntu 18.04.1 LTS (Bionic Beaver)
-        j. CoreOS
+            Ubuntu 19.04
+            Ubuntu 19.10
+        h. CoreOS
             CoreOS Linux (Stable)
             CoreOS Linux (Alpha)
             CoreOS Linux (Beta)

--- a/Testscripts/Linux/ETHTOOL-CHANGE-RINGBUFFER.sh
+++ b/Testscripts/Linux/ETHTOOL-CHANGE-RINGBUFFER.sh
@@ -43,7 +43,7 @@ sts=$(ethtool -g "${SYNTH_NET_INTERFACES[@]}" 2>&1)
 if [[ "$sts" = *"Operation not supported"* ]]; then
     LogMsg "$sts"
     LogMsg "Operation not supported. Test Skipped."
-    SetTestStateAborted
+    SetTestStateSkipped
     exit 0
 fi
 

--- a/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
@@ -39,7 +39,7 @@ fi
 vmbus_version=$(dmesg | grep "Vmbus version" | awk -F: '{print $(NF)}' | awk -F. '{print $1}')
 if [ "$vmbus_version" -lt "3" ]; then
     LogMsg "Info: Host version older than 2012R2. Skipping test."
-    SetTestStateAborted
+    SetTestStateSkipped
     exit 0
 fi
 
@@ -49,7 +49,7 @@ if [[ "$sts" = *"Operation not supported"* ]]; then
     LogErr "$sts"
     kernel_version=$(uname -rs)
     LogErr "Getting number of channels from ethtool is not supported on $kernel_version"
-    SetTestStateAborted
+    SetTestStateSkipped
     exit 0
 fi
 

--- a/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-CHANNEL.sh
@@ -35,6 +35,12 @@ if ! GetSynthNetInterfaces; then
     exit 0
 fi
 
+if [[ $DISTRO != "ubuntu_x"* ]]; then
+    LogErr "This distro $DISTRO does not support channel features"
+    SetTestStateSkipped
+    exit 0
+fi
+
 # Skip when host older than 2012R2
 vmbus_version=$(dmesg | grep "Vmbus version" | awk -F: '{print $(NF)}' | awk -F. '{print $1}')
 if [ "$vmbus_version" -lt "3" ]; then

--- a/Testscripts/Linux/ETHTOOL-CHECK-FEATURES.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-FEATURES.sh
@@ -37,7 +37,7 @@ if ! VerifyIsEthtool; then
     exit 0
 fi
 
-if [[ $DISTRO == "ubuntu 12.04"* ]]; then
+if [[ $DISTRO == "ubuntu_12.04"* ]]; then
     LogErr "This distro $DISTRO does not support $ETHTOOL_KEYS features"
     SetTestStateSkipped
     exit 0

--- a/Testscripts/Linux/ETHTOOL-CHECK-FEATURES.sh
+++ b/Testscripts/Linux/ETHTOOL-CHECK-FEATURES.sh
@@ -37,6 +37,12 @@ if ! VerifyIsEthtool; then
     exit 0
 fi
 
+if [[ $DISTRO == "ubuntu 12.04"* ]]; then
+    LogErr "This distro $DISTRO does not support $ETHTOOL_KEYS features"
+    SetTestStateSkipped
+    exit 0
+fi
+
 GetSynthNetInterfaces
 if ! GetSynthNetInterfaces; then
     msg="ERROR: No synthetic network interfaces found"

--- a/Testscripts/Linux/ETHTOOL-HANDLER-HASH-LEVELS.sh
+++ b/Testscripts/Linux/ETHTOOL-HANDLER-HASH-LEVELS.sh
@@ -21,14 +21,13 @@
 # Source constants file and initialize most common variables
 UtilsInit
 
-CheckResults()
-{
+CheckResults() {
     action="$2"
     status="$1"
     if [[ "$status" = *"Operation not supported"* ]]; then
         LogMsg "$status"
         LogMsg "Operation not supported. Test Skipped."
-        SetTestStateAborted
+        SetTestStateSkipped
         exit 0
     fi
     LogMsg "$status"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -219,6 +219,9 @@ function GetDistro() {
 	#Get distro (snipper take from alsa-info.sh)
 	__DISTRO=$(grep -ihs "Ubuntu\|SUSE\|Fedora\|Debian\|CentOS\|Red Hat Enterprise Linux\|clear-linux-os\|CoreOS" /{etc,usr/lib}/{issue,*release,*version})
 	case $__DISTRO in
+		*Ubuntu*12.04*)
+			DISTRO=ubuntu_12.04
+			;;
 		*Ubuntu*14.04*)
 			DISTRO=ubuntu_14.04
 			;;


### PR DESCRIPTION
Found test failed in previous test cycle, and those tests; ETHTOOL-GET-FEATURES, ETHTOOL-GET-SET-CHANNEL, ETHTOOL-GET-SET-RINGBUFFER, ETHTOOL-GET-SET-TCP-HASHLEVELS, ETHTOOL-GET-SET-UDP-HASHLEVELS failed because they don't support those features. Inside it calls aborted instead of skipped. Like logging, it should be skipped.




