### PR TITLE
Verify FS/GS registers enabled

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -93,5 +93,45 @@ if [ $NUM_PASS -ne "$(wc -w <<< $SAMPLES)" ]; then
     SetTestStateFailed
     exit 1
 fi
+
+echo "----- Running FS/GS Enabled Test -----"
+cd ~
+cat <<EOF >main.c
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+
+#define handle_error(msg) \
+    do { perror(msg); exit(-1); } while (0)
+
+static void handler(int sig, siginfo_t *si, void *unused)
+{
+    exit(-1);
+}
+
+int main() {
+    struct sigaction sa;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_sigaction = handler;
+    if (sigaction(SIGILL, &sa, NULL) == -1)
+        handle_error("sigaction");
+
+    volatile unsigned long x;
+    __asm__ volatile ( "rdfsbase %0" : "=r" (x) );
+    __asm__ volatile ( "wrfsbase %0" :: "r" (x) );
+    __asm__ volatile ( "rdgsbase %0" : "=r" (x) );
+    __asm__ volatile ( "wrgsbase %0" :: "r" (x) );
+    printf("SUCCESS\n");
+    exit(0);
+}
+EOF
+gcc -o test-fsgs-enabled ./main.c
+if [[ "$(./test-fsgs-enabled)" != "SUCCESS" ]]; then
+    SetTestStateFailed
+    exit 1
+fi
+
 SetTestStateCompleted
 exit 0


### PR DESCRIPTION
## Description
SGX-LKL and OpenEnclave SDK rely on FS/GS registers to be enabled. This kernel support was introduced since Jun 11, 2020.

## Design Decision
- Combine new test with existing SGX test case. This avoids starting a new VM.
- Technically, FS/GS support is enabled on all VM types and in all regions. But since this feature (mainly?) affects us ACC team, we run it with our test case.

## Testing Results:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/08/2020 05:07:13
ARM Image Under Test  : Canonical : UbuntuServer : 18_04-lts-gen2 : latest
Initial Kernel Version: 5.3.0-1028-azure
Final Kernel Version  : 5.3.0-1028-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8
ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 4.71
```

```
[LISAv2 Test Results Summary]
Test Run On           : 07/08/2020 05:56:19
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Initial Kernel Version: 4.15.0-1089-azure
Final Kernel Version  : 4.15.0-1089-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 4.35
```