### PR TITLE
Temporarily switch from clang to gcc for sgx tests

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -81,6 +81,9 @@ echo "----- Running Samples Tests -----"
 cd ~
 cp -r /opt/openenclave/share/openenclave/samples/ ~
 source /opt/openenclave/share/openenclave/openenclaverc
+# Temporarily switch compiler from clang to gcc
+export CC=gcc
+export CXX=g++
 SAMPLES=$(find ~/samples/* -maxdepth 0 -type d)
 NUM_PASS=0
 for DIR in $SAMPLES; do


### PR DESCRIPTION
Openenclave SDK samples tests fail with clang compiler. Temporarily switch to gcc to let the tests pass. Will switch back after new OE SDK package is released.