### PR TITLE
DPDK: Change installation steps as make is deprecated

### DIFF
--- a/Testscripts/Linux/dpdkTestPmd.sh
+++ b/Testscripts/Linux/dpdkTestPmd.sh
@@ -97,15 +97,15 @@ runTestPmd()
 	echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages \
 		&& echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages \
 		&&  modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib; \
-		timeout --kill-after 10 10 testpmd --no-pci -m 1024 -c 0x3 -- -i --total-num-mbufs=16384 --coremask=0x2 --rxq=1 --txq=1
+		timeout --kill-after 10 10 dpdk-testpmd --no-pci -m 1024 -c 0x3 -- -i --total-num-mbufs=16384 --coremask=0x2 --rxq=1 --txq=1
 
 	for testmode in $modes; do
 		LogMsg "TestPmd is starting on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs"
-		ssh "${server}" "echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  mount -a && modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout 30 testpmd -l 1-3 -n 2 -w $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --forward-mode=${testmode}  --stats-period 1" 2>&1 > "$HOMEDIR"/dpdkVersion.txt
-		ssh "${server}" "pkill testpmd"
+		ssh "${server}" "echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  mount -a && modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout 30 dpdk-testpmd -l 1-3 -n 2 -w $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --forward-mode=${testmode}  --stats-period 1" 2>&1 > "$HOMEDIR"/dpdkVersion.txt
+		ssh "${server}" "pkill dpdk-testpmd"
 		sleep 60
 		ssh "${server}" "echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"
-		serverTestPmdCmd="echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  mount -a && modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} testpmd -l 0-1 -w $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
+		serverTestPmdCmd="echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages &&  mount -a && modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} dpdk-testpmd -l 0-1 -w $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
 		echo "$serverTestPmdCmd"
 		ssh "${server}" "$serverTestPmdCmd" 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-receiver-$(date +"%m%d%Y-%H%M%S").log &
 		checkCmdExitStatus "TestPmd started on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs"
@@ -113,11 +113,11 @@ runTestPmd()
 
 		LogMsg "TestPmd is starting on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
 
-		echo "timeout ${testDuration} testpmd -l 0-1 -w $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
+		echo "timeout ${testDuration} dpdk-testpmd -l 0-1 -w $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
 		echo 4096 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages \
 			&& echo 1 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages \
 			&& modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib
-		timeout "${testDuration}" testpmd -l 0-1 -w ${pci_info_client} ${vdev} -- \
+		timeout "${testDuration}" dpdk-testpmd -l 0-1 -w ${pci_info_client} ${vdev} -- \
 			--port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 \
 			--forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-sender-$(date +"%m%d%Y-%H%M%S").log &
 		checkCmdExitStatus "TestPmd started on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
@@ -127,8 +127,8 @@ runTestPmd()
 			&& echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages \
 			&& grep -i hug /proc/meminfo
 		ssh "${server}" "echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages && echo 0 > /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages && grep -i hug /proc/meminfo"
-		pkill testpmd
-		ssh "${server}" "pkill testpmd"
+		pkill dpdk-testpmd
+		ssh "${server}" "pkill dpdk-testpmd"
 		sleep 60
 		LogMsg "TestPmd execution for ${testmode} mode is COMPLETED"
 	done


### PR DESCRIPTION
Removed make steps and added meson steps

 PERF-DPDK-SINGLE-CORE-PPS-DS4  below shows failed : the reason of failure is not installation or running of testpmd as you can see the result. The reason is due to a known issue with mellanox mlx4/CX-3 NIC.
```
[LISAv2 Test Results Summary]
Test Run On           : 08/10/2020 22:05:54
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:26

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                22.38 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, TestLocation: eastus2, Kernel Version: 5.3.0-1034-azure


Logs can be found at C:\LISAv2\TE91\TestResults\2020-08-10-15-04-48-5695


[LISAv2 Test Results Summary]
Test Run On           : 08/10/2020 18:47:48
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-SINGLE-CORE-PPS-DS4                                                     FAIL                15.46
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: eastus2, Initial Kernel Version: 5.3.0-1034-azure
      dpdk_version test_mode core max_rx_pps tx_pps_avg rx_pps_avg fwdtx_pps_avg tx_bytes   rx_bytes  fwd_bytes
------------ --------- ---- ---------- ---------- ---------- ------------- --------   --------  ---------
20.08.0-rc3  rxonly    1    296488     406872     250160     0             1574703015 951496090 0
20.08.0-rc3  io        1    1          797792     0          0             3165029270 738       648



Logs can be found at C:\LISAv2\YO58\TestResults\2020-08-10-11-46-44-8001
```
