### PR TITLE
Update verify_vmbus_interrupts.sh

### DIFF
--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -15,8 +15,8 @@
 #        2. Verifies if each CPU has more than 0 interrupts processed.
 #           a) Hypervisor callback interrupts: vmbus messages/events. It could have CPU
 #              with 0 interrupts in big VM size.
-#           b) Hyper-V reenlightenment interrupts: Only used in Nexted virtualization.
-#           c) Hyper-V stimer0 interrupts: new Hyper-V timer, and if exsts, this count
+#           b) Hyper-V reenlightenment interrupts: Only used in Nested virtualization.
+#           c) Hyper-V stimer0 interrupts: new Hyper-V timer, and if exists, this count
 #              should not be zero.
 ################################################################
 

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -59,7 +59,7 @@ function verify_vmbus_interrupts() {
                 intrCount=$(echo "$line" | xargs echo |cut -f $(( core+2 )) -d ' ')
                 if [ "$intrCount" -ne 0 ]; then
                     (( nonCPU0inter++ ))
-                    UpdateSummary "CPU core ${core} is processing VMBUS $intrCount interrupts."
+                    UpdateSummary "CPU core $core be processing VMBUS $intrCount interrupts."
                 fi
             done
         fi
@@ -71,13 +71,13 @@ function verify_vmbus_interrupts() {
         LogErr "None of CPU cores are processing VMBUS interrupts!"
         SetTestStateFailed
     elif [ "$nonCPU0inter" -eq "$cpu_count" ]; then
-        LogMsg "All {$nonCPU0inter} CPU cores are processing interrupts"
+        LogMsg "All $nonCPU0inter CPU cores are processing interrupts"
         SetTestStateCompleted
     elif [ "$nonCPU0inter" -gt "$cpu_count" ]; then
-        LogMsg "All {$nonCPU0inter} CPU cores are processing interrupts. $((nonCPU0inter - cpu_count)) CPUs are processing multiple interrupts"
+        LogMsg "All $nonCPU0inter CPU cores are processing interrupts. $((nonCPU0inter - cpu_count)) CPUs are processing multiple interrupts"
         SetTestStateCompleted
     else
-        UpdateSummary "{$nonCPU0inter} CPU cores are processing interrupts."
+        UpdateSummary "$nonCPU0inter CPU cores are processing interrupts."
         SetTestStateCompleted
     fi
 }


### PR DESCRIPTION
Found the test result failed in the big size VM, because there were some CPU counts idle, which means no vmbus interrupts assigned. That is the expected output in big size VM. 
In the small and mid-size VM, this old script works. 

Updated the verification conditions with only for Hypervisor callback interrupts. This is only interrupted in Azure VM. Big size VMs do not have all CPUs having interrupts. Some should be 0 (idle) because they have enough CPUs assigning to vmbus interrupts already.
If there is any other verification needed, please comment here.

**TEST RESULTS**

[LISAv2 Test Results Summary]
Test Run On           : 07/30/2020 23:49:23
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size Under Test  : Standard_B4ms
Initial Kernel Version: 5.3.0-1034-azure
Final Kernel Version  : 5.3.0-1034-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.61
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_B4ms, SetupType: OneVM, TestLocation: westus2

[LISAv2 Test Results Summary]
Test Run On           : 07/30/2020 23:58:08
ARM Image Under Test  : SUSE : sles-15-sp2 : gen2 : latest
Override VM size Under Test  : Standard_M416ms_v2
Initial Kernel Version: 5.3.18-16-azure
Final Kernel Version  : 5.3.18-16-azure
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.46
      ARMImageName: SUSE sles-15-sp2 gen2 latest, OverrideVMSize: Standard_M416ms_v2, SetupType: OneVM, TestLocation: westus2

[LISAv2 Test Results Summary]
Test Run On           : 07/31/2020 00:10:59
ARM Image Under Test  : RedHat : RHEL : 7.5 : latest
Override VM size Under Test  : Standard_E32_v3
Initial Kernel Version: 3.10.0-862.43.1.el7.x86_64
Final Kernel Version  : 3.10.0-862.43.1.el7.x86_64
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.52
      ARMImageName: RedHat RHEL 7.5 latest, OverrideVMSize: Standard_E32_v3, SetupType: OneVM, TestLocation: westus2
