### PR TITLE
Add a ignorable failed log

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -30,6 +30,7 @@
             <keywords>hv-fcopy-daemon.service: Main process exited, code=exited, status=1/FAILURE</keywords>
             <keywords>hv-fcopy-daemon.service: Failed with result 'exit-code'</keywords>
             <keywords>dnf.*: Failed determining last makecache time</keywords>
+            <keywords>dbus-daemon.*: .system. Activation via systemd failed for unit 'dbus-org.freedesktop.resolve1.service': Unit dbus-org.freedesktop.resolve1.service not found.</keywords>
         </failures>
         <errors>
             <keywords>TLS record write failed</keywords>


### PR DESCRIPTION
There's a new failed log need to be ignored in RHEL-8.3:
dbus-daemon[696]: [system] Activation via systemd failed for unit 'dbus-org.freedesktop.resolve1.service': Unit dbus-org.freedesktop.resolve1.service not found.
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1855252

Test result(only test the VERIFY-BOOT-ERROR-WARNINGS.py):
```
07/14/2020 10:10:18 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: /var/log/messages:3192:Jul 13 15:18:04 wala83f107130643-vm1 dbus-daemon[660]: [system] Activation via systemd failed for unit 'dbus-org.freedesktop.resolve1.service': Unit dbus-org.freedesktop.resolve1.service not found.
```