### PR TITLE
Fix setting instance size for ready platform

### DIFF
--- a/TestControllers/ReadyController.psm1
+++ b/TestControllers/ReadyController.psm1
@@ -103,6 +103,10 @@ Class ReadyController : TestController
 
 		Write-LogInfo "Setting global variables"
 		$this.SetGlobalVariables()
+
+		if ($this.OverrideVMSize) {
+			$this.TestProvider.InstanceSize = $this.OverrideVMSize
+		}
 	}
 
 	[void] SetGlobalVariables() {

--- a/TestProviders/ReadyProvider.psm1
+++ b/TestProviders/ReadyProvider.psm1
@@ -28,6 +28,8 @@ using Module ".\TestProvider.psm1"
 
 Class ReadyProvider : TestProvider
 {
+	[string]$InstanceSize
+
 	[object] DeployVMs([xml] $GlobalConfig, [object] $SetupTypeData, [object] $TestCaseData, [string] $TestLocation, [string] $RGIdentifier, [bool] $UseExistingRG, [string] $ResourceCleanup) {
 		function Create-QuickVMNode() {
 			$objNode = New-Object -TypeName PSObject
@@ -67,8 +69,8 @@ Class ReadyProvider : TestProvider
 		function SetInstanceSize([object] $AllVmData) {
 			$count = 0
 			foreach ($vmData in $AllVMData) {
-				if ($global:OverrideVMSize) {
-					$AllVmData[$count].InstanceSize = $global:OverrideVMSize
+				if ($this.InstanceSize) {
+					$AllVmData[$count].InstanceSize = $this.InstanceSize
 				} else {
 					$coreCount = Run-LinuxCmd -username $global:user -password $global:password -ip $($vmData.PublicIp) -port $($vmData.SSHPort) `
 						-command "cat /proc/cpuinfo | grep -c ^processor"


### PR DESCRIPTION
When -OverrideVMSize is specified for ready platform, set it as the VM instance size. 
This PR fix the problem due to previous change that removed the global OverrideVMSize, 