### PR TITLE
VERIFY-XDP-ACTION-ABORTED: New testcase to validate XDP ACTION ABORTED

### DIFF
--- a/Testscripts/Linux/XDP-Action.sh
+++ b/Testscripts/Linux/XDP-Action.sh
@@ -3,8 +3,8 @@
 # Licensed under the Apache License.
 
 # This script verifies XDP Action - TX or DROP
-# For DROP Action verification script will compare number of ping packets
-#		lossed before XDP DROP action and after XDP DROP action
+# For DROP/ABORTED Action verification script will compare number of ping packets
+#		lossed before XDP DROP/ABORTED action and after XDP DROP/ABORTED action
 # For TX Action verification script will start ping on server and measure the packets captured by tcpdump
 #		Expected result: 0 packets should be captured by tcpdump after TX action as this action
 #		will return all ping packets to sender at hardware level
@@ -66,16 +66,16 @@ beforeString="before"
 afterString="after"
 packetLossInNetwork=10
 
-if [ "${ACTION}" == "DROP" ];then
+if [ "${ACTION}" == "DROP" ] || [ "${ACTION}" == "ABORTED" ];then
 	LogMsg "Initializing validation for XDP Action ${ACTION}"
 
 	# Ping test before changing action
 	ping_test $beforeString
 
-	# Build xdpdump with DROP Config
-	LogMsg "Build XDPDump with DROP flag"
-	ssh ${client} "cd bpf-samples/xdpdump && make clean && CFLAGS='-D __ACTION_DROP__ -I../libbpf/src/root/usr/include' make"
-	check_exit_status "Building xdpdump with DROP config"
+	# Build xdpdump with DROP/ABORTED Config
+	LogMsg "Build XDPDump with ${ACTION} flag"
+	ssh ${client} "cd bpf-samples/xdpdump && make clean && CFLAGS='-D __ACTION_${ACTION}__ -I../libbpf/src/root/usr/include' make"
+	check_exit_status "Building xdpdump with ${ACTION} config"
 
 	# Ping test after changing action
 	ping_test $afterString
@@ -133,7 +133,7 @@ elif [ "${ACTION}" == "TX" ];then
 	fi
 
 else
-	LogErr "Please provide ACTION variable: DROP or TX"
+	LogErr "Please provide ACTION variable: DROP/TX/ABORTED"
 	SetTestStateFailed
 	exit 0
 fi

--- a/XML/TestCases/FunctionalTests-XDP.xml
+++ b/XML/TestCases/FunctionalTests-XDP.xml
@@ -110,6 +110,25 @@
         <Priority>1</Priority>
     </test>
     <test>
+        <testName>VERIFY-XDP-ACTION-ABORTED</testName>
+        <testScript>VERIFY-XDP-ACTION.ps1</testScript>
+        <setupType>TwoVM2NIC</setupType>
+        <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
+        <AdditionalHWConfig>
+            <Networking>SRIOV</Networking>
+        </AdditionalHWConfig>
+        <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh,.\Testscripts\Linux\XDP-Action.sh</files>
+        <TestParameters>
+            <param>ACTION=ABORTED</param>
+            <param>repo_url=XDPDUMP_REPO_URL</param>
+        </TestParameters>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>XDP</Area>
+        <Tags>xdp,network,hv_netvsc,sriov</Tags>
+        <Priority>1</Priority>
+    </test>
+    <test>
         <testName>VERIFY-XDP-MTU</testName>
         <testScript>VERIFY-XDP-MTU.ps1</testScript>
         <setupType>TwoVM2NIC</setupType>


### PR DESCRIPTION
```
[LISAv2 Test Results Summary]
Test Run On           : 06/10/2020 20:59:27
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.7.0-rc5-next-20200514
Final Kernel Version  : 5.7.0-rc5-next-20200514
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:13

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 XDP                  VERIFY-XDP-ACTION-ABORTED                                                         PASS                 8.48


Logs can be found at C:\LISAv2\JT59\TestResults\2020-06-10-13-59-21-1408
```