### PR TITLE
Fix the wrong logic in LSVMBUS case

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -119,6 +119,9 @@ if [ "$scsiAdapters" -gt 1 ]; then
 fi
 
 while IFS='' read -r line || [[ -n "$line" ]]; do
+    if [[ $line =~ "VMBUS ID" ]]; then
+        token=""
+    fi
     if [[ $line =~ "Synthetic network adapter" ]]; then
         token="adapter"
     fi
@@ -157,8 +160,8 @@ else
     expected_scsi_counter=${expected_scsi_counter%.*}
 fi
 
-if [ "$network_counter" != "$expected_network_counter" ] && [ "$scsi_counter" != "$expected_scsi_counter" ]; then
-    error_msg="Error: values are wrong. Expected for network adapter: $VCPU and actual: $network_counter;
+if [ "$network_counter" != "$expected_network_counter" ] || [ "$scsi_counter" != "$expected_scsi_counter" ]; then
+    error_msg="Error: values are wrong. Expected for network adapter: ${expected_network_counter} and actual: $network_counter;
     expected for scsi controller: ${expected_scsi_counter}, actual: $scsi_counter."
     LogErr "$error_msg"
     UpdateSummary "$error_msg"
@@ -166,11 +169,11 @@ if [ "$network_counter" != "$expected_network_counter" ] && [ "$scsi_counter" !=
     exit 0
 fi
 
-msg="Network driver is spread on all $network_counter cores as expected."
+msg="Network driver is spread on all $network_counter cores as expected ${expected_network_counter} cores."
 LogMsg "$msg"
 UpdateSummary "$msg"
 
-msg="Storage driver is spread on all $scsi_counter cores as expected."
+msg="Storage driver is spread on all $scsi_counter cores as expected ${expected_scsi_counter} cores."
 LogMsg "$msg"
 UpdateSummary "$msg"
 


### PR DESCRIPTION
The LSVMBUS.sh didn't count the cores correctly, and didn't verify the scsi_counter.
Before:(I print the expected cores to make it clearer)
```
Thu May 21 20:40:57 2020 : Network driver is spread on all 8 cores as expected 8 cores.
Thu May 21 20:40:57 2020 : Storage driver is spread on all 17 cores as expected 16 cores.
```
After:
```
Thu May 21 20:37:25 2020 : Network driver is spread on all 8 cores as expected 8 cores.
Thu May 21 20:37:25 2020 : Storage driver is spread on all 16 cores as expected 16 cores.
```

But this script doesn't work correctly in some VM families, such as Lv2, and M-series. 
In Lv2, the scsi_count is the same as vCPU number if <=64. 
In M128m, the vCPU is 128 and the expected scsi_count is 64, but actually it is 32. 
I didn't verify it in more VM sizes. But I think we need to make it clear and correct the steps of this case in different VM families.

Thanks!