### PR TITLE
Added no VM reboot option in CPU offline testing iterations

### DIFF
--- a/Testscripts/Windows/CPU-Offline.ps1
+++ b/Testscripts/Windows/CPU-Offline.ps1
@@ -101,7 +101,7 @@ function Main {
 		}
 
 		for ($loopCount = 1;$loopCount -le $max_stress_count;$loopCount++) {
-			if ($vm_reboot -eq "yes") {
+			if (($vm_reboot -eq "yes") -or ($loopCount -eq 1)) {
 				# ##################################################################################
 				# Reboot VM
 				Write-LogInfo "Rebooting VM! - Loop Count: $loopCount"

--- a/Testscripts/Windows/CPU-Offline.ps1
+++ b/Testscripts/Windows/CPU-Offline.ps1
@@ -108,6 +108,7 @@ function Main {
 				$TestProvider.RestartAllDeployments($AllVMData)
 			} else {
 				Write-LogInfo "Loop Count: $loopCount"
+				Start-Sleep -second 60
 			}
 			# Feature test and stress test case with $local_script
 			# Running the local test script

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -721,4 +721,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>DEFAULT_HB_LOOP_COUNT</ReplaceThis>
 		<ReplaceWith>50</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>CPU_OFFLINE_VM_REBOOT</ReplaceThis>
+		<ReplaceWith>yes</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -778,7 +778,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
-            <param>vm_reboot=yes</param>
+            <param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
@@ -795,7 +795,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
-            <param>vm_reboot=yes</param>
+            <param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -778,6 +778,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
+            <param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
@@ -794,6 +795,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
+            <param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -778,6 +778,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
+            <param>vm_reboot=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>
@@ -794,6 +795,7 @@
         <TestParameters>
             <param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
             <param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
+            <param>vm_reboot=yes</param>
         </TestParameters>
         <Platform>Azure</Platform>
         <Category>Functional</Category>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -273,7 +273,7 @@
 			<param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
 			<param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
 			<param>maxIteration=MAX_CPU_OFFLINEONLINE</param>
-			<param>vm_reboot=yes</param>
+			<param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Stress</Category>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -273,6 +273,7 @@
 			<param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
 			<param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
 			<param>maxIteration=MAX_CPU_OFFLINEONLINE</param>
+			<param>vm_reboot=yes</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Stress</Category>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -273,6 +273,7 @@
 			<param>repo_url=CPU_CUSTOM_KERNEL_URL</param>
 			<param>repo_branch=CPU_CUSTOM_KERNEL_BRANCH</param>
 			<param>maxIteration=MAX_CPU_OFFLINEONLINE</param>
+			<param>vm_reboot=CPU_OFFLINE_VM_REBOOT</param>
 		</TestParameters>
 		<Platform>Azure</Platform>
 		<Category>Stress</Category>


### PR DESCRIPTION
On-demand change of no VM reboot in the iterative testing.
Added default value of CPU_OFFLINE_VM_REBOOT

**TEST RESULTS**

[LISAv2 Test Results Summary]
Test Run On           : 07/01/2020 05:12:12
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.8.0-rc1+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:34

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 STRESS-CPU-OFFLINE-ONLINE                                                         PASS                92.37

[LISAv2 Test Results Summary]
Test Run On           : 07/01/2020 15:24:31
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Initial Kernel Version: 4.15.0-1089-azure
Final Kernel Version  : 5.8.0-rc1+
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:51

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 STRESS-CPU-OFFLINE-ONLINE                                                         PASS                108.6