### PR TITLE
Speedup LISA testing when '-ReuseVmOnFailure' and kernel panic in last failed test case

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -621,7 +621,8 @@ Class TestController
 					$readyForReuseVM = $false
 					if ($this.TestProvider.ReuseVmOnFailure) {
 						Write-LogInfo "Try reuse VM instances from last deployment, as '-ReuseVmOnFailure' is True"
-						if($vmData) {
+						# Here the VM is not an initial state after provision, should be responsible immediately, but maybe already kernel panic or no response at all, so if VM is Not Alive after 3 retries, giving up the restart.
+						if($vmData -and ((Is-VmAlive -AllVMDataObject $vmData -MaxRetryCount 3) -eq "True")) {
 							$readyForReuseVM = $this.TestProvider.RestartAllDeployments($vmData)
 						}
 					}


### PR DESCRIPTION
=====Test Log==============

07/21/2020 18:40:32 : [INFO ] End of testing: NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU with SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: southcentralus }, result: ABORTED
07/21/2020 18:40:32 : [INFO ] PASS    - 0
07/21/2020 18:40:32 : [INFO ] SKIPPED - 0
07/21/2020 18:40:32 : [INFO ] FAIL    - 0
07/21/2020 18:40:32 : [INFO ] ABORTED - 1
07/21/2020 18:40:32 : [INFO ] PENDING - 2 

07/21/2020 18:40:32 : [INFO ] Try reuse VM instances from last deployment, as '-ReuseVmOnFailure' is True
07/21/2020 18:40:32 : [INFO ] Trying to connect to deployed VMs.
07/21/2020 18:40:32 : [INFO ] Connecting to 104.214.51.130 : 22 succeeded.
07/21/2020 18:40:32 : [INFO ] The SSH ports for all VMs are open.
07/21/2020 18:40:33 : [INFO ] Restarting LISAv2-OneVM-harz-test-VL68-20200721113623-role-0 from shell...
[LISAv2 Test Results Summary]
Test Run On           : 07/21/2020 18:36:13
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Override VM size Under Test  : Standard_DS1_v2
Initial Kernel Version: 5.3.0-1032-azure
Final Kernel Version  : 5.3.0-1032-azure
Total Test Cases      : 3 (2 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION-MAX-GPU                                          ABORTED                 1.64 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: southcentralus
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.47 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: southcentralus
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    3 CORE                 LSVMBUS                                                                           PASS                 0.89 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS1_v2, SetupType: OneVM, TestLocation: southcentralus


Logs can be found at C:\LISAv2\TestResults\2020-07-21-11-34-22-5843


07/21/2020 18:44:41 : [DEBUG] Creating 'C:\LISAv2\Azure-VL68-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-07-21-11-34-22-5843'
07/21/2020 18:44:41 : [DEBUG] C:\LISAv2\Azure-VL68-TestLogs.zip created successfully.
07/21/2020 18:44:41 : [INFO ] Analyzing test results ...
07/21/2020 18:44:42 : [INFO ] LISAv2 exit code: 1