### PR TITLE
Only some distros should skip crashkernel=auto case

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -333,10 +333,12 @@ Install_Kexec
 #
 # Configure kdump - this has distro specific behaviour
 #
-if ! grep CONFIG_KEXEC_AUTO_RESERVE=y /boot/config-$(uname -r) && [[ "$crashkernel" == "auto" ]];then
-    LogErr "crashkernel=auto doesn't work for this distro. Please use this pattern: crashkernel=X@Y."
-    SetTestStateSkipped
-    exit 0
+if [[ $DISTRO != "redhat_8" ]];then
+    if ! grep CONFIG_KEXEC_AUTO_RESERVE=y /boot/config-$(uname -r) && [[ "$crashkernel" == "auto" ]];then
+        LogErr "crashkernel=auto doesn't work for this distro. Please use this pattern: crashkernel=X@Y."
+        SetTestStateSkipped
+        exit 0
+    fi
 fi
 
 Config_"${OS_FAMILY}"


### PR DESCRIPTION
The CONFIG_KEXEC_AUTO_RESERVE parameter doesn't exist in RHEL-8. And I didn't see it in upstream kernel(2.6.32, 3.10.0) code. So it seems that this parameter only exists in RHEL-6/7. 
This fix is to prevent the wrong TestSkip in RHEL-8. (#773)

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>