### PR TITLE
Escape the character when replace the string in XML file.

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -151,8 +151,12 @@ Class TestController
 				$CurrentXMLText = Get-Content -Path $file.FullName
 				foreach ($Replace in $this.XMLSecrets.secrets.ReplaceTestXMLStrings.Replace)
 				{
-					$ReplaceString = $Replace.Split("=")[0]
-					$ReplaceWith = $Replace.Split("=")[1]
+					if ($Replace.InnerText) {
+						$Replace.InnerText = [System.Security.SecurityElement]::Escape($Replace.InnerText)
+						$ReplaceString, $ReplaceWith = $Replace.InnerText -split '=',2
+					} else {
+						$ReplaceString, $ReplaceWith = $Replace -split '=',2
+					}
 					if ($CurrentXMLText -imatch $ReplaceString)
 					{
 						$content = [System.IO.File]::ReadAllText($file.FullName).Replace($ReplaceString,$ReplaceWith)


### PR DESCRIPTION
Handle this situation - when use string which contains special character like &. 
Will use sasurl for NESTED_IMAGE_UR in internal secret file.