### PR TITLE
Disable firewall in RHEL 7.8

### DIFF
--- a/Testscripts/Linux/perf_fio_nfs.sh
+++ b/Testscripts/Linux/perf_fio_nfs.sh
@@ -6,7 +6,7 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 #
 # Sample script to run sysbench.
 # In this script, we want to bench-mark device IO performance on a mounted folder.
@@ -57,7 +57,7 @@ RunFIO()
 	#
 
 	#Log Config
-	
+
 	mkdir $HOMEDIR/FIOLog/jsonLog
 	mkdir $HOMEDIR/FIOLog/iostatLog
 	mkdir $HOMEDIR/FIOLog/blktraceLog
@@ -65,7 +65,7 @@ RunFIO()
 	#LOGDIR="${HOMEDIR}/FIOLog"
 	JSONFILELOG="${LOGDIR}/jsonLog"
 	IOSTATLOGDIR="${LOGDIR}/iostatLog"
-	LOGFILE="${LOGDIR}/fio-test.log.txt"	
+	LOGFILE="${LOGDIR}/fio-test.log.txt"
 
 	#redirect blktrace files directory
 	Resource_mount=$(mount -l | grep /sdb1 | awk '{print$3}')
@@ -106,7 +106,7 @@ RunFIO()
 		io=$startIO
 		while [ $io -le $maxIO ]
 		do
-			Thread=$startThread			
+			Thread=$startThread
 			while [ $Thread -le $maxThread ]
 			do
 				if [ $Thread -ge 8 ]
@@ -123,7 +123,7 @@ RunFIO()
 				fio $FILEIO --readwrite=$testmode --bs=${io}K --runtime=$ioruntime --iodepth=$Thread --numjobs=$numjobs --output-format=json --output=$jsonfilename --name="iteration"${iteration} >> $LOGFILE
 				iostatPID=$(ps -ef | awk '/iostat/ && !/awk/ { print $2 }')
 				kill -9 $iostatPID
-				Thread=$(( Thread*2 ))		
+				Thread=$(( Thread*2 ))
 				iteration=$(( iteration+1 ))
 			done
 		io=$(( io * io_increment ))
@@ -184,6 +184,7 @@ if [ $? -eq 0 ]; then
 	ssh root@nfs-server-vm ". utils.sh; update_repos"
 	ssh root@nfs-server-vm ". utils.sh; install_package ${nfsServerPackage}"
 	ssh root@nfs-server-vm "echo '/data nfs-client-vm(rw,sync,no_root_squash)' >> /etc/exports"
+	ssh root@nfs-server-vm "iptables -F"
 	ssh root@nfs-server-vm "service ${nfsService} restart"
 	ssh root@nfs-server-vm ". utils.sh; enable_nfs_rhel"
 	#Mount NFS Directory.

--- a/Testscripts/Linux/perf_fio_nfs.sh
+++ b/Testscripts/Linux/perf_fio_nfs.sh
@@ -177,6 +177,10 @@ if [ $? -eq 0 ]; then
 
 	mountDir="/data"
 	cd ${HOMEDIR}
+	ssh root@nfs-server-vm "systemctl stop firewalld"
+	ssh root@nfs-server-vm "systemctl disable firewalld"
+	systemctl stop firewalld
+	systemctl disable firewalld
 	install_fio
 	install_package $nfsClientPackage
 
@@ -184,7 +188,6 @@ if [ $? -eq 0 ]; then
 	ssh root@nfs-server-vm ". utils.sh; update_repos"
 	ssh root@nfs-server-vm ". utils.sh; install_package ${nfsServerPackage}"
 	ssh root@nfs-server-vm "echo '/data nfs-client-vm(rw,sync,no_root_squash)' >> /etc/exports"
-	ssh root@nfs-server-vm "iptables -F"
 	ssh root@nfs-server-vm "service ${nfsService} restart"
 	ssh root@nfs-server-vm ". utils.sh; enable_nfs_rhel"
 	#Mount NFS Directory.

--- a/Testscripts/Linux/perf_fio_nfs.sh
+++ b/Testscripts/Linux/perf_fio_nfs.sh
@@ -177,10 +177,12 @@ if [ $? -eq 0 ]; then
 
 	mountDir="/data"
 	cd ${HOMEDIR}
-	ssh root@nfs-server-vm "systemctl stop firewalld"
-	ssh root@nfs-server-vm "systemctl disable firewalld"
-	systemctl stop firewalld
-	systemctl disable firewalld
+	if [[ $DISTRO == "redhat_7" ]]; then
+		ssh root@nfs-server-vm "systemctl stop firewalld"
+		ssh root@nfs-server-vm "systemctl disable firewalld"
+		systemctl stop firewalld
+		systemctl disable firewalld
+	fi
 	install_fio
 	install_package $nfsClientPackage
 


### PR DESCRIPTION
RHEL 7.8 enabled the firewall by default, and it blocked the test procedure setting up NFS mounting. The fix is for firewall service disable.

TEST RESULT

RedHat RHEL 7.8 latest] [LISAv2 Test Results Summary]
[RedHat RHEL 7.8 latest] Test Run On           : 05/14/2020 06:25:35
[RedHat RHEL 7.8 latest] ARM Image Under Test  : RedHat : RHEL : 7.8 : latest
[RedHat RHEL 7.8 latest] Test Priority         : 0,1,2,3
[RedHat RHEL 7.8 latest] Initial Kernel Version: 3.10.0-1127.el7.x86_64
[RedHat RHEL 7.8 latest] Final Kernel Version  : 3.10.0-1127.el7.x86_64
[RedHat RHEL 7.8 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[RedHat RHEL 7.8 latest] Total Time (dd:hh:mm) : 0:7:16
[RedHat RHEL 7.8 latest] 
[RedHat RHEL 7.8 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[RedHat RHEL 7.8 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[RedHat RHEL 7.8 latest]     1 STORAGE              PERF-STORAGE-OVER-NFS-Synthetic-UDP-4K                                            PASS               433.92 
[RedHat RHEL 7.8 latest] 
[RedHat RHEL 7.8 latest] 
[RedHat RHEL 7.8 latest] Logs can be found at C:\LISAv2\ZW30-20200514062523\TestResults\2020-14-05-06-25-28-8341