### PR TITLE
Fix "RetransSegments" data type. It's should be int.

### DIFF
--- a/Testscripts/Linux/perf_ntttcp.sh
+++ b/Testscripts/Linux/perf_ntttcp.sh
@@ -373,7 +373,7 @@ Run_Ntttcp()
 		rxpackets_sender_value=0.0
 		pktsInterrupt_sender_value=0.0
 		avg_latency_value=0.0
-		retrans_segs_value=0.0
+		retrans_segs_value=0
 		concreatedtime_us_value=0.0
 		for tx_ntttcp_log_file in "${tx_ntttcp_log_files[@]}";
 		do


### PR DESCRIPTION
The data type of "RetransSegments" in database is int. But the test result is decimal. Change the "retrans_segs_value" to int.