### PR TITLE
Make NESTED-KVM-BASIC-VERIFICATION case available in RHEL-8 and add network checkpoints

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -729,4 +729,16 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>DPDK_FAILSAFE_SH_URL</ReplaceThis>
 		<ReplaceWith>https://gallery.technet.microsoft.com/Azure-DPDK-Failsafe-PMD-c34b1a4b/file/183012/1/failsafe.sh</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>NESTED_IMAGE_URL</ReplaceThis>
+		<ReplaceWith></ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>NESTED_VM_USER</ReplaceThis>
+		<ReplaceWith>root</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>NESTED_VM_PASSWORD</ReplaceThis>
+		<ReplaceWith></ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/NestedVmTests.xml
+++ b/XML/TestCases/NestedVmTests.xml
@@ -7,7 +7,7 @@
       <!--The nested image should be qcow2 format, and accessible from a public URL-->
       <param>NestedImageUrl=NESTED_IMAGE_URL</param>
       <param>NestedUser=NESTED_VM_USER</param>
-      <param>NestedUserPassword='NESTED_VM_PASSWORD'</param>
+      <param>NestedUserPassword=NESTED_VM_PASSWORD</param>
       <param>HostFwdPort=60022</param>
     </TestParameters>
     <Timeout>1200</Timeout>


### PR DESCRIPTION
This case is updated for adapting to RHEL-8:
1. Add NESTED_IMAGE_URL, NESTED_VM_USER and NESTED_VM_PASSWORD parameters into the ReplaceableTestParameters.xml, which are used in the params.
2. Add the downloading public file from github.com step, which was mentioned in the description but not deployed in the case. And add another checkpoint that copy file from L1 host to the nested VM
3. Skip RHEL-6/RHEL-7
4. Install epel repo before installing aria2
5. Change "echo" messges to "LogMsg" and some other fixes.

```
[LISAv2 Test Results Summary]
Test Run On           : 07/24/2020 05:09:38
Test Category         : Functional
Initial Kernel Version: 4.18.0-227.el8.x86_64
Final Kernel Version  : 4.18.0-227.el8.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:12

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                     PASS                  8.1
      OsVHD: https://walaautol2.blob.core.windows.net/vhds/RHEL-8.3.0-20200722.n.0.vhd, OverrideVMSize: Standard_E4s_v3, SetupType: OneVM, TestLocation: eastus2, VMGeneration: 1
```