### PR TITLE
Added 2 negative tests to CPU offline/online test case

### DIFF
--- a/Testscripts/Linux/channel_change.sh
+++ b/Testscripts/Linux/channel_change.sh
@@ -33,9 +33,9 @@ idle_cpus=()
 prefix1="Rel_ID="
 suffix1=","
 prefix2="target_cpu="
+FailedCount=0
 
 function Main() {
-	FailedCount=0
 	# Collect the vmbus and cpu id information from the system, and store in /tmp/lsvmbus.output
 	basedir=$(pwd)
 	lsvmbus
@@ -44,16 +44,16 @@ function Main() {
 			chmod +x $basedir/linux/tools/hv/lsvmbus
 			$basedir/linux/tools/hv/lsvmbus -vv > $lsvmbus_output_location
 		else
-			LogErr "File, lsvmbus, not found in the system. Aborted the execution."
-			SetTestStateAborted
-			exit 0
+			wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
+			chmod +x lsvmbus
+			$basedir/lsvmbus -vv > $lsvmbus_output_location
 		fi
 	else
 		lsvmbus -vv > $lsvmbus_output_location
 	fi
 	LogMsg "Successfully recorded lsvmbus output in $lsvmbus_output_location"
 
-	# Before chaning cpu id to 0, reset all cpu ids of each vmbus channel.
+	# Before changing cpu id to 0, reset all cpu ids of each vmbus channel.
 	LogMsg "Resetting CPU ID if non-zero"
 
 	# #######################################################################################

--- a/Testscripts/Linux/channel_change.sh
+++ b/Testscripts/Linux/channel_change.sh
@@ -36,12 +36,32 @@ prefix1="Rel_ID="
 suffix1=","
 prefix2="target_cpu="
 
-function reset_cpu_id() {
-# Read VMBUS ID and store vmbus ids in the array
-# Change the cpu_id from non-zero to 0 in order to set cpu offline.
-# If successful, all cpu_ids in lsvmbus output should be 0 per channel, and generate
-# the list of idle cpus
+function Main() {
+	# Collect the vmbus and cpu id information from the system, and store in /tmp/lsvmbus.output
+	basedir=$(pwd)
+	lsvmbus
+	if [ $? != 0 ]; then
+		if [ -f $basedir/linux/tools/hv/lsvmbus ]; then
+			chmod +x $basedir/linux/tools/hv/lsvmbus
+			$basedir/linux/tools/hv/lsvmbus -vv > $lsvmbus_output_location
+		else
+			LogErr "File, lsvmbus, not found in the system. Aborted the execution."
+			SetTestStateAborted
+			exit 0
+		fi
+	else
+		lsvmbus -vv > $lsvmbus_output_location
+	fi
+	LogMsg "Successfully recorded lsvmbus output in $lsvmbus_output_location"
 
+	# Before chaning cpu id to 0, reset all cpu ids of each vmbus channel.
+	LogMsg "Resetting CPU ID if non-zero"
+
+	# #######################################################################################
+	# Read VMBUS ID and store vmbus ids in the array
+	# Change the cpu_id from non-zero to 0 in order to set cpu offline.
+	# If successful, all cpu_ids in lsvmbus output should be 0 per channel, and generate
+	# the list of idle cpus
 	idx=0
 	cpu_idx=0
 	while IFS=' ' read -a line
@@ -70,6 +90,20 @@ function reset_cpu_id() {
 					if [[ $cpu_id != "0" ]]; then
 						_cpu_id=$(cat $sysfs_path/channels/$rel_id/cpu)
 						idle_cpus+=($_cpu_id)
+						# Set 1 to online file, echo 1 > /sys/devices/system/cpu/cpu<number>/online
+						# Verify the command error: Device or resource busy, because cpu is online already.
+						# negative test
+						dmesg > /tmp/pre-stage.log
+						LogMsg "Took a snapshot of dmesg to /tmp/pre-stage.log"
+						echo 1 > /sys/devices/system/cpu/cpu$_cpu_id/online
+						sleep 1
+						dmesg > /tmp/post-stage.log
+						diff_val=$(diff /tmp/pre-stage.log /tmp/post-stage.log)
+						if [[ $diff_val == *"Device or resource busy"* ]]; then
+							LogMsg "Successfully verified the device busy message"
+						else
+							LogErr "Failed to verify the device busy message. Expected Device or resource busy, but found $diff_val"
+						fi
 						LogMsg "Found the cpu id, $_cpu_id from the channel $rel_id. Will set 0, the default cpu id, to this cpu"
 						echo 0 > $sysfs_path/channels/$rel_id/cpu
 						sleep 1
@@ -78,6 +112,20 @@ function reset_cpu_id() {
 						if [[ $_cpu_id == "0" ]]; then
 							LogMsg "Successfully changed the cpu id of the channel $rel_id from ${idle_cpus[$cpu_idx]} to 0"
 							cpu_idx=$((cpu_idx+1))
+							# Set 0 to online file, echo 0 > /sys/devices/system/cpu/cpu<number>/online
+							# Verify the command error: Device or resource busy
+							# negative test
+							dmesg > /tmp/pre-stage.log
+							LogMsg "Took a snapshot of dmesg to /tmp/pre-stage.log"
+							echo 0 > /sys/devices/system/cpu/cpu$cpu_idx/online
+							sleep 1
+							dmesg > /tmp/post-stage.log
+							diff_val=$(diff /tmp/pre-stage.log /tmp/post-stage.log)
+							if [[ $diff_val == *"Device or resource busy"* ]]; then
+								LogMsg "Successfully verified the device busy message"
+							else
+								LogErr "Failed to verify the device busy message. Expected Device or resource busy, but found $diff_val"
+							fi
 						else
 							LogErr "Failed to change the cpu id of the channel $rel_id from ${idle_cpus[$cpu_idx]} to 0. Expected 0, but found $_cpu_id"
 						fi
@@ -96,31 +144,8 @@ function reset_cpu_id() {
 	done < "$lsvmbus_output_location"
 
 	LogMsg "VMBUS scanning result: ${vmbus_id[@]}"
-	return
-}
 
-function Main() {
-	# Collect the vmbus and cpu id information from the system, and store in /tmp/lsvmbus.output
-	basedir=$(pwd)
-	lsvmbus
-	if [ $? != 0 ]; then
-		if [ -f $basedir/linux/tools/hv/lsvmbus ]; then
-			chmod +x $basedir/linux/tools/hv/lsvmbus
-			$basedir/linux/tools/hv/lsvmbus -vv > $lsvmbus_output_location
-		else
-			LogErr "File, lsvmbus, not found in the system. Aborted the execution."
-			SetTestStateAborted
-			exit 0
-		fi
-	else
-		lsvmbus -vv > $lsvmbus_output_location
-	fi
-	LogMsg "Successfully recorded lsvmbus output in $lsvmbus_output_location"
-
-	# Before chaning cpu id to 0, reset all cpu ids of each vmbus channel.
-	LogMsg "Resetting CPU ID if non-zero"
-	reset_cpu_id
-
+	# #######################################################################################
 	# Select a CPU number where does not associate to vmbus channels from idle_cpus array
 	for id in ${idle_cpus[@]}; do
 		state=$(cat /sys/devices/system/cpu/cpu$id/online)
@@ -128,7 +153,9 @@ function Main() {
 			LogMsg "Verified the current cpu $id is online"
 			dmesg > /tmp/pre-stage.log
 			LogMsg "Took a snapshot of dmesg to /tmp/pre-stage.log"
-			# set cpu to offline
+			# Set 0 to online file, echo 0 > /sys/devices/system/cpu/cpu<number>/online
+			# Verify the dmesg log like ‘smpboot: CPU x is now offline’
+			# Set cpu to offline
 			echo 0 > /sys/devices/system/cpu/cpu$id/online
 			LogMsg "Changed the cpu $id state to offline"
 			sleep 1
@@ -140,6 +167,8 @@ function Main() {
 				diff_val=$(diff /tmp/pre-stage.log /tmp/post-stage.log)
 				if [[ $diff_val == *"CPU $id is now offline"* ]]; then
 					LogMsg "Successfully found dmesg log per cpu offline state change"
+					# Set 1 to online file, echo 1 > /sys/devices/system/cpu/cpu<number>/online
+					# Verify the dmesg log like ‘smpboot: Booting Node xx Processor x APIC 0xXX’
 					# Change back to online
 					echo 1 > /sys/devices/system/cpu/cpu$id/online
 					LogMsg "Changed the cpu $id state to online"


### PR DESCRIPTION
1. Removed the function reset_cpu_id and merge it to the main
2. Added 2 negative tests

**TEST RESULTS**
[LISAv2 Test Results Summary]
Test Run On           : 05/22/2020 19:50:09
ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
Initial Kernel Version: 4.15.0-1082-azure
Final Kernel Version  : 5.6.0+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:43

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 CPU-OFFLINE-VMBUS-INTERRUPT-REASSINGMENT                                          PASS                41.41 


[LISAv2 Test Results Summary]
Test Run On           : 05/22/2020 19:50:13
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.3.0-1020-azure
Final Kernel Version  : 5.6.0+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:26

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 CPU-OFFLINE-VMBUS-INTERRUPT-REASSINGMENT                                          PASS                23.43 


[LISAv2 Test Results Summary]
Test Run On           : 05/22/2020 20:34:29
ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
Initial Kernel Version: 4.15.0-1082-azure
Final Kernel Version  : 5.6.0+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 STRESS-CPU-OFFLINE-ONLINE                                                         PASS                66.86 


[LISAv2 Test Results Summary]
Test Run On           : 05/22/2020 20:34:35
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
Initial Kernel Version: 5.3.0-1020-azure
Final Kernel Version  : 5.6.0+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:32

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 STRESS-CPU-OFFLINE-ONLINE        