### PR TITLE
Fix fio setup dependency for RHEL 7.8

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2292,6 +2292,9 @@ function install_fio () {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos)
 			install_epel
+			if [[ "${DISTRO_VERSION}" == "7.8" ]]; then
+				yum install -y libpmem-devel
+			fi
 			yum -y --nogpgcheck install wget sysstat mdadm blktrace libaio fio bc libaio-devel gcc gcc-c++ kernel-devel
 			if ! command -v fio; then
 				LogMsg "fio is not installed\n Build it from source code now..."


### PR DESCRIPTION
I found this failure in new RHEL 7.8, and it requires this new dependency of xfstest setup.

**TEST RESULT**

[RedHat RHEL 7.8 latest] [LISAv2 Test Results Summary]
[RedHat RHEL 7.8 latest] Test Run On           : 05/11/2020 23:06:33
[RedHat RHEL 7.8 latest] ARM Image Under Test  : RedHat : RHEL : 7.8 : latest
[RedHat RHEL 7.8 latest] Test Priority         : 0,1,2,3
[RedHat RHEL 7.8 latest] Initial Kernel Version: 3.10.0-1127.el7.x86_64
[RedHat RHEL 7.8 latest] Final Kernel Version  : 3.10.0-1127.el7.x86_64
[RedHat RHEL 7.8 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[RedHat RHEL 7.8 latest] Total Time (dd:hh:mm) : 0:3:7
[RedHat RHEL 7.8 latest] 
[RedHat RHEL 7.8 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[RedHat RHEL 7.8 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[RedHat RHEL 7.8 latest]     1 STORAGE              PERF-STORAGE-4K-IO                                                                **PASS**                184.4 
