### PR TITLE
Update Hibernate test case

### DIFF
--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -65,7 +65,7 @@ function Main() {
 				req_pkg="ncurses-devel libelf-dev"
 				;;
 			ubuntu*)
-				req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache"
+				req_pkg="build-essential fakeroot libncurses5-dev libssl-dev ccache bc"
 				;;
 			*)
 				LogErr "$DISTRO does not support hibernation"

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -207,7 +207,6 @@ function Main {
 		}
 
 		# Check the system log if it shows Power Management log
-
 		"hibernation entry", "hibernation exit" | ForEach-Object  {
 			$pm_log_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -i '$_'" -ignoreLinuxExitCode:$true
 			Write-LogInfo "Searching the keyword: $_"
@@ -219,7 +218,6 @@ function Main {
 				Write-LogInfo $pm_log_filter
 			}
 		}
-
 		$testResult = $resultPass
 	} catch {
 		$ErrorMessage =  $_.Exception.Message

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -174,7 +174,6 @@ function Main {
 
 		if ($vmCount -le 0){
 			Write-LogInfo "VM resume completed"
-			break
 		} else {
 			# Either VM hang or VM resume needs longer time.
 			throw "VM resume did not finish, the latest state was $state"

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -157,7 +157,7 @@ function Main {
 			$vmCount = $AllVMData.Count
 			Wait-Time -seconds 15
 			$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "date"
-			if ($state -eq "TestCompleted") {
+			if ($state -eq 0) {
 				$kernelCompileCompleted = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password "dmesg | grep -i 'hibernation exit'"
 				if ($kernelCompileCompleted -ne "hibernation exit") {
 					Write-LogErr "VM $($VMData.RoleName) resumed successfully but could not determine hibernation completion"
@@ -169,11 +169,12 @@ function Main {
 			} else {
 				Write-LogInfo "VM is still resuming!"
 			}
-		}
-		if ($vmCount -le 0){
-			Write-LogInfo "VM resume completed"
-		} else {
-			Throw "VM resume did not finish"
+			if ($vmCount -le 0){
+				Write-LogInfo "VM resume completed"
+				break
+			} else {
+				throw "VM resume did not finish"
+			}
 		}
 
 		#Verify the VM status after power on event

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -663,7 +663,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>HB_CUSTOM_KERNEL_BRANCH</ReplaceThis>
-		<ReplaceWith>next-20200210</ReplaceWith>
+		<ReplaceWith>master</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>CPU_CUSTOM_KERNEL_URL</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -1,6 +1,6 @@
 <TestCases>
 	<test>
-		<testName>Power-hibernate</testName>
+		<testName>POWER-HIBERNATE</testName>
 		<testScript>Power-Hibernate.ps1</testScript>
 		<setupType>OneVMhb</setupType>
 		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>


### PR DESCRIPTION
1. Ubuntu 16.04 needs bc packages
2. Rename TC like other test names' form.
3. Moved the checking point inside of the loop, so does not have to hit the timeout.

Hibernation was completed successfully, but call trace failed the test execution. @dcui confirmed this was something else, and community is working on the fix.