### PR TITLE
Fix issues in KDUMP cases

### DIFF
--- a/Testscripts/Windows/KDUMP-TestScript.ps1
+++ b/Testscripts/Windows/KDUMP-TestScript.ps1
@@ -40,7 +40,7 @@ function Main {
           "NMI"           { $nmi = $fields[1].Trim() }
           "VM2NAME"       { $vm2Name = $fields[1].Trim() }
           "use_nfs"       { $useNFS = $fields[1].Trim() }
-          "VCPU"          { $vCPU = $fields[1].Trim() }
+          "vmCpuNumber"   { $vCPU = $fields[1].Trim() }
           default         {}
         }
     }
@@ -145,12 +145,12 @@ function Main {
         Write-LogInfo "NMI does not support, so it triggers different method"
         if ($vcpu -eq 4){
             Write-LogInfo "Kdump will be triggered on VCPU 3 of 4"
-            $retVal = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
-                -command "taskset -c 2 echo c > /proc/sysrq-trigger"
+            Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+                -command "taskset -c 2 echo c > /proc/sysrq-trigger" -RunInBackGround -runAsSudo | Out-Null
         } else {
             # If directly use plink to trigger kdump, command fails to exit, so use start-process
             Write-LogInfo "Set /proc/sysrq-trigger"
-            Run-LinuxCmd -username  $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+            Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
                 -command "sync; echo c > /proc/sysrq-trigger" -RunInBackGround -runAsSudo | Out-Null
         }
     }

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -565,6 +565,7 @@
         <testScript>KDUMP-TestScript.ps1</testScript>
         <files>.\Testscripts\Linux\KDUMP-Execute.sh,.\Testscripts\Linux\KDUMP-Config.sh,.\Testscripts\Linux\KDUMP-Results.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS2_v2</OverrideVMSize>
         <TestParameters>
             <param>vmCpuNumber=2</param>
             <param>vmMemory=2GB</param>
@@ -620,6 +621,7 @@
         <testScript>KDUMP-TestScript.ps1</testScript>
         <files>.\Testscripts\Linux\KDUMP-Execute.sh,.\Testscripts\Linux\KDUMP-Config.sh,.\Testscripts\Linux\KDUMP-Results.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
         <TestParameters>
             <param>vmCpuNumber=4</param>
             <param>vmMemory=2GB</param>
@@ -638,6 +640,7 @@
         <testScript>KDUMP-TestScript.ps1</testScript>
         <files>.\Testscripts\Linux\KDUMP-Execute.sh,.\Testscripts\Linux\KDUMP-Config.sh,.\Testscripts\Linux\KDUMP-Results.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
+        <OverrideVMSize>Standard_DS5_v2</OverrideVMSize>
         <TestParameters>
             <param>vmCpuNumber=16</param>
             <param>vmMemory=4GB</param>


### PR DESCRIPTION
1. The VM sizes of cases KDUMP-CRASH-DIFFERENT-VCPU, KDUMP-CRASH-SMP and KDUMP-CRASH-16-CORES are all Standard_DS1_v2, which does not match the proposal. This fix overwrite the VM sizes of these 3 cases:
KDUMP-CRASH-DIFFERENT-VCPU -> Standard_DS3_v2
KDUMP-CRASH-SMP -> Standard_DS2_v2
KDUMP-CRASH-16-CORES -> Standard_DS5_v2
2. Fix the wrong parameter name in KDUMP-TestScript.ps1: VCPU -> vmCpuNumber
3. Set sudo permission when trigger kdump at different vCPU.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>