### PR TITLE
Fix hung during run apt upgrade

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -266,8 +266,8 @@ function Main() {
 				fi
 			done
 			LogMsg "*** System updating with the customized ppa"
-			apt update
-			apt upgrade -y
+			update_repos
+			Update_Kernel
 			Verify_Result
 			;;
 		*)

--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -26,8 +26,8 @@ SetTestStateRunning
 
 rm -rf ~/samples
 
-sudo apt-get update
-sudo apt-get -y upgrade
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 echo "----- Checking sgx driver -----"
 if ! modinfo intel_sgx; then
     echo "modinfo intel_sgx failed"

--- a/XML/TestCases/FunctionalTests-SGX.xml
+++ b/XML/TestCases/FunctionalTests-SGX.xml
@@ -9,6 +9,6 @@
         <Category>Functional</Category>
         <Area>SGX</Area>
         <Tags>sgx</Tags>
-        <Priority>1</Priority>
+        <Priority></Priority>
     </test>
 </TestCases>


### PR DESCRIPTION
Test results -

```
[LISAv2 Test Results Summary]
Test Run On           : 06/30/2020 07:11:42
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Initial Kernel Version: 4.15.0-1089-azure
Final Kernel Version  : 4.15.0-1091-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 3.99 

[LISAv2 Test Results Summary]
Test Run On           : 06/30/2020 07:01:47
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Initial Kernel Version: 4.15.0-1089-azure
Final Kernel Version  : 4.15.0-1091-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 4.01 

[LISAv2 Test Results Summary]
Test Run On           : 06/30/2020 05:41:25
ARM Image Under Test  : Canonical : UbuntuServer : 18_04-lts-gen2 : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 4.98 

[LISAv2 Test Results Summary]
Test Run On           : 06/30/2020 05:45:08
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                19.79 
	InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS 
	InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-1-FirstBoot :IMB PingPong Intranode : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS 
	InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS 
	InfiniBand-Verification-2-Reboot : eth0 IP : PASS 
	InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS 
	InfiniBand-Verification-2-Reboot :IMB PingPong Intranode : PASS 
	InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS 
	InfiniBand-Verification-2-Reboot : IMB-P2P : PASS 
	InfiniBand-Verification-2-Reboot : IMB-NBC : PASS 
```