### PR TITLE
Refine testsetup and cleanup for azure platform.

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -73,7 +73,8 @@ function Start-LISAv2 {
 		[string] $ResultDBTestTag = "",
 
 		[switch] $ExitWithZero,
-		[switch] $ForceCustom
+		[switch] $ForceCustom,
+		[switch] $ReuseVmOnFailure
 	)
 
 	PROCESS {

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -213,6 +213,9 @@ Function Add-SetupConfig {
             elseif ($Force) {
                 $test.SetupConfig.$ConfigName = $ConfigValue
             }
+            else {
+                Write-LogWarn "Pre-defined '$($test.SetupConfig.$ConfigName)' (instead of '$ConfigValue') is used as '<$ConfigName>' for test case '$($test.TestName)', if it's not expected, use '-ForceCustom' parameter of LISAv2 to force override it."
+            }
         }
     }
     if ($ConfigValue) {

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -119,7 +119,8 @@ Param(
 	[string] $ResultDBTestTag = "",
 
 	[switch] $ExitWithZero,
-	[switch] $ForceCustom
+	[switch] $ForceCustom,
+	[switch] $ReuseVMOnFailure
 )
 
 

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -332,12 +332,6 @@ Class AzureController : TestController
 			# Only when 'OsVHD' exist from parameters, then we should Add-SetupConfig for 'VMGeneration',
 			#   because HyperVGeneration property for Azure Gallery Image is only decided by the 'ARMImageName' (Publisher, Provider, SKU, Version),
 			#   and from ARM template constraint, there's no Generation property to be applied when deploying with Gallery image with (Publisher, Provider, SKU, Version)
-			# If VMGeneration is null/empty, set the default value '1', so as to make LISAv2 backward compatible
-			if (!$this.VMGeneration) {
-				Write-Loginfo "'-VMGeneration' is not set for HyperV platform, set the default value '1'"
-				$this.VMGeneration = "1"
-				$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
-			}
 			if (("1", "2") -contains $this.CustomParams["VMGeneration"]) {
 				Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -Force $this.ForceCustom
 			}

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -112,6 +112,7 @@ Class TestController
 
 		$this.TestProvider.CustomKernel = $ParamTable["CustomKernel"]
 		$this.TestProvider.CustomLIS = $ParamTable["CustomLIS"]
+		$this.TestProvider.ReuseVmOnFailure = ($ParamTable.ContainsKey("ReuseVmOnFailure"))
 		$this.CustomParams = @{}
 		if ( $ParamTable.ContainsKey("CustomParameters") ) {
 			$ParamTable["CustomParameters"].Split(';').Trim() | ForEach-Object {
@@ -615,6 +616,12 @@ Class TestController
 					# unless '-ReuseVmOnFailure', keep $vmData as last failure environment, no new deployment behavior followed.
 					if ($this.TestProvider.ReuseVmOnFailure) {
 						Write-LogInfo "Keep deployed target machine for future reuse, as '-ReuseVmOnFailure' is True"
+						if($vmData) {
+							$isRestartSuccess = $this.TestProvider.RestartAllDeployments($vmData)
+							if (!$isRestartSuccess) {
+								&$CleanupResource -VmDataToBeDeleted ([ref]$vmData)
+							}
+						}
 					}
 					# unless '-ResourceCleanup = Delete', possibly means choose economy option for saving cost and resources
 					# unless '-UseExistingRG', preserve deployed VMs in the same RG will cause following Testing Aborted (names of resources are fixed in LISAv2)

--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -167,6 +167,25 @@ Class AzureProvider : TestProvider
 		return $false
 	}
 
+	[void] RunTestCaseCleanup ($AllVMData, $CurrentTestData, $CurrentTestResult, $CollectVMLogs, $RemoveFiles, $User, $Password, $SetupTypeData, $TestParameters){
+		try
+		{
+			if ($CurrentTestData.CleanupScript) {
+				foreach ($vmData in $AllVMData) {
+					foreach ($script in $($CurrentTestData.CleanupScript).Split(",")) {
+						$null = Run-SetupScript -Script $script -Parameters $TestParameters -VMData $vmData -CurrentTestData $CurrentTestData -TestProvider $this
+					}
+				}
+			}
+			([TestProvider]$this).RunTestCaseCleanup($AllVMData, $CurrentTestData, $CurrentTestResult, $CollectVMLogs, $RemoveFiles, $User, $Password, $SetupTypeData, $TestParameters)
+		}
+		catch
+		{
+			$ErrorMessage =  $_.Exception.Message
+			Write-Output "EXCEPTION in RunTestCaseCleanup : $ErrorMessage"
+		}
+	}
+
 	[void] RunTestCleanup() {
 		# Wait till all the cleanup background jobs successfully started cleanup of resource groups.
 		$DeleteResourceGroupJobs = Get-Job | Where-Object { $_.Name -imatch "DeleteResourceGroup" }

--- a/Testscripts/Windows/RemoveHardDisk.ps1
+++ b/Testscripts/Windows/RemoveHardDisk.ps1
@@ -22,7 +22,9 @@ function Main {
         $HvServer,
         $TestParams
     )
-
+    if ($global:TestPlatform -ne 'HyperV') {
+        return
+    }
     if ($null -eq $TestParams -or $TestParams.Length -lt 13) {
         # The minimum length testParams string is "IDE=1,1,Fixed"
         Write-LogErr "No testParams provided"

--- a/Testscripts/Windows/RemoveVhdxHardDisk.ps1
+++ b/Testscripts/Windows/RemoveVhdxHardDisk.ps1
@@ -144,6 +144,9 @@ function Main {
         $TestParams
     )
 
+    if ($global:TestPlatform -ne 'HyperV') {
+        return
+    }
     if ($null -eq $testParams -or $testParams.Length -lt 13) {
         # The minimum length testParams string is "IDE=1,1,Fixed
         Write-LogErr "No testParams provided"

--- a/Testscripts/Windows/SETUP-Remove-NVME-Disk.ps1
+++ b/Testscripts/Windows/SETUP-Remove-NVME-Disk.ps1
@@ -13,6 +13,9 @@ function Main {
     param (
         $TestParams, $AllVMData
     )
+    if ($global:TestPlatform -ne 'HyperV') {
+        return
+    }
     $currentTestResult = Create-TestResultObject
     try {
         $testResult = $null

--- a/Testscripts/Windows/SETUP-RemoveIsoFromDvd.ps1
+++ b/Testscripts/Windows/SETUP-RemoveIsoFromDvd.ps1
@@ -19,7 +19,9 @@ function Main {
         $HvServer,
         $TestParams
     )
-
+    if ($global:TestPlatform -ne 'HyperV') {
+        return
+    }
     $controllerNumber = $null
 
     # Check arguments


### PR DESCRIPTION
1. TestCase can define `<CleanupScript>` for itself to do cleanup/reset job and make it ready for the next TestCase to be run from the same setup group.
2. use the optional parameter '-ReuseVmOnFailure' to speedup your tests:  when there's a test case aborted/failed due to some reason, but user wants to reuse the VM instances for the next test case in queue, and get rid of the time cost for a new deployment (which is time consuming).    When the last aborted/failed test case cleanup script is finished (Test case will make sure it's fully cleanup/reset to an intial state for next test case), this '-ReuseVmOnFailure' option will restart VM instances and making sure it's VM-Alive, after that it will run the next test case as usual.   If the Restarting VM failed or VMInstance is not VM-Alive,  LISA will delete the VM resource and start another new deployment (which is current default behavior)
3.  To make backward compatible, as Azure Test Cases will not run `<CleanupScript>` before, only HyperV test cases will run CleanupScripts, so, just return for Azure TestPlatform from those existing cleanup scripts which have been used in the shared test casess (both targets for Azure and HyperV)

@yuxisun1217  Please take a look whether it address your requirement.  As @LiliDeng  commented, creating VM snapshot or backup is time consuming for most scenarios.  if we could not do cleanup/reset the VM by some cleanup scripts,  then deploy another VM in a new resource group (or -UseExistingRG) should be much more efficient than taking a snapshort/backup of VM, and restore the VM to original state for the next test case in queue.

==============Test Log =========================
. 'C:\LISAv2\Run-LisaV2.ps1' -TestPlatform 'Azure' -RGIdentifier 'test-1m' -ARMImageName 'Canonical UbuntuServer 18.04-LTS Latest' -OverrideVMSize 'Standard_DS1_v2' -XMLSecretFile 'xyz.xml' -TestNames 'LSVMBUS,NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU,VERIFY-DEPLOYMENT-PROVISION' -ResourceCleanup 'Delete' -ForceCustom -ReuseVMOnFailure

**I make the first test case aborted on purpose, and let LISA ReuseVmOnFailure, all following test cases get passed, with only one VM instance via one deployment in total.**

07/16/2020 05:36:21 : [INFO ] Prepare test log structure and start testing now ...
07/16/2020 05:36:21 : [INFO ] (1/3) testing started: NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU
07/16/2020 05:36:21 : [INFO ] SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM }
07/16/2020 05:36:21 : [INFO ] Deploy target machine for test if required 
...
07/16/2020 05:39:54 : [INFO ] End of testing: NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU with SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2 }, **result: ABORTED**
07/16/2020 05:39:54 : [INFO ] PASS    - 0
07/16/2020 05:39:54 : [INFO ] SKIPPED - 0
07/16/2020 05:39:54 : [INFO ] FAIL    - 0
07/16/2020 05:39:55 : [INFO ] ABORTED - 1
07/16/2020 05:39:55 : [INFO ] PENDING - 2 

**07/16/2020 05:39:55 : [INFO ] Keep deployed target machine for future reuse, as '-ReuseVmOnFailure' is True
07/16/2020 05:39:56 : [INFO ] Restarting LISAv2-OneVM-test-1m-CA48-20200715223632-role-0 from shell...**

07/16/2020 05:40:05 : [INFO ] Restart-VMFromShell executes successfully.
07/16/2020 05:40:07 : [INFO ] Trying to connect to deployed VMs.
07/16/2020 05:40:28 : [WARN ] TCP test failed
07/16/2020 05:40:28 : [INFO ] Connecting to 52.229.13.145 : 22 failed.
07/16/2020 05:40:28 : [INFO ] 1 VM(s) still waiting for port 22 open.
07/16/2020 05:40:28 : [INFO ] Retrying 1/50 in 3 seconds.
07/16/2020 05:40:31 : [INFO ] Connecting to 52.229.13.145 : 22 succeeded.
07/16/2020 05:40:31 : [INFO ] The SSH ports for all VMs are open.
07/16/2020 05:40:31 : [INFO ] (2/3) testing started: VERIFY-DEPLOYMENT-PROVISION
07/16/2020 05:40:31 : [INFO ] SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM }
07/16/2020 05:40:31 : [INFO ] Run test case against the target machine ...
07/16/2020 05:40:31 : [INFO ] ==> Run test setup script if defined.
07/16/2020 05:40:31 : [INFO ] ==> Check the target machine kernel log.
07/16/2020 05:40:31 : [INFO ] Collecting LISAv2-OneVM-test-1m-CA48-20200715223632-role-0 VM Kernel Initial Logs 
...

07/16/2020 05:42:48 : [INFO ] All files removed from current user lisa home folder successfully. VM IP : 52.229.13.145 PORT : 22
07/16/2020 05:42:49 : [INFO ] End of testing: VERIFY-DEPLOYMENT-PROVISION with SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2 }, **result: PASS**
07/16/2020 05:42:49 : [INFO ] PASS    - 1
07/16/2020 05:42:49 : [INFO ] SKIPPED - 0
07/16/2020 05:42:49 : [INFO ] FAIL    - 0
07/16/2020 05:42:49 : [INFO ] ABORTED - 1
07/16/2020 05:42:49 : [INFO ] PENDING - 1 

07/16/2020 05:42:49 : [INFO ] (3/3) testing started: LSVMBUS
07/16/2020 05:42:49 : [INFO ] SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM }
07/16/2020 05:42:49 : [INFO ] Run test case against the target machine ...
07/16/2020 05:42:49 : [INFO ] ==> Run test setup script if defined.
07/16/2020 05:42:49 : [INFO ] ==> Check the target machine kernel log.
07/16/2020 05:42:49 : [INFO ] Collecting LISAv2-OneVM-test-1m-CA48-20200715223632-role-0 VM Kernel Initial Logs 
...

07/16/2020 05:43:24 : [INFO ] All files removed from current user lisa home folder successfully. VM IP : 52.229.13.145 PORT : 22
07/16/2020 05:43:24 : [INFO ] End of testing: LSVMBUS with SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2 }, result: PASS
07/16/2020 05:43:24 : [INFO ] PASS    - 2
07/16/2020 05:43:24 : [INFO ] SKIPPED - 0
07/16/2020 05:43:24 : [INFO ] FAIL    - 0
07/16/2020 05:43:24 : [INFO ] ABORTED - 1
07/16/2020 05:43:24 : [INFO ] PENDING - 0 

07/16/2020 05:43:25 : [INFO ] Delete deployed target machine 
...
07/16/2020 05:43:33 : [INFO ] Test CA48 finished
07/16/2020 05:43:33 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 07/16/2020 05:36:21
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Override VM size Under Test  : Standard_DS1_v2
Initial Kernel Version: 5.3.0-1032-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 3 (2 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU                                          ABORTED                 1.12 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.29 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    3 CORE                 LSVMBUS                                                                           PASS                 0.59 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: westus2


Logs can be found at C:\LISAv2\TestResults\2020-07-15-22-34-32-0293


07/16/2020 05:43:33 : [DEBUG] Creating 'C:\LISAv2\Azure-CA48-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-07-15-22-34-32-0293'
07/16/2020 05:43:33 : [DEBUG] C:\LISAv2\Azure-CA48-TestLogs.zip created successfully.
07/16/2020 05:43:33 : [INFO ] Analyzing test results ...
07/16/2020 05:43:33 : [INFO ] LISAv2 exit code: 1