### PR TITLE
Fix issue when added repo file not exist.

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2259,10 +2259,13 @@ function add_sles_benchmark_repo () {
 	IFS='- ' read -r -a array <<< "$VERSION"
 	repo_url="https://download.opensuse.org/repositories/benchmark/SLE_${array[0]}_${array[1]}/benchmark.repo"
 	wget $repo_url -O /dev/null -o /dev/null
+	# if no judgement for repo url not existing, the script will hung when execute zypper --no-gpg-checks refresh
 	if [ $? -eq 0 ]; then
 		LogMsg "add_sles_benchmark_repo - $repo_url"
 		zypper addrepo $repo_url
 		zypper --no-gpg-checks refresh
+	else
+		LogMsg "$repo_url doesn't exist"
 	fi
 	return 0
 }

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2258,9 +2258,12 @@ function add_sles_benchmark_repo () {
 	source /etc/os-release
 	IFS='- ' read -r -a array <<< "$VERSION"
 	repo_url="https://download.opensuse.org/repositories/benchmark/SLE_${array[0]}_${array[1]}/benchmark.repo"
-	LogMsg "add_sles_benchmark_repo - $repo_url"
-	zypper addrepo $repo_url
-	zypper --no-gpg-checks refresh
+	wget $repo_url -O /dev/null -o /dev/null
+	if [ $? -eq 0 ]; then
+		LogMsg "add_sles_benchmark_repo - $repo_url"
+		zypper addrepo $repo_url
+		zypper --no-gpg-checks refresh
+	fi
 	return 0
 }
 


### PR DESCRIPTION
Before fix, test will hung since https://download.opensuse.org/repositories/benchmark/SLE_12_SP4/ doesn't exist.
After fix

```
[LISAv2 Test Results Summary]
Test Run On           : 07/28/2020 04:54:53
ARM Image Under Test  : SUSE : sles-sap : 12-sp4-gen2 : latest
Initial Kernel Version: 4.12.14-95.54-default
Final Kernel Version  : 4.12.14-95.54-default
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              PERF-STORAGE-4K-IO                                                                PASS                11.41 
      ARMImageName: SUSE sles-sap 12-sp4-gen2 latest, SetupType: OneVM12Disk, StorageAccountType: Premium_LRS, TestLocation: westus2
      Mode=randread : block_size=4K q_depth=1 iops=115.612813
      Mode=randread : block_size=4K q_depth=2 iops=300.168297
      Mode=randread : block_size=4K q_depth=4 iops=637.652382
      Mode=randread : block_size=4K q_depth=8 iops=2226.508474
      Mode=randread : block_size=4K q_depth=16 iops=8340.874784
      Mode=randread : block_size=4K q_depth=32 iops=17201.738439
      Mode=randread : block_size=4K q_depth=64 iops=29617.852337
      Mode=randread : block_size=4K q_depth=128 iops=45821.338168
      Mode=randread : block_size=4K q_depth=256 iops=52233.252577
```