### PR TITLE
Respect '-ResourceCleanup=Keep' when DeployVMs() results with Errors

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -641,21 +641,29 @@ Class TestController
 					if (!$vmData -or $tcDeployVM) {
 						# Deploy the VM for the setup
 						Write-LogInfo "Deploy target machine for test if required ..."
-						$deployVMStatus = $this.TestProvider.DeployVMs($this.GlobalConfig, $this.SetupTypeTable[$setupType], $currentTestCase, `
+						$deployVMResults = $this.TestProvider.DeployVMs($this.GlobalConfig, $this.SetupTypeTable[$setupType], $currentTestCase, `
 							$this.TestLocation, $this.RGIdentifier, $this.UseExistingRG, $this.ResourceCleanup)
 						$vmData = $null
 						$deployErrors = ""
-						if ($deployVMStatus) {
-							$vmData = $deployVMStatus
-							if ($deployVMStatus.Keys -and ($deployVMStatus.Keys -contains "VmData")) {
-								$vmData = $deployVMStatus.VmData
+						if ($deployVMResults) {
+							# By default set $vmData with $deployVMResults, because providers may return array of vmData directly if no errors.
+							$vmData = $deployVMResults
+							# override the $vmData if $deployResults give VmData specifically with property 'VmData'
+							if ($deployVMResults.Keys -and ($deployVMResults.Keys -contains "VmData")) {
+								$vmData = $deployVMResults.VmData
 							}
-							# if there are deployment errors, skip RunTestCase, just CleanupResource, as this is unrecoverable
-							# and we do not care about the last test run result (Pass or Fail), always CleanupResource
-							if ($vmData -and $deployVMStatus.Error) {
-								$vmData = &$CleanupResource
+							# if there are deployment errors, skip RunTestCase and try to CleanupResource, as this is unrecoverable
+							# and we do not care about the last test run result (Pass or Fail), always try to CleanupResource, unless 'ResourceCleanup = Keep' set
+							if ($vmData -and $deployVMResults.Error) {
+								if ($this.ResourceCleanup -imatch "Keep") {
+									Write-LogWarn "ResourceCleanup = 'Keep' is respected, but following testing may fail, as Deployment Errors detected."
+									$vmData = $null
+								}
+								else {
+									$vmData = &$CleanupResource
+								}
 							}
-							$deployErrors = Trim-ErrorLogMessage $deployVMStatus.Error
+							$deployErrors = Trim-ErrorLogMessage $deployVMResults.Error
 						}
 						if (!$vmData) {
 							# Failed to deploy the VMs, Set the case to abort


### PR DESCRIPTION
Logic change:
=============
When DeployVMs() results with some Errors, meanwhile, '-ResourceCleanup=Keep';   The updated logic won't cleanup VMs /Delete VMs, just log warning messages, but following test case execution may failed/aborted.

=========
Test Result -
```
Initial Kernel Version: 5.4.0-1010-azure
Final Kernel Version  : 5.4.0-1010-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.52 
        FirstBoot : PASS 
        FirstBoot : Call Trace Verification : PASS 
        Reboot : PASS 
        Reboot : Call Trace Verification : PASS 


Logs can be found at C:\LISAv2\TestResults\2020-07-05-16-50-39-2051


05/07/2020 23:57:11 : [DEBUG] Creating 'C:\LISAv2\Azure-LS98-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-07-05-16-50-39-2051'
05/07/2020 23:57:11 : [DEBUG] C:\LISAv2\Azure-LS98-TestLogs.zip created successfully.
05/07/2020 23:57:11 : [INFO ] Analyzing test results ...
05/07/2020 23:57:11 : [INFO ] LISAv2 exit code: 0
```