### PR TITLE
Fix setting sysemd config file for systemd v239 version

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
@@ -60,12 +60,21 @@ function Main {
         Provision-VMsForLisa -allVMData $allVMData -installPackagesOnRoleNames "none"
         #endregion
 
-        # Add a new line configuration in systemd logind.conf. UserTasksMax Sets the maximum number of OS tasks each user may run concurrently.
-        $setSystemdConfig = "sed -i '`$aUserTasksMax=122880' /etc/systemd/logind.conf"
-        foreach ($vmData in $allVMData) {
-            Run-LinuxCmd -ip $vmData.PublicIP -port $vmData.SSHPort -username "root" `
-                    -password $password -command $setSystemdConfig | Out-Null
+        Write-LogInfo "Getting Systemd Version."
+        $getSystemdVersion = "systemctl --version | head -n1 | awk '{ print `$NF }'"
+        $systemdVersion = (Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
+            -username $user -password $password -command $getSystemdVersion ).Trim()
+        Write-LogInfo "Systemd Version is $systemdVersion. Set Systemd user config file..."
+
+        if (($systemdVersion -as [int]) -ge 239) {
+            # In systemd v239 and later, the user default is set via TasksMax= in /usr/lib/systemd/system/user-.slice.d/10-defaults.conf
+            $setSystemdConfig = "sed -i 's/TasksMax.*/TasksMax=122880/' /usr/lib/systemd/system/user-.slice.d/10-defaults.conf"
+        } else {
+            # Add a new line configuration in systemd logind.conf. UserTasksMax sets the maximum number of OS tasks each user may run concurrently.
+            $setSystemdConfig = "sed -i '`$aUserTasksMax=122880' /etc/systemd/logind.conf"
         }
+        Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username $user `
+                    -password $password -command $setSystemdConfig -runAsSudo | Out-Null
 
         # Restart VM to apply systemd setting
         if (-not $TestProvider.RestartAllDeployments($allVMData)) {

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -457,7 +457,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_MULTICLIENTS_TCP_CONNECTIONS</ReplaceThis>
-		<ReplaceWith>(8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240)</ReplaceWith>
+		<ReplaceWith>(8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240 20480 40960 50000 55000)</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_UDP_CONNECTIONS</ReplaceThis>


### PR DESCRIPTION
From systemd v239, the support for option UserTasksMax= in /etc/systemd/logind.conf has been removed.  In systemd v239 and later, The user default is set via TasksMax= in /usr/lib/systemd/system/user-.slice.d/10-defaults.conf. 

Extend 55000 connections for multi-client test.
