### PR TITLE
Add a new test script for RTC time sync-up

### DIFF
--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -102,8 +102,8 @@ echo disk > /sys/power/state
 		# Wait for kernel compilation completion. 90 min timeout
 		$timeout = New-Timespan -Minutes $maxKernelCompileMin
 		$sw = [diagnostics.stopwatch]::StartNew()
+		$vmCount = $AllVMData.Count
 		while ($sw.elapsed -lt $timeout){
-			$vmCount = $AllVMData.Count
 			Wait-Time -seconds 30
 			$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password -command "cat ~/state.txt"
 			if ($state -eq "TestCompleted") {
@@ -190,8 +190,8 @@ echo disk > /sys/power/state
 		# Wait for VM resume for 15 min-timeout
 		$timeout = New-Timespan -Minutes 15
 		$sw = [diagnostics.stopwatch]::StartNew()
+		$vmCount = $AllVMData.Count
 		while ($sw.elapsed -lt $timeout){
-			$vmCount = $AllVMData.Count
 			Wait-Time -seconds 15
 			$state = Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "date > /dev/null; echo $?"
 			if ($state) {

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -274,7 +274,7 @@ echo disk > /sys/power/state
 		if ($beforeTimeStamp -ne $12minAfterTimeStamp) {
 			Write-LogInfo "Successfully verified the beforeTimeStamp was different from 12minAfterTimeStamp"
 		} else {
-			Write-LogErr "Did not find time synced. $beforeTimeStamp to $12minAfterTimeStamp"
+			throw "Did not find time synced. $beforeTimeStamp to $12minAfterTimeStamp"
 		}
 
 		$controllerTimeStamp = Get-Date -format "yyyy"
@@ -283,7 +283,7 @@ echo disk > /sys/power/state
 		if ($12minAfterTimeStamp -eq $controllerTimeStamp) {
 			Write-LogInfo "Successfully verified the system date changed back to correct date"
 		} else {
-			Write-LogErr "Expected VM time changed back to the correct one after sync-up, but found $12minAfterTimeStamp"
+			throw "Expected VM time changed back to the correct one after sync-up, but found $12minAfterTimeStamp"
 		}
 
 		$testResult = $resultPass

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -260,7 +260,6 @@ echo disk > /sys/power/state
 
 		Copy-RemoteFiles -downloadFrom $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log" -runAsSudo
 
-		if ( )
 		$beforeTimeStamp = Get-Content $LogDir\before_timestamp.log
 		Write-LogDbg $beforeTimeStamp
 		$5minAfterTimeStamp = Get-Content $LogDir\5min_after_timestamp.log

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -265,7 +265,7 @@ echo disk > /sys/power/state
 		$5minAfterTimeStamp = Get-Content $LogDir\5min_after_timestamp.log
 		Write-LogDbg $5minAfterTimeStamp
 
-		if (($beforeTimeStamp -ne $5minAfterTimeStamp)) {
+		if ($beforeTimeStamp -ne $5minAfterTimeStamp) {
 			Write-LogInfo "Successfully verified the beforeTimeStamp was different from 5minAfterTimeStamp"
 		} else {
 			Write-LogErr "Did not find time synced. $beforeTimeStamp to $5minAfterTimeStamp"

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -247,17 +247,22 @@ hwclock > after_timestamp.log
 		Copy-RemoteFiles -downloadFrom $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log" -runAsSudo
 
 		$beforeTimeStamp = (Get-Content $LogDir\before_timestamp.log).Split(' ')[0]
+		Write-LogDbg $beforeTimeStamp
 		$afterTimeStamp = (Get-Content $LogDir\after_timestamp.log).Split(' ')[0]
+		Write-LogDbg $afterTimeStamp
 		$instantTiemStamp = (Get-Content $LogDir\instant_timestamp.log).Split(' ')[0]
+		Write-LogDbg $instantTiemStamp
 		$5minAfterTimeStamp = (Get-Content $LogDir\5min_after_timestamp.log).Split(' ')[0]
+		Write-LogDbg $5minAfterTimeStamp
 
-		if ($beforeTimeStamp -eq $afterTimeStamp -eq $instantTiemStamp) {
-			Write-LogInfo "Successfully verified 3 timestmaps were in the same date"
+		if ($beforeTimeStamp -ne $afterTimeStamp) -and ($afterTimeStamp -eq $instantTiemStamp) {
+			Write-LogInfo "Successfully verified the beforeTimeStamp was different from afterTimeStamp"
 		} else {
 			Write-LogErr "Expected 3 timestamps were in the same date in given short time, but found $beforeTimeStamp, $afterTimeStamp, $instantTiemStamp"
 		}
 
 		$controllerTimeStamp = Get-Date -format "yyyy/MM/dd"
+		Write-LogDbg $controllerTimeStamp
 
 		if ($5minAfterTimeStamp -eq $controllerTimeStamp) {
 			Write-LogInfo "Successfully verified the system date changed back to correct date"

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -75,6 +75,7 @@ function Main {
 hwclock --set --date='2033-01-01 00:00:00'
 hwclock > before_timestamp.log
 echo disk > /sys/power/state
+sleep 1
 hwclock > after_timestamp.log
 "@
 		Set-Content "$LogDir\test.sh" $testcommand

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -2,21 +2,20 @@
 # Licensed under the Apache License.
 <#
 .Synopsis
-	Perform a simple VM hibernation in Azure
-	This feature might be available in kernel 5.7 or later. By the time,
-	customized kernel will be built.
+	RTC (Real-Time Clock) returns hardware clock from Hyper-v host.
+	Hibernation does not reset RTC until the next host sync-up time.
 	# Hibernation will be supported in the general purpose VM with max 16G vRAM
 	# and the GPU VMs with max 112G vRAM.
-
 
 .Description
 	This test can be performed in Azure and Hyper-V both. But this script only covers Azure.
 	1. Prepare swap space for hibernation
 	2. Compile a new kernel (optional)
 	3. Update the grub.cfg with resume=UUID=xxxx where is from blkid swap disk
-	4. Hibernate the VM, and verify the VM status
-	5. Resume the VM and verify the VM status.
-	6. Verify no kernel panic or call trace
+	4. Set RTC to future time or past time
+	5. Hibernate the VM
+	5. Resume the VM
+	6. Read RTC timestamp and compare to the original value
 #>
 
 param([object] $AllVmData, [string]$TestParams)
@@ -73,7 +72,10 @@ function Main {
 		}
 
 		$testcommand = @"
+hwclock --set --date='2033-01-01 00:00:00'
+hwclock > before_timestamp.log
 echo disk > /sys/power/state
+hwclock > after_timestamp.log
 "@
 		Set-Content "$LogDir\test.sh" $testcommand
 
@@ -142,28 +144,6 @@ echo disk > /sys/power/state
 			throw "Can not identify VM status before hibernate"
 		}
 
-		$getvf = @"
-cat /proc/net/dev | grep -v Inter | grep -v face > netdev.log
-while IFS= read -r line
-do
-	case "`$line" in
-		*lo* );;
-		*eth0* );;
-		* ) echo `$line | cut -d ':' -f 1;;
-	esac
-done < netdev.log
-"@
-		Set-Content "$LogDir\getvf.sh" $getvf
-
-		Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort -files "$LogDir\getvf.sh" -username $user -password $password -upload
-		Write-LogInfo "Copied the script files to the VM"
-
-		# Getting queue counts and interrupt counts before hibernation
-		$vfname = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash ./getvf.sh" -runAsSudo
-		if ( $vfname -ne '' ) {
-			$tx_queue_count1 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "ethtool -l `$vfname | grep -i tx | tail -n 1 | cut -d ":" -f 2 | tr -d '[:space:]'" -runAsSudo
-			$interrupt_count1 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /proc/interrupts | grep -i mlx | grep -i msi | wc -l" -runAsSudo
-		}
 		# Hibernate the VM
 		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "./test.sh" -runAsSudo -RunInBackground -ignoreLinuxExitCode:$true | Out-Null
 		Write-LogInfo "Sent hibernate command to the VM and continue checking its status in every 15 seconds until 10 minutes timeout "
@@ -198,14 +178,14 @@ done < netdev.log
 		while ($sw.elapsed -lt $timeout){
 			$vmCount = $AllVMData.Count
 			Wait-Time -seconds 15
-			$state = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password -command "date > /dev/null; echo $?"
+			$state = Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "date > /dev/null; echo $?"
 			if ($state) {
-				$kernelCompileCompleted = Run-LinuxCmd -ip $VMData.PublicIP -port $VMData.SSHPort -username $user -password $password -command "dmesg | grep -i 'hibernation exit'"
+				$kernelCompileCompleted = Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "dmesg | grep -i 'hibernation exit'"
 				# This verification might be revised in future. Checking with dmesg is risky.
 				if ($kernelCompileCompleted -ne "hibernation exit") {
-					Write-LogErr "VM $($VMData.RoleName) resumed successfully but could not determine hibernation completion"
+					Write-LogErr "VM $($AllVMData[0].RoleName) resumed successfully but could not determine hibernation completion"
 				} else {
-					Write-LogInfo "VM $($VMData.RoleName) resumed successfully"
+					Write-LogInfo "VM $($AllVMData[0].RoleName) resumed successfully"
 					$vmCount--
 				}
 				break
@@ -220,6 +200,16 @@ done < netdev.log
 			# Either VM hang or VM resume needs longer time.
 			throw "VM resume did not finish, the latest state was $state"
 		}
+
+		Write-LogInfo "Capturing the RTC timestmap to instant_timestamp.log file"
+		Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "hwclock > instant_timestamp.log" -runAsSudo | Out-Null
+
+		Write-LogInfo "Waiting for RTC re-sync in 5 minutes"
+		Start-Sleep -m 5
+
+		Write-LogInfo "Capturing the RTC timestmap to 5min_after_timestamp.log file"
+		Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "hwclock > 5min_after_timestamp.log" -runAsSudo | Out-Null
+
 		#Verify the VM status after power on event
 		$vmStatus = Get-AzVM -Name $vmName -ResourceGroupName $rgName -Status
 		if ($vmStatus.Statuses[1].DisplayStatus -eq "VM running") {
@@ -230,7 +220,7 @@ done < netdev.log
 		}
 
 		# Verify the kernel panic, call trace or fatal error
-		$calltrace_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "dmesg | grep -iE '(call trace|fatal error)'" -ignoreLinuxExitCode:$true
+		$calltrace_filter = Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "dmesg | grep -iE '(call trace|fatal error)'" -ignoreLinuxExitCode:$true
 
 		if ($calltrace_filter -ne "") {
 			Write-LogErr "Found Call Trace or Fatal error in dmesg"
@@ -241,8 +231,8 @@ done < netdev.log
 		}
 
 		# Check the system log if it shows Power Management log
-		"hibernation entry", "hibernation exit" | ForEach-Object  {
-			$pm_log_filter = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /var/log/syslog | grep -i '$_'" -ignoreLinuxExitCode:$true
+		"hibernation entry", "hibernation exit" | ForEach-Object {
+			$pm_log_filter = Run-LinuxCmd -ip $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -command "cat /var/log/syslog | grep -i '$_'" -ignoreLinuxExitCode:$true
 			Write-LogInfo "Searching the keyword: $_"
 			if ($pm_log_filter -eq "") {
 				Write-LogErr "Could not find Power Management log in dmesg"
@@ -253,28 +243,28 @@ done < netdev.log
 			}
 		}
 
-		# Getting queue counts and interrupt counts after resuming.
-		$vfname = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash ./getvf.sh" -runAsSudo
-		if ($vfname -ne '') {
-				$tx_queue_count2 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "ethtool -l ${vfname} | grep -i tx | tail -n 1 | cut -d ":" -f 2 | tr -d '[:space:]'" -runAsSudo
-				$interrupt_count2 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /proc/interrupts | grep -i mlx | grep -i msi | wc -l" -runAsSudo
-		}
-		if ($tx_queue_count1 -ne $tx_queue_count2) {
-			Write-LogErr "Before hibernation, Tx queue count - $tx_queue_count1. After waking up, Tx queue count - $tx_queue_count2"
-			throw "Tx queue counts changed after waking up."
+		Copy-RemoteFiles -downloadFrom $AllVMData[0].PublicIP -port $AllVMData[0].SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log" -runAsSudo
+
+		$beforeTimeStamp = (Get-Content $LogDir\before_timestamp.log).Split(' ')[0]
+		$afterTimeStamp = (Get-Content $LogDir\after_timestamp.log).Split(' ')[0]
+		$instantTiemStamp = (Get-Content $LogDir\instant_timestamp.log).Split(' ')[0]
+		$5minAfterTimeStamp = (Get-Content $LogDir\5min_after_timestamp.log).Split(' ')[0]
+
+		if ($beforeTimeStamp -eq $afterTimeStamp -eq $instantTiemStamp) {
+			Write-LogInfo "Successfully verified 3 timestmaps were in the same date"
 		} else {
-			Write-LogInfo "Successfully verified Tx queue count matching in Current hardware settings."
+			Write-LogErr "Expected 3 timestamps were in the same date in given short time, but found $beforeTimeStamp, $afterTimeStamp, $instantTiemStamp"
 		}
 
-		if ($interrupt_count1 -ne $interrupt_count2) {
-			Write-LogErr "Before hibernation, MSI interrupts of mlx driver - $interrupt_count1. After waking up, MSI interrupts of mlx driver - $interrupt_count2"
-			throw "MSI interrupt counts changed after waking up."
+		$controllerTimeStamp = Get-Date -format "yyyy/MM/dd"
+
+		if ($5minAfterTimeStamp -eq $controllerTimeStamp) {
+			Write-LogInfo "Successfully verified the system date changed back to correct date"
 		} else {
-			Write-LogInfo "Successfully verified MSI interrupt counts matching"
+			Write-LogErr "Expected VM time changed back to the correct one after sync-up, but found $5minAfterTimeStamp"
 		}
 
 		$testResult = $resultPass
-		Copy-RemoteFiles -downloadFrom $receiverVMData.PublicIP -port $receiverVMData.SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log" -runAsSudo
 	} catch {
 		$ErrorMessage =  $_.Exception.Message
 		$ErrorLine = $_.InvocationInfo.ScriptLineNumber

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -72,7 +72,7 @@ function Main {
 		}
 
 		$testcommand = @"
-hwclock --set --date='2033-01-01 00:00:00'
+hwclock --set --date='2033-07-01 00:00:00'
 hwclock > before_timestamp.log
 echo disk > /sys/power/state
 sleep 1

--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -255,7 +255,7 @@ hwclock > after_timestamp.log
 		$5minAfterTimeStamp = (Get-Content $LogDir\5min_after_timestamp.log).Split(' ')[0]
 		Write-LogDbg $5minAfterTimeStamp
 
-		if ($beforeTimeStamp -ne $afterTimeStamp) -and ($afterTimeStamp -eq $instantTiemStamp) {
+		if (($beforeTimeStamp -ne $afterTimeStamp) -and ($afterTimeStamp -eq $instantTiemStamp)) {
 			Write-LogInfo "Successfully verified the beforeTimeStamp was different from afterTimeStamp"
 		} else {
 			Write-LogErr "Expected 3 timestamps were in the same date in given short time, but found $beforeTimeStamp, $afterTimeStamp, $instantTiemStamp"

--- a/Testscripts/Windows/WORKLOAD-HB.ps1
+++ b/Testscripts/Windows/WORKLOAD-HB.ps1
@@ -11,7 +11,7 @@
 .Description
 	1. Prepare swap space for hibernation
 	2. Compile a new kernel (optional)
-	3. Update the grup.cfg with resume=UUID=xxxx where is from blkid swap disk
+	3. Update the grub.cfg with resume=UUID=xxxx where is from blkid swap disk
 	4. Run the first storage or network workload testing
 	5. Hibernate the VM, and verify the VM status
 	5. Resume the VM and verify the VM status.

--- a/XML/TestCases/FunctionalTests-Power.xml
+++ b/XML/TestCases/FunctionalTests-Power.xml
@@ -68,4 +68,20 @@
 		<Tags>power,network</Tags>
 		<Priority>3</Priority>
 	</test>
+	<test>
+		<testName>POWER-CLOCK-SYNC-HIBERNATE</testName>
+		<testScript>HB-CLOCKSYNC.ps1</testScript>
+		<setupType>OneVM</setupType>
+		<OverrideVMSize>Standard_D8s_v3</OverrideVMSize>
+		<files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\SetupHbKernel.sh</files>
+		<TestParameters>
+			<param>hb_url=HB_CUSTOM_KERNEL_URL</param>
+			<param>hb_branch=HB_CUSTOM_KERNEL_BRANCH</param>
+		</TestParameters>
+		<Platform>Azure</Platform>
+		<Category>Functional</Category>
+		<Area>POWER</Area>
+		<Tags>power,time</Tags>
+		<Priority>3</Priority>
+	</test>
 </TestCases>


### PR DESCRIPTION
Added a new test case, POWER-CLOCK-SYNC-HIBERNATE
Fixed typos.
Adjust the code for the time stamp comparison and time values

**TEST RESULTS**

[LISAv2 Test Results Summary]
Test Run On           : 06/20/2020 16:50:50
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1089-azure
Final Kernel Version  : 5.8.0-rc1-next-20200618
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:53

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 POWER                POWER-CLOCK-SYNC-HIBERNATE                                                        PASS                51.18 

[LISAv2 Test Results Summary]
Test Run On           : 06/20/2020 16:50:48
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.8.0-rc1-next-20200618
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:56

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 POWER                POWER-CLOCK-SYNC-HIBERNATE                                                        PASS                54.01 