### PR TITLE
Add validation for load module intel_sgx

### DIFF
--- a/Testscripts/Windows/VALIDATE-INTEL-SGX-DRIVER.ps1
+++ b/Testscripts/Windows/VALIDATE-INTEL-SGX-DRIVER.ps1
@@ -20,6 +20,17 @@ function Main {
 
     $ubuntuVersion = Run-LinuxCmd -Command "cat /etc/issue" `
         -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort
+
+    if (($ubuntuVersion -imatch "Ubuntu 18.04") -or ($ubuntuVersion -imatch "Ubuntu 16.04") -or ($ubuntuVersion -imatch "Ubuntu 20.04") -or ($ubuntuVersion -imatch "Ubuntu 19.10")) {
+        $retVal = Run-LinuxCmd -Command "lsmod | grep -i intel_sgx" -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort -ignoreLinuxExitCode
+        if (!$retVal) {
+            Write-LogErr "Module intel_sgx not load automatically."
+            return "FAIL"
+        } else {
+            Write-LogInfo "Module intel_sgx load automatically - $retVal."
+        }
+    }
+
     if (($ubuntuVersion -notmatch "Ubuntu 18.04") -and ($ubuntuVersion -notmatch "Ubuntu 16.04")) {
         $shortUbuntuVersion = $ubuntuVersion.replace(" \n \l","")
         Write-LogInfo "$shortUbuntuVersion is not supported! Test skipped!"


### PR DESCRIPTION
OESDK does not support Ubuntu 20.04 now, but we need check if the intel_sgx module load automatically or not.

Test results - 

```
07/11/2020 13:11:34 : [DEBUG] .\Tools\plink.exe -ssh -t -i ppkfile -P 22 lisa@51.132.218.37 "lsmod | grep -i intel_sgx"
07/11/2020 13:11:36 : [DEBUG] lsmod | grep -i intel_sgx executed successfully in 2.08 seconds.
07/11/2020 13:11:36 : [INFO ] Module intel_sgx load automatically - intel_sgx              28672  0.

[LISAv2 Test Results Summary]
Test Run On           : 07/11/2020 13:08:28
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Initial Kernel Version: 4.15.0-1091-azure
Final Kernel Version  : 4.15.0-1091-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 3.76 
```

```
07/11/2020 12:52:06 : [DEBUG] .\Tools\plink.exe -ssh -t -i ppkfile -P 22 lisa@51.132.218.102 "lsmod | grep -i intel_sgx"
07/11/2020 12:52:08 : [DEBUG] Command execution returned return code 1 Ignoring..
07/11/2020 12:52:08 : [ERROR] Module intel_sgx not load automatically.
[LISAv2 Test Results Summary]
Test Run On           : 07/11/2020 12:48:13
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts-gen2 : latest
Initial Kernel Version: 5.4.0-1020-azure
Final Kernel Version  : 5.4.0-1020-azure
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               FAIL                 1.52 
```

```
07/11/2020 13:00:55 : [DEBUG] .\Tools\plink.exe -ssh -t -i ppkfile -P 22 lisa@20.49.202.173 "lsmod | grep -i intel_sgx"
07/11/2020 13:00:58 : [DEBUG] lsmod | grep -i intel_sgx executed successfully in 2.29 seconds.
07/11/2020 13:00:58 : [INFO ] Module intel_sgx load automatically - intel_sgx              32768  0.

[LISAv2 Test Results Summary]
Test Run On           : 07/11/2020 12:57:23
ARM Image Under Test  : Canonical : UbuntuServer : 18_04-lts-gen2 : latest
Initial Kernel Version: 5.3.0-1032-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 6.31 
```

```
07/11/2020 11:52:22 : [DEBUG] .\Tools\plink.exe -ssh -t -i ppkfile -P 22 lisa@51.11.141.33 "lsmod | grep -i intel_sgx"
07/11/2020 11:52:24 : [DEBUG] lsmod | grep -i intel_sgx executed successfully in 2.13 seconds.
07/11/2020 11:52:24 : [INFO ] Module intel_sgx load automatically - intel_sgx              32768  0.
[LISAv2 Test Results Summary]
Test Run On           : 07/11/2020 11:49:07
ARM Image Under Test  : Canonical : UbuntuServer : 19_10-daily-gen2 : latest
Initial Kernel Version: 5.3.0-1032-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                            SKIPPED                 1.08 
```