### PR TITLE
update StorageAccount logic for easy onboard.

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -541,7 +541,7 @@ Class TestController
 	}
 
 	# According to Test Parameters $this.TestIterations and $this.OverrideVMSize,
-	# Get an array of expanded possible Tests @({TestName=xxx-<vmSize>-<iteration>;TestVmSize=yyy}, { }, ...)
+	# Get an array of expanded possible Tests @({TestName=xxx-<vmSize>-<iteration>;TestVmSize=<vmSize>}, { }, ...)
 	# If $this.TestIteration and $this.OverrideVMSize are both default value, return just one element in the result array.
 	[array] GetArrayOfExpandedTestConfigsFromTestParameters($testName, $testOverrideVmSize) {
 		$arrayOfTestConfigs = @()

--- a/XML/GlobalConfigurations.xml
+++ b/XML/GlobalConfigurations.xml
@@ -3,7 +3,6 @@
         <Subscription>
             <SubscriptionID>xxxxxxxx-xxxx-xxxx-xxxxx-xxxxxxxxxxxx</SubscriptionID>
             <SubscriptionName>YOUR_SUBSCRIPTION_NAME</SubscriptionName>
-            <ManagementEndpoint>https://management.core.windows.net</ManagementEndpoint>
             <Environment>AzureCloud</Environment>
             <ARMStorageAccount>ExistingStorage_Standard</ARMStorageAccount>
         </Subscription>


### PR DESCRIPTION
- LISAv2 users do not need to create/prepare storage accounts manually, when onboarding LISAv2.  only if they give `-StorageAccount Auto_Complete_RG=Xxx` or have `<ARMStorageAcccount>Auto_Complete_RG=Xxx</ARMStorageAccount>` from .\XML\GlobalConfigurations.xml
- Keep Compatible with <ARMStorageAccount>ExistingStorage_Standard/Premium</ARMStorageAccount>
- Removed useless NewStorage_Standard, and NewStorage_Premium, give instructions for workarounds in case user continue run with -StorageAccount 'NewStorage_xxx'
- Updated document README with detailed instructions for easy onboard, removed useless and confusing expression from README.md
- Other tiny updates for collection deploy errors from inner details.

===========Test Log ==============
06/11/2020 23:34:03 : [INFO ] Test YJ88 finished
06/11/2020 23:34:03 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 06/11/2020 23:28:29
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Initial Kernel Version: 5.3.0-1022-azure
Final Kernel Version  : 5.3.0-1022-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.66 
        FirstBoot : PASS 
        FirstBoot : Call Trace Verification : PASS 
        Reboot : PASS 
        Reboot : Call Trace Verification : PASS 


Logs can be found at C:\LISAv2\TestResults\2020-06-11-16-28-13-8396


06/11/2020 23:34:03 : [DEBUG] Creating 'C:\LISAv2\Azure-YJ88-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-06-11-16-28-13-8396'
06/11/2020 23:34:03 : [DEBUG] C:\LISAv2\Azure-YJ88-TestLogs.zip created successfully.
06/11/2020 23:34:03 : [INFO ] Analyzing test results ...
06/11/2020 23:34:03 : [INFO ] LISAv2 exit code: 0