### PR TITLE
always Log TestResult in Database, even in exception

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -41,6 +41,7 @@ function Start-LISAv2 {
 		[string] $TestTag = "",
 		[string] $TestNames="",
 		[string] $TestPriority="",
+		[string] $TestSetup="",
 
 		# [Optional] Exclude the tests from being executed. (Comma separated values)
 		[string] $ExcludeTests = "",
@@ -186,7 +187,7 @@ function Start-LISAv2 {
 			Write-LogInfo "Test $global:testId finished"
 
 			# Output text summary
-			$plainTextSummary = $testController.TestSummary.GetPlainTextSummary($OsVHD, $ARMImageName, $OverrideVMSize)
+			$plainTextSummary = $testController.TestSummary.GetPlainTextSummary($OsVHD, $testController.ARMImageName, $OverrideVMSize)
 			Write-LogInfo $plainTextSummary
 
 			# Zip the test log folder

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2616,7 +2616,9 @@ Function Add-DefaultTagsToResourceGroup {
 		}
 		Add-ResourceGroupTag -ResourceGroup $ResourceGroup -TagName BuildURL -TagValue $BuildURLTag
 		# Add test name.
-		Add-ResourceGroupTag -ResourceGroup $ResourceGroup -TagName TestName -TagValue $currentTestData.testName
+		if ($currentTestData.testName) {
+			Add-ResourceGroupTag -ResourceGroup $ResourceGroup -TagName TestName -TagValue $currentTestData.testName
+		}
 		# Add LISAv2 launch machine name.
 		Add-ResourceGroupTag -ResourceGroup $ResourceGroup -TagName BuildMachine -TagValue "$env:UserDomain\$env:ComputerName"
 		# Add date-time.

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -111,19 +111,25 @@ Function Match-TestTag($currentTest, $TestTag)
 # Before entering this function, $TestPlatform has been verified as "valid" in Run-LISAv2.ps1.
 # So, here we don't need to check $TestPlatform
 #
-Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $TestTag, $TestPriority, $ExcludeTests)
+Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $TestTag, $TestPriority, $ExcludeTests, $TestSetup)
 {
     $AllLisaTests =  [System.Collections.ArrayList]@()
     $WildCards = @('^','.','[',']','?','+','*')
     $ExcludedTestsCount = 0
 
-    # Check and cleanup the parameters
+    # if the expected filter parameter is 'ALL' or empty ("ALL" -imatch "" return $True), the actually filter used in this function will be '*', except for '$ExcludedTests'
     if ("All" -imatch $TestCategory)   { $TestCategory = "*" }
     if ("All" -imatch $TestArea)       { $TestArea = "*" }
     if ("All" -imatch $TestNames)      { $TestNames = "*" }
     if ("All" -imatch  $TestTag)       { $TestTag = "*" }
     if ("All" -imatch  $TestPriority)  { $TestPriority = "*" }
+    if ("All" -imatch  $TestSetup)     { $TestSetup = "*" }
 
+	$testCategoryArray = @($TestCategory.Trim(', ').Split(',').Trim())
+	$testAreaArray = @($TestArea.Trim(', ').Split(',').Trim())
+	$testNamesArray = @($TestNames.Trim(', ').Split(',').Trim())
+	$testSetupTypeArray = @($TestSetup.Trim(', ').Split(',').Trim())
+	$excludedTestsArray = @($ExcludeTests.Trim(', ').Split(',').Trim())
     # Filter test cases based on the criteria
     foreach ($file in $TestXMLs.FullName) {
         $currentTests = ([xml]( Get-Content -Path $file)).TestCases
@@ -143,16 +149,20 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
             if (!$platformMatched) {
                 continue
             }
-            # case insensitive 'contains', and always complete match the concatenated expression for Category of TestCase
-            if (($TestCategory -ne "*") -and !(@($TestCategory.Trim(', ').Split(',').Trim()) -contains $test.Category)) {
+            # case insensitive 'notcontains', and only select complete matched with the concatenated expression for Category of TestCase, otherwise skip (continue)
+            if (($TestCategory -ne "*") -and ($testCategoryArray -notcontains $test.Category)) {
                 continue
             }
-            # case insensitive 'contains', and always complete match the concatenated expression for Area of TestCase
-            if (($TestArea -ne "*") -and !(@($TestArea.Trim(', ').Split(',').Trim()) -contains $test.Area)) {
+            # case insensitive 'notcontains', and only select complete matched with the concatenated expression for Area of TestCase, otherwise skip (continue)
+            if (($TestArea -ne "*") -and ($testAreaArray -notcontains $test.Area)) {
                 continue
             }
-            # case insensitive 'contains', and always complete match the concatenated expression for TestName of TestCase
-            if (($TestNames -ne "*") -and !(@($TestNames.Trim(', ').Split(',').Trim()) -contains $test.testName)) {
+            # only select TestCase that has SetupType value insensitive matching the expected Setup pattern, otherwise skip (continue)
+            if (($TestSetup -ne "*") -and !$($testSetupTypeArray | Where-Object {"$($test.SetupConfig.SetupType)" -imatch $_})) {
+                continue
+            }
+            # case insensitive 'notcontains', and only select complete matched with the concatenated expression for TestName of TestCase, otherwise skip (continue)
+            if (($TestNames -ne "*") -and ($testNamesArray -notcontains $test.testName)) {
                 continue
             }
 
@@ -168,7 +178,7 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
 
             if ($ExcludeTests) {
                 $ExcludeTestMatched = $false
-                foreach ($TestString in @($ExcludeTests.Trim(', ').Split(',').Trim())) {
+                foreach ($TestString in $excludedTestsArray) {
                     if (($TestString.IndexOfAny($WildCards))-ge 0) {
                         if ($TestString.StartsWith('*')) {
                             $TestString = ".$TestString"
@@ -209,18 +219,38 @@ Function Add-SetupConfig {
         param ([System.Collections.ArrayList]$TestCollections, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
         foreach ($test in $TestCollections) {
             if (!$test.SetupConfig.$ConfigName) {
-                # use CDATA when the value contains XML escaped characters
-                if ($ConfigValue -imatch "&|<|>|'|""") {
-                    $test.SetupConfig.InnerXml += "<$ConfigName><![CDATA['$ConfigValue']]></$ConfigName>"
-                } else {
-                    $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
-                }
+                $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
             }
             elseif ($Force) {
                 $test.SetupConfig.$ConfigName = $ConfigValue
             }
         }
     }
+
+    $IfNotContains = {
+        param ([string]$OriginalConfigValue, [string]$ToBeCheckedConfigValue, [string]$SplitBy)
+
+        $originalConfigValueArr = @($OriginalConfigValue.Trim("$SplitBy ").Split($SplitBy).Trim())
+        if (($originalConfigValueArr.Count -eq 0) -or !$ToBeCheckedConfigValue) {
+            return $True
+        }
+        elseif ($originalConfigValueArr -contains $ToBeCheckedConfigValue) {
+            return $False
+        }
+        else {
+            $matchedPattern = $null
+            $originalConfigValueArr | ForEach-Object {
+                if (!$matchedPattern -and $_.Contains("=~")) {
+                    $pattern = $_.SubString($_.IndexOf("=~") + 2)
+                    if ($ToBeCheckedConfigValue -imatch $pattern) {
+                        $matchedPattern = $pattern
+                    }
+                }
+            }
+            return !$matchedPattern
+        }
+    }
+
     if ($DefaultConfigValue) {
         $expandedConfigValues = @($DefaultConfigValue.Trim("$SplitBy ").Split($SplitBy).Trim())
         if ($expandedConfigValues.Count -gt 1) {
@@ -230,6 +260,7 @@ Function Add-SetupConfig {
             $DefaultConfigValue = $DefaultConfigValue.Trim()
         }
     }
+    $ConfigValue = $ConfigValue.Trim()
     if ($ConfigValue) {
         $messageKeySet = @{}
         $expandedConfigValues = @($ConfigValue.Trim("$SplitBy ").Split($SplitBy).Trim())
@@ -243,15 +274,19 @@ Function Add-SetupConfig {
                         $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
                         $null = $clonedTests.Add($clonedTest)
                     }
-                    else {
+                    elseif ($singleConfigValue) {
                         # If pre-defined, let's decide skip or not
-                        $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
-                        if ($singleConfigValue -and $originalConfigValueArr -notcontains $singleConfigValue) {
+                        if (&$IfNotContains -OriginalConfigValue "$($singleTest.SetupConfig.$ConfigName)" -ToBeCheckedConfigValue "$singleConfigValue" -SplitBy $SplitBy) {
                             $messageKey = "$ConfigName,$($singleTest.TestName),$singleConfigValue"
                             if (!$messageKeySet.ContainsKey($messageKey)) {
                                 Write-LogWarn "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)'  with value '$($singleTest.SetupConfig.$ConfigName)' does not contains '$singleConfigValue', skip this custom setup for '$($singleTest.TestName)'"
                                 $messageKeySet[$messageKey] = $null
                             }
+                        }
+                        else {
+                            $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
+                            $clonedTest.SetupConfig.$ConfigName = $singleConfigValue
+                            $null = $clonedTests.Add($clonedTest)
                         }
                     }
                 }
@@ -266,19 +301,20 @@ Function Add-SetupConfig {
             # Set-Variable -Name ExpandedSetupConfig -Value $true -Scope Global
         }
         else {
-            $ConfigValue = $ConfigValue.Trim()
             $toBeSkippedTests = [System.Collections.ArrayList]@()
             foreach ($singleTest in $AllTests) {
                 # If there's pre-defined value in TestXml, let's decide skip or not
-                if ($singleTest.SetupConfig.$ConfigName -and !$Force) {
-                    $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
-                    if ($ConfigValue -and $originalConfigValueArr -notcontains $ConfigValue) {
+                if ($singleTest.SetupConfig.$ConfigName) {
+                    if ((&$IfNotContains -OriginalConfigValue "$($singleTest.SetupConfig.$ConfigName)" -ToBeCheckedConfigValue "$ConfigValue" -SplitBy $SplitBy) -and !$Force) {
                         $messageKey = "$ConfigName,$($singleTest.TestName),$ConfigValue"
                         if (!$messageKeySet.ContainsKey($messageKey)) {
                             Write-LogWarn "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)' with value '$($singleTest.SetupConfig.$ConfigName)' does not contains '$ConfigValue', skip this custom setup for '$($singleTest.TestName)'"
                             $messageKeySet[$messageKey] = $null
                         }
                         $null = $toBeSkippedTests.Add($singleTest)
+                    }
+                    else {
+                        $singleTest.SetupConfig.$ConfigName = $ConfigValue
                     }
                 }
             }
@@ -297,7 +333,7 @@ Function Add-SetupConfig {
         foreach ($singleTest in $AllTests) {
             # If there's pre-defined value in TestXml, let's expand and apply as custom setup for current TestCase only
             if ($singleTest.SetupConfig.$ConfigName) {
-                $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim())
+                $originalConfigValueArr = @($singleTest.SetupConfig.$ConfigName.Trim("$SplitBy ").Split($SplitBy).Trim()) | Where-Object {!$_.StartsWith("=~")}
                 if ($originalConfigValueArr.Count -gt 1) {
                     $null = $toBeSkippedTests.Add($singleTest)
                     foreach ($singleConfigValue in $originalConfigValueArr) {
@@ -309,6 +345,15 @@ Function Add-SetupConfig {
                     if (!$messageKeySet.ContainsKey($messageKey)) {
                         Write-LogInfo "Pre-defined '<$ConfigName>' of test case '$($singleTest.TestName)' with '$SplitBy' separated value '$($singleTest.SetupConfig.$ConfigName)' has been expanded and applied according to SetupConfig"
                         $messageKeySet[$messageKey] = $null
+                    }
+                }
+                elseif ($originalConfigValueArr.Count -eq 1) {
+                    $singleTest.SetupConfig.$ConfigName = $originalConfigValueArr.ToString()
+                }
+                elseif ($originalConfigValueArr.Count -eq 0) {
+                    # Keep silent for ConfigName that all starts with '=~', silent with no warning message, and try the $DefaultConfigValue
+                    if (!(&$IfNotContains -OriginalConfigValue "$($singleTest.SetupConfig.$ConfigName)" -ToBeCheckedConfigValue "$DefaultConfigValue" -SplitBy $SplitBy)) {
+                        $singleTest.SetupConfig.$ConfigName = $DefaultConfigValue
                     }
                 }
             }

--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -31,7 +31,7 @@ Function New-ResultSummary($testResult, $checkValues, $testName, $metaData) {
 	return $resultString
 }
 
-$ExcludedSetupConfigsToDisplay = @("RGIdentifier","SetupScript","TiPSessionId","TiPCluster","PlatformFaultDomainCount","PlatformUpdateDomainCount")
+$ExcludedSetupConfigsToDisplay = @("RGIdentifier", "SetupType", "SetupScript","TiPSessionId","TiPCluster","PlatformFaultDomainCount","PlatformUpdateDomainCount")
 function ConvertFrom-SetupConfig([object]$SetupConfig, [switch]$WrappingLines) {
 	$resultString = ""
 	$SetupConfig.ChildNodes | Sort-Object LocalName | Foreach-Object {

--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -112,7 +112,7 @@ function Collect-TestLogs {
 	$currentTestResult = Create-TestResultObject
 
 	if ($TestType -eq "sh") {
-		$filesTocopy = "./state.txt, ./summary.log, ./TestExecution.log, ./TestExecutionError.log"
+		$filesTocopy = "./state.txt, ./*summary.log, ./TestExecution.log, ./TestExecutionError.log"
 		Copy-RemoteFiles -download -downloadFrom $PublicIP -downloadTo $LogsDestination `
 			 -Port $SSHPort -Username $Username -password $Password `
 			 -files $filesTocopy

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -72,6 +72,7 @@ Param(
 	[string] $TestTag = "",
 	[string] $TestNames="",
 	[string] $TestPriority="",
+	[string] $TestSetup="",
 
 	# [Optional] Exclude the tests from being executed. (Comma separated values)
 	[string] $ExcludeTests = "",
@@ -134,9 +135,6 @@ $MyInvocation.MyCommand.Parameters.Keys | ForEach-Object {
 		$params[$_] = $value
 		if ($params.TestNames) {
 			$params.TestNames = $params.TestNames.replace(' ','')
-		}
-		if ($params.ARMImageName) {
-			$params.ARMImageName = $params.ARMImageName.trim() -replace '\s{2,}', ' '
 		}
 		Write-Host ($_ + " = " + $params[$_])
 	}

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -43,13 +43,6 @@ Class AzureController : TestController
 		if (!$this.RGIdentifier) {
 			$parameterErrors += "-RGIdentifier is not set"
 		}
-		$ValidateARMImageName = {
-			$ArmImagesToBeUsed = @($this.ARMImageName.Trim(", ").Split(',').Trim())
-			if ($ArmImagesToBeUsed | Where-Object {$_.Split(" ").Count -ne 4}) {
-				$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
-									 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...'")
-			}
-		}
 		if ($ParamTable["StorageAccount"] -imatch "^NewStorage_") {
 			Throw "LISAv2 only supports specified storage account by '-StorageAccount' or candidate parameters values as below. `n
 			Please use '-StorageAccount ""Auto_Complete_RG=XXXResourceGroupName""' or `n
@@ -62,6 +55,13 @@ Class AzureController : TestController
 
 		$this.ARMImageName = $ParamTable["ARMImageName"]
 		$this.SyncEquivalentCustomParameters("ARMImageName", $this.ARMImageName)
+		# After triming multi blanks internally between publisher, offer, sku, and version. Keep sync again between '-ARMImageName' and '-CustomParameters ARMImageName=xxx'
+		if ($this.ARMImageName) {
+			$this.ARMImageName = $this.ARMImageName -replace '\s{2,}', ' '
+			$ParamTable["ARMImageName"] = $this.ARMImageName
+			$this.SyncEquivalentCustomParameters("ARMImageName", $this.ARMImageName)
+		}
+
 		# Validate -ARMImageName and -OsVHD
 		# when both OsVHD and ARMImageName exist, parameterErrors += "..."
 		if ($this.OsVHD -and $this.ARMImageName) {
@@ -83,16 +83,19 @@ Class AzureController : TestController
 			}
 		}
 		elseif ($this.ARMImageName) {
-			&$ValidateARMImageName
+			$ArmImagesToBeUsed = @($this.ARMImageName.Trim(", ").Split(',').Trim())
+			if ($ArmImagesToBeUsed | Where-Object {$_.Split(" ").Count -ne 4}) {
+				$parameterErrors += ("Invalid value for the provided ARMImageName parameter: <'$($this.ARMImageName)'>." + `
+									 "The ARM image should be in the format: '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...'")
+			}
 		}
 
 		if ($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) {
 			if (!$this.CustomParams["TipSessionId"] -or !$this.CustomParams["TipCluster"]) {
 				$parameterErrors += "Both 'TipSessionId' and 'TipCluster' are necessary in CustomParameters when Run-LISAv2 with TiP."
 			}
-			if (!$this.UseExistingRG) {
-				$parameterErrors += "'-UseExistingRG' is necessary when Run-LISAv2 with 'TiPSessionId' and 'TiPCluster'."
-			}
+			# Force $this.UseExistingRG = $true when testing with TiP, and always stick to the provided Resoruce Group by '-RGIdentifier'
+			$this.UseExistingRG = $true
 			if (!$this.TestLocation) {
 				$parameterErrors += "'-TestLocation' is necessary when Run-LISAv2 with 'TiPSessionId' and 'TiPCluster'."
 			}
@@ -138,18 +141,38 @@ Class AzureController : TestController
 				PrepareAutoCompleteStorageAccounts -storageAccountsRGName $storageAccountRG -XMLSecretFile $XMLSecretFile
 			}
 			if ($this.UseExistingRG) {
-				if (!$this.RGIdentifier) {
-					throw "'-RGIdentifier' is necessary and its value must be an existing Resource Group Name when Run-LISAv2 with '-UseExistingRG' on Azure Platform."
-				}
-				else {
-					$existingRG = Get-AzResourceGroup -Name $this.RGIdentifier
-					if (!$existingRG) {
-						throw "'-RGIdentifier' must be an existing Resource Group Name when Run-LISAv2 with '-UseExistingRG' on Azure Platform."
+				$existingRG = Get-AzResourceGroup -Name $this.RGIdentifier -ErrorAction SilentlyContinue
+				if (!$existingRG) {
+					if ($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) {
+						# Create resource group for TiP if resource group does not exist, as '$this.TestLocation' always available after ParseAndValidateParameters()
+						Write-LogInfo "Resource group '$($this.RGIdentifier)' does not exist, create it for TiP"
+						Create-ResourceGroup -RGName $this.RGIdentifier -location $this.TestLocation | Out-Null
 					}
 					else {
-						if (($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) -and (Get-AzResource -ResourceGroupName $this.RGIdentifier | Where-Object { $_.ResourceType -inotmatch "availabilitySets" })) {
-							throw "Existing Resource Group '$($this.RGIdentifier)' is not clean, please remove all other resources, except 'availabilitySets' resource type."
+						throw "'-RGIdentifier' must be an existing Resource Group Name when Run-LISAv2 with '-UseExistingRG' on Azure Platform"
+					}
+				}
+				else {
+					$allExistingResources = Get-AzResource -ResourceGroupName $this.RGIdentifier
+					if (($this.CustomParams["TipSessionId"] -or $this.CustomParams["TipCluster"]) -and $allExistingResources) {
+						Write-LogInfo "Try to cleanup all resources from Resource Group '$($this.RGIdentifier)' for testing with TiP..."
+						$isResoruceCleanedExceptAvailabilitySet = Delete-ResourceGroup -RGName $this.RGIdentifier -UseExistingRG $this.UseExistingRG
+						if ($isResoruceCleanedExceptAvailabilitySet) {
+							$allExistingResources | Where-Object { $_.ResourceType -imatch "availabilitySets" } | ForEach-Object {
+								if (Remove-AzResource -ResourceGroupName $this.RGIdentifier -ResourceName $_.Name -ResourceType $_.ResourceType -Force) {
+									Write-LogInfo "`tCleanup resource group '$($this.RGIdentifier)' successfully."
+								}
+								else {
+									throw "Failed to cleanup resources from '$($this.RGIdentifier)', please remove all resources manually."
+								}
+							}
 						}
+						else {
+							throw "Failed to cleanup resources from '$($this.RGIdentifier)', please remove all resources manually."
+						}
+					}
+					elseif (!$allExistingResources) {
+						Write-LogInfo "Resource group '$($this.RGIdentifier)' is empty, new resources will be deployed"
 					}
 				}
 			}

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -43,7 +43,6 @@ Class HyperVController : TestController
 			$parameterErrors += "-RGIdentifier is not set"
 		}
 		$this.DestinationOsVhdPath = $ParamTable["DestinationOsVhdPath"]
-		$this.SyncEquivalentCustomParameters("VMGeneration", $this.VMGeneration)
 
 		if ($this.VMGeneration -and (("1", "2") -notcontains $this.VMGeneration)) {
 			$parameterErrors += "-VMGeneration '$($this.VMGeneration)' is not supported."


### PR DESCRIPTION
- Previously, when VM deploy failed,  LISA won't record test results in database.

- When testing in progress, kernel panic,  LISA won't record test results in database.

- A few small bugs fixed together.

Now all cases, will record test result into Database
=============TestLog========================

07/25/2020 08:56:03 : [INFO ] Use provided storage key
07/25/2020 08:56:04 : [INFO ] Uploading 16.21KB xxxx --> xxxx
07/25/2020 08:56:04 : [INFO ] Succeeded.
07/25/2020 08:56:04 : [INFO ] Get the SQL query of test results:  done
07/25/2020 08:56:04 : [INFO ] SQLQuery:  INSERT INTO LISAv2Results (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,SubTestName,SubTestResult,ExecutionTag,GuestDistro,KernelVersion,HardwarePlatform,LISVersion,HostVersion,VMSize,VMGeneration,Networking,ARMImage,OsVHD,LogFile,BuildURL) VALUES ('2020-7-25 8:56:3','Azure','westus2','Functional','CORE','L3-CACHE-CHECK','ABORTED','','','','SUSE Linux Enterprise Server 12 SP4','4.12.14-6.29-azure','x86_64','NA','14393-10.0-0-0.305','Standard_D32s_v3','2','Synthetic','SUSE sles 12-sp4-gen2 latest','','xxxx', ''),('2020-7-25 8:56:3','Azure','westus2','Functional','CORE','L3-CACHE-CHECK','ABORTED','','sdfsdf','','SUSE Linux Enterprise Server 12 SP4','4.12.14-6.29-azure','x86_64','NA','14393-10.0-0-0.305','Standard_D32s_v3','2','Synthetic','SUSE sles 12-sp4-gen2 latest','','xxxx', '')
07/25/2020 08:56:04 : [INFO ] Uploading test results to database: DONE
07/25/2020 08:56:04 : [INFO ] Delete deployed target machine ...
07/25/2020 08:56:04 : [INFO ] Try to delete resource group LISAv2-OneVM-harz-test-CK36-20200725015320...
07/25/2020 08:56:06 : [INFO ] Triggering delete operation for Resource Group LISAv2-OneVM-harz-test-CK36-20200725015320
07/25/2020 08:56:06 : [INFO ] Checking for any unmanaged disks in LISAv2-OneVM-harz-test-CK36-20200725015320 ...
07/25/2020 08:56:07 : [INFO ] No any unmanaged VHDs found. Proceeding resource group cleanup.
07/25/2020 08:56:23 : [INFO ] Retrying 'Remove-AzResourceGroup -ResourceGroupName LISAv2-OneVM-harz-test-CK36-20200725015320'. Remaining attempts : 9
07/25/2020 08:56:27 : [INFO ] Successfully triggered delete operation for Resource Group LISAv2-OneVM-harz-test-CK36-20200725015320
07/25/2020 08:56:27 : [INFO ] Successfully started clean up for RG LISAv2-OneVM-harz-test-CK36-20200725015320..
07/25/2020 08:56:27 : [WARN ] VMData is empty (null). Aborting the testing.
07/25/2020 08:56:28 : [INFO ] End of testing: L3-CACHE-CHECK with SetupConfig: { ARMImageName: SUSE sles 12-sp4-gen2 latest, OverrideVMSize: Standard_D32s_v3, SetupType: OneVM, TestLocation: westus2 }, result: Aborted
07/25/2020 08:56:28 : [INFO ] PASS    - 0
07/25/2020 08:56:28 : [INFO ] SKIPPED - 0
07/25/2020 08:56:28 : [INFO ] FAIL    - 0
07/25/2020 08:56:28 : [INFO ] ABORTED - 1
07/25/2020 08:56:28 : [INFO ] PENDING - 0 

07/25/2020 08:56:28 : [INFO ] Cleanup test environment if required ...
07/25/2020 08:56:28 : [INFO ] Test CK36 finished
07/25/2020 08:56:28 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 07/25/2020 08:53:15
ARM Image Under Test  : SUSE : sles : 12-sp4-gen2 : latest
Initial Kernel Version: 4.12.14-6.29-azure
Final Kernel Version  : 4.12.14-6.29-azure
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 L3-CACHE-CHECK                                                                 Aborted                    0 
      ARMImageName: SUSE sles 12-sp4-gen2 latest, OverrideVMSize: Standard_D32s_v3, SetupType: OneVM, TestLocation: westus2
      sdfsdf


Logs can be found at C:\LISAv2\TestResults\2020-07-25-01-52-28-3236


07/25/2020 08:56:28 : [DEBUG] Creating 'C:\LISAv2\Azure-CK36-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-07-25-01-52-28-3236'
07/25/2020 08:56:28 : [DEBUG] C:\LISAv2\Azure-CK36-TestLogs.zip created successfully.
07/25/2020 08:56:28 : [INFO ] Analyzing test results ...
07/25/2020 08:56:28 : [INFO ] LISAv2 exit code: 1

=============Another Test run Log with multi blanks between publisher offer, sku and version=================
. 'C:\LISAv2\Run-LisaV2.ps1' -TestNames 'VERIFY-DEPLOYMENT-PROVISION' -RGIdentifier harz-test -TestPlatform Azure -ARMImageName **'Canonical   UbuntuServer        [a few blank spaces here]      18.04-LTS  Latest,suse sles-15-sp1 gen2 latest'** -XMLSecretFile C:\LISAv2\AzureSecretsTestOnly.xml -EnableTelemetry -ResourceCleanup  'Delete'

07/31/2020 00:58:19 : [INFO ] Test DW94 finished
07/31/2020 00:58:19 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 07/31/2020 00:48:57
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
ARM Image Under Test  : suse : sles-15-sp1 : gen2 : latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.19 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, SetupType: OneVM, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.15 
      ARMImageName: suse sles-15-sp1 gen2 latest, SetupType: OneVM, TestLocation: westus2, Kernel Version: 4.12.14-8.33-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS