### PR TITLE
Fix hit issue when there is no any warn/fail/error in dmesg

### DIFF
--- a/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
@@ -14,9 +14,11 @@ logfile_list = [
 
 
 def _filter_log(keyword):
-    return Run("grep -nw '{}.*' {} --ignore-case --no-message".format(
+    ret = Run("grep -nw '{}.*' {} --ignore-case --no-message".format(
         keyword, ' '.join(logfile_list))).strip().split('\n')
-
+    while("" in ret):
+        ret.remove("")
+    return ret
 
 def RunTest():
     UpdateState("TestRunning")

--- a/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
+++ b/Testscripts/Linux/VERIFY-BOOT-ERROR-WARNINGS.py
@@ -20,6 +20,7 @@ def _filter_log(keyword):
         ret.remove("")
     return ret
 
+
 def RunTest():
     UpdateState("TestRunning")
     Run("dmesg > /tmp/dmesg")


### PR DESCRIPTION
Return value will be [''], it is not NONE, bring in by #763 
Before fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 05/20/2020 08:18:35
ARM Image Under Test  : Credativ : Debian : 9-backports : 9.20200210.1
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        FAIL                 0.78 
```

After fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 05/20/2020 09:35:10
ARM Image Under Test  : Credativ : Debian : 9-backports : 9.20200210.1
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 0.51 
```

Regression test result - 
```
[LISAv2 Test Results Summary]
Test Run On           : 05/20/2020 09:49:12
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.3.0-1020-azure
Final Kernel Version  : 5.3.0-1020-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 0.53 
```