### PR TITLE
Fix Write-WarnInfo with Write-Warning

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -124,7 +124,7 @@ function Start-LISAv2 {
 				$paramValue = (Get-Variable -Name $paramName -ErrorAction "SilentlyContinue").Value
 				if ($paramValue) {
 					if ($paramTable.ContainsKey($paramName)) {
-						Write-WarnInfo "Duplicated parameter '$paramName' and overwrite with value: $($paramTable[$paramName]) -> $paramValue"
+						Write-LogWarn "Duplicated parameter '$paramName' and overwrite with value: $($paramTable[$paramName]) -> $paramValue"
 						$paramTable[$paramName] = $paramValue
 					} else {
 						Write-LogInfo "Setting parameter: $paramName = $paramValue"


### PR DESCRIPTION
There's no "Write-WarnInfo" powershell command, which causes failure at the beginning. Use "Write-LogWarn" instead.