### PR TITLE
Fix platform.dist() removed in Python 3.8, obsolete since Python 2.7

### DIFF
--- a/Testscripts/Linux/WALA-VERIFY-VERBOSE-ENABLED-LOGS.py
+++ b/Testscripts/Linux/WALA-VERIFY-VERBOSE-ENABLED-LOGS.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import platform
 import time
+import sys
 
 parser = argparse.ArgumentParser()
 
@@ -14,13 +15,16 @@ file_path = os.path.dirname(os.path.realpath(__file__))
 constants_path = os.path.join(file_path, "constants.sh")
 params = GetParams(constants_path)
 passwd = params["PASSWORD"]
-
-distro = platform.dist()
+if sys.version_info[0] >= 3:
+    import distro
+    distro = distro.linux_distribution(full_distribution_name=False)
+else:
+    distro = platform.dist()
 
 
 def RunTest():
     UpdateState("TestRunning")
-    if(distro[0] == "CoreOS"):
+    if(distro[0].upper() == "COREOS"):
         versionOutPut = Run("waagent --version")
     else:
         output = Run("pgrep -fa python3.*waagent")
@@ -48,7 +52,7 @@ def RunTest():
 
 
 def Restartwaagent():
-    if (distro[0] == "CoreOS"):
+    if (distro[0].upper() == "COREOS"):
         Run("echo '"+passwd+"' | sudo -S sed -i s/Logs.Verbose=n/Logs.Verbose=y/g  /usr/share/oem/waagent.conf")
     elif (DetectDistro()[0] == 'clear-linux-os'):
         Run("echo '"+passwd+"' | sudo -S sed -i s/Logs.Verbose=n/Logs.Verbose=y/g  \
@@ -57,7 +61,7 @@ def Restartwaagent():
         Run("echo '"+passwd+"' | sudo -S sed -i s/Logs.Verbose=n/Logs.Verbose=y/g  /etc/waagent.conf")
     RunLog.info("Restart waagent service...")
     result = Run("echo '"+passwd+"' | sudo -S find / -name systemctl |wc -l | tr -d '\n'")
-    if (distro[0] == "Ubuntu") or (distro[0] == "debian"):
+    if (distro[0].upper() == "UBUNTU") or (distro[0].upper() == "DEBIAN"):
         Run("echo '"+passwd+"' | sudo -S service walinuxagent restart")
     else:
         if (result == "0") :


### PR DESCRIPTION
Fix #811 
Test results -
```
[LISAv2 Test Results Summary]
Test Run On           : 05/29/2020 15:35:47
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Initial Kernel Version: 5.4.0-1010-azure
Final Kernel Version  : 5.4.0-1010-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-VERBOSE-ENABLED-LOGS                                                  PASS                 3.14 

[LISAv2 Test Results Summary]
Test Run On           : 05/29/2020 15:36:40
ARM Image Under Test  : credativ : Debian : 9-backports : Latest
Initial Kernel Version: 4.19.0-0.bpo.6-cloud-amd64
Final Kernel Version  : 4.19.0-0.bpo.6-cloud-amd64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-VERBOSE-ENABLED-LOGS                                                  PASS                 1.64 

[LISAv2 Test Results Summary]
Test Run On           : 05/29/2020 16:06:45
ARM Image Under Test  : CoreOS : CoreOS : Stable : Latest
Initial Kernel Version: 4.19.123-coreos
Final Kernel Version  : 4.19.123-coreos
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 WALA                 WALA-VERIFY-VERBOSE-ENABLED-LOGS                                                  PASS                  1.7 
```