### PR TITLE
Add ignorable logs

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -24,6 +24,7 @@
             <keywords>microcode_ctl: kernel version ".*" failed early load check for ".*", skipping</keywords>
             <keywords>rngd: Failed to init entropy source 0: Hardware RNG Device</keywords>
             <keywords>open /dev/vmbus/hv_fcopy failed; error: 2 No such file or directory</keywords>
+            <keywords>dnf.*: Failed determining last makecache time</keywords>
         </failures>
         <errors>
             <keywords>TLS record write failed</keywords>
@@ -60,5 +61,6 @@
             <keywords>Started Write warning to Azure ephemeral disk</keywords>
             <keywords>Proceeding WITHOUT firewalling in effect!</keywords>
             <keywords>urandom warning\(s\) missed due to ratelimiting</keywords>
+            <keywords>kdumpctl.*: Warning: There might not be enough space to save a vmcore</keywords>
         </warnings>
 </messages>


### PR DESCRIPTION
After testing these days, I think these error/fail/warning messages should be ignored:

May  6 00:06:10 localhost kdumpctl[1000]: Warning: There might not be enough space to save a vmcore.
May  6 00:08:26 localhost NetworkManager[2930]: <warn>  [1588694906.4903] dns-sd-resolved[dee3d138813c2cd9]: send-updates failed to update systemd-resolved: GDBus.Error:org.freedesktop.resolve1.NoSuchLink: Link 2 not known
May  6 00:16:11 localhost dnf[7457]: Failed determining last makecache time.

Thanks!