### PR TITLE
Fix libmnl-devel not found in 7.8

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -167,8 +167,9 @@ function Install_Dpdk () {
 			ssh "${1}" ". utils.sh && install_epel"
 			ssh "${1}" "yum -y groupinstall 'Infiniband Support' && dracut --add-drivers 'mlx4_en mlx4_ib mlx5_ib' -f && systemctl enable rdma"
 			check_exit_status "Install Infiniband Support on ${1}" "exit"
-			ssh "${1}" "(grep 7.5 /etc/redhat-release || grep 7.6 /etc/redhat-release) && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo"
+			ssh "${1}" "(grep -E '7.5|7.6|7.8' /etc/redhat-release) && curl https://partnerpipelineshare.blob.core.windows.net/kernel-devel-rpms/CentOS-Vault.repo > /etc/yum.repos.d/CentOS-Vault.repo"
 			packages+=(kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel)
+			ssh "${1}" "yum makecache"
 			check_package "libmnl-devel"
 			if [ $? -eq 0 ]; then
 				packages+=("libmnl-devel")


### PR DESCRIPTION
Test Results -

```
[LISAv2 Test Results Summary]
Test Run On           : 05/11/2020 06:41:49
ARM Image Under Test  : Redhat : RHEL : 7.8 : latest
Initial Kernel Version: 3.10.0-1127.el7.x86_64
Final Kernel Version  : 3.10.0-1127.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-FAILSAFE-DURING-TRAFFIC                                               PASS                23.54 
dpdk_version test_mode phase   fwdrx_pps_avg fwdtx_pps_avg
------------ --------- -----   ------------- -------------
18.11.0      txonly    after   4371574       4371575      
18.11.0      txonly    before  4632470       4632470      
18.11.0      txonly    during  68697         68697        
18.11.0      txonly    overall 2426233       2426233 

[LISAv2 Test Results Summary]
Test Run On           : 05/11/2020 04:30:50
ARM Image Under Test  : Redhat : RHEL : 7.8 : latest
Initial Kernel Version: 3.10.0-1127.el7.x86_64
Final Kernel Version  : 3.10.0-1127.el7.x86_64
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                  6.2 
    2 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                 4.86 
```

