### PR TITLE
Revert back priority from 2 => 1 for MULTICONNECTION NTTTCP tests.

### DIFF
--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -23,7 +23,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
-        <Priority>2</Priority>
+        <Priority>1</Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-TCP-THROUGHPUT-MULTICONNECTION-NTTTCP-SRIOV</testName>
@@ -49,7 +49,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
-        <Priority>2</Priority>
+        <Priority>1</Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICONNECTION-NTTTCP-Synthetic</testName>
@@ -76,7 +76,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
-        <Priority>2</Priority>
+        <Priority>1</Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICONNECTION-NTTTCP-SRIOV</testName>
@@ -103,7 +103,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
-        <Priority>2</Priority>
+        <Priority>1</Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic</testName>
@@ -124,7 +124,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
-        <Priority>1</Priority>
+        <Priority></Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-TCP-THROUGHPUT-MULTICLIENTS-NTTTCP-SRIOV</testName>
@@ -145,7 +145,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
-        <Priority>1</Priority>
+        <Priority></Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICLIENTS-NTTTCP-Synthetic</testName>
@@ -167,7 +167,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc</Tags>
-        <Priority>2</Priority>
+        <Priority></Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-UDP-1K-THROUGHPUT-MULTICLIENTS-NTTTCP-SRIOV</testName>
@@ -189,7 +189,7 @@
         <Category>Performance</Category>
         <Area>NETWORK</Area>
         <Tags>network,hv_netvsc,sriov</Tags>
-        <Priority>2</Priority>
+        <Priority></Priority>
     </test>
     <test>
         <testName>PERF-NETWORK-TCP-LATENCY-Synthetic</testName>


### PR DESCRIPTION
Unset priority for MULTICLIENTS NTTTCP tests, since it will use 9 * 20 core