### PR TITLE
Change expectedSriov to 8

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -757,7 +757,7 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <TestParameters>
-            <param>expectedSriov=7</param>
+            <param>expectedSriov=8</param>
             <param>expectedNvme=10</param>
         </TestParameters>
         <Platform>Azure</Platform>


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

The case PCI-DEVICE-DISABLE-ENABLE-SRIOV-NVME creates a VM with 8 SRIOV NICs, but the expected SRIOV nic number is 7, which makes the case failed. After change it to 8 the case passed.
The failed log before:
```
Sat Apr 25 01:42:09 2020 : SR-IOV NICs count does not match expected inside the VM, expected 7 found 8
```

But I'm really confused that why this case passed in the past...Currently it cannot pass anymore only if I change expectedSriov to 8.