### PR TITLE
Remove resource disk on HyperV and update storage test cases.

### DIFF
--- a/Libraries/HyperV.psm1
+++ b/Libraries/HyperV.psm1
@@ -405,14 +405,6 @@ function Create-HyperVGroupDeployment([string]$HyperVGroupName, $HyperVGroupXML,
                     $Out = Set-VM -VM $NewVM -ProcessorCount $CurrentVMCpu -StaticMemory  -CheckpointType Disabled -Notes "$HyperVGroupName"
                     Write-LogInfo "Add-VMGroupMember -Name $HyperVGroupName -VM $($NewVM.Name)"
                     $Out = Add-VMGroupMember -Name "$HyperVGroupName" -VM $NewVM -ComputerName $HyperVHost
-                    $ResourceDiskPath = Join-Path $env:TEMP "ResourceDisk-$((Get-Date).Ticks)-sdb${vhdSuffix}"
-                    if ($DestinationOsVHDPath -ne "VHDs_Destination_Path") {
-                        $ResourceDiskPath = "$DestinationOsVHDPath\ResourceDisk-$((Get-Date).Ticks)-sdb${vhdSuffix}"
-                    }
-                    Write-LogInfo "New-VHD -Path $ResourceDiskPath -SizeBytes 1GB -Dynamic -ComputerName $HyperVHost"
-                    New-VHD -Path $ResourceDiskPath -SizeBytes 1GB -Dynamic -ComputerName $HyperVHost
-                    Write-LogInfo "Add-VMHardDiskDrive -ControllerType SCSI -Path $ResourceDiskPath -VM $($NewVM.Name)"
-                    Add-VMHardDiskDrive -ControllerType SCSI -Path $ResourceDiskPath -VM $NewVM
                     if ($NewVM.AutomaticStopAction -ne "Shutdown") {
                         Write-LogInfo "Set-VM -Name $CurrentVMName -ComputerName $HyperVHost -AutomaticStopAction Shutdown"
                         try {

--- a/Testscripts/Linux/PartitionDisks.sh
+++ b/Testscripts/Linux/PartitionDisks.sh
@@ -29,90 +29,9 @@ if [ $? -ne 0 ]; then
     exit 2
 fi
 
-os_disk=$(get_OSdisk)
-LogMsg "OS disk:$os_disk"
-
-count=0
-for disk in $(cat /proc/partitions | grep sd | awk '{print $4}')
-do
-    if [[ "$disk" != "$os_disk"* ]];
-    then
-        ((count++))
-    fi
-done
-
-((count--))
-
-for driveName in /dev/sd*[^0-9];
-do
-    #
-    # Skip the OS disk
-    #
-    if [ $driveName != "/dev/${os_disk}" ]; then
-
-    # Delete the existing partition
-    for (( c=1 ; c<=count; count--))
-        do
-            (echo d; echo $c ; echo ; echo w) |  fdisk $driveName &>~/summary.log
-            sleep 5
-        done
-    
-    # Partition Drive
-    (echo n; echo p; echo 1; echo ; echo +500M; echo ; echo w) | fdisk $driveName &>~/summary.log
-    sleep 5
-    (echo n; echo p; echo 2; echo ; echo; echo ; echo w) | fdisk $driveName &>~/summary.log
-    sleep 5
-    sts=$?
-    if [ 0 -ne ${sts} ]; then
-        LogErr "Error:  Partitioning disk Failed ${sts}"
-        UpdateSummary "Partitioning disk $driveName : Failed"
-        SetTestStateAborted
-        exit 1
-    else
-        UpdateSummary "Partitioning disk $driveName : Success"
-    fi
-
-    sleep 1
-
-   # Create file system on it .
-   echo "y" | mkfs.$FILESYS ${driveName}1  &>~/summary.log; echo "y" | mkfs.$FILESYS ${driveName}2 &>~/summary.log
-   sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  creating filesystem  Failed ${sts}"
-            UpdateSummary " Creating FileSystem $filesys on disk $driveName : Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            msg="Creating FileSystem $FILESYS on disk  $driveName : Success"
-            LogMsg "$msg"
-            UpdateSummary "$msg"
-        fi
-
-   sleep 1
-
-   # mount the disk
-   MountName="/mnt/1"
-   if [ ! -e ${MountName} ]; then
-     mkdir $MountName
-   fi
-   MountName1="/mnt/2"
-   if [ ! -e ${MountName1} ]; then
-     mkdir $MountName1
-   fi
-   mount ${driveName}1 $MountName &>~/summary.log; mount ${driveName}2 $MountName1 &>~/summary.log
-   sts=$?
-       if [ 0 -ne ${sts} ]; then
-           LogErr "Error:  mounting disk Failed ${sts}"
-           UpdateSummary " Mounting disk $driveName on $MountName: Failed"
-           SetTestStateAborted
-           exit 1
-       else
-           LogMsg "mounting disk ${driveName}1 on ${MountName}"
-           LogMsg "mounting disk ${driveName}2 on ${MountName1}"
-           UpdateSummary " Mounting disk ${driveName}1 : Success"
-           UpdateSummary " Mounting disk ${driveName}2 : Success"
-       fi
-fi
-done
+delete_partition
+make_partition 2
+make_filesystem 2 "${FILESYS}"
+mount_disk 2
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/STOR-Large-CopyFile.sh
+++ b/Testscripts/Linux/STOR-Large-CopyFile.sh
@@ -175,12 +175,14 @@ do
 done
 
 echo "constants disk count= $diskCount"
+os_disk=$(get_OSdisk)
+LogMsg "OS disk: $os_disk"
 
 # Compute the number of sd* drives on the system
 for driveName in /dev/sd*[^0-9];
 do
-    # Skip /dev/sda
-    if [ ${driveName} = "/dev/sda" ] || [ ${driveName} = "/dev/sdb" ]; then
+    # Skip the OS disk
+    if [ ${driveName} = "/dev/${os_disk}" ]; then
         continue
     fi
 

--- a/Testscripts/Linux/STOR-Lis-Disk.sh
+++ b/Testscripts/Linux/STOR-Lis-Disk.sh
@@ -96,7 +96,7 @@ sd_count=$(ls /dev/sd*[^0-9] | wc -l)
 # Subtract the boot disk and resource from the sd_count, then make
 # sure the two disk counts match
 #
-sd_count=$((sd_count - 2))
+sd_count=$((sd_count - 1))
 LogMsg "/dev/sd* disk count = $sd_count"
 
 if [ $sd_count != $disk_count ]; then
@@ -113,13 +113,11 @@ fi
 fixed_disk_size=1073741824
 disk_4k_size=4096
 dynamic_disk_size=136365211648
-
+os_disk=$(get_OSdisk)
+LogMsg "OS disk: $os_disk"
 for drive_name in /dev/sd*[^0-9]; do
-    # Skip /dev/sda and /dev/sdb
-    if [ ${drive_name} = "/dev/sda" ]; then
-        continue
-    fi
-    if [ ${drive_name} = "/dev/sdb" ]; then
+    # Skip the OS disk
+    if [ ${drive_name} = "/dev/${os_disk}" ]; then
         continue
     fi
 

--- a/Testscripts/Linux/STORAGE-HotRemove.sh
+++ b/Testscripts/Linux/STORAGE-HotRemove.sh
@@ -46,7 +46,7 @@ sdCount=$(fdisk -l | grep -c "Disk /dev/sd*")
 
 # Subtract the boot disk from the sdCount, then make
 # sure the two disk counts match
-sdCount=$((sdCount-2))
+sdCount=$((sdCount-1))
 LogMsg "fdisk -l disk count = $sdCount"
 
 if [ $sdCount == $diskCount ]; then

--- a/Testscripts/Linux/STORAGE-LargeDisk.sh
+++ b/Testscripts/Linux/STORAGE-LargeDisk.sh
@@ -169,7 +169,7 @@ done
 
 # Subtract the boot disk from the sdCount, then make
 # sure the two disk counts match
-sdCount=$((sdCount-2))
+sdCount=$((sdCount-1))
 echo "/dev/sd* disk count = $sdCount"
 
 if [ $sdCount != $diskCount ];
@@ -178,12 +178,14 @@ then
     SetTestStateAborted
     exit 0
 fi
+os_disk=$(get_OSdisk)
+LogMsg "OS disk: $os_disk"
 
 for driveName in /dev/sd*[^0-9];
 do
 
-    # Skip /dev/sda
-    if [ "${driveName}" = "/dev/sda" ] || [ "${driveName}" = "/dev/sdb" ]; then
+    # Skip the OS disk
+    if [ "${driveName}" = "/dev/${os_disk}" ]; then
         continue
     fi
 

--- a/Testscripts/Linux/STOR_VSS_Disk_Fail.sh
+++ b/Testscripts/Linux/STOR_VSS_Disk_Fail.sh
@@ -17,91 +17,13 @@ if [ ! ${FILESYS} ]; then
     SetTestStateAborted
     exit 1
 fi
-# Count the Number of partition present in added new Disk.
-count=0
-for disk in $(cat /proc/partitions | grep sd | awk '{print $4}')
-do
-    if [[ "$disk" != "sda"* ]] && [[ "$disk" != "sdb"* ]];
-    then
-        ((count++))
-    fi
-done
-((count--))
-# Format, Partition and mount all the new disk on this system.
-for driveName in /dev/sd*[^0-9];
-do
-    #
-    # Skip /dev/sda && /dev/sdb
-    #
-    if [ $driveName != "/dev/sda" ] && [ $driveName != "/dev/sdb" ] ; then
-        # Delete the existing partition
-        for (( c=1 ; c<=count; count--))
-        do
-            (echo d; echo $c ; echo ; echo w) |  fdisk $driveName &>~/summary.log
-            sleep 5
-        done
-        # Partition Drive
-        (echo n; echo p; echo 1; echo ; echo +500M; echo ; echo w) | fdisk $driveName &>~/summary.log
-        (echo n; echo p; echo 2; echo ; echo; echo ; echo w) | fdisk $driveName &>~/summary.log
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  Partitioning disk Failed ${sts}"
-            UpdateSummary "Partitioning disk $driveName : Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            UpdateSummary "Partitioning disk $driveName : Success"
-        fi
-        sleep 1
-        # Create file system on it.
-        echo "y" | mkfs.$FILESYS ${driveName}1 ; echo "y" | mkfs.$FILESYS ${driveName}2
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  creating filesystem  Failed ${sts}"
-            UpdateSummary " Creating FileSystem $filesys on disk $driveName : Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            msg="Creating FileSystem $FILESYS on disk  $driveName : Success"
-            LogMsg "$msg"
-            UpdateSummary "$msg"
-        fi
-        sleep 1
-        # mount the partition to two paths
-        MountName="/mnt/1"
-        if [ ! -e ${MountName} ]; then
-            mkdir $MountName
-        fi
-        MountName1="/mnt/2"
-        if [ ! -e ${MountName1} ]; then
-            mkdir $MountName1
-        fi
-        mount ${driveName}1 $MountName &>~/summary.log; mount ${driveName}2 $MountName1 &>~/summary.log
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  mounting disk Failed ${sts}"
-            UpdateSummary " Mounting disk $driveName on $MountName: Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            LogMsg "mounting disk ${driveName}1 on ${MountName}"
-            LogMsg "mounting disk ${driveName}2 on ${MountName1}"
-            UpdateSummary " Mounting disk ${driveName}1 : Success"
-            UpdateSummary " Mounting disk ${driveName}2 : Success"
-        fi
-        # Now Freeze one of the volume.
-        fsfreeze -f $MountName1
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "fsfreeze disk Failed ${sts}"
-            UpdateSummary "Failed to fsfreeze $MountName1"
-            SetTestStateAborted
-            exit 1
-        else
-            LogMsg "fsfreeze succeed"
-            UpdateSummary "fsfreeze $MountName1: Success"
-        fi
-    fi
-done
+
+delete_partition
+make_partition 2
+make_filesystem 2 "${FILESYS}"
+mount_disk 2
+MountName1="/mnt/2"
+fsfreeze -f "$MountName1"
+check_exit_status "fsfreeze $MountName1" "exit"
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/STOR_VSS_Disk_Mount_Multi_Paths.sh
+++ b/Testscripts/Linux/STOR_VSS_Disk_Mount_Multi_Paths.sh
@@ -27,79 +27,23 @@ if [ $? -ne 0 ]; then
     SetTestStateAborted
     exit 2
 fi
-# Count the Number of partition present in added new Disk.
-count=0
-for disk in $(cat /proc/partitions | grep sd | awk '{print $4}')
-do
-    if [[ "$disk" != "sda"* ]] && [[ "$disk" != "sdb"* ]];
-    then
-        ((count++))
-    fi
-done
 
-((count--))
-# Format, Partition and mount all the new disk on this system.
-for driveName in /dev/sd*[^0-9];
-do
-    #
-    # Skip /dev/sda
-    #
-    if [ $driveName != "/dev/sda" ] && [ $driveName != "/dev/sdb" ] ; then
-        # Delete the existing partition
-        for (( c=1 ; c<=count; count--))
-        do
-            (echo d; echo $c ; echo ; echo w) |  fdisk $driveName &>~/summary.log
-            sleep 5
-        done
-        # Partition Drive
-        (echo n; echo p; echo 1; echo ; echo +500M; echo ; echo w) | fdisk $driveName &>~/summary.log
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  Partitioning disk Failed ${sts}"
-            UpdateSummary "Partitioning disk $driveName : Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            UpdateSummary "Partitioning disk $driveName : Success"
-        fi
-        sleep 1
-        # Create file system on it.
-        echo "y" | mkfs.$FILESYS ${driveName}1  &>~/summary.log
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  creating filesystem  Failed ${sts}"
-            UpdateSummary " Creating FileSystem $filesys on disk $driveName : Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            msg="Creating FileSystem $FILESYS on disk  $driveName : Success"
-            LogMsg "$msg"
-            UpdateSummary "$msg"
-        fi
-
-        sleep 1
-        # mount the partition to two paths
-        MountName="/mnt/1"
-        if [ ! -e ${MountName} ]; then
-            mkdir $MountName
-        fi
-        MountName1="/mnt/2"
-        if [ ! -e ${MountName1} ]; then
-            mkdir $MountName1
-        fi
-        mount ${driveName}1 $MountName &>~/summary.log; mount ${driveName}1 $MountName1 &>~/summary.log
-        sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "Error:  mounting disk Failed ${sts}"
-            UpdateSummary " Mounting disk $driveName on $MountName: Failed"
-            SetTestStateAborted
-            exit 1
-        else
-            LogMsg "mounting disk ${driveName}1 on ${MountName}"
-            LogMsg "mounting disk ${driveName}1 on ${MountName1}"
-            UpdateSummary " Mounting disk ${driveName}1 : Success"
-        fi
-    fi
-done
+delete_partition
+make_partition 2
+make_filesystem 2 "${FILESYS}"
+sleep 1
+# mount the same partition to two paths
+MountName="/mnt/1"
+if [ ! -e ${MountName} ]; then
+    mkdir $MountName
+fi
+MountName1="/mnt/2"
+if [ ! -e ${MountName1} ]; then
+    mkdir $MountName1
+fi
+mount ${driveName}1 $MountName
+check_exit_status "Mounting disk ${driveName}1 on $MountName" "exit"
+mount ${driveName}1 $MountName1
+check_exit_status "Mounting disk ${driveName}1 on $MountName1" "exit"
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/STOR_VSS_ISCSI_PartitionDisks.sh
+++ b/Testscripts/Linux/STOR_VSS_ISCSI_PartitionDisks.sh
@@ -3,7 +3,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 #
-count=0
 #######################################################################
 # Connects to a iscsi target. It takes the target ip as an argument.
 #######################################################################
@@ -53,12 +52,6 @@ function iScsi_Connect() {
 # Main script body
 #
 #######################################################################
-
-# Cleanup any old summary.log files
-if [ -e ~/summary.log ]; then
-    rm -rf ~/summary.log
-fi
-
 # Source utils.sh
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
@@ -103,76 +96,9 @@ fi
 # Connect to the iSCSI Target
 iScsi_Connect
 check_exit_status "iScsi connection to $TargetIP" "exit"
-
-# Count the Number of partition present in added new Disk .
-for disk in $(cat /proc/partitions | grep sd | awk '{print $4}')
-do
-        if [[ "$disk" != "sda"*  && "$disk" != "sdb"* ]]; then
-            ((count++))
-        fi
-done
-
-((count--))
-
-# Format, Partition and mount all the new disk on this system.
-for driveName in /dev/sd*[^0-9]; do
-    #
-    # Skip /dev/sda and /dev/sdb
-    #
-    if [[ $driveName == "/dev/sda"  || $driveName == "/dev/sdb" ]] ; then
-        continue
-    fi
-
-    # Delete the exisiting partition
-    for (( c=1 ; c<=count; count--)); do
-        (echo d; echo $c ; echo ; echo w) | fdisk $driveName
-    done
-
-    # Partition Drive
-    (echo n; echo p; echo 1; echo ; echo +500M; echo ; echo w) | fdisk $driveName
-    (echo n; echo p; echo 2; echo ; echo; echo ; echo w) | fdisk $driveName
-    sts=$?
-    if [ 0 -ne ${sts} ]; then
-        echo "ERROR:  Partitioning disk Failed ${sts}"
-        SetTestStateAborted
-        UpdateSummary " Partitioning disk $driveName : Failed"
-        exit 1
-    else
-        LogMsg "Partitioning disk $driveName : Success"
-        UpdateSummary " Partitioning disk $driveName : Success"
-    fi
-
-    sleep 1
-
-# Create file sytem on it .
-    echo "y" | mkfs.$FILESYS ${driveName}1  ; echo "y" | mkfs.$FILESYS ${driveName}2
-    check_exit_status "Creating·FileSystem·$filesys·on·disk·$driveName" "exit"
-
-    sleep 1
-
-# mount the disk .
-    MountName="/mnt/1"
-    if [ ! -e ${MountName} ]; then
-        mkdir $MountName
-    fi
-    MountName1="/mnt/2"
-    if [ ! -e ${MountName1} ]; then
-        mkdir $MountName1
-    fi
-    mount  ${driveName}1 $MountName ; mount  ${driveName}2 $MountName1
-    sts=$?
-        if [ 0 -ne ${sts} ]; then
-            LogErr "mounting disk Failed ${sts}"
-            SetTestStateAborted
-            UpdateSummary " Mounting disk $driveName on $MountName: Failed"
-            exit 1
-        else
-            LogMsg "mounting disk ${driveName}1 on ${MountName}"
-            LogMsg "mounting disk ${driveName}2 on ${MountName1}"
-            UpdateSummary " Mounting disk ${driveName}1 : Success"
-            UpdateSummary " Mounting disk ${driveName}2 : Success"
-        fi
-    done
-
+delete_partition
+make_partition 2
+make_filesystem 2 "${FILESYS}"
+mount_disk 2
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/get_data_disk_dev_name.sh
+++ b/Testscripts/Linux/get_data_disk_dev_name.sh
@@ -23,15 +23,7 @@ for dev in /dev/sd*[^0-9]; do
     if [ $dev == "/dev/$os_disk" ]; then
         continue
     fi
-    # Skip the resource disk based on the disk size.
-    # It's not an accurate method when size of other data disks is 1GB,
-    # but it does not effect the test because the resource disk is also a data disk.
-    lsblk  --output SIZE -n -d $dev 2> /dev/null | grep -i "1G" > /dev/null
-    if [ 0 -eq $? ]; then
-        # Set a default name in case size of all data disks is 1GB
-        deviceName=$dev
-        continue
-    fi
+
     deviceName=$dev
     break
 done

--- a/Testscripts/Linux/nested_kvm_storage_perf.sh
+++ b/Testscripts/Linux/nested_kvm_storage_perf.sh
@@ -157,7 +157,7 @@ Collect_Logs()
 ############################################################
 Update_Test_State $ICA_TESTRUNNING
 
-disks=$(ls -l /dev | grep sd[c-z]$ | awk '{print $10}')
+disks=$(get_AvailableDisks)
 Remove_Raid
 
 if [[ $RaidOption == 'RAID in L1' ]]; then

--- a/Testscripts/Linux/nobarrier.sh
+++ b/Testscripts/Linux/nobarrier.sh
@@ -47,13 +47,11 @@ function create_raid_and_mount() {
 	local list=""
 
 	LogMsg "IO test setup started.."
-	list=($(fdisk -l | grep 'Disk.*/dev/sd[a-z]' |awk  '{print $2}' | sed s/://| sort| grep -v "/dev/sd[ab]$" ))
+	list=$(get_AvailableDisks)
 
 	lsblk
 	install_package mdadm
-	LogMsg "--- Raid $deviceName creation started ---"
-	(echo y)| mdadm --create $deviceName --level 0 --raid-devices ${#list[@]} ${list[@]}
-	check_exit_status "$deviceName Raid creation"
+	create_raid0 "$list" "$deviceName"
 
 	time mkfs -t $format $deviceName
 	check_exit_status "$deviceName Raid format"

--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -48,15 +48,6 @@ UpdateTestState()
 	echo "${1}" > $STATE_FILE
 }
 
-get_AvailableDisks() {
-	for disk in $(lsblk | grep "sd[a-z].*disk" | cut -d ' ' -f1);
-	do
-		if [ $(df | grep -c $disk) -eq 0 ]; then
-			echo $disk
-		fi
-	done
-}
-
 RunFIO()
 {
 	UpdateTestState $ICA_TESTRUNNING

--- a/Testscripts/Linux/pktgenSetup.sh
+++ b/Testscripts/Linux/pktgenSetup.sh
@@ -102,7 +102,7 @@ download_pktgen_scripts ${server} ${pktgenDir}
 
 vfName=$(get_vf_name)
 if [ -z "${vfName}" ]; then
-        LogWarn "VF Name is not detected. Please check vm configuration."
+        LogErr "VF Name is not detected. Please check vm configuration."
 fi
 # Store current xdp drop queue variables
 pakcetDropBefore=$(calculate_packets_drop $vfName)

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1987,7 +1987,7 @@ function check_exit_status() {
 				exit $exit_status
 				;;
 			*)
-				LogWarn "Unsupported check_exit_status option: ${test_state}"
+				LogErr "Unsupported check_exit_status option: ${test_state}"
 				;;
 		esac
 	else
@@ -2798,14 +2798,18 @@ function install_netperf () {
 	fi
 }
 
-# Get the active NIC name
-function get_active_nic_name () {
+function install_net_tools () {
 	if [[ $DISTRO_NAME == "sles" ]] && [[ $DISTRO_VERSION =~ 15 ]] || [[ $DISTRO_NAME == "sle_hpc" ]]; then
 		zypper_install "net-tools-deprecated" > /dev/null 2>&1
 	fi
 	if [[ "${DISTRO_NAME}" == "ubuntu" ]]; then
 		apt_get_install "net-tools" > /dev/null 2>&1
 	fi
+}
+
+# Get the active NIC name
+function get_active_nic_name () {
+	install_net_tools
 	echo $(route | grep '^default' | grep -o '[^ ]*$')
 }
 
@@ -3554,6 +3558,10 @@ function get_OSdisk() {
 # Sets the $PLATFORM variable to one of the following: Azure, HyperV
 # Takes no arguments
 function GetPlatform() {
+	which route
+	if [ $? -ne 0 ]; then
+		install_net_tools
+	fi
 	route -n | grep "169.254.169.254" > /dev/null
 	if [[ $? == 0 ]];then
 		http_code=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance?api-version=2019-06-01" -w "%{http_code}" -o /dev/null -s -m 3)
@@ -3621,5 +3629,95 @@ function Run_SSHCommand()
 		else
 			ssh "${ip}" "${cmd}"
 		fi
+	done
+}
+
+get_AvailableDisks() {
+	for disk in $(lsblk | grep "sd[a-z].*disk" | cut -d ' ' -f1); do
+		if [ $(df | grep -c $disk) -eq 0 ]; then
+			echo $disk
+		fi
+	done
+}
+
+delete_partition() {
+	all_disks=$(get_AvailableDisks)
+
+	declare -A TEST_DICT
+	for disk in ${all_disks}; do
+		count=0
+		count=$(cat /proc/partitions | grep "$disk" | wc -l)
+		TEST_DICT["$disk"]=$((count-1))
+	done
+
+	for disk in "${!TEST_DICT[@]}"; do
+		count="${TEST_DICT[$disk]}"
+		LogMsg "Disk /dev/$disk has ${TEST_DICT[$disk]} partition"
+		for ((c=1 ; c<=$((count-1)); c++)); do
+			LogMsg "Delete the $c partition of disk /dev/$disk"
+			(echo d; echo $c ; echo ; echo w) | fdisk "/dev/$disk"
+			sleep 5
+		done
+		if [[ $count -ne 0 ]]; then
+			LogMsg "Delete the last partition of disk /dev/$disk"
+			(echo d; echo ; echo w) | fdisk "/dev/$disk"
+			sleep 5
+		fi
+	done
+}
+
+function make_partition() {
+	os_disk=$(get_OSdisk)
+	paratition_count="$1"
+	for driveName in /dev/sd*[^0-9]; do
+		if [ $driveName == "/dev/${os_disk}" ] ; then
+			continue
+		fi
+		for ((c=1 ; c<="$paratition_count"; c++)); do
+			if [ $c -eq 1 ]; then
+				(echo n; echo p; echo $c; echo ; echo +500M; echo ; echo w) | fdisk $driveName
+			else
+				(echo n; echo p; echo $c; echo ; echo; echo ; echo w) | fdisk $driveName
+			fi
+			check_exit_status "Make the ${c} partition for disk $driveName" "exit"
+		done
+	done
+}
+
+function make_filesystem() {
+	os_disk=$(get_OSdisk)
+	paratition_count="$1"
+	filesys="$2"
+	option="-f"
+	if [ "$filesys" = "ext4" ]; then
+		option="-F"
+	fi
+	for driveName in /dev/sd*[^0-9]; do
+		if [ $driveName == "/dev/${os_disk}" ] ; then
+			continue
+		fi
+		for ((c=1 ; c<="$paratition_count"; c++)); do
+			echo "y" | mkfs.$filesys $option "${driveName}$c"
+			check_exit_status "Creating FileSystem $filesys on disk ${driveName}${c}" "exit"
+		done
+	done
+}
+
+function mount_disk() {
+	os_disk=$(get_OSdisk)
+	paratition_count="$1"
+	for driveName in /dev/sd*[^0-9]; do
+		if [ $driveName == "/dev/${os_disk}" ] ; then
+			continue
+		fi
+		for ((c=1 ; c<="$paratition_count"; c++)); do
+			MountName="/mnt/$c"
+			if [ ! -e ${MountName} ]; then
+				mkdir $MountName
+			fi
+			sleep 1
+			mount  "${driveName}$c" $MountName
+			check_exit_status "Mounting disk ${driveName}${c} on $MountName" "exit"
+		done
 	done
 }

--- a/Testscripts/Linux/validate-da.sh
+++ b/Testscripts/Linux/validate-da.sh
@@ -133,6 +133,10 @@ function check_prereqs() {
         exit 0
     fi
 
+    which curl
+    if [ $? -ne 0 ]; then
+        install_package curl
+    fi
     LogMsg "Preconditions met"
 }
 

--- a/Testscripts/Windows/CLEANUP-DiffDiskGrowth.ps1
+++ b/Testscripts/Windows/CLEANUP-DiffDiskGrowth.ps1
@@ -153,7 +153,7 @@ function Main {
     if ($controller) {
         $drive = Get-VMHardDiskDrive $controller -ControllerLocation $lun
         if ($drive) {
-            Write-LogErr "Removing $controllerType $controllerID $lun"
+            Write-LogInfo "Removing $controllerType $controllerID $lun"
             Remove-VMHardDiskDrive $drive
         } else {
             Write-LogInfo "Drive $controllerType $controllerID,$Lun does not exist"

--- a/Testscripts/Windows/STORAGE-HotUnplug.ps1
+++ b/Testscripts/Windows/STORAGE-HotUnplug.ps1
@@ -157,7 +157,7 @@ function Main {
         Start-Sleep -Seconds 5
         $diskNumber = Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
             -command "fdisk -l | grep 'Disk /dev/sd*' | grep -v 'Disk /dev/sda' | wc -l" -RunAsSudo
-        if ($diskNumber -ne 2) {
+        if ($diskNumber -ne 1) {
             Write-LogErr "Failed to attach VHDx"
             return "FAIL"
         }

--- a/Testscripts/Windows/VERIFY-SRIOV-FAILSAFE-XDP.ps1
+++ b/Testscripts/Windows/VERIFY-SRIOV-FAILSAFE-XDP.ps1
@@ -129,7 +129,7 @@ collect_VM_properties
             }
         }
 
-        $currentStatus = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort `
+        $currentStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
             -username $user -password $password -command "tail -1 ~/xdpConsoleLogs.txt" -runAsSudo
         $currentState = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
             -username $user -password $password -command "cat state.txt" -runAsSudo

--- a/XML/TestCases/Other.xml
+++ b/XML/TestCases/Other.xml
@@ -69,10 +69,8 @@
     <testScript>DEPLOY-LONG-TERM-VM.ps1</testScript>
     <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\prepare_ltpt_vm.sh,.\Testscripts\Linux\CreateRaid.sh</files>
     <Platform>Azure</Platform>
-    <Category>
-    </Category>
-    <Area>
-    </Area>
+    <Category>Stress</Category>
+    <Area>LONG-HAUL</Area>
     <Tags>LongPerfStress</Tags>
     <SetupConfig>
       <SetupType>long-term</SetupType>


### PR DESCRIPTION
Before to align azure VM (has OS disk and resource disk by default), on HyperV platform it attached one more disk.
But it makes us hard to detect which disks are data disk for storage test cases, sometimes the device change name from sda to sdb or any other names. 

This PR is to remove resource disk on HyperV.