### PR TITLE
Testscripts/Linux/channel_change: Remove two test scenarios

### DIFF
--- a/Testscripts/Linux/channel_change.sh
+++ b/Testscripts/Linux/channel_change.sh
@@ -46,18 +46,6 @@ function Main() {
 			echo "$_vmbus_ch:$_cpu" >> $OriginalSource
 			if [ $_cpu != 0 ]; then
 				idle_cpus+=($_cpu)
-				# Set 0 to online file, echo 0 > /sys/devices/system/cpu/cpu<number>/online
-				oldState=$(cat /sys/devices/system/cpu/cpu$_cpu/online)
-				echo 0 > /sys/devices/system/cpu/cpu$_cpu/online 2>&1
-				sleep 1
-				newState=$(cat /sys/devices/system/cpu/cpu$_cpu/online)
-				# Verify the cpu id change
-				if [[ $newState = $oldState ]]; then
-					LogMsg "Successfully verified NO cpu state change, because it was used."
-				else
-					LogErr "Failed to verify the cpu state NO change. Expected $oldState, found $newState"
-					FailedCount=$((FailedCount+1))
-				fi
 
 				# Now reset this cpu id to 0.
 				LogMsg "Set the vmbus channel $_vmbus_ch's cpu to the default cpu, 0"
@@ -133,15 +121,6 @@ function Main() {
 			_cpu=$(echo $line | cut -d ":" -f 2)
 			if [ $_cpu != 0 ]; then
 				LogMsg "Testing for sysfs: $_path, vmbus channel: $_vmbus_ch, cpu id: $_cpu"
-				# read the cpu id from the actual system
-				_cpu_id=$(cat $_path/channels/$_vmbus_ch/cpu)
-				# The current cpu id should be 0
-				if [ $_cpu_id = 0 ]; then
-					LogMsg "Verified the current cpu id is 0"
-				else
-					LogErr "Failed to verify the currenct cpu id. Expected 0 but found $_cpu_id"
-					FailedCount=$((FailedCount+1))
-				fi
 				# Change to random number
 				cpu_rdn=$(($RANDOM % $max_cpu))
 				echo $cpu_rdn > $_path/channels/$_vmbus_ch/cpu


### PR DESCRIPTION
While the two scenarios meet current expectation/behaviors, there is no
guarantee that this will be the case with future kernel releases and in
fact there are active works aiming to modify such behaviors (e.g. [1]).

[1] https://lkml.kernel.org/r/20200526223218.184057-1-parri.andrea@gmail.com

Signed-off-by: Andrea Parri (Microsoft) <parri.andrea@gmail.com>

**TEST RESULT**

[canonical ubuntuserver 18.04-lts Latest] [LISAv2 Test Results Summary]
[canonical ubuntuserver 18.04-lts Latest] Test Run On           : 06/02/2020 16:48:44
[canonical ubuntuserver 18.04-lts Latest] ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
[canonical ubuntuserver 18.04-lts Latest] Initial Kernel Version: 5.3.0-1022-azure
[canonical ubuntuserver 18.04-lts Latest] Final Kernel Version  : 5.7.0-rc2
[canonical ubuntuserver 18.04-lts Latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[canonical ubuntuserver 18.04-lts Latest] Total Time (dd:hh:mm) : 0:0:24
[canonical ubuntuserver 18.04-lts Latest] 
[canonical ubuntuserver 18.04-lts Latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[canonical ubuntuserver 18.04-lts Latest] -------------------------------------------------------------------------------------------------------------------------------------------
[canonical ubuntuserver 18.04-lts Latest]     1 CORE                 CPU-OFFLINE-VMBUS-INTERRUPT-REASSINGMENT                                          PASS                20.89 

[canonical ubuntuserver 16.04-lts Latest] [LISAv2 Test Results Summary]
[canonical ubuntuserver 16.04-lts Latest] Test Run On           : 06/02/2020 16:48:38
[canonical ubuntuserver 16.04-lts Latest] ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
[canonical ubuntuserver 16.04-lts Latest] Initial Kernel Version: 4.15.0-1083-azure
[canonical ubuntuserver 16.04-lts Latest] Final Kernel Version  : 5.7.0-rc2
[canonical ubuntuserver 16.04-lts Latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[canonical ubuntuserver 16.04-lts Latest] Total Time (dd:hh:mm) : 0:0:27
[canonical ubuntuserver 16.04-lts Latest] 
[canonical ubuntuserver 16.04-lts Latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[canonical ubuntuserver 16.04-lts Latest] -------------------------------------------------------------------------------------------------------------------------------------------
[canonical ubuntuserver 16.04-lts Latest]     1 CORE                 CPU-OFFLINE-VMBUS-INTERRUPT-REASSINGMENT                                          PASS                24.37 

[canonical ubuntuserver 18.04-lts Latest] [LISAv2 Test Results Summary]
[canonical ubuntuserver 18.04-lts Latest] Test Run On           : 06/02/2020 17:16:38
[canonical ubuntuserver 18.04-lts Latest] ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : Latest
[canonical ubuntuserver 18.04-lts Latest] Initial Kernel Version: 5.3.0-1022-azure
[canonical ubuntuserver 18.04-lts Latest] Final Kernel Version  : 5.7.0-rc2
[canonical ubuntuserver 18.04-lts Latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[canonical ubuntuserver 18.04-lts Latest] Total Time (dd:hh:mm) : 0:1:33
[canonical ubuntuserver 18.04-lts Latest] 
[canonical ubuntuserver 18.04-lts Latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[canonical ubuntuserver 18.04-lts Latest] -------------------------------------------------------------------------------------------------------------------------------------------
[canonical ubuntuserver 18.04-lts Latest]     1 CORE                 STRESS-CPU-OFFLINE-ONLINE                                                         PASS                90.12 

[canonical ubuntuserver 16.04-lts Latest] [LISAv2 Test Results Summary]
[canonical ubuntuserver 16.04-lts Latest] Test Run On           : 06/02/2020 17:16:33
[canonical ubuntuserver 16.04-lts Latest] ARM Image Under Test  : canonical : ubuntuserver : 16.04-lts : Latest
[canonical ubuntuserver 16.04-lts Latest] Initial Kernel Version: 4.15.0-1083-azure
[canonical ubuntuserver 16.04-lts Latest] Final Kernel Version  : 5.7.0-rc2
[canonical ubuntuserver 16.04-lts Latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[canonical ubuntuserver 16.04-lts Latest] Total Time (dd:hh:mm) : 0:1:35
[canonical ubuntuserver 16.04-lts Latest] 
[canonical ubuntuserver 16.04-lts Latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[canonical ubuntuserver 16.04-lts Latest] -------------------------------------------------------------------------------------------------------------------------------------------
[canonical ubuntuserver 16.04-lts Latest]     1 CORE                 STRESS-CPU-OFFLINE-ONLINE                                                         PASS                93.06 