### PR TITLE
add '-OverrideVMSize' to be measured by LISAv2 for selecting TestLocation automatically

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -241,6 +241,9 @@ Class TestController
 		$vmSizes | ForEach-Object {
 			if ($_ -and !($AllTestVMSizes.$_)) { $AllTestVMSizes["$_"] = @{} }
 		}
+		$this.OverrideVMSize | ForEach-Object {
+			if ($_ -and !($AllTestVMSizes.$_)) { $AllTestVMSizes["$_"] = @{} }
+		}
 		# Inject custom parameters
 		if ($CustomTestParameters) {
 			Write-LogInfo "Checking custom parameters ..."


### PR DESCRIPTION
add '-OverrideVMSize' to be measured by LISAv2 for selecting TestLocation automatically

========Test Log==========================
[LISAv2 Test Results Summary]
Test Run On           : 07/07/2020 07:11:17
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size      : Standard_L80s_v2
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1028-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 PERF-NVME-4K-IO                                                                   PASS                 9.51 
	Mode=randread : block_size=4K q_depth=80 iops=167592.845173 
	Mode=randread : block_size=4K q_depth=160 iops=1656818.045497 
	Mode=randread : block_size=4K q_depth=320 iops=2547562.024097 
	Mode=randread : block_size=4K q_depth=640 iops=3429972.994109 
	Mode=randread : block_size=4K q_depth=1280 iops=3643441.290529 
	Mode=randread : block_size=4K q_depth=2560 iops=3680651.002707 
	Mode=randread : block_size=4K q_depth=5120 iops=3680840.823630 
	Mode=randread : block_size=4K q_depth=10240 iops=3673482.759003 
	Mode=randread : block_size=4K q_depth=20480 iops=3674479.366921 


Logs can be found at C:\LISAv2\DJ35\TestResults\2020-07-07-07-10-40-1331


07/07/2020 07:23:43 : [DEBUG] Creating 'C:\LISAv2\DJ35\Azure-DJ35-TestLogs.zip' from 'C:\LISAv2\DJ35\TestResults\2020-07-07-07-10-40-1331'
07/07/2020 07:23:46 : [DEBUG] C:\LISAv2\DJ35\Azure-DJ35-TestLogs.zip created successfully.
07/07/2020 07:23:46 : [INFO ] Analyzing test results ...
07/07/2020 07:23:46 : [INFO ] LISAv2 exit code: 0
