### PR TITLE
Fix case DYNAMIC-MEMORY-VERIFY-UDEV and MOUNT-CD

### DIFF
--- a/Testscripts/Linux/CORE-InitrdModulesCheck.sh
+++ b/Testscripts/Linux/CORE-InitrdModulesCheck.sh
@@ -75,10 +75,7 @@ fi
 
 # Rebuild array to exclude built-in modules
 skip_modules=()
-config_path="/boot/config-$(uname -r)"
-if [[ $(detect_linux_distribution) == 'coreos' ]]; then
-    config_path="/usr/lib/kernel/config-$(uname -r)"
-fi
+config_path=$(get_bootconfig_path)
 declare -A config_modulesDic
 config_modulesDic=(
 [CONFIG_HYPERV=y]="hv_vmbus.ko"

--- a/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
+++ b/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
@@ -12,16 +12,8 @@
 
 # Source constants file and initialize most common variables
 UtilsInit
-items=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
-
-case $DISTRO in
-    redhat_7|centos_7|redhat_8|centos_8)
-        items=(SUBSYSTEM!=\"memory\", GOTO=\"memory_hotplug_end\")
-    ;;
-    *)
-    ;;
-esac
-
+items1=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
+items2=(SUBSYSTEM!=\"memory\", GOTO=\"memory_hotplug_end\")
 #######################################################################
 #
 # Main script body
@@ -34,10 +26,27 @@ if [ -e summary.log ]; then
     rm -rf summary.log
 fi
 
+config_path=$(get_bootconfig_path)
+
+# /sys/devices/system/memory/auto_online_blocks = online => when the memory is hot-added, it will be online automatically
+if grep CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE=y $config_path; then
+    LogMsg "CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE=y is set in $config_path, then no need to check udev rules on $DISTRO"
+    value_of_aob=$(cat /sys/devices/system/memory/auto_online_blocks)
+    if [ "$value_of_aob" == "online" ]; then
+        LogMsg "Value of /sys/devices/system/memory/auto_online_blocks is expected - online"
+        SetTestStateCompleted
+        exit 0
+    else
+        LogErr "Value of /sys/devices/system/memory/auto_online_blocks is unexpected - $value_of_aob"
+        SetTestStateFailed
+        exit 0
+    fi
+fi
+
 # Search in /etc/udev and /lib/udev folders
 for udevfile in $(find /etc/udev/ /lib/udev/ -name "*.rules*"); do # search for all the .rules files
     match_count=0
-    for i in "${items[@]}"
+    for i in "${items2[@]}"
     do
         grep "$i" "$udevfile" > /dev/null # grep for the udev rule
         sts=$?
@@ -45,7 +54,22 @@ for udevfile in $(find /etc/udev/ /lib/udev/ -name "*.rules*"); do # search for 
              match_count=$(expr $match_count + 1)
         fi
     done
-    if [ ${#items[@]} -eq "$match_count" ]; then
+    if [ ${#items2[@]} -eq "$match_count" ]; then
+        filelist=("${filelist[@]}" $udevfile) # populate an array with the results
+    fi
+done
+
+for udevfile in $(find /etc/udev/ /lib/udev/ -name "*.rules*"); do # search for all the .rules files
+    match_count=0
+    for i in "${items1[@]}"
+    do
+        grep "$i" "$udevfile" > /dev/null # grep for the udev rule
+        sts=$?
+        if [ 0 -eq ${sts} ]; then
+             match_count=$(expr $match_count + 1)
+        fi
+    done
+    if [ ${#items1[@]} -eq "$match_count" ]; then
         filelist=("${filelist[@]}" $udevfile) # populate an array with the results
     fi
 done
@@ -67,7 +91,7 @@ else
     LogMsg "Error: No Hot-Add udev rules found on the system!"
     SetTestStateFailed
     UpdateSummary "Hot-Add udev rules: Failed!"
-    exit 1
+    exit 0
 fi
 
 SetTestStateCompleted

--- a/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
+++ b/Testscripts/Linux/DM_HotAdd_Verify_udev.sh
@@ -12,8 +12,8 @@
 
 # Source constants file and initialize most common variables
 UtilsInit
-items1=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
-items2=(SUBSYSTEM!=\"memory\", GOTO=\"memory_hotplug_end\")
+hotaddmemory_rule_keywords1=(SUBSYSTEM==\"memory\", ACTION==\"add\", ATTR{state}=\"online\")
+hotaddmemory_rule_keywords2=(SUBSYSTEM!=\"memory\", GOTO=\"memory_hotplug_end\")
 #######################################################################
 #
 # Main script body
@@ -35,41 +35,36 @@ if grep CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE=y $config_path; then
     if [ "$value_of_aob" == "online" ]; then
         LogMsg "Value of /sys/devices/system/memory/auto_online_blocks is expected - online"
         SetTestStateCompleted
-        exit 0
     else
         LogErr "Value of /sys/devices/system/memory/auto_online_blocks is unexpected - $value_of_aob"
         SetTestStateFailed
-        exit 0
     fi
+    exit 0
 fi
 
 # Search in /etc/udev and /lib/udev folders
 for udevfile in $(find /etc/udev/ /lib/udev/ -name "*.rules*"); do # search for all the .rules files
     match_count=0
-    for i in "${items2[@]}"
+    for i in "${hotaddmemory_rule_keywords1[@]}"
     do
-        grep "$i" "$udevfile" > /dev/null # grep for the udev rule
-        sts=$?
-        if [ 0 -eq ${sts} ]; then
+        if grep "$i" "$udevfile"; then
              match_count=$(expr $match_count + 1)
         fi
     done
-    if [ ${#items2[@]} -eq "$match_count" ]; then
+    if [ ${#hotaddmemory_rule_keywords1[@]} -eq "$match_count" ]; then
         filelist=("${filelist[@]}" $udevfile) # populate an array with the results
     fi
 done
 
 for udevfile in $(find /etc/udev/ /lib/udev/ -name "*.rules*"); do # search for all the .rules files
     match_count=0
-    for i in "${items1[@]}"
+    for i in "${hotaddmemory_rule_keywords2[@]}"
     do
-        grep "$i" "$udevfile" > /dev/null # grep for the udev rule
-        sts=$?
-        if [ 0 -eq ${sts} ]; then
+        if grep "$i" "$udevfile"; then
              match_count=$(expr $match_count + 1)
         fi
     done
-    if [ ${#items1[@]} -eq "$match_count" ]; then
+    if [ ${#hotaddmemory_rule_keywords2[@]} -eq "$match_count" ]; then
         filelist=("${filelist[@]}" $udevfile) # populate an array with the results
     fi
 done

--- a/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
+++ b/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
@@ -96,6 +96,7 @@ for (( i = 0 ; i < 2 ; i++ )); do
     fi
 done
 
+LogMsg "Check - support to update lro or not by filter keyword 'fix' from the line of large-receive-offload."
 lro_output=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" | grep -i large-receive-offload | grep -i fixed)
 if [[ $? != 0 ]];then
     for (( i = 0 ; i < 2 ; i++ )); do

--- a/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
+++ b/Testscripts/Linux/ETHTOOL-GRO-LRO.sh
@@ -96,9 +96,8 @@ for (( i = 0 ; i < 2 ; i++ )); do
     fi
 done
 
-GetPlatform
-# Disable/Enable LRO (HyperV only)
-if [[ $PLATFORM == "HyperV" ]];then
+lro_output=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" | grep -i large-receive-offload | grep -i fixed)
+if [[ $? != 0 ]];then
     for (( i = 0 ; i < 2 ; i++ )); do
         # Show LRO status
         sts=$(ethtool -k "${SYNTH_NET_INTERFACES[@]}" 2>&1 | grep large-receive-offload | awk {'print $2'})
@@ -127,7 +126,7 @@ if [[ $PLATFORM == "HyperV" ]];then
         fi
     done
 else
-    LogMsg "Azure doesn't support changing LRO. Skip."
+    LogMsg "lro is fixed, can't set value for it, lro output is - $lro_output"
 fi
 
 SetTestStateCompleted

--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -333,8 +333,9 @@ Install_Kexec
 #
 # Configure kdump - this has distro specific behaviour
 #
+config_path=$(get_bootconfig_path)
 if [[ $DISTRO != "redhat_8" ]];then
-    if ! grep CONFIG_KEXEC_AUTO_RESERVE=y /boot/config-$(uname -r) && [[ "$crashkernel" == "auto" ]];then
+    if ! grep CONFIG_KEXEC_AUTO_RESERVE=y "$config_path" && [[ "$crashkernel" == "auto" ]];then
         LogErr "crashkernel=auto doesn't work for this distro. Please use this pattern: crashkernel=X@Y."
         SetTestStateSkipped
         exit 0

--- a/Testscripts/Linux/NET-IFUP-IFDOWN.sh
+++ b/Testscripts/Linux/NET-IFUP-IFDOWN.sh
@@ -60,8 +60,8 @@ ReloadNetvsc()
 }
 # Source constants file and initialize most common variables
 UtilsInit
-
-netvsc_includes=$(grep CONFIG_HYPERV_NET=y /boot/config-$(uname -r))
+config_path=$(get_bootconfig_path)
+netvsc_includes=$(grep CONFIG_HYPERV_NET=y "$config_path")
 if [ $netvsc_includes ]; then
     LogMsg "Info: Skiping case since hv_netvsc module as it is built-in."
     SetTestStateSkipped

--- a/Testscripts/Linux/NET-Max-NICs.sh
+++ b/Testscripts/Linux/NET-Max-NICs.sh
@@ -32,7 +32,8 @@ function Configure_HV_Interfaces
     fi
 
     if [ ! -z "${HV_LEGACY_NICS+x}" ]; then
-        grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m" /boot/config-$(uname -r)
+        config_path=$(get_bootconfig_path)
+        grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m" "$config_path"
         if [ $? -ne 0 ]; then
             LogErr "Tulip driver is not configured. Test skipped"
             SetTestStateSkipped

--- a/Testscripts/Linux/NET-Test-Legacy.sh
+++ b/Testscripts/Linux/NET-Test-Legacy.sh
@@ -29,7 +29,8 @@ UtilsInit
 GetDistro
 
 # Check for tulip driver. If it's not present, test will be skipped
-grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m" /boot/config-$(uname -r)
+config_path=$(get_bootconfig_path)
+grep "CONFIG_NET_TULIP=y\|CONFIG_TULIP=m" "$config_path"
 if [ $? -ne 0 ]; then
     LogMsg "Warn: Tulip driver is not configured. Test skipped"
     SetTestStateSkipped

--- a/Testscripts/Linux/RELOAD-MODULES.sh
+++ b/Testscripts/Linux/RELOAD-MODULES.sh
@@ -32,12 +32,7 @@ HYPERV_MODULES=(hv_vmbus hv_netvsc hv_storvsc hv_utils hv_balloon hid_hyperv hyp
 MODULES_TO_RELOAD=(hv_netvsc)
 MODULES_NOT_TO_RELOAD=(hyperv_fb)
 skip_modules=()
-config_path="/boot/config-$(uname -r)"
-if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-    config_path="/usr/lib/kernel/config-$(uname -r)"
-elif [[ $(detect_linux_distribution) == coreos ]];then
-    config_path="/usr/boot/config-$(uname -r)"
-fi
+config_path=$(get_bootconfig_path)
 
 declare -A config_modulesDic
 config_modulesDic=(

--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -43,10 +43,7 @@ case $DISTRO in
         fi
 
         skip_modules=()
-        config_path="/boot/config-$(uname -r)"
-        if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-            config_path="/usr/lib/kernel/config-$(uname -r)"
-        fi
+        config_path=$(get_bootconfig_path)
         LogMsg "Set the configuration path to $config_path"
 
         declare -A config_modulesDic

--- a/Testscripts/Linux/restart-interface-reload-netvsc.sh
+++ b/Testscripts/Linux/restart-interface-reload-netvsc.sh
@@ -40,8 +40,8 @@ Run()
 ############################################################
 # Main body
 ############################################################
-config_path="/boot/config-$(uname -r)"
-netvsc_includes=$(grep CONFIG_HYPERV_NET=y $config_path)
+config_path=$(get_bootconfig_path)
+netvsc_includes=$(grep CONFIG_HYPERV_NET=y "$config_path")
 if [ $netvsc_includes ]; then
     LogMsg "Module hv_netvsc is builtin, skip the case."
     SetTestStateSkipped

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3632,7 +3632,7 @@ function Run_SSHCommand()
 	done
 }
 
-get_AvailableDisks() {
+function get_AvailableDisks() {
 	for disk in $(lsblk | grep "sd[a-z].*disk" | cut -d ' ' -f1); do
 		if [ $(df | grep -c $disk) -eq 0 ]; then
 			echo $disk
@@ -3640,7 +3640,7 @@ get_AvailableDisks() {
 	done
 }
 
-delete_partition() {
+function delete_partition() {
 	all_disks=$(get_AvailableDisks)
 
 	declare -A TEST_DICT

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3721,3 +3721,13 @@ function mount_disk() {
 		done
 	done
 }
+
+function get_bootconfig_path() {
+	config_path="/boot/config-$(uname -r)"
+	if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
+		config_path="/usr/lib/kernel/config-$(uname -r)"
+	elif [[ $(detect_linux_distribution) == coreos ]];then
+		config_path="/usr/boot/config-$(uname -r)"
+	fi
+	echo "$config_path"
+}

--- a/Testscripts/Linux/xfstesting.sh
+++ b/Testscripts/Linux/xfstesting.sh
@@ -176,12 +176,7 @@ Main() {
         exit 0
     fi
     GetDistro
-    config_path="/boot/config-$(uname -r)"
-    if [[ $(detect_linux_distribution) == clear-linux-os ]]; then
-        config_path="/usr/lib/kernel/config-$(uname -r)"
-    elif [[ $(detect_linux_distribution) == coreos ]];then
-        config_path="/usr/boot/config-$(uname -r)"
-    fi
+    config_path=$(get_bootconfig_path)
 
     grep -q "CONFIG_BTRFS_FS is not set" $config_path
     if [ $? -eq 0 ] && [ $FSTYP == "btrfs" ];then


### PR DESCRIPTION
DYNAMIC-MEMORY-VERIFY-UDEV => it will check if there is any udev rule to make memory online once there are hot memory added, but there is a new config CONFIG_MEMORY_HOTPLUG_DEFAULT_ONLINE introduced in to auto bring in memory online.

MOUNT-CD => before, it use distro as judgment condition, it is not correct, should use CONFIG_ATA_PIIX to judge.


ETHTOOL-GET-SET-GRO-LRO => previous design is not correct, it is not related with platform, but host build version, lower host version, this value is fixed (can't be updated), higher host version, this value can be changed.