### PR TITLE
Fix small issue in SetupHbKernel.sh

### DIFF
--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -133,7 +133,7 @@ function Main() {
 
 	if [[ "$DISTRO" =~ "redhat" ]];then
 		_entry=$(cat /etc/default/grub | grep 'rootdelay=')
-		if [ $_entry ]; then
+		if [ "$_entry" ]; then
 			sed -i -e "s/rootdelay=300/rootdelay=300 resume=$sw_uuid/g" /etc/default/grub
 			LogMsg "$?: Updated the /etc/default/grub with resume=$sw_uuid"
 		else


### PR DESCRIPTION
There's no "" around "_entry" in line#136, which causes a failure and go to the wrong branch.

bash -x SetupHbKernel.sh
Before:
```
+ _entry='GRUB_CMDLINE_LINUX="console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 crashkernel=auto"'
+ '[' 'GRUB_CMDLINE_LINUX="console=tty1' console=ttyS0 earlyprintk=ttyS0 rootdelay=300 'crashkernel=auto"' ']'
SetupHbKernel.sh: line 136: [: too many arguments
+ echo 'GRUB_CMDLINE_LINUX_DEFAULT=console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243'
+ LogMsg '0: Added resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243 in /etc/default/grub file'
```
After:
```
+ _entry='GRUB_CMDLINE_LINUX="console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 crashkernel=auto"
GRUB_CMDLINE_LINUX_DEFAULT=console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243'
+ '[' 'GRUB_CMDLINE_LINUX="console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 crashkernel=auto"
GRUB_CMDLINE_LINUX_DEFAULT=console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243' ']'
+ sed -i -e 's/rootdelay=300/rootdelay=300 resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243/g' /etc/default/grub
+ LogMsg '0: Updated the /etc/default/grub with resume=UUID=82405dc0-a488-4e3c-96f4-65a308c0f243'
```