### PR TITLE
Fix issue the vhd name is null in CAPTURE-VHD-BEFORE-TEST test case

### DIFF
--- a/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
+++ b/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
@@ -32,6 +32,7 @@ function Main {
         Write-LogInfo "Shutting down VM..."
         $null = Stop-AzVM -Name $captureVMData.RoleName -ResourceGroupName $captureVMData.ResourceGroupName -Force
         Write-LogInfo "VM shutdown successful."
+        $Append = $Global:TestID
         if ($env:BUILD_NAME){
             $Append += "-$env:BUILD_NAME"
         }
@@ -39,8 +40,8 @@ function Main {
             $Append += "-$env:BUILD_NUMBER"
         }
         #Copy the OS VHD with different name.
-        if ($CurrentTestData.SetupScript.ARMImageName) {
-            $ARMImage = $CurrentTestData.SetupScript.ARMImageName.Split(" ")
+        if ($CurrentTestData.SetupConfig.ARMImageName) {
+            $ARMImage = $CurrentTestData.SetupConfig.ARMImageName.Split(" ")
             $newVHDName = "EOSG-AUTOBUILT-$($ARMImage[0])-$($ARMImage[1])-$($ARMImage[2])-$($ARMImage[3])-$Append"
         }
         if ($global:BaseOsVHD) {


### PR DESCRIPTION
Before fix:
CAPTURE-VHD-BEFORE-TEST, the name of vhd uploaded in the storage account is .vhd. The name is null.

We don't have SetupScript in $CurrentTestData.