### PR TITLE
Fixing code integration gap in hibernation tests

### DIFF
--- a/Testscripts/Windows/HB-CLOCKSYNC.ps1
+++ b/Testscripts/Windows/HB-CLOCKSYNC.ps1
@@ -154,6 +154,13 @@ fi
 "@
 		Set-Content "$LogDir\getyear.sh" $getyear
 
+		#region Upload files to VM
+		foreach ($VMData in $AllVMData) {
+			Copy-RemoteFiles -uploadTo $VMData.PublicIP -port $VMData.SSHPort -files "$constantsFile,$($CurrentTestData.files),$LogDir\*.sh" -username $user -password $password -upload
+			Write-LogInfo "Copied the script files to the VM"
+		}
+		#endregion
+
 		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "hwclock --set --date='2033-07-01 12:00:00'" -runAsSudo -ignoreLinuxExitCode:$true | Out-Null
 		Start-Sleep -seconds 1
 		Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash getyear.sh" -runAsSudo -ignoreLinuxExitCode:$true | Out-Null

--- a/Testscripts/Windows/Power-Hibernate.ps1
+++ b/Testscripts/Windows/Power-Hibernate.ps1
@@ -184,16 +184,6 @@ install_package "ethtool"
 			}
 			#endregion
 
-      # Getting queue counts and interrupt counts before hibernation
-      $vfname = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash ./getvf.sh" -runAsSudo
-      if ( $vfname -ne '' ) {
-        $tx_queue_count1 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "ethtool -l `$vfname | grep -i tx | tail -n 1 | cut -d ":" -f 2 | tr -d '[:space:]'" -runAsSudo
-        $interrupt_count1 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /proc/interrupts | grep -i mlx | grep -i msi | wc -l" -runAsSudo
-      }
-      # Hibernate the VM
-      Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "./test.sh" -runAsSudo -RunInBackground -ignoreLinuxExitCode:$true | Out-Null
-      Write-LogInfo "Sent hibernate command to the VM and continue checking its status in every 15 seconds until 10 minutes timeout "
-
 			# Getting queue counts and interrupt counts before hibernation
 			$vfname = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash ./getvf.sh" -runAsSudo
 			if ( $vfname -ne '' ) {


### PR DESCRIPTION
Last a couple of PR conflict/merge created gaps in code integration. I re-run all the below tests and make sure no break-point.
There is a duplicated code block & missing upload step of the bash script.

<Summary of all hibernation tests>

1. POWER-HIBERNATE - passed
2. POWER-STORAGE-WORKLOAD-HIBERNATE - passed
3. POWER-HIBERNATE-SRIOV- passed
4. POWER-NETWORK-WORKLOAD-HIBERNATE - passed
5. POWER-MEMORY-WORKLOAD-HIBERNATE - passed
6. POWER-VMRESIZE-HIBERNATE - passed
7. POWER-CLOCK-SYNC-HIBERNATE - passed
8. STRESS-POWER-HIBERNATE - passed
