### PR TITLE
[ETHTOOL-GET-SET-GRO-LRO] Add LRO checkpoints and run LRO only on HyperV

### DIFF
--- a/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
+++ b/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
@@ -22,18 +22,31 @@ UtilsInit
 
 CheckResults()
 {
-    action="$1"
-    sts=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" 2>&1 | grep generic-receive-offload | awk {'print $2'})
+    case $1 in
+        lro)
+            feature="large-receive-offload"
+            ;;
+        gro)
+            feature="generic-receive-offload"
+            ;;
+        *)
+            echo "Error: no such feature $2! Exit."
+            SetTestStateAborted
+            exit 0
+            ;;
+    esac
+    action="$2"
+    sts=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" 2>&1 | grep $feature | awk {'print $2'})
     if [ "$action" == "disabled" ] && [ "$sts" == "on" ]; then
-        LogMsg "Generic-receive-offload NOT disabled."
+        LogMsg "$feature NOT disabled."
         SetTestStateFailed
         exit 0 
     elif [ "$action" == "enabled" ] && [ "$sts" == "off" ]; then 
-        LogMsg "Generic-receive-offload NOT enabled."
+        LogMsg "$feature NOT enabled."
         SetTestStateFailed
         exit 0
     else
-        LogMsg "Generic-receive-offload is $action."
+        LogMsg "$feature is $action."
     fi
 }
 
@@ -66,7 +79,7 @@ for (( i = 0 ; i < 2 ; i++ )); do
             exit 0
         fi
         # Check if is disabled
-        CheckResults "disabled"
+        CheckResults "gro" "disabled"
     elif [[ "$sts" == "off" ]];then
         # Enable GRO
         if ! ethtool -K "${SYNTH_NET_INTERFACES[@]}" gro on >/dev/null 2>&1;then
@@ -75,23 +88,46 @@ for (( i = 0 ; i < 2 ; i++ )); do
             exit 0
         fi
         # Check if is enabled
-        CheckResults "enabled"
+        CheckResults "gro" "enabled"
     else
         LogMsg "Cannot get status of generic-receive-offload."
         SetTestStateFailed
         exit 0
-    fi   
+    fi
 done
 
-# Disable/Enable LRO
-LogMsg "LRO status:"
-ethtool -k "${SYNTH_NET_INTERFACES[@]}" | grep large-receive-offload 
-LogMsg "Enable large-receive-offload:"
-ethtool -K "${SYNTH_NET_INTERFACES[@]}" lro on
-LogMsg "LRO status:"
-ethtool -k "${SYNTH_NET_INTERFACES[@]}" | grep large-receive-offload
-LogMsg "Disable large-receive-offload:"
-ethtool -K "${SYNTH_NET_INTERFACES[@]}" lro off
+# Disable/Enable LRO (HyperV only)
+if [[ $TEST_PLATFORM == "HyperV" ]];then
+    for (( i = 0 ; i < 2 ; i++ )); do
+        # Show LRO status
+        sts=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" 2>&1 | grep large-receive-offload | awk {'print $2'})
+        if [[ "$sts" == "on" ]];then
+            # Disable LRO
+            if ! ethtool -K "${SYNTH_NET_INTERFACES[@]}" lro off >/dev/null 2>&1;then
+                LogMsg "Cannot disable large-receive-offload."
+                SetTestStateFailed
+                exit 0
+            fi
+            # Check if is disabled
+            CheckResults "lro" "disabled"
+        elif [[ "$sts" == "off" ]];then
+            # Enable LRO
+            if ! ethtool -K "${SYNTH_NET_INTERFACES[@]}" lro on >/dev/null 2>&1;then
+                LogMsg "Cannot enable large-receive-offload."
+                SetTestStateFailed
+                exit 0
+            fi
+            # Check if is enabled
+            CheckResults "lro" "enabled"
+        else
+            LogMsg "Cannot get status of large-receive-offload."
+            SetTestStateFailed
+            exit 0
+        fi
+    done
+else
+    LogMsg "Azure doesn't support changing LRO. Skip."
+fi
 
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Windows/ETHTOOL-GRO-LRO.ps1
+++ b/Testscripts/Windows/ETHTOOL-GRO-LRO.ps1
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+param([String] $TestParams,
+      [object] $AllVmData)
+
+function Main {
+    Write-LogInfo "Generating constants.sh ..."
+    $constantsFile = "$LogDir\constants.sh"
+    Set-Content -Value "TEST_PLATFORM=$($TestPlatform)" -Path $constantsFile
+    Write-LogInfo "constants.sh created successfully..."
+
+    Copy-RemoteFiles -uploadTo $allVmData.PublicIP -port $allVmData.SSHPort `
+        -files "$constantsFile" -username $user -password $password -upload
+    #
+    # Run the guest VM side script
+    #
+    try {
+        Run-LinuxCmd -username $user -password $password -ip $allVmData.PublicIP -port $allVmData.SSHPort `
+            "bash ETHTOOL-GRO-LRO.sh" -runAsSudo | Out-Null
+
+        $status = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
+            -username $user -password $password -command "cat state.txt"
+        Copy-RemoteFiles -downloadFrom $allVMData.PublicIP -port $allVMData.SSHPort `
+            -username $user -password $password -download `
+            -downloadTo $LogDir -files "*.txt, *.log"
+        if ($status -imatch "TestFailed") {
+            Write-LogErr "Test failed."
+            $testResult = "FAIL"
+        }   elseif ($status -imatch "TestAborted") {
+            Write-LogErr "Test Aborted."
+            $testResult = "ABORTED"
+        }   elseif ($status -imatch "TestSkipped") {
+            Write-LogErr "Test Skipped."
+            $testResult = "SKIPPED"
+        }   elseif ($status -imatch "TestCompleted") {
+            Write-LogInfo "Test Completed."
+            $testResult = "PASS"
+        }   else {
+            Write-LogErr "Test execution is not successful, check test logs in VM."
+            $testResult = "ABORTED"
+        }
+    } catch {
+        $ErrorMessage =  $_.Exception.Message
+        $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+        Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+        $testResult = "FAIL"
+    } finally {
+        if (!$testResult) {
+            $testResult = "ABORTED"
+        }
+    }
+    Write-LogInfo "Test result: $testResult"
+    return $testResult
+}
+
+Main

--- a/XML/TestCases/FunctionalTests-Network.xml
+++ b/XML/TestCases/FunctionalTests-Network.xml
@@ -533,7 +533,7 @@
     </test>
     <test>
         <testName>ETHTOOL-GET-SET-GRO-LRO</testName>
-        <testScript>ETHTOOL-GRO-LRO.sh</testScript>
+        <testScript>ETHTOOL-GRO-LRO.ps1</testScript>
         <files>.\TestScripts\Linux\ETHTOOL-GRO-LRO.sh,.\TestScripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
         <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
1. Before, it only run lro change command but not check result. So I add checkpoints for the LRO operations. 
2. The LRO change is not supported in Azure. So add a .ps1 script to pass the platform in, and only run LRO part in HyperV.