### PR TITLE
ntttcpTest.log was removed, fix nested cases

### DIFF
--- a/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_nat.sh
+++ b/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_nat.sh
@@ -130,7 +130,6 @@ Collect_Logs() {
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcp-test-logs-receiver.tar /home/${NestedUser}"
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcp-test-logs-sender.tar /home/${NestedUser}"
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/report.log /home/${NestedUser}"
-    remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcpTest.log /home/${NestedUser}"
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcpConsoleLogs /home/${NestedUser}"
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/nested_properties.csv /home/${NestedUser}"
     check_exit_status "Get the NTTTCP report" "exit"

--- a/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_hyperv_ntttcp_different_l1_public_bridge.sh
@@ -127,7 +127,6 @@ Collect_Logs() {
     remote_exec -host $SERVER_IP_ADDR -user root -passwd $NestedUserPassword -port 22 "tar -cf ./ntttcp-test-logs-receiver.tar ./ntttcp-${testType}-test-logs-receiver"
     remote_copy -host $SERVER_IP_ADDR -user root -passwd $NestedUserPassword -port 22 -filename "ntttcp-test-logs-receiver.tar" -remote_path "/root" -cmd "get" 
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/report.log /home/${NestedUser}"
-    remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcpTest.log /home/${NestedUser}"
     remote_exec -host localhost -user root -passwd $NestedUserPassword -port 22 "mv /root/ntttcpConsoleLogs /home/${NestedUser}"
     check_exit_status "Get the NTTTCP report" "exit"
 }

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_nat.sh
@@ -214,7 +214,6 @@ Collect_Logs()
     Remote_Exec_Wrapper "root" $HOST_FWD_PORT  ". ./utils.sh && collect_VM_properties nested_properties.csv"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcp-test-logs-sender.tar" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcpConsoleLogs" "get"
-    Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcpTest.log" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "nested_properties.csv" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "report.log" "get"
 

--- a/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_different_l1_public_bridge.sh
@@ -195,7 +195,6 @@ Collect_Logs()
     Remote_Exec_Wrapper "root" $HOST_FWD_PORT  ". ./utils.sh && collect_VM_properties nested_properties.csv"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcp-test-logs-sender.tar" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcpConsoleLogs" "get"
-    Remote_Copy_Wrapper "root" $HOST_FWD_PORT "ntttcpTest.log" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "nested_properties.csv" "get"
     Remote_Copy_Wrapper "root" $HOST_FWD_PORT "report.log" "get"
 

--- a/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
@@ -219,7 +219,6 @@ Collect_Logs() {
 	Remote_Exec_Wrapper "root" $CLIENT_HOST_FWD_PORT ". utils.sh  && collect_VM_properties nested_properties.csv"
 	Remote_Copy_Wrapper "root" $CLIENT_HOST_FWD_PORT "ntttcp-test-logs-sender.tar" "get"
 	Remote_Copy_Wrapper "root" $CLIENT_HOST_FWD_PORT "ntttcpConsoleLogs" "get"
-	Remote_Copy_Wrapper "root" $CLIENT_HOST_FWD_PORT "ntttcpTest.log" "get"
 	Remote_Copy_Wrapper "root" $CLIENT_HOST_FWD_PORT "nested_properties.csv" "get"
 	Remote_Exec_Wrapper "root" $SERVER_HOST_FWD_PORT "mv ./ntttcp-${testType}-test-logs ./ntttcp-${testType}-test-logs-receiver"
 	Remote_Exec_Wrapper "root" $SERVER_HOST_FWD_PORT "tar -cf ./ntttcp-test-logs-receiver.tar ./ntttcp-${testType}-test-logs-receiver"

--- a/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-NAT.ps1
+++ b/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-NAT.ps1
@@ -616,7 +616,7 @@ function Main () {
 		Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$nestedUser/nested_properties.csv" -downloadTo $LogDir -port $nestVMClientSSHPort -username $nestedUser -password $nestedPassword
 
 		if ($testResult -imatch $resultPass) {
-			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$nestedUser/ntttcpConsoleLogs, /home/$nestedUser/ntttcpTest.log" -downloadTo $LogDir -port $nestVMClientSSHPort -username $nestedUser -password $nestedPassword
+			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$nestedUser/ntttcpConsoleLogs" -downloadTo $LogDir -port $nestVMClientSSHPort -username $nestedUser -password $nestedPassword
 			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$nestedUser/nested_properties.csv, /home/$nestedUser/report.log" -downloadTo $LogDir -port $nestVMClientSSHPort -username $nestedUser -password $nestedPassword
 			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$nestedUser/ntttcp-test-logs-receiver.tar, /home/$nestedUser/ntttcp-test-logs-sender.tar" -downloadTo $LogDir -port $nestVMClientSSHPort -username $nestedUser -password $nestedPassword
 

--- a/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
+++ b/Testscripts/Windows/NESTED-HYPERV-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
@@ -337,7 +337,7 @@ function Main () {
 
 		if ($testResult -imatch $resultPass)
 		{
-			Copy-RemoteFiles -download -downloadFrom $nttcpClientIP -files "/home/$nestedUser/ntttcpConsoleLogs, /home/$nestedUser/ntttcpTest.log" -downloadTo $LogDir -port $nestVMSSHPort -username $nestedUser -password $nestedPassword
+			Copy-RemoteFiles -download -downloadFrom $nttcpClientIP -files "/home/$nestedUser/ntttcpConsoleLogs" -downloadTo $LogDir -port $nestVMSSHPort -username $nestedUser -password $nestedPassword
 			Copy-RemoteFiles -download -downloadFrom $nttcpClientIP -files "/home/$nestedUser/nested_properties.csv, /home/$nestedUser/report.log" -downloadTo $LogDir -port $nestVMSSHPort -username $nestedUser -password $nestedPassword
 			Copy-RemoteFiles -download -downloadFrom $nttcpClientIP -files "/home/$nestedUser/ntttcp-test-logs-receiver.tar, /home/$nestedUser/ntttcp-test-logs-sender.tar" -downloadTo $LogDir -port $nestVMSSHPort -username $nestedUser -password $nestedPassword
 

--- a/Testscripts/Windows/NESTED-KVM-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
+++ b/Testscripts/Windows/NESTED-KVM-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
@@ -168,7 +168,7 @@ function Main () {
 
 		if ($testResult -imatch $resultPass)
 		{
-			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$user/ntttcpConsoleLogs, /home/$user/ntttcpTest.log" -downloadTo $LogDir -port $hs2vm1sshport -username $user -password $password
+			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$user/ntttcpConsoleLogs" -downloadTo $LogDir -port $hs2vm1sshport -username $user -password $password
 			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$user/nested_properties.csv, /home/$user/report.log" -downloadTo $LogDir -port $hs2vm1sshport -username $user -password $password
 			Copy-RemoteFiles -download -downloadFrom $hs2VIP -files "/home/$user/ntttcp-test-logs-receiver.tar, /home/$user/ntttcp-test-logs-sender.tar" -downloadTo $LogDir -port $hs2vm1sshport -username $user -password $password
 

--- a/Testscripts/Windows/NESTED-KVM-NTTTCP-PRIVATE-BRIDGE.ps1
+++ b/Testscripts/Windows/NESTED-KVM-NTTTCP-PRIVATE-BRIDGE.ps1
@@ -139,7 +139,7 @@ function Main {
         Copy-RemoteFiles -download -downloadFrom $hs1VIP -files "/home/$user/VM_properties.csv" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 
         if ($testResult -imatch $resultPass) {
-            $files = "/home/$user/ntttcpConsoleLogs, /home/$user/ntttcpTest.log, /home/$user/report.log, /home/$user/nested_properties.csv"
+            $files = "/home/$user/ntttcpConsoleLogs, /home/$user/report.log, /home/$user/nested_properties.csv"
             Copy-RemoteFiles -download -downloadFrom $hs1VIP -files $files -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
             $files = "/home/$user/ntttcp-test-logs-receiver.tar, /home/$user/ntttcp-test-logs-sender.tar"
             Copy-RemoteFiles -download -downloadFrom $hs1VIP -files $files -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password


### PR DESCRIPTION

PR #907 remove ntttcpTest.log, it breaks nested test cases.

```
[LISAv2 Test Results Summary]
Test Run On           : 07/18/2020 06:53:00
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Initial Kernel Version: 5.3.0-1032-azure
Final Kernel Version  : 5.3.0-1034-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               AZURE-NESTED-KVM-NTTTCP-DIFFERENT-L1-NAT                                          PASS                37.27 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_E16s_v3, SetupType: TwoVM2NIC, TestLocation: eastus2
    2 NESTED               NESTED-KVM-NTTTCP-PRIVATE-BRIDGE                                                  PASS                29.26 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_E16s_v3, SetupType: OneVM, TestLocation: eastus2
```