### PR TITLE
Rename <hostname>-messages.txt to <hostname>-var-log-messages.txt

### DIFF
--- a/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
@@ -104,8 +104,8 @@ def CollectLogs():
     hostname = os.uname()[1]
     for logfile in logfiles:
         if os.path.exists(logfile):
-            dst = "{}/{}-{}.txt".format(os.getcwd(), hostname,
-                                        os.path.basename(logfile))
+            dst = "{}/{}{}.txt".format(os.getcwd(), hostname,
+                                       logfile.replace('/', '-'))
             try:
                 RunLog.info("Copying {} to {}...".format(logfile, dst))
                 copyfile(logfile, dst)


### PR DESCRIPTION
Rename <hostname>-messages.txt to <hostname>-var-log-messages.txt (#790 )
Before:
```
05/11/2020 11:15:45 AM : INFO : Copying /var/log/messages to /home/azureuser/LISAv2-OneVM-walaautodev-UB34-20200510201003-role-0-messages.txt...
```
After:
```
05/11/2020 02:34:04 PM : INFO : Copying /var/log/messages to /home/azureuser/LISAv2-OneVM-walaautodev-UB34-20200510201003-role-0-var-log-messages.txt...
```