### PR TITLE
add warning for OverrideVMSize

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -213,6 +213,9 @@ Function Add-SetupConfig {
             elseif ($Force) {
                 $test.SetupConfig.$ConfigName = $ConfigValue
             }
+            else {
+                Write-LogWarn "Pre-defined '$($test.SetupConfig.$ConfigName)' (instead of '$ConfigValue') is used as '<$ConfigName>' for test case '$($test.TestName)', if it's not expected, use '-ForceCustom' parameter of LISAv2 to force override it."
+            }
         }
     }
     if ($ConfigValue) {


### PR DESCRIPTION
Log warning for user to apply '-ForceCustom', if it's not expected.

e.g, testing without -ForceCustom like:
. 'C:\LISAv2\Run-LisaV2.ps1' -TestPlatform 'Azure' -RGIdentifier 'test-1m' -ARMImageName 'Canonical UbuntuServer 18.04-LTS Latest' -OverrideVMSize 'Standard_NC24rs_v3' -XMLSecretFile 'xxx.xml' -TestNames 'NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU' -ResourceCleanup 'Delete'
===========Test Log======================

07/15/2020 18:17:59 : [INFO ] CUDA_DRIVER=10.1.105-1 injected to case NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU
**07/15/2020 18:18:00 : [WARN ] Pre-defined 'Standard_NC24' (instead of 'Standard_NC24rs_v3') is used as `'<OverrideVMSize>'` for test case 'NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU', if it's not expected, use '-ForceCustom' parameter of LISAv2 to force override it.**
07/15/2020 18:18:00 : [INFO ] Measure VM capabilities of current subscription...
07/15/2020 18:18:21 : [INFO ] Measure vCPUs, Family, and AvailableLocations for each test VM Size...