### PR TITLE
Fix test issue hit in SLES15 SP1.

### DIFF
--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -75,8 +75,9 @@ function skip_test() {
 			unsupport_flag=1
 		fi
 		if [ $unsupport_flag = 1 ]; then
-			LogErr "$DISTRO not supported. Abort the test."
-			SetTestStateAborted
+			LogErr "$DISTRO not supported. Skip the test."
+			SetTestStateSkipped
+			exit 0
 		fi
 	fi
 }

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2103,6 +2103,7 @@ function yum_remove () {
 # Zypper install packages, parameter: package name
 function zypper_install () {
 	package_name=$1
+	CheckInstallLockSLES
 	sudo zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys in $package_name
 	check_exit_status "zypper_install $package_name" "exit"
 }
@@ -2274,6 +2275,7 @@ function add_sles_network_utilities_repo () {
 				LogErr "Unsupported SLES version $DISTRO_VERSION for add_sles_network_utilities_repo"
 				return 1
 		esac
+		CheckInstallLockSLES
 		zypper addrepo $repo_url
 		zypper --no-gpg-checks refresh
 		return 0
@@ -2326,7 +2328,7 @@ function install_fio () {
 			;;
 
 		sles|sle_hpc)
-			if [[ $DISTRO_VERSION =~ 12|15 ]]; then
+			if [[ $DISTRO_VERSION =~ 12|15* ]]; then
 				add_sles_benchmark_repo
 				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget mdadm blktrace libaio1 sysstat bc
 				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install fio
@@ -3406,6 +3408,16 @@ function CheckInstallLockUbuntu() {
         CheckInstallLockUbuntu
     else
         LogMsg "No apt lock present."
+    fi
+}
+
+function CheckInstallLockSLES() {
+    if pidof zypper;then
+        LogMsg "Another install is in progress. Waiting 1 seconds."
+        sleep 1
+        CheckInstallLockSLES
+    else
+        LogMsg "No zypper lock present."
     fi
 }
 


### PR DESCRIPTION
- Fix issue when another zypper process is running.
- Skip unsupported distro in GPU 
- Add entry for install fio on SLES 15 SP1

Test results - 
```
[LISAv2 Test Results Summary]
Test Run On           : 06/13/2020 12:51:15
ARM Image Under Test  : SUSE : sles-15-sp1 : gen1 : 2020.06.10
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                 3.75 

[LISAv2 Test Results Summary]
Test Run On           : 06/13/2020 12:39:47
ARM Image Under Test  : SUSE : sles-15-sp1 : gen1 : 2020.06.10
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:34

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-FILE-SYSTEM-VERIFICATION-GENERIC                                             PASS                32.52 

[LISAv2 Test Results Summary]
Test Run On           : 06/13/2020 12:17:33
ARM Image Under Test  : SUSE : sles-15-sp1 : gen1 : 2020.06.10
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                  SKIPPED                 1.19 
	Using nVidia driver : GRID 

[LISAv2 Test Results Summary]
Test Run On           : 06/13/2020 12:13:34
ARM Image Under Test  : SUSE : sles-15-sp1 : gen1 : 2020.06.10
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-MAX-DISK-VALIDATION                                                          PASS                 1.47 
```