### PR TITLE
Add new case Power-hibernate-SRIOV for BZ#1841973

### DIFF
--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -185,14 +185,14 @@ function Main {
 			throw "Can not identify VM status after resuming"
 		}
 
-		# Verify the kernel panic or call trace
-		$calltrace_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -i 'call trace'" -ignoreLinuxExitCode:$true
+		# Verify the kernel panic, call trace or fatal error
+		$calltrace_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -iE '(call trace|fatal error)'" -ignoreLinuxExitCode:$true
 
 		if ($calltrace_filter -ne "") {
-			Write-LogErr "Found Call Trace in dmesg"
-			throw "Call trace in dmesg"
+			Write-LogErr "Found Call Trace or Fatal error in dmesg"
+			throw "Call trace or Fatal error in dmesg"
 		} else {
-			Write-LogInfo "Not found Call Trace in dmesg"
+			Write-LogInfo "Not found Call Trace and Fatal error in dmesg"
 		}
 
 		# Check the system log if it shows Power Management log

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -14,4 +14,22 @@
 		<Tags>power</Tags>
 		<Priority>3</Priority>
 	</test>
+	<test>
+		<testName>POWER-HIBERNATE-SRIOV</testName>
+		<testScript>Power-Hibernate.ps1</testScript>
+		<setupType>OneVMhb</setupType>
+		<AdditionalHWConfig>
+			<Networking>SRIOV</Networking>
+		</AdditionalHWConfig>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
+		<TestParameters>
+			<param>hb_url=Hb_CustomKernelURL</param>
+			<param>hb_branch=Hb_CustomKernelBranch</param>
+		</TestParameters>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>POWER</Area>
+		<Tags>power</Tags>
+		<Priority>3</Priority>
+	</test>
 </TestCases>


### PR DESCRIPTION
1. Add a hibernation case when SRIOV is enabled. 
2. Filter "Fatal error" logs after resume to hit the "fatal error" issue:
The patch is here: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=8fc3e29be9248048f449793502c15af329f35c6e