### PR TITLE
Support RHEL-8 in all the XDP cases

### DIFF
--- a/Testscripts/Linux/XDP-Action.sh
+++ b/Testscripts/Linux/XDP-Action.sh
@@ -18,11 +18,13 @@ function ping_test () {
 
 	xdpdumpCommand="cd bpf-samples/xdpdump && timeout 20 ./xdpdump -i ${nicName} > ~/xdpdumpout_${logSuffix}.txt"
 	LogMsg "Starting xdpdump on ${client} with command: ${xdpdumpCommand}"
-	ssh ${client} "sh -c '${xdpdumpCommand} &'"
+	ssh -f ${client} "sh -c '${xdpdumpCommand}'"
 
 	LogMsg "Starting ping on ${server} with command: ping -I ${nicName} -c 10 ${clientSecondIP} > ~/pingOut_${logSuffix}.txt"
 	ssh ${server} "ping -I ${nicName} -c 10 ${clientSecondIP} > ~/pingOut_${logSuffix}.txt"
 	check_exit_status "ping test ${logSuffix} XDPDump-${ACTION} config"
+	# Cleanup xdpdump process
+	killall xdpdump
 }
 
 # Helper function

--- a/Testscripts/Windows/VERIFY-SRIOV-FAILSAFE-XDP.ps1
+++ b/Testscripts/Windows/VERIFY-SRIOV-FAILSAFE-XDP.ps1
@@ -11,6 +11,7 @@ param([object] $AllVmData,
 	[object] $CurrentTestData)
 
 $MIN_KERNEL_VERSION = "5.6"
