### PR TITLE
Revert "Temporarily switch from clang to gcc for sgx tests (#757)"

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -81,9 +81,6 @@ echo "----- Running Samples Tests -----"
 cd ~
 cp -r /opt/openenclave/share/openenclave/samples/ ~
 source /opt/openenclave/share/openenclave/openenclaverc
-# Temporarily switch compiler from clang to gcc
-export CC=gcc
-export CXX=g++
 SAMPLES=$(find ~/samples/* -maxdepth 0 -type d)
 NUM_PASS=0
 for DIR in $SAMPLES; do


### PR DESCRIPTION
This reverts commit a3708a04e2580d246f5aa43cde25985423b7cb87.