### PR TITLE
New test: Validate Dependency Agent

### DIFF
--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#######################################################################
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+# validate-da.sh
+# Description:
+#    Validate the installation and uninstallation of the Dependency Agent.
+#    Validate the enable and disable of the Dependency Agent.
+#######################################################################
+
+set -e
+set -x
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+
+function check_prereqs() {
+	LogMsg "Checking for preconditions"
+
+	if [[ $EUID -ne 0 ]]; then
+	   LogErr "This script must be run as root" 
+	   exit 1
+	fi
+
+	[ -d "/opt/microsoft/dependency-agent" ] && LogErr "Directory /opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/var/opt/microsoft/dependency-agent" ] && LogErr "Directory /var/opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/etc/opt/microsoft/dependency-agent" ] && LogErr "Directory /etc/opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/lib/microsoft-dependency-agent" ] && LogErr "Directory /lib/microsoft-dependency-agent exists." && exit 1
+	[ -d "/etc/init.d/microsoft-dependency-agent" ] && LogErr "Directory /etc/init.d/microsoft-dependency-agent exists." && exit 1
+
+	LogMsg "Preconditions met"
+}
+
+function download_da_linux_installer() {
+	LogMsg "Download Dependency Agent Linux installer"
+
+	curl -L https://aka.ms/dependencyagentlinux -o InstallDependencyAgent-Linux64.bin
+
+	chmod +x InstallDependencyAgent-Linux64.bin
+}
+
+function verify_install_da() {
+	./InstallDependencyAgent-Linux64.bin -vme
+
+	ret=$?
+	if [ $ret -ne 0 ]; then
+	        LogErr "Install failed with exit code ${ret}"
+	        exit 1
+	else
+	        LogMsg "Installed with exit code 0"
+	fi
+
+	[ ! -f "/opt/microsoft/dependency-agent/uninstall" ] && LogErr "/opt/microsoft/dependency-agent/uninstall does not exist." && exit 1
+	[ ! -f "/etc/init.d/microsoft-dependency-agent" ] && LogErr "/etc/init.d/microsoft-dependency-agent does not exist." && exit 1
+	[ ! -f "/var/opt/microsoft/dependency-agent/log/install.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/install.log does not exist." && exit 1
+
+	bin_version=$(./InstallDependencyAgent-Linux64.bin --version | awk '{print $5}')
+	install_log_version=$(awk "NR==3" /var/opt/microsoft/dependency-agent/log/install.log | grep 'Dependency Agent version.revision'|cut -f2 -d ":")
+	if [ "$bin_version" -ne "$install_log_version" ]; then
+	        LogErr "Version mismatch between bin version and install log version"
+	        exit 1
+	else
+	        LogMsg "Version matches between bin version and install log version"
+	fi
+
+	LogMsg "Install tests passed successfully"
+}
+
+function verify_uninstall_da() {
+
+	bash /opt/microsoft/dependency-agent/uninstall
+	
+	ret=$?
+	if [ $ret -ne 0 ]; then
+	        LogErr "Uninstall failed with exit code ${ret}"
+	        exit 1
+	else
+	        LogMsg "Uninstalled with exit code 0"
+	fi
+
+	[ -d "/opt/microsoft/dependency-agent" ] && LogErr "Directory /opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/var/opt/microsoft/dependency-agent" ] && LogErr "Directory /var/opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/etc/opt/microsoft/dependency-agent" ] && LogErr "Directory /etc/opt/microsoft/dependency-agent exists." && exit 1
+	[ -d "/lib/microsoft-dependency-agent" ] && LogErr "Directory /lib/microsoft-dependency-agent exists." && exit 1
+	[ -d "/etc/init.d/microsoft-dependency-agent" ] && LogErr "Directory /etc/init.d/microsoft-dependency-agent exists." && exit 1
+
+	LogMsg "Uninstall tests passed successfully"
+}
+
+function setup_network_trace() {
+    LogMsg "Setup network trace"
+	watch -n 5 curl https://microsoft.com &>/dev/null &
+	watch_pid=$!
+}
+
+function enable_disable_da(){
+	verify_install_da
+	
+	sleep 30
+	[ ! -f "/var/opt/microsoft/dependency-agent/log/service.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log does not exist." && exit 1
+
+	service_log_time=$(date -r /var/opt/microsoft/dependency-agent/log/service.log +%s)
+	current_time=$(date +%s)
+	time_elapsed=$(($current_time - $service_log_time))
+	sleep $((120-$time_elapsed))
+
+	[ ! -f "/var/opt/microsoft/dependency-agent/log/service.log.1" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.1 does not exist." && exit 1
+	[ -f "/var/opt/microsoft/dependency-agent/log/service.log.2" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.2 exist." && exit 1
+	[ ! -c "/dev/msda" ] && LogErr "/dev/msda does not exist." && exit 1
+
+	! grep -iq "driver setup status=0" /var/opt/microsoft/dependency-agent/log/service.log.1 && LogErr "driver setup status=0 not found" && exit 1
+	! grep -iq "starting the dependency agent" /var/opt/microsoft/dependency-agent/log/service.log && LogErr "starting the dependency agent not found" && exit 1
+	
+	sleep 60
+	[ ! -f "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log does not exist." && exit 1
+	[ ! -f "/etc/opt/microsoft/dependency-agent/config/DA_PID" ] && LogErr "/etc/opt/microsoft/dependency-agent/config/DA_PID does not exist." && exit 1
+	
+	if grep -iq "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID; then
+        x=$(grep -i "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID)
+        strings /proc/$x/cmdline | grep "/opt/microsoft/dependency-agent/bin/microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && exit 1)
+	else
+		LogErr "PID not found in DA_PID"
+		exit 1 
+	fi
+	
+	sleep 120
+	! ls /var/opt/microsoft/dependency-agent/storage/*.bb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist." && exit 1
+
+	sleep 90
+	! ls /var/opt/microsoft/dependency-agent/storage/*.hb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist." && exit 1
+	[ ! -f "/etc/opt/microsoft/dependency-agent/config/DA_PID" ] && LogErr "/etc/opt/microsoft/dependency-agent/config/DA_PID does not exist." && exit 1
+
+	if grep -iq "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID; then
+        x=$(grep -i "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID)
+        strings /proc/$x/cmdline | grep "/opt/microsoft/dependency-agent/bin/microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && exit 1)
+	else
+		LogErr "PID not found in DA_PID"
+		exit 1 
+	fi
+
+	dmesg | egrep -w "BUG:|Modules linked in:|Call Trace:​" && LogErr "Found BUG/Modules linked in/Call Trace in dmesg" && exit 1
+
+	verify_uninstall_da
+	pkill $watch_pid
+
+	LogMsg "Enable/Disable DA tests passed successfully"
+}
+
+check_prereqs
+download_da_linux_installer
+verify_install_da
+verify_uninstall_da
+setup_network_trace
+enable_disable_da
+
+LogMsg "Validate DA tests completed"
+SetTestStateCompleted
+exit 0

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -24,10 +24,12 @@ GetDistro
 
 readonly dir_list=(/opt/microsoft/dependency-agent /var/opt/microsoft/dependency-agent /etc/opt/microsoft/dependency-agent /lib/microsoft-dependency-agent /etc/init.d/microsoft-dependency-agent)
 
-readonly da_pid_file="/etc/opt/microsoft/dependency-agent/config/DA_PID"
-readonly uninstaller="/opt/microsoft/dependency-agent/uninstall"
-readonly da_log_dir="/var/opt/microsoft/dependency-agent/log"
 readonly da_installer="InstallDependencyAgent-Linux64.bin"
+readonly uninstaller="/opt/microsoft/dependency-agent/uninstall"
+
+readonly da_pid_file="/etc/opt/microsoft/dependency-agent/config/DA_PID"
+readonly da_log_dir="/var/opt/microsoft/dependency-agent/log"
+readonly da_storage_dir="/var/opt/microsoft/dependency-agent/storage"
 
 function test_case_cleanup(){
     [ -f $uninstaller ] && $uninstaller
@@ -233,14 +235,14 @@ function enable_disable_da(){
 
     # Wait for events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.bb files
     sleep 120
-    if ! ls /var/opt/microsoft/dependency-agent/storage/*.bb; then
-        fail_test "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist."
+    if ! ls $da_storage_dir/*.bb>/dev/null; then
+        fail_test "$da_storage_dir/*.bb does not exist."
     fi
 
     # Wait for more events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.hb files
     sleep 90
-    if ! ls /var/opt/microsoft/dependency-agent/storage/*.hb; then
-        fail_test "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist."
+    if ! ls $da_storage_dir/*.hb>/dev/null; then
+        fail_test "$da_storage_dir/*.hb does not exist."
     fi
     verify_da_pid
 

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -261,7 +261,8 @@ function enable_disable_da(){
             if [ -f  "/sys/devices/system/cpu/vulnerabilities/spectre_v2" ]; then
                 word=$(head -n 1 "/sys/devices/system/cpu/vulnerabilities/spectre_v2" | awk '{print $1}')
                 if [ $word == "Mitigation:" ]; then
-                    fail_test "Spectre mitigation found"
+                    log=$(tail -n 20 "$da_log_dir/service.log.1")
+                    fail_test "$log"
                 fi
             fi
             if [ -c "/dev/msda" ]; then 

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -22,64 +22,75 @@ set -x
 # Get distro information
 GetDistro
 
-dir_list=(/opt/microsoft/dependency-agent /var/opt/microsoft/dependency-agent /etc/opt/microsoft/dependency-agent /lib/microsoft-dependency-agent /etc/init.d/microsoft-dependency-agent)
-supported_distro_list=(redhat centos suse debian ubuntu)
+readonly dir_list=(/opt/microsoft/dependency-agent /var/opt/microsoft/dependency-agent /etc/opt/microsoft/dependency-agent /lib/microsoft-dependency-agent /etc/init.d/microsoft-dependency-agent)
+readonly supported_distro_list=(redhat centos suse debian ubuntu)
 
 readonly da_pid_file="/etc/opt/microsoft/dependency-agent/config/DA_PID"
+readonly uninstaller="/opt/microsoft/dependency-agent/uninstall"
 
 function test_case_cleanup(){
-    /opt/microsoft/dependency-agent/uninstall
+    [ -f "$uninstaller" ] && eval $uninstaller
 
-    for dir in "${dir_list[@]}"
-    do
-        rm -rf $dir
-    done
+    rm -rf "${dir_list[@]}"
 
-    kill $watch_pid
+    # This can be a NOP if the test exits before calling generate_network_activity
+    kill $network_activity_generator_pid
 
     LogMsg "Finished cleaning up test cases"
 }
 
 # Calls the cleanup function when interupted or exited
-trap test_case_cleanup SIGINT EXIT
+trap test_case_cleanup SIGINT EXIT SIGHUP SIGQUIT SIGTERM
 
-function verify_directory() {
-    failed_assertions=0
+function fail_test() {
+    LogErr "$*"
+    SetTestStateFailed
+    exit 0
+}
+
+function verify_directory_exists() {
+    failed_assertions=false
     for dir in "${dir_list[@]}"
     do
-        [ -d $dir ] && LogErr "Directory $dir exists." && SetTestStateFailed && failed_assertions=$[[failed_assertions+1]]
+        [ -d $dir ] && LogErr "Directory $dir exists." && failed_assertions=true
     done
 
-    if ["$failed_assertions" -gt 0]; then
+    if [ $failed_assertions ]; then
         LogErr "Some/All directories exists"
-        SetTestStateFailed
-        exit 0
+        echo "$failed_assertions"
     fi
 }
 
 function verify_distro() {
     LogMsg "Current distro: $DISTRO"
-    for distro in "${supported_distro_list[@]}"
-    do
-        if [[ "$distro"* == $DISTRO ]]; then
-        LogMsg "Supported Distro family"
-        break
-    else
-        LogErr "Unsupported Distro family"
-        SetTestStateSkipped
-        exit 0
-    done
+
+    case $DISTRO in
+        redhat | centos | suse | debian | ubuntu)
+            LogMsg "Supported Distro family: $DISTRO"
+            ;;
+        *)
+            fail_test "Unsupported Distro family: $DISTRO"
+            ;;
+    esac
+}
+
+function verify_expected_file() {
+    if [ ! -f "$1" ]; then
+        fail_test "${1} doesn't exist."
+    fi
 }
 
 function verify_da_pid() {
-    [ ! -f $da_pid_file ] && LogErr "$da_pid_file does not exist." && SetTestStateFailed && exit 0
+    [ ! -f $da_pid_file ] && fail_test "$da_pid_file does not exist."
 
     if x=$(sed -n '/^[1-9][0-9]*$/p;q' $da_pid_file); then
-        strings /proc/$x/cmdline | grep "microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && SetTestStateFailed && exit 0)
+        if [ strings /proc/$x/cmdline | fgrep -q  -e "microsoft-dependency-agent-manager" ]; then
+            LogMsg "PID matched"
+        else
+            fail_test "PID not matched"
+        fi
     else
-        LogErr "PID not found in DA_PID"
-        SetTestStateFailed
-        exit 0
+        fail_test "PID not found in DA_PID"
     fi
 }
 
@@ -87,13 +98,16 @@ function check_prereqs() {
     LogMsg "Checking for preconditions"
 
     if [[ $EUID -ne 0 ]]; then
-        LogErr "This script must be run as root" 
-        SetTestStateFailed
-        exit 0
+        fail_test "This script must be run as root"
     fi
 
-    verify_directory
     verify_distro
+
+    directory_exists=$(verify_directory_exists)
+    if [ "directory_exists" == "true" ]; then
+        SetTestStateAborted
+        exit 0
+    fi
 
     LogMsg "Preconditions met"
 }
@@ -101,53 +115,54 @@ function check_prereqs() {
 function download_da_linux_installer() {
     LogMsg "Download Dependency Agent Linux installer"
 
-    curl -L https://aka.ms/dependencyagentlinux -o InstallDependencyAgent-Linux64.bin
+    if [ ! curl -L https://aka.ms/dependencyagentlinux -o InstallDependencyAgent-Linux64.bin ]; then
+        fail_test Download failed
+    fi
 
     chmod +x InstallDependencyAgent-Linux64.bin
 }
 
 function verify_install_da() {
+    LogMsg "Starting Install tests"
+
     ./InstallDependencyAgent-Linux64.bin -vme
 
     ret=$?
     if [ $ret -ne 0 ]; then
-        LogErr "Install failed with exit code ${ret}"
-        SetTestStateFailed
-        exit 0
-    else
-        LogMsg "Installed with exit code 0"
+        fail_test "Install failed with exit code ${ret}"
     fi
+    LogMsg "Dependency Agent installed successfully"
 
-    [ ! -f "/opt/microsoft/dependency-agent/uninstall" ] && LogErr "/opt/microsoft/dependency-agent/uninstall does not exist." && SetTestStateFailed && exit 0
-    [ ! -f "/etc/init.d/microsoft-dependency-agent" ] && LogErr "/etc/init.d/microsoft-dependency-agent does not exist." && SetTestStateFailed && exit 0
-    [ ! -f "/var/opt/microsoft/dependency-agent/log/install.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/install.log does not exist." && SetTestStateFailed && exit 0
+    verify_expected_file "$uninstaller"
+    verify_expected_file "/etc/init.d/microsoft-dependency-agent"
+    verify_expected_file "/var/opt/microsoft/dependency-agent/log/install.log"
 
     bin_version=$(./InstallDependencyAgent-Linux64.bin --version | awk '{print $5}')
     install_log_version=$(sed -n 's/^Dependency Agent version\.revision: //p' /var/opt/microsoft/dependency-agent/log/install.log)
     if [ "$bin_version" -ne "$install_log_version" ]; then
-        LogErr "Version mismatch between bin version($bin_version) and install log version($install_log_version)"
-        SetTestStateFailed
-        exit 0
-    else
-        LogMsg "Version matches between bin version and install log version"
+        fail_test "Version mismatch between bin version($bin_version) and install log version($install_log_version)"
     fi
+    LogMsg "Version matches between bin version and install log version"
 
     LogMsg "Install tests passed successfully"
 }
 
 function verify_uninstall_da() {
-    /opt/microsoft/dependency-agent/uninstall
+    LogMsg "Starting uninstall tests"
+
+    eval $uninstaller
 
     ret=$?
     if [ $ret -ne 0 ]; then
-        LogErr "Uninstall failed with exit code ${ret}"
-        SetTestStateFailed
-        exit 0
+        fail_test "Uninstall failed with exit code ${ret}"
     else
         LogMsg "Uninstalled with exit code 0"
     fi
 
-    verify_directory
+    directory_exists=$(verify_directory_exists)
+    if [ "directory_exists" == "true" ]; then
+        fail_test "Directory exists"
+    fi
 
     LogMsg "Uninstall tests passed successfully"
 }
@@ -155,15 +170,17 @@ function verify_uninstall_da() {
 function generate_network_activity() {
     LogMsg "Generate network activity"
     watch -n 5 curl https://microsoft.com &>/dev/null &
-    watch_pid=$!
+    network_activity_generator_pid=$!
 }
 
 function enable_disable_da(){
+    LogMsg "Starting Enable/Disable DA tests"
+
     verify_install_da
 
     # Wait for 30s and check for service.log
     sleep 30
-    [ ! -f "/var/opt/microsoft/dependency-agent/log/service.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log does not exist." && SetTestStateFailed && exit 0
+    verify_expected_file "/var/opt/microsoft/dependency-agent/log/service.log"
 
     # Check for service.log.1 file and confirm service.log.2 doesn't exist
     service_log_time=$(date -r /var/opt/microsoft/dependency-agent/log/service.log +%s)
@@ -178,30 +195,30 @@ function enable_disable_da(){
         sleep 5
     done
 
-    [ ! -f "/var/opt/microsoft/dependency-agent/log/service.log.1" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.1 does not exist." && SetTestStateFailed && exit 0
-    [ -f "/var/opt/microsoft/dependency-agent/log/service.log.2" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.2 exist." && SetTestStateFailed && exit 0
-    [ ! -c "/dev/msda" ] && LogErr "/dev/msda does not exist." && SetTestStateFailed && exit 0
+    verify_expected_file "/var/opt/microsoft/dependency-agent/log/service.log.1"
+    [ -f "/var/opt/microsoft/dependency-agent/log/service.log.2" ] && fail_test "/var/opt/microsoft/dependency-agent/log/service.log.2 exist."
+    [ ! -c "/dev/msda" ] && fail_test "/dev/msda does not exist."
 
     # Check for "driver setup status=0" and "starting the dependency agent" in service.log.1 and service.log respectively
-    ! grep -iq "driver setup status=0" /var/opt/microsoft/dependency-agent/log/service.log.1 && LogErr "driver setup status=0 not found" && SetTestStateFailed && exit 0
-    ! grep -iq "starting the dependency agent" /var/opt/microsoft/dependency-agent/log/service.log && LogErr "starting the dependency agent not found" && SetTestStateFailed && exit 0
+    ! grep -iq "driver setup status=0" /var/opt/microsoft/dependency-agent/log/service.log.1 && fail_test "driver setup status=0 not found"
+    ! grep -iq "starting the dependency agent" /var/opt/microsoft/dependency-agent/log/service.log && fail_test starting the dependency agent not found
 
     # Wait for DA to be running and verify by checking for MicrosoftDependencyAgent.log
     sleep 60
-    [ ! -f "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log does not exist." && SetTestStateFailed && exit 0
+    verify_expected_file "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log"
     verify_da_pid
 
     # Wait for events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.bb files
     sleep 120
-    ! ls /var/opt/microsoft/dependency-agent/storage/*.bb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist." && SetTestStateFailed && exit 0
+    ! ls /var/opt/microsoft/dependency-agent/storage/*.bb && fail_test "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist."
 
     # Wait for more events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.hb files
     sleep 90
-    ! ls /var/opt/microsoft/dependency-agent/storage/*.hb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist." && SetTestStateFailed && exit 0
+    ! ls /var/opt/microsoft/dependency-agent/storage/*.hb && fail_test "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist."
     verify_da_pid
 
     dmesg_error=$(dmesg | fgrep -e BUG: -e "Modules linked in:" -e "Call Trace:​" -A 20)
-    [ ! -z "$dmesg_error" ] && LogErr "$dmesg_error" && SetTestStateFailed && exit 0
+    [ ! -z "$dmesg_error" ] && fail_test "$dmesg_error"
 
     verify_uninstall_da
 
@@ -220,19 +237,6 @@ function test_case_enable_disable_da(){
     LogMsg "Starting Test Case 2: Enable/Disable DA" 
     generate_network_activity
     enable_disable_da
-}
-
-function test_case_cleanup(){
-    /opt/microsoft/dependency-agent/uninstall
-
-    for dir in "${dir_list[@]}"
-    do
-        rm -rf $dir
-    done
-
-    kill $watch_pid
-
-    LogMsg "Finished cleaning up test cases"
 }
 
 test_case_install_uninstall_da

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -19,144 +19,202 @@ set -x
     exit 0
 }
 
+# Get distro information
+GetDistro
+
+dir_list=(/opt/microsoft/dependency-agent /var/opt/microsoft/dependency-agent /etc/opt/microsoft/dependency-agent /lib/microsoft-dependency-agent /etc/init.d/microsoft-dependency-agent)
+supported_distro_list=(redhat centos suse debian ubuntu)
+
+readonly da_pid_file="/etc/opt/microsoft/dependency-agent/config/DA_PID"
+
+function verify_directory() {
+    failed_assertions=0
+    for dir in "${dir_list[@]}"
+    do
+        [ -d $dir ] && LogErr "Directory $dir exists." && SetTestStateFailed && failed_assertions=$[[failed_assertions+1]]
+    done
+
+    if ["$failed_assertions" -gt 0]; then
+        LogErr "Some/All directories exists"
+        SetTestStateFailed
+        exit 0
+    fi
+}
+
+function verify_distro() {
+    LogMsg "Current distro: $DISTRO"
+    for distro in "${supported_distro_list[@]}"
+    do
+        if [[ "$distro"* == $DISTRO ]]; then
+        LogMsg "Supported Distro family"
+        break
+    else
+        LogErr "Unsupported Distro family"
+        SetTestStateSkipped
+        exit 0
+    done
+}
+
+function verify_da_pid() {
+    [ ! -f $da_pid_file ] && LogErr "$da_pid_file does not exist." && SetTestStateFailed && exit 0
+
+    if x=$(sed -n '/^[1-9][0-9]*$/p;q' $da_pid_file); then
+        strings /proc/$x/cmdline | grep "/opt/microsoft/dependency-agent/bin/microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && SetTestStateFailed && exit 0)
+    else
+        LogErr "PID not found in DA_PID"
+        SetTestStateFailed
+        exit 0
+    fi
+}
+
 function check_prereqs() {
-	LogMsg "Checking for preconditions"
+    LogMsg "Checking for preconditions"
 
-	if [[ $EUID -ne 0 ]]; then
-	   LogErr "This script must be run as root" 
-	   exit 1
-	fi
+    if [[ $EUID -ne 0 ]]; then
+        LogErr "This script must be run as root" 
+        SetTestStateFailed
+        exit 0
+    fi
 
-	[ -d "/opt/microsoft/dependency-agent" ] && LogErr "Directory /opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/var/opt/microsoft/dependency-agent" ] && LogErr "Directory /var/opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/etc/opt/microsoft/dependency-agent" ] && LogErr "Directory /etc/opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/lib/microsoft-dependency-agent" ] && LogErr "Directory /lib/microsoft-dependency-agent exists." && exit 1
-	[ -d "/etc/init.d/microsoft-dependency-agent" ] && LogErr "Directory /etc/init.d/microsoft-dependency-agent exists." && exit 1
+    verify_directory
+    verify_distro
 
-	LogMsg "Preconditions met"
+    LogMsg "Preconditions met"
 }
 
 function download_da_linux_installer() {
-	LogMsg "Download Dependency Agent Linux installer"
+    LogMsg "Download Dependency Agent Linux installer"
 
-	curl -L https://aka.ms/dependencyagentlinux -o InstallDependencyAgent-Linux64.bin
+    curl -L https://aka.ms/dependencyagentlinux -o InstallDependencyAgent-Linux64.bin
 
-	chmod +x InstallDependencyAgent-Linux64.bin
+    chmod +x InstallDependencyAgent-Linux64.bin
 }
 
 function verify_install_da() {
-	./InstallDependencyAgent-Linux64.bin -vme
+    ./InstallDependencyAgent-Linux64.bin -vme
 
-	ret=$?
-	if [ $ret -ne 0 ]; then
-	        LogErr "Install failed with exit code ${ret}"
-	        exit 1
-	else
-	        LogMsg "Installed with exit code 0"
-	fi
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        LogErr "Install failed with exit code ${ret}"
+        SetTestStateFailed
+        exit 0
+    else
+        LogMsg "Installed with exit code 0"
+    fi
 
-	[ ! -f "/opt/microsoft/dependency-agent/uninstall" ] && LogErr "/opt/microsoft/dependency-agent/uninstall does not exist." && exit 1
-	[ ! -f "/etc/init.d/microsoft-dependency-agent" ] && LogErr "/etc/init.d/microsoft-dependency-agent does not exist." && exit 1
-	[ ! -f "/var/opt/microsoft/dependency-agent/log/install.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/install.log does not exist." && exit 1
+    [ ! -f "/opt/microsoft/dependency-agent/uninstall" ] && LogErr "/opt/microsoft/dependency-agent/uninstall does not exist." && SetTestStateFailed && exit 0
+    [ ! -f "/etc/init.d/microsoft-dependency-agent" ] && LogErr "/etc/init.d/microsoft-dependency-agent does not exist." && SetTestStateFailed && exit 0
+    [ ! -f "/var/opt/microsoft/dependency-agent/log/install.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/install.log does not exist." && SetTestStateFailed && exit 0
 
-	bin_version=$(./InstallDependencyAgent-Linux64.bin --version | awk '{print $5}')
-	install_log_version=$(awk "NR==3" /var/opt/microsoft/dependency-agent/log/install.log | grep 'Dependency Agent version.revision'|cut -f2 -d ":")
-	if [ "$bin_version" -ne "$install_log_version" ]; then
-	        LogErr "Version mismatch between bin version and install log version"
-	        exit 1
-	else
-	        LogMsg "Version matches between bin version and install log version"
-	fi
+    bin_version=$(./InstallDependencyAgent-Linux64.bin --version | awk '{print $5}')
+    install_log_version=$(sed -n 's/^Dependency Agent version\.revision: //p' /var/opt/microsoft/dependency-agent/log/install.log)
+    if [ "$bin_version" -ne "$install_log_version" ]; then
+        LogErr "Version mismatch between bin version($bin_version) and install log version($install_log_version)"
+        SetTestStateFailed
+        exit 0
+    else
+        LogMsg "Version matches between bin version and install log version"
+    fi
 
-	LogMsg "Install tests passed successfully"
+    LogMsg "Install tests passed successfully"
 }
 
 function verify_uninstall_da() {
+    /opt/microsoft/dependency-agent/uninstall
 
-	bash /opt/microsoft/dependency-agent/uninstall
-	
-	ret=$?
-	if [ $ret -ne 0 ]; then
-	        LogErr "Uninstall failed with exit code ${ret}"
-	        exit 1
-	else
-	        LogMsg "Uninstalled with exit code 0"
-	fi
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        LogErr "Uninstall failed with exit code ${ret}"
+        SetTestStateFailed
+        exit 0
+    else
+        LogMsg "Uninstalled with exit code 0"
+    fi
 
-	[ -d "/opt/microsoft/dependency-agent" ] && LogErr "Directory /opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/var/opt/microsoft/dependency-agent" ] && LogErr "Directory /var/opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/etc/opt/microsoft/dependency-agent" ] && LogErr "Directory /etc/opt/microsoft/dependency-agent exists." && exit 1
-	[ -d "/lib/microsoft-dependency-agent" ] && LogErr "Directory /lib/microsoft-dependency-agent exists." && exit 1
-	[ -d "/etc/init.d/microsoft-dependency-agent" ] && LogErr "Directory /etc/init.d/microsoft-dependency-agent exists." && exit 1
+    verify_directory
 
-	LogMsg "Uninstall tests passed successfully"
+    LogMsg "Uninstall tests passed successfully"
 }
 
-function setup_network_trace() {
-    LogMsg "Setup network trace"
-	watch -n 5 curl https://microsoft.com &>/dev/null &
-	watch_pid=$!
+function generate_network_activity() {
+    LogMsg "Generate network activity"
+    watch -n 5 curl https://microsoft.com &>/dev/null &
+    watch_pid=$!
 }
 
 function enable_disable_da(){
-	verify_install_da
-	
-	sleep 30
-	[ ! -f "/var/opt/microsoft/dependency-agent/log/service.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log does not exist." && exit 1
+    verify_install_da
 
-	service_log_time=$(date -r /var/opt/microsoft/dependency-agent/log/service.log +%s)
-	current_time=$(date +%s)
-	time_elapsed=$(($current_time - $service_log_time))
-	sleep $((120-$time_elapsed))
+    # Wait for 30s and check for service.log
+    sleep 30
+    [ ! -f "/var/opt/microsoft/dependency-agent/log/service.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log does not exist." && SetTestStateFailed && exit 0
 
-	[ ! -f "/var/opt/microsoft/dependency-agent/log/service.log.1" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.1 does not exist." && exit 1
-	[ -f "/var/opt/microsoft/dependency-agent/log/service.log.2" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.2 exist." && exit 1
-	[ ! -c "/dev/msda" ] && LogErr "/dev/msda does not exist." && exit 1
+    # Check for service.log.1 file and confirm service.log.2 doesn't exist
+    # TODO: Need to revisit the retry logic.
+    service_log_time=$(date -r /var/opt/microsoft/dependency-agent/log/service.log +%s)
+    current_time=$(date +%s)
+    time_elapsed=$(($current_time - $service_log_time))
+    sleep $((120-$time_elapsed))
 
-	! grep -iq "driver setup status=0" /var/opt/microsoft/dependency-agent/log/service.log.1 && LogErr "driver setup status=0 not found" && exit 1
-	! grep -iq "starting the dependency agent" /var/opt/microsoft/dependency-agent/log/service.log && LogErr "starting the dependency agent not found" && exit 1
-	
-	sleep 60
-	[ ! -f "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log does not exist." && exit 1
-	[ ! -f "/etc/opt/microsoft/dependency-agent/config/DA_PID" ] && LogErr "/etc/opt/microsoft/dependency-agent/config/DA_PID does not exist." && exit 1
-	
-	if grep -iq "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID; then
-        x=$(grep -i "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID)
-        strings /proc/$x/cmdline | grep "/opt/microsoft/dependency-agent/bin/microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && exit 1)
-	else
-		LogErr "PID not found in DA_PID"
-		exit 1 
-	fi
-	
-	sleep 120
-	! ls /var/opt/microsoft/dependency-agent/storage/*.bb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist." && exit 1
+    [ ! -f "/var/opt/microsoft/dependency-agent/log/service.log.1" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.1 does not exist." && SetTestStateFailed && exit 0
+    [ -f "/var/opt/microsoft/dependency-agent/log/service.log.2" ] && LogErr "/var/opt/microsoft/dependency-agent/log/service.log.2 exist." && SetTestStateFailed && exit 0
+    [ ! -c "/dev/msda" ] && LogErr "/dev/msda does not exist." && SetTestStateFailed && exit 0
 
-	sleep 90
-	! ls /var/opt/microsoft/dependency-agent/storage/*.hb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist." && exit 1
-	[ ! -f "/etc/opt/microsoft/dependency-agent/config/DA_PID" ] && LogErr "/etc/opt/microsoft/dependency-agent/config/DA_PID does not exist." && exit 1
+    # Check for "driver setup status=0" and "starting the dependency agent" in service.log.1 and service.log respectively
+    ! grep -iq "driver setup status=0" /var/opt/microsoft/dependency-agent/log/service.log.1 && LogErr "driver setup status=0 not found" && SetTestStateFailed && exit 0
+    ! grep -iq "starting the dependency agent" /var/opt/microsoft/dependency-agent/log/service.log && LogErr "starting the dependency agent not found" && SetTestStateFailed && exit 0
 
-	if grep -iq "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID; then
-        x=$(grep -i "^[1-9][0-9]*$" /etc/opt/microsoft/dependency-agent/config/DA_PID)
-        strings /proc/$x/cmdline | grep "/opt/microsoft/dependency-agent/bin/microsoft-dependency-agent-manager" && LogMsg "PID matched" || (LogErr "PID not matched" && exit 1)
-	else
-		LogErr "PID not found in DA_PID"
-		exit 1 
-	fi
+    # Wait for DA to be running and verify by checking for MicrosoftDependencyAgent.log
+    sleep 60
+    [ ! -f "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log" ] && LogErr "/var/opt/microsoft/dependency-agent/log/MicrosoftDependencyAgent.log does not exist." && SetTestStateFailed && exit 0
+    verify_da_pid
 
-	dmesg | egrep -w "BUG:|Modules linked in:|Call Trace:​" && LogErr "Found BUG/Modules linked in/Call Trace in dmesg" && exit 1
+    # Wait for events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.bb files
+    sleep 120
+    ! ls /var/opt/microsoft/dependency-agent/storage/*.bb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.bb does not exist." && SetTestStateFailed && exit 0
 
-	verify_uninstall_da
-	pkill $watch_pid
+    # Wait for more events and verify by checking for /var/opt/microsoft/dependency-agent/storage/*.hb files
+    sleep 90
+    ! ls /var/opt/microsoft/dependency-agent/storage/*.hb && LogErr "/var/opt/microsoft/dependency-agent/storage/*.hb does not exist." && SetTestStateFailed && exit 0
+    verify_da_pid
 
-	LogMsg "Enable/Disable DA tests passed successfully"
+    dmesg | egrep -w "BUG:|Modules linked in:|Call Trace:​" && LogErr "Found BUG/Modules linked in/Call Trace in dmesg" && SetTestStateFailed && exit 0
+
+    verify_uninstall_da
+
+    LogMsg "Enable/Disable DA tests passed successfully"
 }
 
-check_prereqs
-download_da_linux_installer
-verify_install_da
-verify_uninstall_da
-setup_network_trace
-enable_disable_da
+function test_case_install_uninstall_da(){
+    LogMsg "Starting Test Case 1: Install/Uninstall DA"
+    check_prereqs
+    download_da_linux_installer
+    verify_install_da
+    verify_uninstall_da
+}
+
+function test_case_enable_disable_da(){
+    LogMsg "Starting Test Case 2: Enable/Disable DA" 
+    generate_network_activity
+    enable_disable_da
+}
+
+function test_case_cleanup(){
+    /opt/microsoft/dependency-agent/uninstall
+
+    for dir in "${dir_list[@]}"
+    do
+        rm -rf $dir
+    done
+
+    kill $watch_pid
+
+    LogMsg "Finished cleaning up test cases"
+}
+
+test_case_install_uninstall_da
+test_case_enable_disable_da
+test_case_cleanup
 
 LogMsg "Validate DA tests completed"
 SetTestStateCompleted

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -145,7 +145,7 @@ function download_da_linux_installer() {
 function verify_install_da() {
     LogMsg "Starting Install tests"
 
-    "$da_installer" -vme
+    "$da_installer" -$1
 
     ret=$?
     if [ $ret -ne 0 ]; then
@@ -195,7 +195,7 @@ function generate_network_activity() {
 function enable_disable_da(){
     LogMsg "Starting Enable/Disable DA tests"
 
-    verify_install_da
+    verify_install_da s
 
     # Wait for 30s for DA to start running and check for service.log
     sleep 30
@@ -220,10 +220,6 @@ function enable_disable_da(){
         fail_test "$da_log_dir/service.log.2 exist."
     fi
     
-    if [ ! -c "/dev/msda" ]; then 
-        fail_test "/dev/msda does not exist."
-    fi
-    
     # Check for "driver setup status=0" and "starting the dependency agent" in service.log.1 and service.log respectively
     
     if ! driver_status=$(sed -n '/Driver setup status=//s/^[^=]*//p' $da_log_dir/service.log.1); then
@@ -242,6 +238,10 @@ function enable_disable_da(){
             fail_test did not find driver setup status
             ;;
     esac
+
+    if [ ! -c "/dev/msda" ]; then 
+        fail_test "/dev/msda does not exist."
+    fi
 
     if ! fgrep -q -e "Starting the Dependency Agent" $da_log_dir/service.log; then
         fail_test "starting the dependency agent not found"
@@ -277,7 +277,7 @@ function enable_disable_da(){
 
 function test_case_install_uninstall_da(){
     LogMsg "Starting Test Case 1: Install/Uninstall DA"
-    verify_install_da
+    verify_install_da vme
     verify_uninstall_da
 }
 

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -247,6 +247,12 @@ function enable_disable_da(){
         =0)
             # expected result
             ;;
+        =36)
+            # Unsupported kernel case
+            LogErr "Unsupported kernel case"
+            SetTestStateSkipped
+            exit 0
+            ;;
         =*)
             # anything except =0 indicated setup failure
             fail_test Unexpected driver setup status $driver_status

--- a/Testscripts/Windows/VALIDATE-DA.ps1
+++ b/Testscripts/Windows/VALIDATE-DA.ps1
@@ -34,7 +34,7 @@ function Main {
         return "FAIL"
     }
 
-    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort ($remoteScriptName + "." + $remoteScriptType) -runAsSudo
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -runMaxAllowedTime 480 -command "sudo bash $remoteScriptName.$remoteScriptType" -runAsSudo
     $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $remoteScriptName -TestType $remoteScriptType `
         -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `
         -TestName $currentTestData.testName

--- a/Testscripts/Windows/VALIDATE-DA.ps1
+++ b/Testscripts/Windows/VALIDATE-DA.ps1
@@ -29,8 +29,8 @@ function Main {
     #######################################################################
 
     # Checking the input arguments
-    if (-not $VMName) {
-        Write-LogErr "VM name is null!"
+    if ($VMName.length -eq 0) {
+        Write-LogErr "VM name is empty!"
         return "FAIL"
     }
 

--- a/Testscripts/Windows/VALIDATE-DA.ps1
+++ b/Testscripts/Windows/VALIDATE-DA.ps1
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+    This script validates Dependency Agent.
+
+.Description
+    The script will install the Latest Dependency Agent and validate install/uninstall
+    scenarios as well as enable/disable scenarios.
+'
+#>
+param([String] $TestParams,
+      [object] $AllVmData)
+function Main {
+    param (
+        $VMName,
+        $Ipv4,
+        $VMPort,
+        $VMUserName,
+        $VMPassword
+    )
+
+    $remoteScript = "validate-da.sh"
+    #######################################################################
+    #
+    #	Main body script
+    #
+    #######################################################################
+
+    # Checking the input arguments
+    if (-not $VMName) {
+        Write-LogErr "VM name is null!"
+        return "FAIL"
+    }
+
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $remoteScript -runAsSudo
+    $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $remoteScript.split(".")[0] -TestType "sh" `
+        -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `
+        -TestName $currentTestData.testName
+    $resultArr += $testResult
+    Write-LogInfo "Test result : $testResult"
+    $currentTestResult = Create-TestResultObject
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+    return $currentTestResult
+}
+Main -VMName $AllVMData.RoleName `
+    -Ipv4 $AllVMData.PublicIP -VMPort $AllVMData.SSHPort `
+    -VMUserName $user -VMPassword $password

--- a/Testscripts/Windows/VALIDATE-DA.ps1
+++ b/Testscripts/Windows/VALIDATE-DA.ps1
@@ -13,14 +13,15 @@ param([String] $TestParams,
       [object] $AllVmData)
 function Main {
     param (
-        $VMName,
-        $Ipv4,
-        $VMPort,
-        $VMUserName,
-        $VMPassword
+        [String] $VMName,
+        [String] $Ipv4,
+        [int] $VMPort,
+        [String] $VMUserName,
+        [String] $VMPassword
     )
 
-    $remoteScript = "validate-da.sh"
+    $remoteScriptName = "validate-da"
+    $remoteScriptType = "sh"
     #######################################################################
     #
     #	Main body script
@@ -33,8 +34,8 @@ function Main {
         return "FAIL"
     }
 
-    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort $remoteScript -runAsSudo
-    $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $remoteScript.split(".")[0] -TestType "sh" `
+    Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort ($remoteScriptName + "." + $remoteScriptType) -runAsSudo
+    $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $remoteScriptName -TestType $remoteScriptType `
         -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `
         -TestName $currentTestData.testName
     $resultArr += $testResult

--- a/Testscripts/Windows/VALIDATE-DA.ps1
+++ b/Testscripts/Windows/VALIDATE-DA.ps1
@@ -34,6 +34,8 @@ function Main {
         return "FAIL"
     }
 
+    # Running validate-da script
+    # runMaxAllowedTime accounts for sum of sleep time in the validate-da script. This helps prevent timeout during execution.
     Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -runMaxAllowedTime 480 -command "sudo bash $remoteScriptName.$remoteScriptType" -runAsSudo
     $testResult = Collect-TestLogs -LogsDestination $LogDir -ScriptName $remoteScriptName -TestType $remoteScriptType `
         -PublicIP $Ipv4 -SSHPort $VMPort -Username $VMUserName -password $VMPassword `

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -806,7 +806,7 @@
         <testScript>VALIDATE-DA.ps1</testScript>
         <files>.\Testscripts\Linux\validate-da.sh,.\Testscripts\Linux\utils.sh</files>
         <setupType>OneVM</setupType>
-        <Platform>HyperV</Platform>
+        <Platform>Azure,HyperV</Platform>
         <Category>Functional</Category>
         <Area>DA</Area>
         <Tags>da</Tags>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -801,4 +801,15 @@
         <Tags>cpu</Tags>
         <Priority>3</Priority>
     </test>
+    <test>
+        <testName>VALIDATE-DEPENDENCY-AGENT</testName>
+        <testScript>VALIDATE-DA.ps1</testScript>
+        <files>.\Testscripts\Linux\validate-da.sh,.\Testscripts\Linux\utils.sh</files>
+        <setupType>OneVM</setupType>
+        <Platform>HyperV</Platform>
+        <Category>Functional</Category>
+        <Area>DA</Area>
+        <Tags>da</Tags>
+        <Priority>0</Priority>
+    </test>  
 </TestCases>


### PR DESCRIPTION
Added new tests to validate Dependency Agent

It mainly covers two areas:

- Install/Uninstall tests for DA
- Enable/Disable tests for DA

Test result:

[LISAv2 Test Results Summary]
Test Run On           : 07/01/2020 20:11:44
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1028-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DA                   VALIDATE-DEPENDENCY-AGENT                                                         PASS                 7.16


Logs can be found at C:\repos\LISAv2\TestResults\2020-07-01-13-11-40-8886