### PR TITLE
By default use managed disk.

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -272,7 +272,7 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
 		$RGrandomWord = ([System.IO.Path]::GetRandomFileName() -replace '[^a-z]')
 		$RGRandomNumber = Get-Random -Minimum 11111 -Maximum 99999
 
-		$UseManagedDisks = $CurrentTestData.AdditionalHWConfig.DiskType -contains "managed"
+		$UseManagedDisks = $CurrentTestData.AdditionalHWConfig.DiskType -inotcontains "unmanaged"
 		if ($UseManagedDisks) {
 			$DiskType = "Managed"
 		} else {

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -9,9 +9,6 @@
 			<param>hb_url=Hb_CustomKernelURL</param>
 			<param>hb_branch=Hb_CustomKernelBranch</param>
 		</TestParameters>
-		<AdditionalHWConfig>
-			<DiskType>Managed</DiskType>
-		</AdditionalHWConfig>
 		<Platform>Azure</Platform>
 		<Category>Functional</Category>
 		<Area>POWER</Area>

--- a/XML/TestCases/FunctionalTests-SGX.xml
+++ b/XML/TestCases/FunctionalTests-SGX.xml
@@ -5,9 +5,6 @@
         <setupType>OneVM</setupType>
         <OverrideVMSize>Standard_DC2s_v2</OverrideVMSize>
         <files>.\Testscripts\Linux\validate-intel-sgx-driver.sh,.\Testscripts\Linux\utils.sh</files>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>SGX</Area>

--- a/XML/TestCases/FunctionalTests-Storage.xml
+++ b/XML/TestCases/FunctionalTests-Storage.xml
@@ -754,9 +754,6 @@
             <param>DiskSize=30</param>
             <param>DiskSku=DATA_DISK_SKU</param>
         </testParameters>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>STORAGE</Area>
@@ -772,9 +769,6 @@
             <param>DiskSize=30</param>
             <param>DiskSku=DATA_DISK_SKU</param>
         </testParameters>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>STORAGE</Area>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -20,6 +20,9 @@
         <files></files>
         <setupType>OneVM</setupType>
         <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
+        <AdditionalHWConfig>
+            <OSDiskType>Ephemeral</OSDiskType>
+        </AdditionalHWConfig>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -20,10 +20,6 @@
         <files></files>
         <setupType>OneVM</setupType>
         <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-            <OSDiskType>Ephemeral</OSDiskType>
-        </AdditionalHWConfig>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>CORE</Area>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -81,9 +81,6 @@
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enable_root.sh,.\Testscripts\Linux\enable_passwordless_root.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM1DiskNested</setupType>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>
@@ -144,9 +141,6 @@
         <testScript>NESTED-KVM-STORAGE-PERF.ps1</testScript>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_storage_perf.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\enable_root.sh,.\Testscripts\Linux\enable_passwordless_root.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM6DiskNested</setupType>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>
@@ -295,9 +289,6 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_ntttcp_different_l1_nat.sh,.\Testscripts\Linux\enable_root.sh,.\Testscripts\Linux\enable_passwordless_root.sh,.\Testscripts\Linux\perf_ntttcp.sh,.\Testscripts\Linux\nat_qemu_ifup.sh,</files>
         <setupType>TwoVM2NIC</setupType>
         <OverrideVMSize>Standard_E16s_v3</OverrideVMSize>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <TestParameters>
             <!--The nested image should be qcow2 format, and accessible from a public URL-->
             <param>NestedImageUrl=NESTED_IMAGE_URL</param>
@@ -395,7 +386,6 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM1DiskNested</setupType>
         <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
             <OSType>Windows</OSType>
         </AdditionalHWConfig>
         <TestParameters>
@@ -429,7 +419,6 @@
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nested_vm_utils.sh,.\Testscripts\Linux\nested_kvm_perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <setupType>OneVM6DiskNested</setupType>
         <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
             <OSType>Windows</OSType>
         </AdditionalHWConfig>
         <TestParameters>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -290,7 +290,6 @@
         <testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
         <setupType>OneVM12Disk</setupType>
         <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
             <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
         </AdditionalHWConfig>
         <setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</setupScript>
@@ -318,9 +317,6 @@
         <testName>PERF-STORAGE-1024K-IO</testName>
         <testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
         <setupType>OneVM12Disk</setupType>
-        <AdditionalHWConfig>
-            <DiskType>Managed</DiskType>
-        </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
         <TestParameters>
             <param>modes=PERF-STORAGE-1024K-IO-MODES</param>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -157,7 +157,6 @@
 		<testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
 		<setupType>OneVM12Disk</setupType>
 		<AdditionalHWConfig>
-			<DiskType>Managed</DiskType>
 			<StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
 		</AdditionalHWConfig>
 		<setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</setupScript>


### PR DESCRIPTION
Now default disk type is unmanaged disk type, change it into managed disk type by default.

Default
```
.\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lili' -TestPlatform 'Azure' -StorageAccount 'ExistingStorage_Standard' -VMGeneration '1' -EnableTelemetry -ARMImageName 'Canonical UbuntuServer 18.04-LTS latest' -TestNames 'VERIFY-DEPLOYMENT-PROVISION' -ResourceCleanup 'Default' -XMLSecretFile '****' -ExitWithZero

04/20/2020 08:29:48 : [INFO ] Added Managed-Persistent OS disk : LISAv2-OneVM-lili-LV27-20200420082938-role-0-OSDisk

[LISAv2 Test Results Summary]
Test Run On           : 04/20/2020 08:29:20
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1036-azure
Final Kernel Version  : 5.0.0-1036-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.15 
	FirstBoot : PASS 
	FirstBoot : Call Trace Verification : PASS 
	Reboot : PASS 
	Reboot : Call Trace Verification : PASS 
```

Override use unmanaged disk -
```
.\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'lili' -TestPlatform 'Azure' -StorageAccount 'ExistingStorage_Standard' -VMGeneration '1' -EnableTelemetry -ARMImageName 'Canonical UbuntuServer 18.04-LTS latest' -TestNames 'VERIFY-DEPLOYMENT-PROVISION' -ResourceCleanup 'Default' -XMLSecretFile '****' -CustomParameters 'DiskType=UnManaged' -ExitWithZero

04/20/2020 08:32:34 : [INFO ] The AdditionalHWConfig DiskType of case VERIFY-DEPLOYMENT-PROVISION is set to UnManaged

04/20/2020 08:33:03 : [INFO ] Added Unmanaged-Persistent OS disk : LISAv2-OneVM-lili-BK98-20200420083253-role-0-OSDisk

[LISAv2 Test Results Summary]
Test Run On           : 04/20/2020 08:32:34
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.0.0-1036-azure
Final Kernel Version  : 5.0.0-1036-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.18 
	FirstBoot : PASS 
	FirstBoot : Call Trace Verification : PASS 
	Reboot : PASS 
	Reboot : Call Trace Verification : PASS 
```
