### PR TITLE
Delete the definition of Run_SSHCommand in perf_ntttcp.sh

### DIFF
--- a/Testscripts/Linux/perf_ntttcp.sh
+++ b/Testscripts/Linux/perf_ntttcp.sh
@@ -71,24 +71,6 @@ if [ ! "${nicName}" ]; then
 	exit 1
 fi
 
-localaddress=$(hostname -i)
-
-Run_SSHCommand()
-{
-	ips="$1"
-	cmd="$2"
-	IFS=',' read -r -a array <<< "$ips"
-	for ip in "${array[@]}"
-	do
-		LogMsg "Execute ${cmd} on ${ip}"
-		if [[ ${localaddress} = ${ip} ]]; then
-			bash -c "${cmd}"
-		else
-			ssh "${ip}" "${cmd}"
-		fi
-	done
-}
-
 # Make & build ntttcp on client and server Machine
 LogMsg "Configuring client ${client}..."
 Run_SSHCommand "${client}" ". $UTIL_FILE && install_ntttcp ${ntttcpVersion} ${lagscopeVersion}"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3546,8 +3546,9 @@ function GetPlatform() {
 # $2 == command
 function Run_SSHCommand()
 {
-	ips="$1"
-	cmd="$2"
+	ips=${1}
+	cmd=${2}
+	localaddress=$(hostname -i)
 	IFS=',' read -r -a array <<< "$ips"
 	for ip in "${array[@]}"
 	do


### PR DESCRIPTION
Delete the definition of Run_SSHCommand in perf_ntttcp.sh.
```
[LISAv2 Test Results Summary]
Test Run On           : 07/28/2020 09:46:25
ARM Image Under Test  : RedHat : RHEL : 7-LVM : latest
Initial Kernel Version: 3.10.0-1127.el7.x86_64
Final Kernel Version  : 3.10.0-1127.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-THROUGHPUT-MULTICONNECTION-NTTTCP-SRIOV                          PASS                14.06 
      ARMImageName: RedHat RHEL 7-LVM latest, Networking: SRIOV, SetupType: TwoVM2Host, TestLocation: westus2
      Connections=20480 : throughput=2.38Gbps cyclesPerByte_sender=174.03 cyclesPerByte_receiver=22.75 Avg_TCP_lat=4029.689 pktsPerInterrupt=7.59 conCreatedTime=3399131 
retransSegs=4423467.0
      Connections=40960 : throughput=2.45Gbps cyclesPerByte_sender=169.38 cyclesPerByte_receiver=30.05 Avg_TCP_lat=5465.905 pktsPerInterrupt=8.83 conCreatedTime=3950216 
retransSegs=5327563.0
      Connections=50000 : throughput=2.29Gbps cyclesPerByte_sender=181.29 cyclesPerByte_receiver=31.45 Avg_TCP_lat=4499.201 pktsPerInterrupt=8.55 conCreatedTime=4890738 
retransSegs=2936507.0
      Connections=55000 : throughput=2.36Gbps cyclesPerByte_sender=175.73 cyclesPerByte_receiver=42.30 Avg_TCP_lat=5360.564 pktsPerInterrupt=8.73 conCreatedTime=5002901 
retransSegs=3831154.0
      
```