### PR TITLE
TestNames, TestCategory, and TestArea using case insensitive -contains for matching

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -149,16 +149,16 @@ Function Collect-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Tes
             if (!$platformMatched) {
                 continue
             }
-
-            if (!($TestCategory.Split(",").Contains($test.Category)) -and ($TestCategory -ne "*")) {
+            # case insensitive 'contains', and always complete match the concatenated expression for Category of TestCase
+            if (!($TestCategory.Trim(', ').Split(',').Trim() -contains $test.Category) -and ($TestCategory -ne "*")) {
                 continue
             }
-
-            if (!($TestArea.Split(",").Contains($test.Area)) -and ($TestArea -ne "*")) {
+            # case insensitive 'contains', and always complete match the concatenated expression for Area of TestCase
+            if (!($TestArea.Trim(', ').Split(',').Trim() -contains $test.Area) -and ($TestArea -ne "*")) {
                 continue
             }
-
-            if (!($TestNames.Split(",").Contains($test.testName)) -and ($TestNames -ne "*")) {
+            # case insensitive 'contains', and always complete match the concatenated expression for TestName of TestCase
+            if (!($TestNames.Trim(', ').Split(',').Trim() -contains $test.testName) -and ($TestNames -ne "*")) {
                 continue
             }
 
@@ -174,12 +174,12 @@ Function Collect-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Tes
 
             if ($ExcludeTests) {
                 $ExcludeTestMatched = $false
-                foreach ($TestString in $ExcludeTests.Split(",")) {
+                foreach ($TestString in $ExcludeTests.Trim(', ').Split(',').Trim()) {
                     if (($TestString.IndexOfAny($WildCards))-ge 0) {
                         if ($TestString.StartsWith('*')) {
                             $TestString = ".$TestString"
                         }
-                        if ($test.TestName -match $TestString) {
+                        if ($test.TestName -imatch $TestString) {
                             Write-LogInfo "Excluded Test  : $($test.TestName) [Wildcards match]"
                             $ExcludeTestMatched = $true
                         }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -656,7 +656,7 @@ Class TestController
 							# and we do not care about the last test run result (Pass or Fail), always try to CleanupResource, unless 'ResourceCleanup = Keep' set
 							if ($vmData -and $deployVMResults.Error) {
 								if ($this.ResourceCleanup -imatch "Keep") {
-									Write-LogWarn "ResourceCleanup = 'Keep' is respected, but following testing may fail, as Deployment Errors detected."
+									Write-LogWarn "ResourceCleanup = 'Keep' is respected, current test will abort, as deployment error(s) detected."
 									$vmData = $null
 								}
 								else {


### PR DESCRIPTION
TestNames, TestCategory, and TestArea using case insensitive matching
With this change,  a case typo in a copied string with many many characters when running LISAv2  with -TestNames "ABC-De, Xxx-yyy",  can also select the available test case names 'ABC-DE' and 'XXX-YYY'.

Otherwise, user may wait for a long time, then realized the target test case is not selected as expected because of a case typo.

A log warning comments update with clear expression. 

======== Test Run Result ==========
05/08/2020 18:05:51 : [INFO ] Test MU63 finished
05/08/2020 18:05:51 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 05/08/2020 17:59:24
ARM Image Under Test  : Canonical : 0001-com-ubuntu-server-focal : 20_04-lts : latest
Initial Kernel Version: 5.4.0-1010-azure
Final Kernel Version  : 5.4.0-1010-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.53 
        FirstBoot : PASS 
        FirstBoot : Call Trace Verification : PASS 
        Reboot : PASS 
        Reboot : Call Trace Verification : PASS 


Logs can be found at C:\LISAv2\TestResults\2020-08-05-10-58-56-8682