### PR TITLE
improve resource cleanup orders for -UseExistingRG, and update default network security group rules

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -98,7 +98,7 @@ function Start-LISAv2 {
 			Set-Variable -Name "WorkingDirectory" -Value $workingDirectory -Scope Global
 
 			# Prepare log folder
-			$testTimestamp = Get-Date -Format 'yyyy-dd-MM-HH-mm-ss-ffff'
+			$testTimestamp = Get-Date -Format 'yyyy-MM-dd-HH-mm-ss-ffff'
 			$logDir = Join-Path $workingDirectory "TestResults\${testTimestamp}"
 			New-Item -ItemType "Directory" -Path $logDir -Force | Out-Null
 			Write-LogInfo "Logging directory: $logDir"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -425,11 +425,7 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
 
 		if ($EnableNSG) {
 			$securityRulesXml = [xml](Get-Content -Path "$WorkingDirectory\XML\Other\NetworkSecurityGroupRules.xml")
-			if ($OSType -imatch "Windows") {
-				$securityRules = $securityRulesXml.platform.windows.rule
-			} else {
-				$securityRules = $securityRulesXml.platform.linux.rule
-			}
+			$securityRules = $securityRulesXml.LISAv2NetworkSecurityGroupRules.rule
 		}
 
 		if ($UseExistingRG) {
@@ -609,6 +605,10 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
 			Add-Content -Value "$($indents[4])^securityRules^:" -Path $jsonFile
 			Add-Content -Value "$($indents[4])[" -Path $jsonFile
 			$securityRules | ForEach-Object {
+				$destinationPortRanges = @($_.properties.destinationPortRanges.Trim(', ').Split(',').Trim())
+				$destinationPortRanges | ForEach-Object {$i = 0; $i += 0} {$destinationPortRanges[$i] = "^$_^"; $i++}
+				$sourceAddressPrefixes = @($_.properties.sourceAddressPrefixes.Trim(', ').Split(',').Trim())
+				$sourceAddressPrefixes | ForEach-Object {$i = 0; $i += 0} {$sourceAddressPrefixes[$i] = "^$_^"; $i++}
 				Add-Content -Value "$($indents[5]){" -Path $jsonFile
 				Add-Content -Value "$($indents[6])^name^: ^$($_.name)^," -Path $jsonFile
 				Add-Content -Value "$($indents[6])^properties^:" -Path $jsonFile
@@ -616,8 +616,8 @@ Function Create-AllResourceGroupDeployments($SetupTypeData, $TestCaseData, $Dist
 				Add-Content -Value "$($indents[7])^description^: ^$($_.properties.description)^," -Path $jsonFile
 				Add-Content -Value "$($indents[7])^protocol^: ^$($_.properties.protocol)^," -Path $jsonFile
 				Add-Content -Value "$($indents[7])^sourcePortRange^: ^$($_.properties.sourcePortRange)^," -Path $jsonFile
-				Add-Content -Value "$($indents[7])^destinationPortRange^: $($_.properties.destinationPortRange)," -Path $jsonFile
-				Add-Content -Value "$($indents[7])^sourceAddressPrefix^: ^$($_.properties.sourceAddressPrefix)^," -Path $jsonFile
+				Add-Content -Value "$($indents[7])^destinationPortRanges^: [$($destinationPortRanges -Join ',')]," -Path $jsonFile
+				Add-Content -Value "$($indents[7])^sourceAddressPrefixes^: [$($sourceAddressPrefixes -Join ',')]," -Path $jsonFile
 				Add-Content -Value "$($indents[7])^destinationAddressPrefix^: ^$($_.properties.destinationAddressPrefix)^," -Path $jsonFile
 				Add-Content -Value "$($indents[7])^access^: ^$($_.properties.access)^," -Path $jsonFile
 				Add-Content -Value "$($indents[7])^priority^: ^$($_.properties.priority)^," -Path $jsonFile
@@ -1821,16 +1821,20 @@ Function Delete-ResourceGroup([string]$RGName, [bool]$UseExistingRG, [string]$Pa
     Function RemoveAzResourcesByResourceType([string] $ResourceType4iMatch) {
         $unlockedResources | Where-Object {$_.ResourceType -imatch $ResourceType4iMatch} | ForEach-Object {
             try {
-                $null = Remove-AzResource -ResourceGroupName $RGName -ResourceName $_.Name -ResourceType $_.ResourceType -Force -Verbose
+                if (Remove-AzResource -ResourceGroupName $RGName -ResourceName $_.Name -ResourceType $_.ResourceType -Force) {
+                    Write-LogInfo "`tDeleted resource '$($_.Name)' successfully."
+                }
+                else {
+                    Write-LogWarn "`tFailed to delete resource '$($_.Name)', will try to remove it in next attempt $($attempts + 1)"
+                }
             } catch {
-                Write-LogErr "Failed to delete resource $($_.Name). We will try to remove it in next attempt $($attempts + 1)"
+                Write-LogErr "`tException when removing resource '$($_.Name)', will try to remove it in next attempt $($attempts + 1)"
             }
         }
     }
 
     Write-LogInfo "Try to delete resource group $RGName..."
     try {
-        Write-LogInfo "Checking if $RGName exists..."
         $ResourceGroup = Get-AzResourceGroup -Name $RGName -ErrorAction Ignore
     }
     catch {
@@ -1859,10 +1863,15 @@ Function Delete-ResourceGroup([string]$RGName, [bool]$UseExistingRG, [string]$Pa
                         break
                     }
                     else {
-                        RemoveAzResourcesByResourceType -ResourceType4iMatch 'Microsoft.Network/loadBalancers'
-                        RemoveAzResourcesByResourceType -ResourceType4iMatch 'Microsoft.Compute/virtualMachines'
-                        RemoveAzResourcesByResourceType -ResourceType4iMatch 'Microsoft.Network/networkInterfaces'
-                        RemoveAzResourcesByResourceType -ResourceType4iMatch 'Microsoft'
+                        Write-LogInfo "Start removing resoruces from '$RGName', attempt $($attempts) ..."
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Compute/virtualMachines$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Compute/disks$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Network/networkInterfaces$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Network/virtualNetworks$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Network/loadBalancers$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Network/publicIPAddresses$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\.Network/networkSecurityGroups$'
+                        RemoveAzResourcesByResourceType -ResourceType4iMatch '^Microsoft\..+/(?!(virtualMachines|disks|networkInterfaces|virtualNetworks|loadBalancers|publicIPAddresses|networkSecurityGroups)).+$'
                     }
                     $attempts++
                 }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -603,19 +603,17 @@ Class TestController
 	[void] RunTestCasesInSequence([int]$TestIterations)
 	{
 		$executionCount = 0
-
-		foreach ($setupKey in $this.SetupTypeToTestCases.Keys) {
-			$setupType = $setupKey.Split(',')[0]
-
-			$vmData = $null
-			$lastResult = $null
-			$tests = 0
-
-			$CleanupResource = {
+		$CleanupResource = {
+			if ($vmData) {
 				Write-LogInfo "Delete deployed target machine ..."
 				$null = $this.TestProvider.DeleteVMs($vmData, $this.SetupTypeTable[$setupType], $this.UseExistingRG); $null
 			}
-
+		}
+		foreach ($setupKey in $this.SetupTypeToTestCases.Keys) {
+			$setupType = $setupKey.Split(',')[0]
+			$vmData = $null
+			$lastResult = $null
+			$tests = 0
 			foreach ($currentTestCase in $this.SetupTypeToTestCases[$setupKey]) {
 				# array like: @({TestName=xxx-<vmSize>-<iteration>;TestVmSize=yyy}, { }, ...)
 				$arrayOfTestConfigs = $this.GetArrayOfExpandedTestConfigsFromTestParameters($currentTestCase.testName, $currentTestCase.OverrideVMSize)

--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -65,7 +65,7 @@ Class AzureProvider : TestProvider
 				} else {
 					$ErrorMessage = "One or more deployments failed. " + $isAllDeployed[4]
 					Write-LogErr $ErrorMessage
-					return @{"VmData" = $null; "Error" = $ErrorMessage}
+					return @{"VmData" = $allVMData; "Error" = $ErrorMessage}
 				}
 			}
 			$isVmAlive = Is-VmAlive -AllVMDataObject $allVMData
@@ -83,7 +83,7 @@ Class AzureProvider : TestProvider
 					if (!$customStatus) {
 						$ErrorMessage = "Failed to set custom config in VMs."
 						Write-LogErr $ErrorMessage
-						return @{"VmData" = $null; "Error" = $ErrorMessage}
+						return @{"VmData" = $allVMData; "Error" = $ErrorMessage}
 					}
 				}
 			}

--- a/XML/Other/NetworkSecurityGroupRules.xml
+++ b/XML/Other/NetworkSecurityGroupRules.xml
@@ -1,49 +1,16 @@
-<!--# We define inbound and outbound security rules for Windows VM or Linux VM in this file.-->
-<platform>
-    <linux>
-        <rule>
-            <name>Lisav2SecurityRule1</name>
-            <properties>
-                <description>Lisav2SecurityRule1</description>
-                <protocol>tcp</protocol>
-                <sourcePortRange>*</sourcePortRange>
-                <destinationPortRange>22</destinationPortRange>
-                <sourceAddressPrefix>10.0.0.4/32</sourceAddressPrefix>
-                <destinationAddressPrefix>*</destinationAddressPrefix>
-                <access>Allow</access>
-                <priority>125</priority>
-                <direction>Inbound</direction>
-            </properties>
-        </rule>
-    </linux>
-    <windows>
-        <rule>
-            <name>Lisav2SecurityRule2</name>
-            <properties>
-                <description>Lisav2SecurityRule2</description>
-                <protocol>tcp</protocol>
-                <sourcePortRange>*</sourcePortRange>
-                <destinationPortRange>5985</destinationPortRange>
-                <sourceAddressPrefix>10.0.0.4/32</sourceAddressPrefix>
-                <destinationAddressPrefix>*</destinationAddressPrefix>
-                <access>Allow</access>
-                <priority>150</priority>
-                <direction>Inbound</direction>
-            </properties>
-        </rule>
-        <rule>
-            <name>Lisav2SecurityRule3</name>
-            <properties>
-                <description>Lisav2SecurityRule3</description>
-                <protocol>tcp</protocol>
-                <sourcePortRange>*</sourcePortRange>
-                <destinationPortRange>3389</destinationPortRange>
-                <sourceAddressPrefix>10.0.0.4/32</sourceAddressPrefix>
-                <destinationAddressPrefix>*</destinationAddressPrefix>
-                <access>Allow</access>
-                <priority>151</priority>
-                <direction>Inbound</direction>
-            </properties>
-        </rule>
-    </windows>
-</platform>
+<LISAv2NetworkSecurityGroupRules>
+    <rule>
+        <name>LISAv2SecurityRule1</name>
+        <properties>
+            <description>LISAv2SecurityRule1</description>
+            <protocol>tcp</protocol>
+            <sourcePortRange>*</sourcePortRange>
+            <destinationPortRanges>22,3389,5985,5986</destinationPortRanges>
+            <sourceAddressPrefixes>127.0.0.1/32</sourceAddressPrefixes>
+            <destinationAddressPrefix>*</destinationAddressPrefix>
+            <access>Allow</access>
+            <priority>200</priority>
+            <direction>Inbound</direction>
+        </properties>
+    </rule>
+</LISAv2NetworkSecurityGroupRules>


### PR DESCRIPTION
No framework logic change, just update with optimization/improvement for better performance and consolidation.
1. Just refine the logic of removing orders to speed up cleanup when -UseExistingRG.
2. Change TestResult folder name with yyyy-MM-dd, instead of yyyy-dd-MM
3. Update default security rules with selfloop ip, which means no actual rules applied.

====Test Run Result==========
05/14/2020 17:28:02 : [INFO ] End of testing: PERF-NVME-4K-IO , result: PASS
05/14/2020 17:28:02 : [INFO ] PASS    - 1
05/14/2020 17:28:02 : [INFO ] SKIPPED - 0
05/14/2020 17:28:02 : [INFO ] FAIL    - 0
05/14/2020 17:28:02 : [INFO ] ABORTED - 0
05/14/2020 17:28:02 : [INFO ] PENDING - 0

05/14/2020 17:28:02 : [INFO ] Delete deployed target machine ...
05/14/2020 17:28:03 : [INFO ] Try to delete resource group eas1yummvo54i0...
05/14/2020 17:28:07 : [INFO ] Start removing resoruces from 'eas1yummvo54i0', attempt 0 ...
Remove-AzResource : OperationNotAllowed : Disk eas1yummvo54i0-role-0-OSDisk is attached to VM /subscriptions/38e26629-7
592-4e7d-95fe-e66f4eb3c52f/resourceGroups/eas1yummvo54i0/providers/Microsoft.Compute/virtualMachines/eas1yummvo54i0-rol
e-0.
CorrelationId: acb89b38-6597-4647-beee-6f9ecd1d64b5
At C:\lisa\lisav2\Libraries\Azure.psm1:1824 char:21
+ ...         if (Remove-AzResource -ResourceGroupName $RGName -ResourceNam ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : CloseError: (:) [Remove-AzResource], ErrorResponseMessageException
    + FullyQualifiedErrorId : Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.RemoveAzureResourceCmdle
   t

05/14/2020 17:28:07 : [WARN ]   Failed to delete resource 'eas1yummvo54i0-role-0-OSDisk', will try to remove it in next attempt 1
05/14/2020 17:29:38 : [INFO ]   Deleted resource 'eas1yummvo54i0-role-0' successfully.
05/14/2020 17:29:38 : [INFO ]   Deleted resource 'eas1yummvo54i0-role-0-PrimaryNIC' successfully.
05/14/2020 17:29:49 : [INFO ]   Deleted resource 'LISAv2-VirtualNetwork' successfully.
05/14/2020 17:30:00 : [INFO ]   Deleted resource 'LISAv2-LoadBalancer' successfully.
05/14/2020 17:30:11 : [INFO ]   Deleted resource 'LISAv2-PublicIPv4-64620' successfully.
05/14/2020 17:30:12 : [INFO ] Start removing resoruces from 'eas1yummvo54i0', attempt 1 ...
05/14/2020 17:31:13 : [INFO ]   Deleted resource 'eas1yummvo54i0-role-0-OSDisk' successfully.
05/14/2020 17:31:13 : [INFO ] Resources in eas1yummvo54i0 were deleted.
05/14/2020 17:31:13 : [INFO ] Successfully started clean up for RG eas1yummvo54i0..
05/14/2020 17:31:13 : [INFO ] Cleanup test environment if required ...
05/14/2020 17:31:13 : [INFO ] Test NJ66 finished
05/14/2020 17:31:13 : [INFO ]
[LISAv2 Test Results Summary]
Test Run On           : 05/14/2020 17:17:23
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : 18.04.202002180
Initial Kernel Version: 5.0.0-1032-azure
Final Kernel Version  : 5.0.0-1032-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 PERF-NVME-4K-IO                                                                   PASS                  7.8
        Mode=randread : block_size=4K q_depth=64 iops=200594.046531
        Mode=randwrite : block_size=4K q_depth=64 iops=188107.121822
        Mode=read : block_size=4K q_depth=64 iops=187985.630846
        Mode=write : block_size=4K q_depth=64 iops=198654.938369


Logs can be found at C:\lisa\lisav2\TestResults\2020-05-14-17-17-19-7636


05/14/2020 17:31:13 : [DEBUG] Creating 'C:\lisa\lisav2\Azure-NJ66-TestLogs.zip' from 'C:\lisa\lisav2\TestResults\2020-05-14-17-17-19-7636'
05/14/2020 17:31:15 : [DEBUG] C:\lisa\lisav2\Azure-NJ66-TestLogs.zip created successfully.
05/14/2020 17:31:15 : [INFO ] Analyzing test results ...
05/14/2020 17:31:15 : [INFO ] LISAv2 exit code: 0