### PR TITLE
Add a utils function to identify platform and enhance ETHTOOL-GRO-LRO

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3440,3 +3440,21 @@ function get_OSdisk() {
 
 	echo "$os_disk"
 }
+
+# Function to get current platform (Azure/HyperV) by checking if the metadata route 169.254.169.254 exists
+# Sets the $PLATFORM variable to one of the following: Azure, HyperV
+# Takes no arguments
+function GetPlatform() {
+	route -n | grep "169.254.169.254" > /dev/null
+	if [[ $? == 0 ]];then
+		http_code=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2019-06-01" -w "%{http_code}" -o /dev/null -s -m 3)
+		if [[ "$http_code" == "200" ]];then
+			PLATFORM="Azure"
+		else
+			PLATFORM="HyperV"
+		fi
+	else
+		PLATFORM="HyperV"
+	fi
+	LogMsg "Running on platform: $PLATFORM"
+}


### PR DESCRIPTION
Another patch of #868 .
1. Add a function "GetPlatform" in utils.sh to identify platform (Azure/HyperV) by checking metadata route 169.254.169.254 and try to curl from it. It sets a variable $PLATFORM to one of the following: Azure, HyperV.
2. Base on (1), only run LRO part in HyperV.