### PR TITLE
Get cpu count from vm directly. current design will fail the case when override the VM size.

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKEVENT.sh
+++ b/Testscripts/Linux/TIME-CLOCKEVENT.sh
@@ -89,6 +89,7 @@ UnbindClockEvent()
 # MAIN SCRIPT
 #
 GetDistro
+VCPU=$(nproc)
 case $DISTRO in
     redhat_6 | centos_6)
         LogMsg "WARNING: $DISTRO does not support Hyper-V clockevent."

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -188,9 +188,6 @@
 	<testName>TIME-CLOCKEVENT-UP</testName>
 	<testScript>TIME-CLOCKEVENT.sh</testScript>
 	<files>.\TestScripts\Linux\TIME-CLOCKEVENT.sh,.\TestScripts\Linux\utils.sh</files>
-	<TestParameters>
-	<param>VCPU=1</param>
-	</TestParameters>
 	<Platform>Azure,HyperV</Platform>
 	<Category>Functional</Category>
 	<Area>CORE</Area>
@@ -204,9 +201,6 @@
 	<testName>TIME-CLOCKEVENT-SMP</testName>
 	<testScript>TIME-CLOCKEVENT.sh</testScript>
 	<files>.\TestScripts\Linux\TIME-CLOCKEVENT.sh,.\TestScripts\Linux\utils.sh</files>
-	<TestParameters>
-	<param>VCPU=8</param>
-	</TestParameters>
 	<Platform>Azure,HyperV</Platform>
 	<Category>Functional</Category>
 	<Area>CORE</Area>


### PR DESCRIPTION
Current VCPU is hardcode, and when override size has different vCPU, test will fail.

After fix -

```
[LISAv2 Test Results Summary]
Test Run On           : 07/28/2020 09:09:08
ARM Image Under Test  : suse : sles-15-sp1 : gen1 : latest
Override VM size Under Test  : Standard_DS15_v2
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKEVENT-UP                                                                PASS                 0.34 
      ARMImageName: suse sles-15-sp1 gen1 latest, OverrideVMSize: Standard_DS15_v2, SetupType: OneVM, TestLocation: westus2
    2 CORE                 TIME-CLOCKEVENT-SMP                                                               PASS                 2.33 
      ARMImageName: suse sles-15-sp1 gen1 latest, OverrideVMSize: Standard_DS15_v2, SetupType: OneVM, TestLocation: westus2
```

Before fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 07/28/2020 09:16:26
ARM Image Under Test  : suse : sles-15-sp1 : gen1 : latest
Override VM size Under Test  : Standard_DS15_v2
Initial Kernel Version: 4.12.14-8.33-azure
Final Kernel Version  : 4.12.14-8.33-azure
Total Test Cases      : 2 (0 Passed, 2 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKEVENT-UP                                                                FAIL                 0.65 
      ARMImageName: suse sles-15-sp1 gen1 latest, OverrideVMSize: Standard_DS15_v2, SetupType: OneVM, TestLocation: westus2
    2 CORE                 TIME-CLOCKEVENT-SMP                                                               FAIL                 0.59 
      ARMImageName: suse sles-15-sp1 gen1 latest, OverrideVMSize: Standard_DS15_v2, SetupType: OneVM, TestLocation: westus2
```