### PR TITLE
update AzContext legacy code and add cleanup

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2715,7 +2715,7 @@ function Add-AzureAccountFromSecretsFile {
             Write-LogInfo "Authenticating Azure PS session using Service Principal..."
             $pass = ConvertTo-SecureString $key -AsPlainText -Force
             $mycred = New-Object System.Management.Automation.PSCredential ($ClientID, $pass)
-            $null = Add-AzAccount -ServicePrincipal -Tenant $TenantID -Credential $mycred
+            $null = Connect-AzAccount -ServicePrincipal -Tenant $TenantID -Credential $mycred
             $UserAuthenticated = $true
         } elseif ($AzureContextFilePath) {
             # Scenario 2: Azure context file path is avaialble in Secret File
@@ -2751,8 +2751,8 @@ function Add-AzureAccountFromSecretsFile {
 
         if ( $UserAuthenticated ) {
             #Verify if the user is Authorized to use the subscription.
-            $selectedSubscription = Select-AzSubscription -SubscriptionId $XmlSecrets.secrets.SubscriptionID  -ErrorAction SilentlyContinue
-            if ( $selectedSubscription.Subscription.Id -eq $XmlSecrets.secrets.SubscriptionID ) {
+            $azContextResult = Set-AzContext -Subscription $XmlSecrets.secrets.SubscriptionID -ErrorAction SilentlyContinue
+            if ($azContextResult -and ($azContextResult.Subscription.Id -eq $XmlSecrets.secrets.SubscriptionID)) {
                 Write-LogInfo "Current Subscription : $subIDMasked."
             } else {
                 Throw "There was an error when selecting $subIDMasked."

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -55,7 +55,9 @@ Function Write-Log() {
 		} else {
 			$LogDir = $env:TEMP
 		}
-
+		if (!$LogFileName) {
+			$LogFileName = "LISAv2-Test-$(Get-Date -Format 'yyyy-MM-dd-HH-mm-ss-ffff').log"
+		}
 		$LogFileFullPath = Join-Path $LogDir $LogFileName
 		if (!(Test-Path $LogFileFullPath)) {
 			New-Item -path $LogDir -name $LogFileName -type "file" | Out-Null

--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -182,5 +182,7 @@ Class AzureProvider : TestProvider
 			Write-LogInfo "*************************************************************"
 			$DeleteResourceGroupJobs | Remove-Job -Force
 		}
+		# Clean up AzContext
+		Clear-AzContext -Force -ErrorAction SilentlyContinue | Out-NULL
 	}
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,9 @@ jobs:
       vmImage: 'windows-2019'
     steps:
     - powershell: Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck -AllowClobber
+    - powershell: Install-PackageProvider NuGet -Force | Out-Null
+    - powershell: Set-PSRepository PSGallery -InstallationPolicy Trusted | Out-Null
+    - powershell: Install-Module -Name Az -AllowClobber -Scope AllUsers | Out-Null
     - powershell:
         Invoke-Pester . -EnableExit -PassThru
   - job: 'PowerShellCodeCheck_PSScriptAnalyzer'


### PR DESCRIPTION
1. Remove legacy code of Account Selection and Cleanup, use new and recommended way.
2. Add $LogFileName if not defined (invoke from Utilities)
==========Rest Result=========================
```
[LISAv2 Test Results Summary]
Test Run On           : 05/19/2020 07:17:32
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Initial Kernel Version: 5.3.0-1020-azure
Final Kernel Version  : 5.3.0-1020-azure
Total Test Cases      : 3 (3 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NET-IFUP-IFDOWN                                                                   PASS                 4.29 
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.42 
        FirstBoot : PASS 
        FirstBoot : Call Trace Verification : PASS 
        Reboot : PASS 
        Reboot : Call Trace Verification : PASS 
    3 NETWORK              NET-SET-STATIC-MAC                                                                PASS                 1.18 
```