### PR TITLE
Fix double echo by LogErr

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -172,19 +172,24 @@ function SetTestStateRunning() {
 	return $?
 }
 
+# Echos the date and $1 to stdout.
+function __EchoWithDate() {
+    echo $(date "+%a %b %d %T %Y") : "$1"
+}
+
 # Logging function. The way LIS currently runs scripts and collects log files, just echo the message
 # $1 == Message
 function LogMsg() {
-	echo $(date "+%a %b %d %T %Y") : "${1}"
-	echo $(date "+%a %b %d %T %Y") : "${1}" >> "./TestExecution.log"
+    __EchoWithDate "$1"
+    __EchoWithDate "$1" >> "./TestExecution.log"
 }
 
 # Error Logging function. The way LIS currently runs scripts and collects log files, just echo the message
 # $1 == Message
 function LogErr() {
-	echo $(date "+%a %b %d %T %Y") : "${1}"
-	echo $(date "+%a %b %d %T %Y") : "${1}" >> "./TestExecutionError.log"
-	UpdateSummary "${1}"
+    __EchoWithDate "$1"
+    __EchoWithDate "$1" >> "./TestExecutionError.log"
+    UpdateSummary "$1"
 }
 
 # Update summary file with message $1
@@ -202,7 +207,8 @@ function UpdateSummary() {
         LogMsg "Summary file $__LIS_SUMMARY_FILE either does not exist or is not a regular file. Trying to create it..."
         echo "$1" >> "$__LIS_SUMMARY_FILE" || return 1
     fi
-    LogMsg "$1"
+
+    __EchoWithDate "$1" >> "./TestExecution.log"
 
     return 0
 }


### PR DESCRIPTION
Note that this file has inconsistent indentation, so I just made these
consistent with each other in the fewest changes.

This fixes #859.

```
$ . utils.sh 
$ LogMsg "foo"
Thu Jun 11 13:36:44 2020 : foo
$ LogErr "foo"
Thu Jun 11 13:36:47 2020 : foo
Thu Jun 11 13:36:47 2020 : Summary file .../summary.log either does not exist or is not a regular file. Trying to create it...
$ cat summary.log 
foo
$ cat TestExecution.log
Thu Jun 11 13:36:44 2020 : foo
Thu Jun 11 13:36:47 2020 : Summary file .../summary.log either does not exist or is not a regular file. Trying to create it...
Thu Jun 11 13:36:47 2020 : foo
$ cat TestExecutionError.log 
Thu Jun 11 13:36:47 2020 : foo
```

We don't really have unit tests or contributing guidelines, so...here's my best 😅