### PR TITLE
Fix setting systemd config file for system v239

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
@@ -60,6 +60,20 @@ function Main {
         Provision-VMsForLisa -allVMData $allVMData -installPackagesOnRoleNames "none"
         #endregion
 
+        # Add a new line configuration in systemd logind.conf. UserTasksMax Sets the maximum number of OS tasks each user may run concurrently.
+        $setSystemdConfig = "sed -i '`$aUserTasksMax=122880' /etc/systemd/logind.conf"
+        foreach ($vmData in $allVMData) {
+            Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username "root" `
+                    -password $password -command $setSystemdConfig | Out-Null
+        }
+
+        # Restart VM to apply systemd setting
+        if (-not $TestProvider.RestartAllDeployments($allVMData)) {
+            Write-LogErr "Unable to connect to VM after restart!"
+            $currentTestResult.TestResult = "ABORTED"
+            return $currentTestResult
+        }
+
         Write-LogInfo "Getting Active NIC Name."
         if ($TestPlatform -eq "HyperV") {
             $clientNicName = Get-GuestInterfaceByVSwitch $TestParams.PERF_NIC $clientVMData.RoleName `
@@ -166,20 +180,24 @@ collect_VM_properties
                     $testType = "TCP"
                     $test_connections = ($line.Trim() -Replace " +"," ").Split(" ")[0]
                     $throughput_gbps = ($line.Trim() -Replace " +"," ").Split(" ")[1]
-                    $cycle_per_byte = ($line.Trim() -Replace " +"," ").Split(" ")[2]
+                    $cycles_per_byte = ($line.Trim() -Replace " +"," ").Split(" ")[2]
                     $average_tcp_latency = ($line.Trim() -Replace " +"," ").Split(" ")[3]
                     $txpackets_sender = ($line.Trim() -Replace " +"," ").Split(" ")[4]
                     $rxpackets_sender = ($line.Trim() -Replace " +"," ").Split(" ")[5]
                     $pktsInterrupt_sender = ($line.Trim() -Replace " +"," ").Split(" ")[6]
-                    $connResult = "throughput=$throughput_gbps`Gbps cyclePerBytet=$cycle_per_byte Avg_TCP_lat=$average_tcp_latency"
+                    $concreatedtime = ($line.Trim() -Replace " +"," ").Split(" ")[7]
+                    $retrans_segs = ($line.Trim() -Replace " +"," ").Split(" ")[8]
+                    $connResult = "throughput=$throughput_gbps`Gbps cyclesPerByte=$cycles_per_byte Avg_TCP_lat=$average_tcp_latency pktsPerInterrupt=$pktsInterrupt_sender conCreatedTime=$concreatedtime retransSegs=$retrans_segs"
                     $currentNtttcpResultObject["meta_data"]["connections"] = $test_connections
                     $currentNtttcpResultObject["meta_data"]["type"] = $testType
-                    $currentNtttcpResultObject["cycle_per_byte"] = $cycle_per_byte
+                    $currentNtttcpResultObject["cycles_per_byte"] = $cycles_per_byte
                     $currentNtttcpResultObject["tx_throughput_gbps"] = $throughput_gbps
                     $currentNtttcpResultObject["average_tcp_latency"] = $average_tcp_latency
                     $currentNtttcpResultObject["txpackets_sender"] = $txpackets_sender
                     $currentNtttcpResultObject["rxpackets_sender"] = $rxpackets_sender
                     $currentNtttcpResultObject["pktsInterrupt_sender"] = $pktsInterrupt_sender
+                    $currentNtttcpResultObject["concreatedtime"] = $concreatedtime
+                    $currentNtttcpResultObject["retrans_segs"] = $retrans_segs
                 }
                 $ntttcpResults += $currentNtttcpResultObject
                 $metadata = "Connections=$test_connections"
@@ -246,10 +264,13 @@ collect_VM_properties
                     $resultMap["DatagramLoss"] = $($Line[3])
                 } else {
                     $resultMap["Throughput_Gbps"] = $($Line[1])
+                    $resultMap["SenderCyclesPerByte"] = $($Line[2])
                     $resultMap["Latency_ms"] = $($Line[3])
                     $resultMap["TXpackets"] = $($Line[4])
                     $resultMap["RXpackets"] = $($Line[5])
                     $resultMap["PktsInterrupts"] = $($Line[6])
+                    $resultMap["ConnectionsCreatedTime"] = $($Line[7])
+                    $resultMap["RetransSegments"] = $($Line[8])
                 }
                 if ($TestPlatform -eq "Azure") {
                     $resultMap["NumberOfReceivers"] = $numberOfReceivers

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -453,7 +453,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_TCP_CONNECTIONS</ReplaceThis>
-		<ReplaceWith>(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240)</ReplaceWith>
+		<ReplaceWith>(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240 20480 40960 50000 55000)</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_MULTICLIENTS_TCP_CONNECTIONS</ReplaceThis>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -11,7 +11,7 @@
       <param>testDuration=NTTTCP_RUNTIME_IN_SECONDS</param>
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_TCP_CONNECTIONS</param>
-      <param>ntttcpVersion=NTTTCP_VERSION</param>
+      <param>ntttcpVersion=master</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure,HyperV</Platform>
@@ -37,7 +37,7 @@
       <param>testDuration=NTTTCP_RUNTIME_IN_SECONDS</param>
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_TCP_CONNECTIONS</param>
-      <param>ntttcpVersion=NTTTCP_VERSION</param>
+      <param>ntttcpVersion=master</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure,HyperV</Platform>
@@ -113,7 +113,7 @@
       <param>testDuration=NTTTCP_RUNTIME_IN_SECONDS</param>
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_MULTICLIENTS_TCP_CONNECTIONS</param>
-      <param>ntttcpVersion=NTTTCP_VERSION</param>
+      <param>ntttcpVersion=master</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure</Platform>
@@ -134,7 +134,7 @@
       <param>testDuration=NTTTCP_RUNTIME_IN_SECONDS</param>
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_MULTICLIENTS_TCP_CONNECTIONS</param>
-      <param>ntttcpVersion=NTTTCP_VERSION</param>
+      <param>ntttcpVersion=master</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure</Platform>


### PR DESCRIPTION
From systemd v239, the support for option UserTasksMax= in /etc/systemd/logind.conf has been removed. 
In systemd v239 and later, The user default is set via TasksMax= in /usr/lib/systemd/system/user-.slice.d/10-defaults.conf. 