### PR TITLE
VERIFY-XDP-COMPLANCE supports RHEL-8

### DIFF
--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -49,6 +49,14 @@ function Install_XDP_Dependencies(){
                 exit 1
             fi
         ;;
+        rhel)
+            yum install -y --nogpgcheck git llvm clang elfutils-devel make
+            if [ $? -ne 0 ]; then
+                LogErr "ERROR: Failed to install required packages on ${DISTRO_STRING}"
+                SetTestStateFailed
+                exit 1
+            fi
+        ;;
         * )
             LogErr "Distribution (${DISTRO_NAME}) is not supported by this script."
             SetTestStateSkipped


### PR DESCRIPTION
RHEL supports XDP since RHEL-8.3. Add RHEL if-statement to support RHEL-8.
One question is that when I execute ./xdpdump -i eth1, it shows a warning message:
```
# ./xdpdump -i eth1
libbpf: Error loading ELF section .BTF: -22. Ignored and continue.
```
But it doesn't impact the result. 

Azure result:
```
[LISAv2 Test Results Summary]
Test Run On           : 06/23/2020 10:54:27
VHD Under Test        : https://walaautol2.blob.core.windows.net/vhds/RHEL-8.3.0-20200616.0.vhd
Test Category         : Functional
Initial Kernel Version: 4.18.0-214.el8.x86_64
Final Kernel Version  : 4.18.0-214.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 XDP                  VERIFY-XDP-COMPLIANCE                                                             PASS                 7.36
```