### PR TITLE
fix bug of LISAv2 orchestrator recover from last deployment failure when -UseExistingRG

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1241,7 +1241,7 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
 			Add-Content -Value "$($indents[3])^dependsOn^: " -Path $jsonFile
 			Add-Content -Value "$($indents[3])[" -Path $jsonFile
 			if (!$createAvailabilitySet) {
-				#Add-Content -Value "$($indents[4])^[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]^," -Path $jsonFile
+				Add-Content -Value "$($indents[4])^[resourceId('Microsoft.Compute/availabilitySets','$availabilitySetName')]^" -Path $jsonFile
 			}
 			else {
 				Add-Content -Value "$($indents[4])^[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]^," -Path $jsonFile

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1556,14 +1556,15 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
                                 -StorageAccount $used_SC
             $validateCurrentTime = Get-Date
             $elapsedWaitTime = ($validateCurrentTime - $validateStartTime).TotalSeconds
-            if ( (!$readyToDeploy) -and ($elapsedWaitTime -lt $coreCountExceededTimeout)) {
+            # Don't wait if -UseExistingRG, otherwise waiting for resource cleanup and freeing quota
+            if ($elapsedWaitTime -gt $coreCountExceededTimeout -or $UseExistingRG) {
+                break
+            }
+            elseif (!$readyToDeploy) {
                 $waitPeriod = Get-Random -Minimum 1 -Maximum 10 -SetSeed (Get-Random)
                 Write-LogInfo "Timeout in approx. $($coreCountExceededTimeout - $elapsedWaitTime) seconds..."
                 Write-LogInfo "Waiting $waitPeriod minutes..."
                 Start-Sleep -Seconds ($waitPeriod * 60)
-            }
-            if ( $elapsedWaitTime -gt $coreCountExceededTimeout ) {
-                break
             }
         }
         if ($readyToDeploy) {
@@ -1846,10 +1847,10 @@ Function Delete-ResourceGroup([string]$RGName, [bool]$UseExistingRG, [string]$Pa
             if ($UseExistingRG) {
                 $attempts = 0
                 if ($PatternOfResourceNamePrefix) {
-                    $PatternOfResourceNamePrefix += '|disk'
+                    $PatternOfResourceNamePrefix += '|disk|NIC'
                 }
                 else {
-                    $PatternOfResourceNamePrefix = 'disk'
+                    $PatternOfResourceNamePrefix = 'disk|NIC'
                 }
                 while ($attempts -le 10) {
                     # Get LISAv2 deployed resources and ResourceType is NOT 'AvailabilitySets'
@@ -2047,64 +2048,65 @@ Function Get-AllDeploymentData([string]$ResourceGroups, [string]$PatternOfResour
             | Where-Object {$pIp = (Get-AzPublicIpAddress -Name $_.name -ResourceGroupName $ResourceGroup); `
                 return (($pIP.IpAddress -ne "Not Assigned") -and ($_.Name -imatch '^LISAv2-.+'))} `
             | Select-Object -Last 1
-        if (!$RGIPsdata) {
-            Write-LogWarn "    No available Microsoft.Network/publicIPAddresses resources, return empty VmData..."
-            break
-        }
 
         $AllVMs = Get-AzVM -ResourceGroupName $ResourceGroup
         foreach ($testVM in $RGVMs)
         {
             $testVMDetails = $AllVMs | Where-Object { $_.Name -eq $testVM.Name }
             $QuickVMNode = Create-QuickVMNode
-            $lbDetails = Get-AzLoadBalancer -ResourceGroupName $ResourceGroup -Name $LBdata.Name
-            $InboundNatRules = $lbDetails.InboundNatRules
-            foreach ($endPoint in $InboundNatRules)
-            {
-                if ( $endPoint.Name -imatch $testVM.ResourceName)
+            if ($LBdata) {
+                $lbDetails = Get-AzLoadBalancer -ResourceGroupName $ResourceGroup -Name $LBdata.Name
+                $InboundNatRules = $lbDetails.InboundNatRules
+                foreach ($endPoint in $InboundNatRules)
                 {
-                    $endPointName = "$($endPoint.Name)".Replace("$($testVM.Name)-","")
-                    Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($endPointName)Port" -Value $endPoint.FrontendPort -Force
+                    if ( $endPoint.Name -imatch $testVM.ResourceName)
+                    {
+                        $endPointName = "$($endPoint.Name)".Replace("$($testVM.Name)-","")
+                        Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($endPointName)Port" -Value $endPoint.FrontendPort -Force
+                    }
+                }
+                $LoadBalancingRules = $lbDetails.LoadBalancingRules
+                foreach ( $LBrule in $LoadBalancingRules )
+                {
+                    if ( $LBrule.Name -imatch "$ResourceGroup-LB-" )
+                    {
+                        $endPointName = "$($LBrule.Name)".Replace("$ResourceGroup-LB-","")
+                        Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($endPointName)Port" -Value $LBrule.FrontendPort -Force
+                    }
+                }
+                $Probes = $lbDetails.Probes
+                foreach ( $Probe in $Probes )
+                {
+                    if ( $Probe.Name -imatch "$ResourceGroup-LB-" )
+                    {
+                        $probeName = "$($Probe.Name)".Replace("$ResourceGroup-LB-","").Replace("-probe","")
+                        Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($probeName)ProbePort" -Value $Probe.Port -Force
+                    }
                 }
             }
-            $LoadBalancingRules = $lbDetails.LoadBalancingRules
-            foreach ( $LBrule in $LoadBalancingRules )
-            {
-                if ( $LBrule.Name -imatch "$ResourceGroup-LB-" )
+            if ($NICdata) {
+                $AllNICs = Get-AzNetworkInterface -ResourceGroupName $ResourceGroup
+                foreach ($nic in $NICdata)
                 {
-                    $endPointName = "$($LBrule.Name)".Replace("$ResourceGroup-LB-","")
-                    Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($endPointName)Port" -Value $LBrule.FrontendPort -Force
-                }
-            }
-            $Probes = $lbDetails.Probes
-            foreach ( $Probe in $Probes )
-            {
-                if ( $Probe.Name -imatch "$ResourceGroup-LB-" )
-                {
-                    $probeName = "$($Probe.Name)".Replace("$ResourceGroup-LB-","").Replace("-probe","")
-                    Add-Member -InputObject $QuickVMNode -MemberType NoteProperty -Name "$($probeName)ProbePort" -Value $Probe.Port -Force
-                }
-            }
-
-            $AllNICs = Get-AzNetworkInterface -ResourceGroupName $ResourceGroup
-            foreach ( $nic in $NICdata )
-            {
-                $nicDetails = $AllNICs | Where-Object { $_.Name -eq $nic.Name }
-                if (($nic.Name.Replace("-PrimaryNIC","") -eq $testVM.Name) -and ( $nic.Name -imatch "PrimaryNIC"))
-                {
-                    $QuickVMNode.InternalIP = "$($nicDetails.IpConfigurations[0].PrivateIPAddress)"
-                }
-                if (($nic.Name.Replace("-ExtraNetworkCard-1","") -eq $testVM.Name) -and ($nic.Name -imatch "ExtraNetworkCard-1"))
-                {
-                    $QuickVMNode.SecondInternalIP = "$($nicDetails.IpConfigurations[0].PrivateIPAddress)"
+                    $nicDetails = $AllNICs | Where-Object { $_.Name -eq $nic.Name }
+                    if (($nic.Name.Replace("-PrimaryNIC","") -eq $testVM.Name) -and ( $nic.Name -imatch "PrimaryNIC"))
+                    {
+                        $QuickVMNode.InternalIP = "$($nicDetails.IpConfigurations[0].PrivateIPAddress)"
+                    }
+                    if (($nic.Name.Replace("-ExtraNetworkCard-1","") -eq $testVM.Name) -and ($nic.Name -imatch "ExtraNetworkCard-1"))
+                    {
+                        $QuickVMNode.SecondInternalIP = "$($nicDetails.IpConfigurations[0].PrivateIPAddress)"
+                    }
                 }
             }
             $QuickVMNode.ResourceGroupName = $ResourceGroup
-            $ipDetails = Get-AzPublicIpAddress -Name $RGIPsdata.name -ResourceGroupName $ResourceGroup
-            $QuickVMNode.PublicIP = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv4" }).ipAddress
-            $QuickVMNode.PublicIPv6 = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv6" }).ipAddress
-            $QuickVMNode.URL = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv4" }).dnsSettings.fqdn
-            $QuickVMNode.URLv6 = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv6" }).dnsSettings.fqdn
+            if ($RGIPsdata) {
+                $ipDetails = Get-AzPublicIpAddress -Name $RGIPsdata.name -ResourceGroupName $ResourceGroup
+                $QuickVMNode.PublicIP = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv4" }).ipAddress
+                $QuickVMNode.PublicIPv6 = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv6" }).ipAddress
+                $QuickVMNode.URL = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv4" }).dnsSettings.fqdn
+                $QuickVMNode.URLv6 = ($ipDetails | Where-Object { $_.publicIPAddressVersion -eq "IPv6" }).dnsSettings.fqdn
+            }
             $QuickVMNode.RoleName = $testVM.Name
             $QuickVMNode.Status = $testVMDetails.ProvisioningState
             $QuickVMNode.InstanceSize = $testVMDetails.hardwareProfile.vmSize

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -346,6 +346,10 @@ function Is-VmAlive {
         $AllVMDataObject,
         $MaxRetryCount = 50
     )
+	if ((!$AllVMDataObject) -or (!$AllVMDataObject.RoleName)) {
+		Write-LogWarn "Empty/Invalid collection of AllVMDataObject."
+		return "False"
+	}
 
     Write-LogInfo "Trying to connect to deployed VMs."
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -654,6 +654,7 @@ Class TestController
 							}
 						}
 					}
+					return $vmData
 				}
 
 				for ($indexOfTC = 0; $indexOfTC -lt $arrayOfTestConfigs.Count; $indexOfTC++) {
@@ -686,7 +687,7 @@ Class TestController
 							}
 							# if there are deployment errors, skip RunTestCase, just CleanupResource, as this is unrecoverable
 							if ($vmData -and $deployVMStatus.Error) {
-								&$CleanupResource
+								$vmData = &$CleanupResource
 							}
 							$deployErrors = Trim-ErrorLogMessage $deployVMStatus.Error
 						}
@@ -704,7 +705,7 @@ Class TestController
 					$lastResult = $this.RunOneTestCase($vmData, $currentTestCase, $executionCount, $this.SetupTypeTable[$setupType], ($tests -ne 0))
 					$tests++
 
-					&$CleanupResource
+					$vmData = &$CleanupResource
 				}
 			}
 


### PR DESCRIPTION
fix bug of LISAv2 orchestrator recover and ready to deploy the next testcase from last deployment failure; add more resources to be collected from Delete-ResourceGroup



05/01/2020 22:54:22 : [INFO ] Test CO63 finished
05/01/2020 22:54:22 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 05/01/2020 22:21:47
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.3.0-1020-azure
Final Kernel Version  : 5.3.0-1020-azure
Total Test Cases      : 4 (3 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:32

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-VERIFY-MAX-VF-CONNECTION                                                    PASS                  7.6 
    2 SRIOV                SRIOV-VERIFY-SINGLE-VF-CONNECTION-MAX-VCPU                                        PASS                  3.4 
    3 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                     SKIPPED                 2.04 
    4 SRIOV                SRIOV-RELOAD-MODULE                                                               PASS                 2.65 

