### PR TITLE
Remove reuseVmOnFailure on HyperV

### DIFF
--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -30,7 +30,6 @@ Class HyperVProvider : TestProvider
 {
 	[string] $VMGeneration
 	[string] $BaseCheckpoint = "ICAbase"
-	[bool]   $ReuseVmOnFailure = $true
 
 	[object] DeployVMs([xml] $GlobalConfig, [object] $SetupTypeData, [object] $TestCaseData, [string] $TestLocation, [string] $RGIdentifier, [bool] $UseExistingRG, [string] $ResourceCleanup) {
 		$allVMData = @()


### PR DESCRIPTION
Sometimes the case abort/fail for not getting the IP, but we still use this VM since reuseVmOnFailure=$true, then all of remain cases will fail/abort.