### PR TITLE
Fix bug of testing with TiP for FaultDomainCount and enable testing with multi predefined setup config

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -118,9 +118,6 @@ Function Assert-DeploymentLimitation($RGXMLData, [ref]$TargetLocation, $CurrentT
 		return $networkErrors
 	}
 
-	if ($CurrentTestData.SetupConfig.TiPSessionId -and $CurrentTestData.SetupConfig.TiPCluster) {
-		return $true
-	}
 	$VMGeneration = $CurrentTestData.SetupConfig.VMGeneration
 	$OsVHD = $CurrentTestData.SetupConfig.OsVHD
 	$overFlowErrors = 0
@@ -412,7 +409,7 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 	}
 }
 
-Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $RGIdentifier, [string]$TestLocation, $GlobalConfig, $TiPSessionId, $TipCluster, $UseExistingRG, $ResourceCleanup, $PlatformFaultDomainCount, $PlatformUpdateDomainCount, [boolean]$EnableNSG = $false) {
+Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $RGIdentifier, [string]$TestLocation, $GlobalConfig, $UseExistingRG, $ResourceCleanup, [boolean]$EnableNSG = $false) {
 	Function GenerateAzDeploymentJSONFile ($RGName, $ImageName, $osVHD, $RGXMLData, $Location, $azuredeployJSONFilePath, $StorageAccountName) {
 		#Random Data
 		$RGrandomWord = ([System.IO.Path]::GetRandomFileName() -replace '[^a-z]')
@@ -669,30 +666,22 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 				Add-Content -Value "$($indents[4])^name^: ^Aligned^" -Path $jsonFile
 				Add-Content -Value "$($indents[3])}," -Path $jsonFile
 			}
-			if ( $TiPSessionId -and $TiPCluster) {
+			if ($CurrentTestData.SetupConfig.TiPSessionId) {
 				Add-Content -Value "$($indents[3])^tags^:" -Path $jsonFile
 				Add-Content -Value "$($indents[3]){" -Path $jsonFile
-				Add-Content -Value "$($indents[4])^TipNode.SessionId^: ^$TiPSessionId^" -Path $jsonFile
+				Add-Content -Value "$($indents[4])^TipNode.SessionId^: ^$($CurrentTestData.SetupConfig.TiPSessionId)^" -Path $jsonFile
 				Add-Content -Value "$($indents[3])}," -Path $jsonFile
 			}
 
-			$faultDomainCount = 2
-			$updateDomainCount = 5
-			if ($PlatformFaultDomainCount) {
-				$faultDomainCount = $PlatformFaultDomainCount
-			}
-			if ($PlatformUpdateDomainCount) {
-				$updateDomainCount = $PlatformUpdateDomainCount
-			}
 			Add-Content -Value "$($indents[3])^properties^:" -Path $jsonFile
 			Add-Content -Value "$($indents[3]){" -Path $jsonFile
-			Add-Content -Value "$($indents[4])^platformFaultDomainCount^:$faultDomainCount," -Path $jsonFile
-			Add-Content -Value "$($indents[4])^platformUpdateDomainCount^:$updateDomainCount" -Path $jsonFile
-			if ( $TiPSessionId -and $TiPCluster) {
+			Add-Content -Value "$($indents[4])^platformFaultDomainCount^:$($CurrentTestData.SetupConfig.PlatformFaultDomainCount)," -Path $jsonFile
+			Add-Content -Value "$($indents[4])^platformUpdateDomainCount^:$($CurrentTestData.SetupConfig.PlatformUpdateDomainCount)" -Path $jsonFile
+			if ($CurrentTestData.SetupConfig.TiPCluster) {
 				Add-Content -Value "$($indents[4])," -Path $jsonFile
 				Add-Content -Value "$($indents[4])^internalData^:" -Path $jsonFile
 				Add-Content -Value "$($indents[4]){" -Path $jsonFile
-				Add-Content -Value "$($indents[5])^pinnedFabricCluster^ : ^$TiPCluster^" -Path $jsonFile
+				Add-Content -Value "$($indents[5])^pinnedFabricCluster^ : ^$($CurrentTestData.SetupConfig.TiPCluster)^" -Path $jsonFile
 				Add-Content -Value "$($indents[4])}" -Path $jsonFile
 			}
 			Add-Content -Value "$($indents[3])}" -Path $jsonFile
@@ -1637,6 +1626,9 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 		$validateStartTime = Get-Date
 		Write-LogInfo "Checking the subscription usage..."
 		$readyToDeploy = $false
+		if ($CurrentTestData.SetupConfig.TiPSessionId -and $CurrentTestData.SetupConfig.TiPCluster -and $CurrentTestData.SetupConfig.TestLocation) {
+			$readyToDeploy = $true
+		}
 		$coreCountExceededTimeout = 3600
 		while (!$readyToDeploy) {
 			$readyToDeploy = Assert-DeploymentLimitation -RGXMLData $RG -TargetLocation ([ref]$location) -CurrentTestData $CurrentTestData

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -113,7 +113,7 @@ Function Match-TestTag($currentTest, $TestTag)
 #
 Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $TestTag, $TestPriority, $ExcludeTests)
 {
-    $AllLisaTests = @()
+    $AllLisaTests =  [System.Collections.ArrayList]@()
     $WildCards = @('^','.','[',']','?','+','*')
     $ExcludedTestsCount = 0
 
@@ -190,7 +190,7 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
 
             if (!($AllLisaTests | Where-Object {$_.TestName -eq $test.TestName})) {
                 Write-LogInfo "Collected test: $($test.TestName) from $file"
-                $AllLisaTests += $test
+                $null = $AllLisaTests.Add($test)
             } else {
                 Write-LogWarn "Ignore duplicated test: $($test.TestName) from $file"
             }
@@ -199,50 +199,120 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
     if ($ExcludeTests) {
         Write-LogInfo "$ExcludedTestsCount Test Cases have been excluded"
     }
-    return $AllLisaTests
+    return ,$AllLisaTests
 }
 
 Function Add-SetupConfig {
-    param ([ref]$AllTests, [string]$ConfigName, [string]$ConfigValue, [string]$SplitBy = ',', [bool]$Force = $false)
+    param ([System.Collections.ArrayList]$AllTests, [string]$ConfigName, [string]$ConfigValue, [string]$DefaultConfigValue, [string]$SplitBy = ',', [bool]$Force = $false)
+
     $AddSplittedConfigValue = {
-        param ([object[]]$TestArray, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
-        foreach ($test in $TestArray) {
+        param ([System.Collections.ArrayList]$TestCollections, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
+        foreach ($test in $TestCollections) {
             if (!$test.SetupConfig.$ConfigName) {
                 $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
             }
             elseif ($Force) {
                 $test.SetupConfig.$ConfigName = $ConfigValue
             }
-            else {
-                Write-LogWarn "Pre-defined '$($test.SetupConfig.$ConfigName)' (instead of '$ConfigValue') is used as '<$ConfigName>' for test case '$($test.TestName)', if it's not expected, use '-ForceCustom' parameter of LISAv2 to force override it."
-            }
+        }
+    }
+    if ($DefaultConfigValue) {
+        $expandedConfigValues = @($DefaultConfigValue.Trim("$SplitBy ").Split($SplitBy).Trim())
+        if ($expandedConfigValues.Count -gt 1) {
+            Write-LogErr "Only support singular value (spliting by '$SplitBy') as default value. '$DefaultConfigValue' is invalid."
+        }
+        else {
+            $DefaultConfigValue = $DefaultConfigValue.Trim()
         }
     }
     if ($ConfigValue) {
+        $messageKeySet = @{}
         $expandedConfigValues = @($ConfigValue.Trim("$SplitBy ").Split($SplitBy).Trim())
         if ($expandedConfigValues.Count -gt 1) {
-            $updatedTests = @()
+            $updatedTests = [System.Collections.ArrayList]@()
             foreach ($singleConfigValue in $expandedConfigValues) {
-                $clonedTestsArray = @()
-                foreach ($singleTest in $AllTests.Value) {
-                    $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
-                    $clonedTestsArray += $clonedTest
+                $clonedTests = [System.Collections.ArrayList]@()
+                foreach ($singleTest in $AllTests) {
+                    # If not pre-defined in TestXml, or -ForceCustom used, duplicate
+                    if (!$singleTest.SetupConfig.$ConfigName -or $Force) {
+                        $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
+                        $null = $clonedTests.Add($clonedTest)
+                    }
+                    else {
+                        # If pre-defined, let's decide skip or not
+                        $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
+                        if ($singleConfigValue -and $originalConfigValueArr -notcontains $singleConfigValue) {
+                            $messageKey = "$ConfigName,$($singleTest.TestName),$singleConfigValue"
+                            if (!$messageKeySet.ContainsKey($messageKey)) {
+                                Write-LogWarn "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)'  with value '$($singleTest.SetupConfig.$ConfigName)' does not contains '$singleConfigValue', skip this custom setup for '$($singleTest.TestName)'"
+                                $messageKeySet[$messageKey] = $null
+                            }
+                        }
+                    }
                 }
-                &$AddSplittedConfigValue -TestArray $clonedTestsArray -ConfigName $ConfigName -ConfigValue $singleConfigValue -Force $Force
-                $clonedTestsArray | Foreach-Object {$updatedTests += $_}
+                &$AddSplittedConfigValue -TestCollections $clonedTests -ConfigName $ConfigName -ConfigValue $singleConfigValue -Force $Force
+                $clonedTests | Foreach-Object {$null = $updatedTests.Add($_)}
                 if ($Force) {
                     Write-LogWarn "Force customized '<$ConfigName>' with value '$singleConfigValue' for all selected Test Cases."
                 }
             }
-            $AllTests.Value = $updatedTests
+            $AllTests.Clear()
+            $AllTests.AddRange($updatedTests)
             # Set-Variable -Name ExpandedSetupConfig -Value $true -Scope Global
         }
         else {
-            &$AddSplittedConfigValue -TestArray $AllTests.Value -ConfigName $ConfigName -ConfigValue $ConfigValue -Force $Force
+            $ConfigValue = $ConfigValue.Trim()
+            $toBeSkippedTests = [System.Collections.ArrayList]@()
+            foreach ($singleTest in $AllTests) {
+                # If there's pre-defined value in TestXml, let's decide skip or not
+                if ($singleTest.SetupConfig.$ConfigName -and !$Force) {
+                    $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
+                    if ($ConfigValue -and $originalConfigValueArr -notcontains $ConfigValue) {
+                        $messageKey = "$ConfigName,$($singleTest.TestName),$ConfigValue"
+                        if (!$messageKeySet.ContainsKey($messageKey)) {
+                            Write-LogWarn "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)' with value '$($singleTest.SetupConfig.$ConfigName)' does not contains '$ConfigValue', skip this custom setup for '$($singleTest.TestName)'"
+                            $messageKeySet[$messageKey] = $null
+                        }
+                        $null = $toBeSkippedTests.Add($singleTest)
+                    }
+                }
+            }
+            $toBeSkippedTests | Foreach-Object {$AllTests.RemoveAt($AllTests.IndexOf($_))}
+            &$AddSplittedConfigValue -TestCollections $AllTests -ConfigName $ConfigName -ConfigValue $ConfigValue -Force $Force
             if ($Force) {
                 Write-LogWarn "Force customized '<$ConfigName>' with value '$ConfigValue' for all selected Test Cases."
             }
         }
+    }
+    else {
+        # If no Config Value provided, check self pre-defined value, and expand it as custom setup configurations
+        $toBeSkippedTests = [System.Collections.ArrayList]@()
+        $toBeAddedTests = [System.Collections.ArrayList]@()
+        $messageKeySet = @{}
+        foreach ($singleTest in $AllTests) {
+            # If there's pre-defined value in TestXml, let's expand and apply as custom setup for current TestCase only
+            if ($singleTest.SetupConfig.$ConfigName) {
+                $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
+                if ($originalConfigValueArr.Count -gt 1) {
+                    $null = $toBeSkippedTests.Add($singleTest)
+                    foreach ($singleConfigValue in $originalConfigValueArr) {
+                        $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
+                        $clonedTest.SetupConfig.$ConfigName = $singleConfigValue
+                        $null = $toBeAddedTests.Add($clonedTest)
+                    }
+                    $messageKey = "$ConfigName,$($singleTest.TestName),$($singleTest.SetupConfig.$ConfigName)"
+                    if (!$messageKeySet.ContainsKey($messageKey)) {
+                        Write-LogInfo "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)' with '$SplitBy' separated value '$($singleTest.SetupConfig.$ConfigName)' has been expanded and applied according to SetupConfig"
+                        $messageKeySet[$messageKey] = $null
+                    }
+                }
+            }
+            elseif ($DefaultConfigValue) {
+                $singleTest.SetupConfig.InnerXml += "<$ConfigName>$DefaultConfigValue</$ConfigName>"
+            }
+        }
+        $toBeSkippedTests | Foreach-Object {$AllTests.RemoveAt($AllTests.IndexOf($_))}
+        $toBeAddedTests | Foreach-Object {$null = $AllTests.Add($_)}
     }
 }
 

--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -31,7 +31,7 @@ Function New-ResultSummary($testResult, $checkValues, $testName, $metaData) {
 	return $resultString
 }
 
-$ExcludedSetupConfigsToDisplay = @("RGIdentifier","SetupScript")
+$ExcludedSetupConfigsToDisplay = @("RGIdentifier","SetupScript","TiPSessionId","TiPCluster","PlatformFaultDomainCount","PlatformUpdateDomainCount")
 function ConvertFrom-SetupConfig([object]$SetupConfig, [switch]$WrappingLines) {
 	$resultString = ""
 	$SetupConfig.ChildNodes | Sort-Object LocalName | Foreach-Object {

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -40,6 +40,9 @@ Class AzureController : TestController
 	[void] ParseAndValidateParameters([Hashtable]$ParamTable) {
 		$parameterErrors = ([TestController]$this).ParseAndValidateParameters($ParamTable)
 
+		if (!$this.RGIdentifier) {
+			$parameterErrors += "-RGIdentifier is not set"
+		}
 		$ValidateARMImageName = {
 			$ArmImagesToBeUsed = @($this.ARMImageName.Trim(", ").Split(',').Trim())
 			if ($ArmImagesToBeUsed | Where-Object {$_.Split(" ").Count -ne 4}) {
@@ -240,6 +243,11 @@ Class AzureController : TestController
 
 		Write-LogInfo "Setting global variables"
 		$this.SetGlobalVariables()
+	}
+
+	[void] SetGlobalVariables() {
+		([TestController]$this).SetGlobalVariables()
+
 		if (!$global:AllTestVMSizes) {
 			Set-Variable -Name AllTestVMSizes -Value @{} -Option ReadOnly -Scope Global
 		}
@@ -312,8 +320,6 @@ Class AzureController : TestController
 		if (("Windows", "Linux") -contains $this.CustomParams["OSType"]) {
 			Add-SetupConfig -AllTests $AllTests -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
 		}
-		Add-SetupConfig -AllTests $AllTests -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
-
 		if ($this.CustomParams.TiPSessionId -and $this.CustomParams.TiPCluster -and $this.CustomParams.PlatformFaultDomainCount -and $this.CustomParams.PlatformUpdateDomainCount) {
 			Add-SetupConfig -AllTests $AllTests -ConfigName "TiPSessionId" -ConfigValue $this.CustomParams.TiPSessionId -Force $true
 			Add-SetupConfig -AllTests $AllTests -ConfigName "TiPCluster" -ConfigValue $this.CustomParams.TiPCluster -Force $true

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -39,20 +39,12 @@ Class AzureController : TestController
 
 	[void] ParseAndValidateParameters([Hashtable]$ParamTable) {
 		$parameterErrors = ([TestController]$this).ParseAndValidateParameters($ParamTable)
-		if ($this.TiPSessionId -or $this.TipCluster) {
-			if (!$this.UseExistingRG) {
-				$parameterErrors += "'-UseExistingRG' is necessary when Run-LISAv2 with 'TiPSessionId' and 'TiPCluster'."
-			}
-		}
 
 		$ValidateARMImageName = {
 			$ArmImagesToBeUsed = @($this.ARMImageName.Trim(", ").Split(',').Trim())
 			if ($ArmImagesToBeUsed | Where-Object {$_.Split(" ").Count -ne 4}) {
 				$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
 									 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...'")
-			}
-			else {
-				$this.SyncEquivalentCustomParameters("ARMImageName", $this.ARMImageName)
 			}
 		}
 		if ($ParamTable["StorageAccount"] -imatch "^NewStorage_") {
@@ -66,6 +58,7 @@ Class AzureController : TestController
 		}
 
 		$this.ARMImageName = $ParamTable["ARMImageName"]
+		$this.SyncEquivalentCustomParameters("ARMImageName", $this.ARMImageName)
 		# Validate -ARMImageName and -OsVHD
 		# when both OsVHD and ARMImageName exist, parameterErrors += "..."
 		if ($this.OsVHD -and $this.ARMImageName) {
@@ -75,39 +68,53 @@ Class AzureController : TestController
 			if ($this.OsVHD -and [System.IO.Path]::GetExtension($this.OsVHD) -ne ".vhd" -and !$this.OsVHD.Contains("vhd")) {
 				$parameterErrors += "-OsVHD $($this.OsVHD) does not have .vhd (.vhdx is not supported) extension required by Platform Azure."
 			}
-			if (("1", "2") -notcontains $this.VMGeneration) {
-				$parameterErrors += "-VMGeneration '$($this.VMGeneration)' is empty, or not yet supported."
+			if ($this.VMGeneration -and (("1", "2") -notcontains $this.VMGeneration)) {
+				$parameterErrors += "-VMGeneration '$($this.VMGeneration)' is not supported."
 			}
 		}
 		elseif (!$this.ARMImageName) {
-			# Both $this.OsVHD and $this.ARMImageName are empty, try to load <DefaultARMImageName> from .\XML\GlobalConfigurations.xml
-			if (!$this.ARMImageName -and $this.GlobalConfig) {
-				# $this.GlobalConfig has been set by base ([TestController]$this).ParseAndValidateParameters() at the beginning of this overwritten function
-				$this.ARMImageName = $this.GlobalConfig.Global.Azure.DefaultARMImageName
-				if (!$this.ARMImageName) {
-					$parameterErrors += "-OsVHD <'VHD_Name.vhd'>, or -ARMImageName '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...', or <DefaultARMImageName> from .\XML\GlobalConfigurations.xml if required."
-				}
-				else {
-					&$ValidateARMImageName
-				}
+			# Both $this.OsVHD and $this.ARMImageName are empty, <DefaultARMImageName> from .\XML\GlobalConfigurations.xml should be applied as default value
+			# $this.GlobalConfig has been set by base ([TestController]$this).ParseAndValidateParameters() at the beginning of this overwritten function
+			if (!$this.GlobalConfig.Global.Azure.DefaultARMImageName) {
+				$parameterErrors += "-OsVHD <'VHD_Name.vhd'>, or -ARMImageName '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...', or <DefaultARMImageName> from .\XML\GlobalConfigurations.xml if required."
 			}
 		}
 		elseif ($this.ARMImageName) {
 			&$ValidateARMImageName
 		}
 
-		$this.TestProvider.TipSessionId = $this.CustomParams["TipSessionId"]
-		$this.TestProvider.TipCluster = $this.CustomParams["TipCluster"]
-		$this.TestProvider.PlatformFaultDomainCount = $this.CustomParams["PlatformFaultDomainCount"]
-		$this.TestProvider.PlatformUpdateDomainCount = $this.CustomParams["PlatformUpdateDomainCount"]
+		if ($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) {
+			if (!$this.CustomParams["TipSessionId"] -or !$this.CustomParams["TipCluster"]) {
+				$parameterErrors += "Both 'TipSessionId' and 'TipCluster' are necessary in CustomParameters when Run-LISAv2 with TiP."
+			}
+			if (!$this.UseExistingRG) {
+				$parameterErrors += "'-UseExistingRG' is necessary when Run-LISAv2 with 'TiPSessionId' and 'TiPCluster'."
+			}
+			if (!$this.TestLocation) {
+				$parameterErrors += "'-TestLocation' is necessary when Run-LISAv2 with 'TiPSessionId' and 'TiPCluster'."
+			}
+			if (!$this.CustomParams["PlatformFaultDomainCount"]) {
+				Write-LogWarn "'PlatformFaultDomainCount' is not provided in CustomParameters, use default value 1"
+				$this.CustomParams["PlatformFaultDomainCount"] = 1
+			}
+			if (!$this.CustomParams["PlatformUpdateDomainCount"]) {
+				Write-LogWarn "'PlatformUpdateDomainCount' is not provided in CustomParameters, use default value 1"
+				$this.CustomParams["PlatformUpdateDomainCount"] = 1
+			}
+		}
+		else {
+			if (!$this.CustomParams["PlatformFaultDomainCount"]) {
+				$this.CustomParams["PlatformFaultDomainCount"] = 2
+			}
+			if (!$this.CustomParams["PlatformUpdateDomainCount"]) {
+				$this.CustomParams["PlatformUpdateDomainCount"] = 5
+			}
+		}
 		$this.TestProvider.EnableTelemetry = $ParamTable["EnableTelemetry"]
 		if ($this.CustomParams["EnableNSG"] -and $this.CustomParams["EnableNSG"] -eq "true") {
 			$this.TestProvider.EnableNSG = $true
 		}
 
-		if (!$this.RGIdentifier) {
-			$parameterErrors += "-RGIdentifier is not set"
-		}
 		if ($parameterErrors.Count -gt 0) {
 			$parameterErrors | ForEach-Object { Write-LogErr $_ }
 			throw "Failed to validate the test parameters provided. Please fix above issues and retry."
@@ -137,7 +144,7 @@ Class AzureController : TestController
 						throw "'-RGIdentifier' must be an existing Resource Group Name when Run-LISAv2 with '-UseExistingRG' on Azure Platform."
 					}
 					else {
-						if (($this.TiPSessionId -or $this.TipCluster) -and (Get-AzResource -ResourceGroupName $this.RGIdentifier | Where-Object { $_.ResourceType -inotmatch "availabilitySets" })) {
+						if (($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) -and (Get-AzResource -ResourceGroupName $this.RGIdentifier | Where-Object { $_.ResourceType -inotmatch "availabilitySets" })) {
 							throw "Existing Resource Group '$($this.RGIdentifier)' is not clean, please remove all other resources, except 'availabilitySets' resource type."
 						}
 					}
@@ -233,6 +240,9 @@ Class AzureController : TestController
 
 		Write-LogInfo "Setting global variables"
 		$this.SetGlobalVariables()
+		if (!$global:AllTestVMSizes) {
+			Set-Variable -Name AllTestVMSizes -Value @{} -Option ReadOnly -Scope Global
+		}
 	}
 
 	[void] PrepareTestImage() {
@@ -288,53 +298,51 @@ Class AzureController : TestController
 		}
 	}
 
-	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [object[]]$AllTests) {
-		if (!$global:AllTestVMSizes) {
-			Set-Variable -Name AllTestVMSizes -Value @{} -Option ReadOnly -Scope Global
-		}
+	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [System.Collections.ArrayList]$AllTests) {
 		# Inject Networking=SRIOV/Synthetic, DiskType=Managed, OverrideVMSize to test case data
 		if (("sriov", "synthetic") -contains $this.CustomParams["Networking"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "Networking" -ConfigValue $this.CustomParams["Networking"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "Networking" -ConfigValue $this.CustomParams["Networking"] -Force $this.ForceCustom
 		}
 		if (("managed", "unmanaged") -contains $this.CustomParams["DiskType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "DiskType" -ConfigValue $this.CustomParams["DiskType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "DiskType" -ConfigValue $this.CustomParams["DiskType"] -Force $this.ForceCustom
 		}
 		if (("Specialized", "Generalized") -contains $this.CustomParams["ImageType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"] -Force $this.ForceCustom
 		}
 		if (("Windows", "Linux") -contains $this.CustomParams["OSType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
 		}
-		if (@($this.CustomParams["RGIdentifier"].Split(",")).Count -eq 1) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
+
+		if ($this.CustomParams.TiPSessionId -and $this.CustomParams.TiPCluster -and $this.CustomParams.PlatformFaultDomainCount -and $this.CustomParams.PlatformUpdateDomainCount) {
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TiPSessionId" -ConfigValue $this.CustomParams.TiPSessionId -Force $true
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TiPCluster" -ConfigValue $this.CustomParams.TiPCluster -Force $true
+			Add-SetupConfig -AllTests $AllTests -ConfigName "PlatformFaultDomainCount" -ConfigValue $this.CustomParams.PlatformFaultDomainCount -Force $true
+			Add-SetupConfig -AllTests $AllTests -ConfigName "PlatformUpdateDomainCount" -ConfigValue $this.CustomParams.PlatformUpdateDomainCount -Force $true
 		}
 		else {
-			Write-LogErr "'RGIdentifier' must not contain ',' and multiple values of RDIdentifier is not supported for now."
+			Add-SetupConfig -AllTests $AllTests -ConfigName "PlatformFaultDomainCount" -ConfigValue $this.CustomParams.PlatformFaultDomainCount -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "PlatformUpdateDomainCount" -ConfigValue $this.CustomParams.PlatformUpdateDomainCount -Force $this.ForceCustom
 		}
-		if ($this.CustomParams.TiPSessionId -and $this.CustomParams.TiPCluster) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TiPSessionId" -ConfigValue $this.CustomParams.TiPSessionId -Force $this.ForceCustom
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TiPCluster" -ConfigValue $this.CustomParams.TiPCluster -Force $this.ForceCustom
-		}
+
 		# Multiple TestLocations (parameter '-TestLocation' with value like 'eastus,westus') means to deploy from different Regions,
 		# so spliting with default Splitby (','), and apply multi single ConfigValues to $AllTests one by one.
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -Force $this.ForceCustom
 		if ($this.TestIterations -gt 1) {
 			$testIterationsParamValue = @(1..$this.TestIterations) -join ','
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
 		}
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
 		# 'OsVHD' should not coexist with 'ARMImageName', when OsVHD exist, take OsVHD as prioritized than ARMImageName
 		if (!$this.CustomParams["OsVHD"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "ARMImageName" -ConfigValue $this.CustomParams["ARMImageName"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "ARMImageName" -ConfigValue $this.CustomParams["ARMImageName"] -DefaultConfigValue $this.GlobalConfig.Global.Azure.DefaultARMImageName -Force $this.ForceCustom
 		}
 		else {
 			# Only when 'OsVHD' exist from parameters, then we should Add-SetupConfig for 'VMGeneration',
 			#   because HyperVGeneration property for Azure Gallery Image is only decided by the 'ARMImageName' (Publisher, Provider, SKU, Version),
 			#   and from ARM template constraint, there's no Generation property to be applied when deploying with Gallery image with (Publisher, Provider, SKU, Version)
-			if (("1", "2") -contains $this.CustomParams["VMGeneration"]) {
-				Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -Force $this.ForceCustom
-			}
+			Add-SetupConfig -AllTests $AllTests -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -DefaultConfigValue "1" -Force $this.ForceCustom
 		}
 
 		foreach ($test in $AllTests) {
@@ -355,7 +363,7 @@ Class AzureController : TestController
 		$AllTests.SetupConfig.OverrideVMSize | Sort-Object -Unique | Foreach-Object {
 			if (!($global:AllTestVMSizes.$_)) { $global:AllTestVMSizes["$_"] = @{} }
 		}
-		$this.TotalCaseNum = @($AllTests).Count
+		$this.TotalCaseNum = ([System.Collections.ArrayList]$AllTests).Count
 	}
 
 	[void] LoadTestCases($WorkingDirectory, $CustomTestParameters) {

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -39,6 +39,9 @@ Class HyperVController : TestController
 	[void] ParseAndValidateParameters([Hashtable]$ParamTable) {
 		$parameterErrors = ([TestController]$this).ParseAndValidateParameters($ParamTable)
 
+		if (!$this.RGIdentifier) {
+			$parameterErrors += "-RGIdentifier is not set"
+		}
 		$this.DestinationOsVhdPath = $ParamTable["DestinationOsVhdPath"]
 		$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
 
@@ -135,9 +138,6 @@ Class HyperVController : TestController
 		if (("sriov", "synthetic") -contains $this.CustomParams["Networking"]) {
 			Add-SetupConfig -AllTests $AllTests -ConfigName "Networking" -ConfigValue $this.CustomParams["Networking"] -Force $this.ForceCustom
 		}
-		if (("managed", "unmanaged") -contains $this.CustomParams["DiskType"]) {
-			Add-SetupConfig -AllTests $AllTests -ConfigName "DiskType" -ConfigValue $this.CustomParams["DiskType"] -Force $this.ForceCustom
-		}
 		if (("Specialized", "Generalized") -contains $this.CustomParams["ImageType"]) {
 			Add-SetupConfig -AllTests $AllTests -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"] -Force $this.ForceCustom
 		}
@@ -145,7 +145,6 @@ Class HyperVController : TestController
 			Add-SetupConfig -AllTests $AllTests -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
 		}
 		Add-SetupConfig -AllTests $AllTests -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -DefaultConfigValue "1" -Force $this.ForceCustom
-		Add-SetupConfig -AllTests $AllTests -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
 		# As Hyper-V do not need to separate TestLocations ('localhost,AnotherServerName') for one TestCase.
 		# Instead, multiple TestLocations must always stick together for every test case.
 		# So, use a fake SplitBy to avoid TestLocations been Splitted for different TestCases.

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -40,21 +40,13 @@ Class HyperVController : TestController
 		$parameterErrors = ([TestController]$this).ParseAndValidateParameters($ParamTable)
 
 		$this.DestinationOsVhdPath = $ParamTable["DestinationOsVhdPath"]
+		$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
 
-		# If VMGeneration is null/empty, set the default value '1', so as to make LISAv2 backward compatible
-		if (!$this.VMGeneration) {
-			Write-Loginfo "'-VMGeneration' is not set for HyperV platform, set the default value '1'"
-			$this.VMGeneration = "1"
-			$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
+		if ($this.VMGeneration -and (("1", "2") -notcontains $this.VMGeneration)) {
+			$parameterErrors += "-VMGeneration '$($this.VMGeneration)' is not supported."
 		}
-		if (("1", "2") -contains $this.VMGeneration) {
-			if ($this.VMGeneration -eq "2" -and $this.OsVHD `
-						-and [System.IO.Path]::GetExtension($this.OsVHD) -ne ".vhdx") {
-				$parameterErrors += "-VMGeneration 2 requires .vhdx files."
-			}
-		}
-		else {
-			$parameterErrors += "-VMGeneration '$($this.VMGeneration)' is empty, or not yet supported."
+		elseif ($this.VMGeneration -eq "2" -and $this.OsVHD -and [System.IO.Path]::GetExtension($this.OsVHD) -ne ".vhdx") {
+			$parameterErrors += "-VMGeneration 2 requires .vhdx files."
 		}
 
 		if (!$this.OsVHD ) {
@@ -139,38 +131,31 @@ Class HyperVController : TestController
 		Set-Variable -Name VMIntegrationKeyValuePairExchange -Value "Key-Value Pair Exchange" -Scope Global
 	}
 
-	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [object[]]$AllTests) {
+	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [System.Collections.ArrayList]$AllTests) {
 		if (("sriov", "synthetic") -contains $this.CustomParams["Networking"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "Networking" -ConfigValue $this.CustomParams["Networking"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "Networking" -ConfigValue $this.CustomParams["Networking"] -Force $this.ForceCustom
 		}
 		if (("managed", "unmanaged") -contains $this.CustomParams["DiskType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "DiskType" -ConfigValue $this.CustomParams["DiskType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "DiskType" -ConfigValue $this.CustomParams["DiskType"] -Force $this.ForceCustom
 		}
 		if (("Specialized", "Generalized") -contains $this.CustomParams["ImageType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "ImageType" -ConfigValue $this.CustomParams["ImageType"] -Force $this.ForceCustom
 		}
 		if (("Windows", "Linux") -contains $this.CustomParams["OSType"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "OSType" -ConfigValue $this.CustomParams["OSType"] -Force $this.ForceCustom
 		}
-		if (("1", "2") -contains $this.CustomParams["VMGeneration"]) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -Force $this.ForceCustom
-		}
-		if (@($this.CustomParams["RGIdentifier"].Split(",")).Count -eq 1) {
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
-		}
-		else {
-			Write-LogErr "'RGIdentifier' could only be applied with multiple values, must not contain ',' in RGIdentifier value"
-		}
+		Add-SetupConfig -AllTests $AllTests -ConfigName "VMGeneration" -ConfigValue $this.CustomParams["VMGeneration"] -DefaultConfigValue "1" -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "RGIdentifier" -ConfigValue $this.CustomParams["RGIdentifier"] -Force $this.ForceCustom
 		# As Hyper-V do not need to separate TestLocations ('localhost,AnotherServerName') for one TestCase.
 		# Instead, multiple TestLocations must always stick together for every test case.
 		# So, use a fake SplitBy to avoid TestLocations been Splitted for different TestCases.
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -SplitBy ';' -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -SplitBy ';' -Force $this.ForceCustom
 		if ($this.TestIterations -gt 1) {
 			$testIterationsParamValue = @(1..$this.TestIterations) -join ','
-			Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
 		}
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
-		Add-SetupConfig -AllTests ([ref]$AllTests) -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
+		Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
 
 		foreach ($test in $AllTests) {
 			# Put test case to hashtable, per setupType,OverrideVMSize,networking,diskType,osDiskType,switchName
@@ -186,6 +171,6 @@ Class HyperVController : TestController
 				}
 			}
 		}
-		$this.TotalCaseNum = @($AllTests).Count
+		$this.TotalCaseNum = ([System.Collections.ArrayList]$AllTests).Count
 	}
 }

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -132,20 +132,13 @@ Class TestController
 		$this.SyncEquivalentCustomParameters("TestLocation", $this.TestLocation)
 		$this.SyncEquivalentCustomParameters("OsVHD", $this.OsVHD)
 		$this.SyncEquivalentCustomParameters("OverrideVMSize", $this.OverrideVMSize)
-		$this.SyncEquivalentCustomParameters("RGIdentifier", $this.RGIdentifier)
 		# Sync VMGeneration with whatever values it got from command parameter;
 		# if $null/empty, inherited controller will update it with default value
 		$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
 
 		$parameterErrors = @()
 		# Validate general parameters
-		if (!$this.RGIdentifier) {
-			$parameterErrors += "-RGIdentifier is not set"
-		}
-		elseif (@($this.RGIdentifier.Split(",")).Count -ne 1) {
 
-			Write-LogErr "'RGIdentifier' must not contain ',' and multiple values (seperated by ',') of RDIdentifier is not supported."
-		}
 		return $parameterErrors
 	}
 
@@ -561,7 +554,7 @@ Class TestController
 					# Deploy the VM for the setup
 					Write-LogInfo "Deploy target machine for test if required ..."
 					$deployVMResults = $this.TestProvider.DeployVMs($this.GlobalConfig, $this.SetupTypeTable[$setupType], $currentTestCase, `
-						$currentTestCase.SetupConfig.TestLocation, $currentTestCase.SetupConfig.RGIdentifier, $this.UseExistingRG, $this.ResourceCleanup)
+						$currentTestCase.SetupConfig.TestLocation, $this.RGIdentifier, $this.UseExistingRG, $this.ResourceCleanup)
 					$vmData = $null
 					$deployErrors = ""
 					if ($deployVMResults) {

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -139,6 +139,13 @@ Class TestController
 
 		$parameterErrors = @()
 		# Validate general parameters
+		if (!$this.RGIdentifier) {
+			$parameterErrors += "-RGIdentifier is not set"
+		}
+		elseif (@($this.RGIdentifier.Split(",")).Count -ne 1) {
+
+			Write-LogErr "'RGIdentifier' must not contain ',' and multiple values (seperated by ',') of RDIdentifier is not supported."
+		}
 		return $parameterErrors
 	}
 
@@ -219,7 +226,7 @@ Class TestController
 		$this.TestCasePassStatus = @($global:ResultPass, $global:ResultSkipped)
 	}
 
-	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [object[]]$AllTests) {
+	[void] PrepareSetupTypeToTestCases([hashtable]$SetupTypeToTestCases, [System.Collections.ArrayList]$AllTests) {
 		# The multiple TestLocation may be separated by ','
 		# and in most cases, the multiple TestLocations should always stick together for certain one TestCase.
 		# So, use a fake SplitBy ';' to avoid TestLocations being Splitted into multi single ConfigValues for $AllTests.
@@ -241,7 +248,7 @@ Class TestController
 				}
 			}
 		}
-		$this.TotalCaseNum = @($AllTests).Count
+		$this.TotalCaseNum = ([System.Collections.ArrayList]$AllTests).Count
 	}
 
 	[void] LoadTestCases($WorkingDirectory, $CustomTestParameters) {

--- a/TestProviders/AzureProvider.psm1
+++ b/TestProviders/AzureProvider.psm1
@@ -54,9 +54,8 @@ Class AzureProvider : TestProvider
 			}
 			if (!$allVMData) {
 				$isAllDeployed = Invoke-AllResourceGroupDeployments -SetupTypeData $SetupTypeData -CurrentTestData $TestCaseData -RGIdentifier $RGIdentifier `
-					-TestLocation $TestCaseData.SetupConfig.TestLocation -GlobalConfig $GlobalConfig -TipSessionId $this.TipSessionId -TipCluster $this.TipCluster `
-					-UseExistingRG $UseExistingRG -ResourceCleanup $ResourceCleanup -PlatformFaultDomainCount $this.PlatformFaultDomainCount `
-					-PlatformUpdateDomainCount $this.PlatformUpdateDomainCount -EnableNSG $this.EnableNSG
+					-TestLocation $TestCaseData.SetupConfig.TestLocation -GlobalConfig $GlobalConfig `
+					-UseExistingRG $UseExistingRG -ResourceCleanup $ResourceCleanup -EnableNSG $this.EnableNSG
 
 				if ($isAllDeployed[0] -eq "True") {
 					$deployedGroups = $isAllDeployed[1]

--- a/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
+++ b/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
@@ -32,9 +32,6 @@ function Main {
         Write-LogInfo "Shutting down VM..."
         $null = Stop-AzVM -Name $captureVMData.RoleName -ResourceGroupName $captureVMData.ResourceGroupName -Force
         Write-LogInfo "VM shutdown successful."
-        if ($CurrentTestData.SetupScript.RGIdentifier) {
-            $Append = $CurrentTestData.SetupScript.RGIdentifier
-        }
         if ($env:BUILD_NAME){
             $Append += "-$env:BUILD_NAME"
         }


### PR DESCRIPTION
- Fix bug of testing with TiP
- Enable testing with multi predefined setupconfig

> If command given value is not in pre-defined scope, skip run this test case, unless '-ForceCustom' used in LISAv2 command

> If give any -TestLocation or -ARMImageName from LISA command,  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM will be skipped as test log example.

This change is most useful to TVM test requirement. @prash2611
=============Test Log================
If we have test defined like this:
`<test>
	<TestName>VERIFY-DEPLOYMENT-PROVISION</TestName>
	<testScript>VERIFY-DEPLOYMENT-PROVISION.ps1</testScript>
	<files>
	</files>
	<TestParameters>
	<!-- Custom expected number of cores inside the VM. Empty by default. -->
	<param>vCpu=VCPU</param>
	</TestParameters>
	<Platform>Azure,HyperV</Platform>
	<Category>Functional</Category>
	<Area>CORE</Area>
	<Tags>provision</Tags>
	<Priority>0</Priority>
	<SetupConfig>
		<TestLocation>westus2,southcentralus</TestLocation>
		<ARMImageName>Canonical UbuntuServer 18.04-LTS Latest,RedHat RHEL 78-gen2 latest</ARMImageName>
		<SetupType>OneVM</SetupType>
	</SetupConfig>
</test>`

`  <test>
    <testName>VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM</testName>
    <testScript>VALIDATE-INTEL-SGX-DRIVER.ps1</testScript>
    <files>.\Testscripts\Linux\validate-intel-sgx-driver.sh,.\Testscripts\Linux\utils.sh</files>
    <Platform>Azure</Platform>
    <Category>Functional</Category>
    <Area>SGX</Area>
    <Tags>sgx</Tags>
    <Priority>
    </Priority>
    <SetupConfig>
      <TestLocation>uksouth</TestLocation>
      <SetupType>OneVM</SetupType>
      <OverrideVMSize>Standard_DC2s_v2</OverrideVMSize>
      <VMGeneration>2</VMGeneration>
      <ARMImageName>Canonical UbuntuServer 18_04-lts-gen2 latest</ARMImageName>
    </SetupConfig>
  </test>`

[LISAv2 Test Results Summary]
Test Run On           : 07/23/2020 21:16:36
Initial Kernel Version: 3.10.0-1127.el7.x86_64
Final Kernel Version  : 3.10.0-1127.el7.x86_64
Total Test Cases      : 5 (5 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:28

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.24 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, SetupType: OneVM, TestLocation: westus2
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.51 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, SetupType: OneVM, TestLocation: southcentralus
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    3 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 3.99 
      ARMImageName: Canonical UbuntuServer 18_04-lts-gen2 latest, OverrideVMSize: Standard_DC2s_v2, SetupType: OneVM, TestLocation: uksouth, VMGeneration: 2
    4 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.38 
      ARMImageName: RedHat RHEL 78-gen2 latest, SetupType: OneVM, TestLocation: southcentralus
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    5 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.09 
      ARMImageName: RedHat RHEL 78-gen2 latest, SetupType: OneVM, TestLocation: westus2
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      


Logs can be found at C:\LISAv2\TestResults\2020-07-23-14-14-22-5996


07/23/2020 21:45:02 : [DEBUG] Creating 'C:\LISAv2\Azure-CH71-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-07-23-14-14-22-5996'
07/23/2020 21:45:02 : [DEBUG] C:\LISAv2\Azure-CH71-TestLogs.zip created successfully.
07/23/2020 21:45:02 : [INFO ] Analyzing test results ...
07/23/2020 21:45:02 : [INFO ] LISAv2 exit code: 0


Another log of Skipping..

07/23/2020 22:27:10 : [INFO ] Validating XML Files from C:\LISAv2\XML folder recursively...
07/23/2020 22:27:10 : [INFO ] Collected test: VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM from C:\LISAv2\XML\TestCases\FunctionalTests-SGX.xml
07/23/2020 22:27:11 : [INFO ] Collected test: VERIFY-DEPLOYMENT-PROVISION from C:\LISAv2\XML\TestCases\FunctionalTests.xml
07/23/2020 22:27:11 : [INFO ] 2 Test Cases have been collected
07/23/2020 22:27:13 : [INFO ] VCPU= injected to case VERIFY-DEPLOYMENT-PROVISION
`**07/23/2020 22:27:13 : [WARN ] Pre-defined '<TestLocation>' of test case 'VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM' with value 'uksouth' does not contains 'centralus', skip this custom setup for 'VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM'**`
