### PR TITLE
Multi OverrideVMSize supported in Measure-SubscriptionCapabilities

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -241,7 +241,7 @@ Class TestController
 		$vmSizes | ForEach-Object {
 			if ($_ -and !($AllTestVMSizes.$_)) { $AllTestVMSizes["$_"] = @{} }
 		}
-		$this.OverrideVMSize | ForEach-Object {
+		$this.OverrideVMSize.Split(", ").Trim() | ForEach-Object {
 			if ($_ -and !($AllTestVMSizes.$_)) { $AllTestVMSizes["$_"] = @{} }
 		}
 		# Inject custom parameters


### PR DESCRIPTION
Add support for multi values in '-OverrideVMSize' 

Commands:
.\Run-LisaV2.ps1 -TestLocation 'westus2' -RGIdentifier 'harzTest' -TestPlatform 'Azure' -StorageAccount 'ExistingStorage_Standard' -VMGeneration '1' -EnableTelemetry -ARMImageName 'Canonical UbuntuServer 18.04-LTS latest' -TestNames 'PERF-NVME-4K-IO' -OverrideVMSize 'Standard_L80s_v2,Standard_L48s_v2' -ResourceCleanup 'Default' -XMLSecretFile '****' -CustomTestParameters

===========Test Logs=====================
[LISAv2 Test Results Summary]
Test Run On           : 07/07/2020 17:14:44
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size      : Standard_L80s_v2,Standard_L48s_v2
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1028-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:23

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 PERF-NVME-4K-IO-Standard_L80s_v2                                                  PASS                 9.44 
	Mode=randread : block_size=4K q_depth=80 iops=271920.711669 
	Mode=randread : block_size=4K q_depth=160 iops=1611160.450142 
	Mode=randread : block_size=4K q_depth=320 iops=2462396.861443 
	Mode=randread : block_size=4K q_depth=640 iops=3370450.519679 
	Mode=randread : block_size=4K q_depth=1280 iops=3667019.641626 
	Mode=randread : block_size=4K q_depth=2560 iops=3699065.074294 
	Mode=randread : block_size=4K q_depth=5120 iops=3680282.981145 
	Mode=randread : block_size=4K q_depth=10240 iops=3699650.235546 
	Mode=randread : block_size=4K q_depth=20480 iops=3677874.000735 
    2 NVME                 PERF-NVME-4K-IO-Standard_L48s_v2                                                  PASS                 8.58 
	Mode=randread : block_size=4K q_depth=48 iops=159146.864409 
	Mode=randread : block_size=4K q_depth=96 iops=1247472.439111 
	Mode=randread : block_size=4K q_depth=192 iops=1851865.385158 
	Mode=randread : block_size=4K q_depth=384 iops=2131507.313309 
	Mode=randread : block_size=4K q_depth=768 iops=2189894.515530 
	Mode=randread : block_size=4K q_depth=1536 iops=2195004.972183 
	Mode=randread : block_size=4K q_depth=3072 iops=2195960.963585 
	Mode=randread : block_size=4K q_depth=6144 iops=2201225.440298 
	Mode=randread : block_size=4K q_depth=12288 iops=2203746.489555 


Logs can be found at C:\LISAv2\FP31\TestResults\2020-07-07-17-13-57-0502


07/07/2020 17:38:27 : [DEBUG] Creating 'C:\LISAv2\FP31\Azure-FP31-TestLogs.zip' from 'C:\LISAv2\FP31\TestResults\2020-07-07-17-13-57-0502'
07/07/2020 17:38:31 : [DEBUG] C:\LISAv2\FP31\Azure-FP31-TestLogs.zip created successfully.
07/07/2020 17:38:31 : [INFO ] Analyzing test results ...
07/07/2020 17:38:31 : [INFO ] LISAv2 exit code: 0