### PR TITLE
Fix not checking messages issue and add some ignorable logs

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -19,15 +19,20 @@
             <keywords>display-manager.service</keywords>
             <keywords>ACPI PCC probe failed</keywords>
             <keywords>Failed to access perfctr msr</keywords>
+            <keywords>Failed to init entropy source hwrng</keywords>
+            <keywords>augenrules.*: failure 1</keywords>
+            <keywords>microcode_ctl: kernel version ".*" failed early load check for ".*", skipping</keywords>
+            <keywords>rngd: Failed to init entropy source 0: Hardware RNG Device</keywords>
+            <keywords>open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory</keywords>
         </failures>
         <errors>
             <keywords>TLS record write failed</keywords>
             <keywords>state ensure error</keywords>
             <keywords>got unexpected HTTP status code</keywords>
             <keywords>Error getting hardware address for "eth0": No such device</keywords>
-            <keywords>codec can't encode character</keywords>
-            <keywords>Failed to set certificate key file [gnutls error -64: Error while reading file.]</keywords>
-            <keywords>audispd: Error - /etc/audisp/plugins.d/wdgsmart-syslog.conf isn't owned by root</keywords>
+            <keywords>codec can\'t encode character</keywords>
+            <keywords>Failed to set certificate key file \[gnutls error -64: Error while reading file.\]</keywords>
+            <keywords>audispd: Error - /etc/audisp/plugins.d/wdgsmart-syslog.conf isn\'t owned by root</keywords>
             <keywords>Condition check resulted in Process error reports when automatic reporting is enabled</keywords>
             <keywords>error trying to compare the snap system key: system-key missing on disk</keywords>
             <keywords>open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory</keywords>
@@ -37,11 +42,14 @@
             <keywords>floppy: error -5 while reading block 0</keywords>
             <keywords>Broken pipe</keywords>
             <keywords>errors=remount-ro</keywords>
+            <keywords>smartd.*: Device: /dev/.*, Bad IEC \(SMART\) mode page, err=5, skip device</keywords>
+            <keywords>GPT: Use GNU Parted to correct GPT errors</keywords>
+            <keywords>RAS: Correctable Errors collector initialized</keywords>
         </errors>
         <warnings>
             <keywords>WARNING Daemon VM is provisioned, but the VM unique identifier has changed -- clearing cached state</keywords>
             <keywords>WARNING! Cached DHCP leases will be deleted</keywords>
-            <keywords>Unconfined exec qualifier (ux) allows some dangerous environment variables</keywords>
+            <keywords>Unconfined exec qualifier \(ux\) allows some dangerous environment variables</keywords>
             <keywords>Stopped Write warning to Azure ephemeral disk</keywords>
             <keywords>reloading interface list</keywords>
             <keywords>Server preferred version:</keywords>
@@ -51,6 +59,6 @@
             <keywords>Added ephemeral disk warning to</keywords>
             <keywords>Started Write warning to Azure ephemeral disk</keywords>
             <keywords>Proceeding WITHOUT firewalling in effect!</keywords>
-            <keywords>urandom warning(s) missed due to ratelimiting</keywords>
+            <keywords>urandom warning\(s\) missed due to ratelimiting</keywords>
         </warnings>
 </messages>

--- a/XML/Other/ignorable-walalog-errors.xml
+++ b/XML/Other/ignorable-walalog-errors.xml
@@ -10,5 +10,9 @@
         <keywords>.*ERROR:Traceback \(most recent call last\):\n[^\n]*in DoDhcpWork\n[^\n]*ERROR:    receiveBuffer = sock.recv\(1024\)\n[^\n]*ERROR:timeout: timed out\n[^\n]*ERROR:</keywords>
         <keywords>.*error result is 0 output is : Adding repository 'msft-rdma-pack' \[......done\].*</keywords>
         <keywords>ERROR Event: name=WALinuxAgent, op=Download, message=Incarnation 1 failed to get Prod package list: \(000008\)Failed to fetch ExtensionManifest from all sources</keywords>
+        <keywords>.*Error: .CGroupsException. The daemon.s PID .* was already added to the legacy cgroup; this invalidates resource usage data.*</keywords>
+        <keywords>.*Daemon Error getting cloud-init enabled status from systemctl: Command '\['systemctl', 'is-enabled', 'cloud-init-local.service'\]' returned non-zero exit status 1</keywords>
+        <keywords>.*Daemon Error getting cloud-init enabled status from service: Command '\['service', 'cloud-init', 'status'\]' returned non-zero exit status 4</keywords>
+        <keywords>.*Daemon sfdisk with --part-type failed \[1\], retrying with -c</keywords>
     </errors>
 </messages>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -84,7 +84,7 @@
     <test>
         <testName>VERIFY-BOOT-ERROR-WARNINGS</testName>
         <testScript>VERIFY-BOOT-ERROR-WARNINGS.py</testScript>
-        <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\VERIFY-BOOT-ERROR-WARNINGS.py,.\XML\Other\ignorable-boot-errors.xml</files>
+        <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\VERIFY-BOOT-ERROR-WARNINGS.py,.\XML\Other\ignorable-boot-errors.xml,.\XML\Other\ignorable-walalog-errors.xml</files>
         <setupType>OneVM</setupType>
         <Platform>Azure,WSL</Platform>
         <Category>Functional</Category>


### PR DESCRIPTION
Signed-off-by: Yuxin Sun <yuxisun@redhat.com>

Before, the case didn't check /var/log/messages if there's no errors in syslog. 
Now this case checks error/fail/warnings in /var/log/syslog, /var/log/messages and dmesg.
Keywords use "<keyword>.*"(e.g. err.*, fail.*) to match messages like "err/errors", "failed/failure"...
Change ignorable-boot-errors to regex to match messages more flexible.
Add some ignorable messages. (I'm not quite sure if all of these messages should be ignored. Could anyone please help to double check that? Thanks!)

Currently case passed in RHEL-7.9/8.2.