### PR TITLE
XDP Testcases: Introduced XDPDump_Repo_URL replaceable string

### DIFF
--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -67,7 +67,7 @@ function Install_XDPDump(){
 
     local install_ip="${1}"
     LogMsg "Cloning and building xdpdump"
-    ssh ${install_ip} "git clone --recurse-submodules https://github.com/Netronome/bpf-samples.git"
+    ssh ${install_ip} "git clone --recurse-submodules ${repo_url}"
     ssh ${install_ip} "cd bpf-samples/xdpdump && make"
     check_exit_status "xdpdump build on ${install_ip}" "exit"
 

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -677,4 +677,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>MAX_CPU_OFFLINEONLINE</ReplaceThis>
 		<ReplaceWith>10</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>XDPDUMP_REPO_URL</ReplaceThis>
+		<ReplaceWith>https://github.com/abhimarathe/bpf-samples.git</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests-XDP.xml
+++ b/XML/TestCases/FunctionalTests-XDP.xml
@@ -8,6 +8,9 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh</files>
+        <TestParameters>
+            <param>repo_url=XDPDUMP_REPO_URL</param>
+        </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>XDP</Area>
@@ -23,6 +26,9 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh</files>
+        <TestParameters>
+            <param>repo_url=XDPDUMP_REPO_URL</param>
+        </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>XDP</Area>
@@ -38,6 +44,9 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh</files>
+        <TestParameters>
+            <param>repo_url=XDPDUMP_REPO_URL</param>
+        </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>XDP</Area>
@@ -53,6 +62,9 @@
             <Networking>SRIOV</Networking>
         </AdditionalHWConfig>
         <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh</files>
+        <TestParameters>
+            <param>repo_url=XDPDUMP_REPO_URL</param>
+        </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
         <Area>XDP</Area>


### PR DESCRIPTION
XDPDump Upstream repo has been forked to abhimarathe/bpf-samples to reduce maintenance efforts.

`[LISAv2 Test Results Summary]
Test Run On           : 06/01/2020 16:29:29
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1022-azure
Final Kernel Version  : 5.7.0-rc5-next-20200514
Total Test Cases      : 4 (4 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:2:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 XDP                  VERIFY-SRIOV-FAILSAFE-XDP                                                         PASS                 22.6
    2 XDP                  VERIFY-XDP-LOAD-UNLOAD                                                            PASS                 6.63
    3 XDP                  VERIFY-XDP-MULTIPLE-NICS                                                          PASS                 8.16
    4 XDP                  VERIFY-XDP-COMPLIANCE                                                             PASS                 5.62


Logs can be found at C:\LISAv2\YQ81\TestResults\2020-06-01-09-29-22-7194`