### PR TITLE
Ignore error message in VERIFY-BOOT-ERROR-WARNINGS case

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -52,6 +52,7 @@
             <keywords>smartd.*: Device: /dev/.*, Bad IEC \(SMART\) mode page, err=5, skip device</keywords>
             <keywords>GPT: Use GNU Parted to correct GPT errors</keywords>
             <keywords>RAS: Correctable Errors collector initialized</keywords>
+            <keywords>BERT: Boot Error Record Table support is disabled. Enable it by using bert_enable as kernel parameter</keywords>
         </errors>
         <warnings>
             <keywords>WARNING Daemon VM is provisioned, but the VM unique identifier has changed -- clearing cached state</keywords>


### PR DESCRIPTION
In RHEL-7.9 downstream kernel there's a new message that hits the "error" keyword:
BERT: Boot Error Record Table support is disabled. Enable it by using bert_enable as kernel parameter
It's not an error log and should be ignored.