### PR TITLE
fix bug in Select-TestCases

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -117,7 +117,7 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
     $WildCards = @('^','.','[',']','?','+','*')
     $ExcludedTestsCount = 0
 
-    # if the expected filter parameter is 'ALL' or empty ("ALL" -imatch "" return $True), the actually filter used in this function will be '*', except for '$ExcludedTests'
+    # if the expected filter parameter is 'ALL' or empty or $null (-imatch successfully), the actually filter used in this function will be '*', except for '$ExcludedTests'
     if ("All" -imatch $TestCategory)   { $TestCategory = "*" }
     if ("All" -imatch $TestArea)       { $TestArea = "*" }
     if ("All" -imatch $TestNames)      { $TestNames = "*" }
@@ -125,11 +125,22 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
     if ("All" -imatch  $TestPriority)  { $TestPriority = "*" }
     if ("All" -imatch  $TestSetup)     { $TestSetup = "*" }
 
-    $testCategoryArray = @($TestCategory.Trim(', ').Split(',').Trim())
-    $testAreaArray = @($TestArea.Trim(', ').Split(',').Trim())
-    $testNamesArray = @($TestNames.Trim(', ').Split(',').Trim())
-    $testSetupTypeArray = @($TestSetup.Trim(', ').Split(',').Trim())
-    $excludedTestsArray = @($ExcludeTests.Trim(', ').Split(',').Trim())
+    $testCategoryArray = $testAreaArray = $testNamesArray = $testSetupTypeArray = $excludedTestsArray = @()
+    if ($TestCategory -and ($TestCategory -ne "*")) {
+        $testCategoryArray = @($TestCategory.Trim(', ').Split(',').Trim())
+    }
+    if ($TestArea -and ($TestArea -ne "*")) {
+        $testAreaArray = @($TestArea.Trim(', ').Split(',').Trim())
+    }
+    if ($TestNames -and ($TestNames -ne "*")) {
+        $testNamesArray = @($TestNames.Trim(', ').Split(',').Trim())
+    }
+    if ($TestSetup -and ($TestSetup -ne "*")) {
+        $testSetupTypeArray = @($TestSetup.Trim(', ').Split(',').Trim())
+    }
+    if ($ExcludeTests) {
+        $excludedTestsArray = @($ExcludeTests.Trim(', ').Split(',').Trim())
+    }
 
     # Filter test cases based on the criteria
     foreach ($file in $TestXMLs.FullName) {


### PR DESCRIPTION
If Select-TestCases() parameters is $null, it will throw exception when Trim().Split(), but currently LISAv2 won't throw exception for now because 'TestArea'  and other field values will be string default value '', not $null, even if there's no corresponding parameters provided.

Fix in the PR to handle $null value in parameters of Select-TestCases(), no impact to other logic.

================Test Logs=====================
[LISAv2 Test Results Summary]
Test Run On           : 08/06/2020 08:19:12
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.08 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      


Logs can be found at C:\LISAv2\TestResults\2020-08-06-01-18-27-6684


08/06/2020 08:23:15 : [DEBUG] Creating 'C:\LISAv2\Azure-MN75-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-08-06-01-18-27-6684'
08/06/2020 08:23:15 : [DEBUG] C:\LISAv2\Azure-MN75-TestLogs.zip created successfully.
08/06/2020 08:23:15 : [INFO ] Analyzing test results ...
08/06/2020 08:23:15 : [INFO ] LISAv2 exit code: 0