+$RHEL_MIN_KERNEL_VERSION = "4.18.0-213"
 
 # This function will start ping and xdpdump on client
 function Ping-XDPDump {
@@ -88,9 +89,18 @@ function Main {
         $currentKernelVersion = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
             -username $user -password $password -command "uname -r"
         # ToDo: Update Minimum kernel version check once patches are in downstream distro.
-        if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0 -or $global:DetectedDistro -ne "UBUNTU"){
-            Write-LogInfo "Minimum kernel version required for XDP: $MIN_KERNEL_VERSION."`
-                "Unsupported kernel version: $currentKernelVersion or Unsupported distro: $($global:DetectedDistro)."
+        if ($global:DetectedDistro -eq "UBUNTU"){
+            if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } elseif ($global:DetectedDistro -eq "REDHAT"){
+            if ((Compare-KernelVersion $currentKernelVersion $RHEL_MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } else {
+            Write-LogInfo "Unsupported distro: $($global:DetectedDistro)."
             return $global:ResultSkipped
         }
 

--- a/Testscripts/Windows/VERIFY-XDP-ACTION.ps1
+++ b/Testscripts/Windows/VERIFY-XDP-ACTION.ps1
@@ -11,6 +11,7 @@ param([object] $AllVmData,
     [object] $CurrentTestData)
 
 $MIN_KERNEL_VERSION = "5.6"
+$RHEL_MIN_KERNEL_VERSION = "4.18.0-213"
 $iFaceName = "eth1"
 
 function Main {
@@ -49,9 +50,18 @@ function Main {
         $currentKernelVersion = Run-LinuxCmd -ip $receiverVMData.PublicIP -port $receiverVMData.SSHPort `
                 -username $user -password $password -command "uname -r"
         # ToDo: Update Minimum kernel version check once patches are in downstream distro.
-        if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0 -or $global:DetectedDistro -ne "UBUNTU"){
-            Write-LogInfo "Minimum kernel version required for XDP: $MIN_KERNEL_VERSION."`
-                "Unsupported kernel version: $currentKernelVersion or Unsupported distro: $($global:DetectedDistro)."
+        if ($global:DetectedDistro -eq "UBUNTU"){
+            if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } elseif ($global:DetectedDistro -eq "REDHAT"){
+            if ((Compare-KernelVersion $currentKernelVersion $RHEL_MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } else {
+            Write-LogInfo "Unsupported distro: $($global:DetectedDistro)."
             return $global:ResultSkipped
         }
 

--- a/Testscripts/Windows/VERIFY-XDP-MTU.ps1
+++ b/Testscripts/Windows/VERIFY-XDP-MTU.ps1
@@ -11,6 +11,7 @@ param([object] $AllVmData,
     [object] $CurrentTestData)
 
 $MIN_KERNEL_VERSION = "5.6"
+$RHEL_MIN_KERNEL_VERSION = "4.18.0-213"
 $iFaceName = "eth1"
 
 function Main {
@@ -49,9 +50,18 @@ function Main {
         $currentKernelVersion = Run-LinuxCmd -ip $receiverVMData.PublicIP -port $receiverVMData.SSHPort `
             -username $user -password $password -command "uname -r"
         # ToDo: Update Minimum kernel version check once patches are in downstream distro.
-        if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0 -or $global:DetectedDistro -ne "UBUNTU"){
-            Write-LogInfo "Minimum kernel version required for XDP: $MIN_KERNEL_VERSION."`
-                "Unsupported kernel version: $currentKernelVersion or Unsupported distro: $($global:DetectedDistro)."
+        if ($global:DetectedDistro -eq "UBUNTU"){
+            if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } elseif ($global:DetectedDistro -eq "REDHAT"){
+            if ((Compare-KernelVersion $currentKernelVersion $RHEL_MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } else {
+            Write-LogInfo "Unsupported distro: $($global:DetectedDistro)."
             return $global:ResultSkipped
         }
 

--- a/Testscripts/Windows/VERIFY-XDP-MULTIPLE-NICS.ps1
+++ b/Testscripts/Windows/VERIFY-XDP-MULTIPLE-NICS.ps1
@@ -11,6 +11,7 @@ param([object] $AllVmData,
     [object] $CurrentTestData)
 
 $MIN_KERNEL_VERSION = "5.6"
+$RHEL_MIN_KERNEL_VERSION = "4.18.0-213"
 $iface1 = "eth1"
 $iface2 = "eth2"
 
@@ -71,9 +72,18 @@ function Main {
         $currentKernelVersion = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
                 -username $user -password $password -command "uname -r"
         # ToDo: Update Minimum kernel version check once patches are in downstream distro.
-        if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0 -or $global:DetectedDistro -ne "UBUNTU"){
-            Write-LogInfo "Minimum kernel version required for XDP: $MIN_KERNEL_VERSION."`
-                "Unsupported kernel version: $currentKernelVersion or Unsupported distro: $($global:DetectedDistro)."
+        if ($global:DetectedDistro -eq "UBUNTU"){
+            if ((Compare-KernelVersion $currentKernelVersion $MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } elseif ($global:DetectedDistro -eq "REDHAT"){
+            if ((Compare-KernelVersion $currentKernelVersion $RHEL_MIN_KERNEL_VERSION) -lt 0){
+                Write-LogInfo "Unsupported kernel version: $currentKernelVersion"
+                return $global:ResultSkipped
+            }
+        } else {
+            Write-LogInfo "Unsupported distro: $($global:DetectedDistro)."
             return $global:ResultSkipped
         }
 


### PR DESCRIPTION
1. Support RHEL-8 in all the XDP cases:
VERIFY-XDP-LOAD-UNLOAD
VERIFY-XDP-ACTION-DROP
VERIFY-XDP-ACTION-TX
VERIFY-XDP-ACTION-ABORTED
VERIFY-XDP-MTU
VERIFY-SRIOV-FAILSAFE-XDP
VERIFY-XDP-MULTIPLE-NICS

2. In XDP-Action.sh, the ```ssh ${client} "sh -c '${xdpdumpCommand} &'``` command cannot be run in background. Change to "ssh -f". And killall xdpdump process after each xdpdump test.