### PR TITLE
Add new case: VERIFY-UIO-DRIVER

### DIFF
--- a/Testscripts/Linux/verify_uio_driver.sh
+++ b/Testscripts/Linux/verify_uio_driver.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+########################################################################
+#
+# Description:
+#       This script was created to verify the uio_hv_generic module.
+#
+#       The test performs the following steps:
+#         1. Assign a NIC to uio_hv_generic driver and check the uio device
+#         2. Restore to hv_netvsc and check the eth1
+#
+########################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "ERROR: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+#######################################################################
+# Pre-settings & Functions
+#######################################################################
+# Check distro and kernel version
+case "$DISTRO" in
+    redhat_7)
+        if ! CheckVMFeatureSupportStatus "3.10.0-692"; then
+            LogMsg "INFO: this kernel version does not support uio feature, skip test"
+            UpdateSummary "INFO: this kernel version does not support uio feature, skip test"
+            SetTestStateSkipped
+            exit 0
+        fi
+        ;;
+    redhat_8)
+        UpdateSummary "$DISTRO support uio feature. Continue."
+        ;;
+    # TODO: Need to add other distros support, e.g. Ubuntu/SLES...
+    *)
+        LogMsg "$Distro is not supported in this case now. Skip."
+        SetTestStateSkipped
+        exit 0
+        ;;
+esac
+
+# Get device_id and class_id
+device_id=$(cat /sys/class/net/eth1/device/device_id | tr -d '{}')
+class_id=$(cat /sys/class/net/eth1/device/class_id | tr -d '{}')
+
+function register_uio() {
+    LogMsg "Register eth1 to uio"
+    output=$(modprobe uio_hv_generic 2>&1)
+    lsmod | grep uio_hv_generic
+    VerifyExitCodeZero "Verify uio_hv_generic is loaded"
+
+    [ -z "$output" ]
+    VerifyExitCodeZero "Verify no output while modprobing uio_hv_generic" "Output: $output"
+
+    echo ${class_id} > /sys/bus/vmbus/drivers/uio_hv_generic/new_id
+    echo ${device_id} > /sys/bus/vmbus/drivers/hv_netvsc/unbind
+    echo ${device_id} > /sys/bus/vmbus/drivers/uio_hv_generic/bind
+    # Verify /dev/uio0 exists
+    [ -e /dev/uio0 ]
+    VerifyExitCodeZero "Verify /dev/uio0 exists"
+}
+
+function recovery() {
+    LogMsg "Restore to hv_netvsc"
+    echo ${device_id} > /sys/bus/vmbus/drivers/uio_hv_generic/unbind
+    echo ${device_id} > /sys/bus/vmbus/drivers/hv_netvsc/bind
+    # Verify uio0 is removed and eth1 exists
+    [ ! -e /dev/uio0 ]
+    VerifyExitCodeZero "Verify /dev/uio0 is removed"
+    ip addr show eth1
+    VerifyExitCodeZero "Verify eth1 exists"
+    # Remove uio_hv_generic module
+    rmmod uio_hv_generic
+    VerifyExitCodeZero "rmmod uio_hv_generic"
+    lsmod | grep uio_hv_generic
+    VerifyExitCodeNotZero "Remove uio_hv_generic"
+}
+
+register_uio
+recovery
+
+SetTestStateCompleted

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -968,4 +968,21 @@
 	<SetupType>OneVM</SetupType>
 	</SetupConfig>
 </test>
+<test>
+	<testName>VERIFY-UIO-DRIVER</testName>
+	<testScript>verify_uio_driver.sh</testScript>
+	<files>.\Testscripts\Linux\verify_uio_driver.sh,.\Testscripts\Linux\utils.sh</files>
+	<TestParameters>
+	<param>NIC_1=NetworkAdapter,None,InvalidNIC</param>
+	</TestParameters>
+	<Platform>Azure,HyperV</Platform>
+	<Category>Functional</Category>
+	<Area>CORE</Area>
+	<Tags>uio,network</Tags>
+	<Priority>2</Priority>
+	<SetupConfig>
+	<SetupType>OneVM2NIC</SetupType>
+	<setupScript>.\Testscripts\Windows\SETUP-NET-Add-NIC.ps1</setupScript>
+	</SetupConfig>
+</test>
 </TestCases>


### PR DESCRIPTION
This case is for registering NIC to uio driver and then restore back to hv_netvsc.
The test performs the following steps:
         1. Assign a NIC to uio_hv_generic driver and check the uio device
         2. Restore to hv_netvsc and check the eth1

```
[LISAv2 Test Results Summary]
Test Run On           : 07/20/2020 06:28:55
Test Category         : Functional
Initial Kernel Version: 4.18.0-224.el8.x86_64
Final Kernel Version  : 4.18.0-224.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 UIO                  VERIFY-UIO-DRIVER                                                                 PASS                 2.35
      OsVHD: https://walaautol2.blob.core.windows.net/vhds/RHEL-8.3.0-20200715.n.0.vhd, SetupType: OneVM2NIC, TestLocation: eastus2, VMGeneration: 1
```