### PR TITLE
Stress test: Add FIO stress test with long time

### DIFF
--- a/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
+++ b/Testscripts/Windows/PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1
@@ -263,6 +263,14 @@ function Main {
             Write-LogErr "Test Aborted. Last known status : $currentStatus."
             $testResult = "ABORTED"
         } elseif ($finalStatus -imatch "TestCompleted") {
+            $testResult = "PASS"
+        } elseif ($finalStatus -imatch "TestRunning") {
+            Write-LogInfo "Powershell job for test is completed but test is still running."
+            $testResult = "FAILED"
+        }
+
+        if ($testResult -eq "PASS" -or $testResult -eq "FAIL") {
+            Write-LogInfo "Copying remote files..."
             Copy-RemoteFiles -downloadFrom $allVMData.PublicIP -port $allVMData.SSHPort `
                 -username "root" -password $password -download -downloadTo $LogDir -files "FIOTest-*.tar.gz"
             Copy-RemoteFiles -downloadFrom $allVMData.PublicIP -port $allVMData.SSHPort `
@@ -271,12 +279,8 @@ function Main {
                 -username "root" -password $password -command "/root/ParseFioTestLogs.sh" `
                 -runMaxAllowedTime $TestParams.parseTimeout
             Copy-RemoteFiles -downloadFrom $allVMData.PublicIP -port $allVMData.SSHPort `
-                -username "root" -password $password -download -downloadTo $LogDir `
-                -files "perf_fio.csv"
-            $testResult = "PASS"
-        } elseif ($finalStatus -imatch "TestRunning") {
-            Write-LogInfo "Powershell job for test is completed but test is still running."
-            $testResult = "FAILED"
+                    -username "root" -password $password -download -downloadTo $LogDir `
+                    -files "perf_fio.csv"
         }
         Write-LogInfo "Test result: $testResult"
         if ($testResult -ne "PASS") {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -98,6 +98,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>720</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>FIO_STRESS_LONGTIME_RUNTIME</ReplaceThis>
+		<ReplaceWith>9000</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>DPDK_TEST_DURATION_IN_SECONDS</ReplaceThis>
 		<ReplaceWith>120</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -208,7 +208,7 @@
 			<param>testType=StressLongTime</param>
 		</TestParameters>
 		<cleanupScript>.\Testscripts\Windows\RemoveHardDisk.ps1</cleanupScript>
-		<Platform>Azure,HyperV</Platform>
+		<Platform>Azure</Platform>
 		<Category></Category>
 		<Area></Area>
 		<Tags>stress,hv_storvsc,storage</Tags>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -181,4 +181,37 @@
 		<Tags>stress,hv_storvsc,storage</Tags>
 		<Priority></Priority>
 	</test>
+	<test>
+		<testName>STRESS-STORAGE-4K-IO-WITHVERIFY-LONGTIME</testName>
+		<testScript>PERF-STORAGE-MULTIDISK-RAID0-FIO.ps1</testScript>
+		<setupType>OneVM12Disk</setupType>
+		<AdditionalHWConfig>
+			<DiskType>Managed</DiskType>
+			<StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
+		</AdditionalHWConfig>
+		<setupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</setupScript>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_fio.sh,.\Testscripts\Linux\fio_jason_parser.sh,.\Testscripts\Linux\JSON.awk,.\Tools\gawk</files>
+		<TestParameters>
+			<param>modes=STRESS-STORAGE-4K-IO-MODES</param>
+			<param>chunkSize=256</param>
+			<param>ioSize=5000T</param>
+			<param>fileSystem=xfs</param>
+			<param>startQDepth=64</param>
+			<param>maxQDepth=2048</param>
+			<param>startIO=4</param>
+			<param>maxIO=256</param>
+			<param>fileSize=16G</param>
+			<param>ioruntime=FIO_STRESS_LONGTIME_RUNTIME</param>
+			<param>PHYSICAL_NUMBER=1</param>
+			<param>SCSI=1,1,RAID</param>
+			<param>parseTimeout=FIO_LOG_PARSE_TIMEOUT</param>
+			<param>testType=StressLongTime</param>
+		</TestParameters>
+		<cleanupScript>.\Testscripts\Windows\RemoveHardDisk.ps1</cleanupScript>
+		<Platform>Azure,HyperV</Platform>
+		<Category></Category>
+		<Area></Area>
+		<Tags>stress,hv_storvsc,storage</Tags>
+		<Priority></Priority>
+	</test>
 </TestCases>


### PR DESCRIPTION
Add a FIO stress test with long time about 5 days. Compared with the fio test we already have, the new test case has some changes as below:
1. When creating RAID, make the chunk size is 256K.
2. Xfs file system with default settings created on 'md0'.
3. Higher IO depth(256,512,1024,2048)
4. More block sizes(4k,16K,64K,256K)
5. Longer testing time, about 5 days.