### PR TITLE
Write an empty line before appending id_rsa.pub to authorized_keys

### DIFF
--- a/Testscripts/Linux/enable_passwordless_root.sh
+++ b/Testscripts/Linux/enable_passwordless_root.sh
@@ -37,6 +37,7 @@ else
         fi
     fi
     if [ -f /root/.ssh/authorized_keys ]; then
+        echo >> /root/.ssh/authorized_keys
         cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
     else
         cat /root/.ssh/id_rsa.pub > /root/.ssh/authorized_keys


### PR DESCRIPTION
In my images there's no '\n' at the end of the last line in authorized_keys. If write .pub key into it directly, it will be appended IN the last line but not after the last line. So add an empty line first to avoid this issue. (#866 )

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>