### PR TITLE
Fix issue for focal.

### DIFF
--- a/Testscripts/Linux/containers_utils.sh
+++ b/Testscripts/Linux/containers_utils.sh
@@ -82,7 +82,7 @@ function InstallDockerEngine() {
 
     LogMsg "InstallDockerEngine on $DISTRO"
     update_repos
-
+    GetOSVersion
     case $DISTRO in
         ubuntu*|debian*)
             LogMsg "Uninstall old versions of Docker."
@@ -93,7 +93,13 @@ function InstallDockerEngine() {
             LogMsg "Add Docker's official GPG key."
             curl -fsSL https://download.docker.com/linux/$DISTRO_NAME/gpg | sudo apt-key add -
             LogMsg "Set up the stable repository."
-            add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$DISTRO_NAME $(lsb_release -cs) stable"
+            # Temporary fix till driver for ubuntu20 series list under https://docs.docker.com/engine/install/ubuntu/
+            if [[ $os_RELEASE =~ 20.* ]]; then
+                release="bionic"
+            else
+                release=$(lsb_release -cs)
+            fi
+            add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$DISTRO_NAME ${release} stable"
             apt-get update
             install_package "docker-ce docker-ce-cli containerd.io"
             ret=$?

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -71,8 +71,8 @@ function InstallCUDADrivers() {
 
     ubuntu*)
         GetOSVersion
-        # Temporary fix till driver for ubuntu19 series list under http://developer.download.nvidia.com/compute/cuda/repos/
-        if [[ $os_RELEASE =~ 19.* ]]; then
+        # Temporary fix till driver for ubuntu19 and ubuntu20 series list under http://developer.download.nvidia.com/compute/cuda/repos/
+        if [[ $os_RELEASE =~ 19.* ]] || [[ $os_RELEASE =~ 20.* ]]; then
             LogMsg "There is no cuda driver for $os_RELEASE, used the one for 18.10"
             os_RELEASE="18.10"
         fi


### PR DESCRIPTION
Cuda driver for focal not exist, but bionic cuda driver works against it.
The same situation for docker, temp fix till those package available.

Test results - 
```
[LISAv2 Test Results Summary]
Test Run On           : 05/17/2020 08:28:35
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Initial Kernel Version: 5.4.0-1010-azure
Final Kernel Version  : 5.4.0-1012-azure
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CONTAINER            DOCKER-BASIC-JAVA-APP                                                             PASS                 2.65 
    2 CONTAINER            DOCKER-BASIC-DOTNET-APP                                                           PASS                 2.46 
    3 CONTAINER            DOCKER-BASIC-PYTHON-APP                                                           PASS                 1.47 

[LISAv2 Test Results Summary]
Test Run On           : 05/17/2020 08:12:47
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Initial Kernel Version: 5.4.0-1010-azure
Final Kernel Version  : 5.4.0-1012-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:27

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CONTAINER            DOCKER-COMPOSE-WORDPRESS-MYSQL-APP                                                PASS                 3.49 
    2 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                13.76 
	Using nVidia driver : CUDA 
	lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS 
	lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS 
	lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS 
	nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS 
```