### PR TITLE
Bring up scheduler benchmark test from lis-test

### DIFF
--- a/Testscripts/Linux/perf_scheduler.sh
+++ b/Testscripts/Linux/perf_scheduler.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+#######################################################################
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+# perf_scheduler.sh
+# Description:
+#    Download and run hackbench and schbench test
+# Supported Distros:
+#    Ubuntu, SUSE, RedHat, CentOS
+#######################################################################
+HOMEDIR=$(pwd)
+UTIL_FILE="./utils.sh"
+LOG_FOLDER="${HOMEDIR}/scheduler_log"
+HACKBENCH_RESULT="${LOG_FOLDER}/results_hackbench.csv"
+SCHBENCH_RESULT="${LOG_FOLDER}/results_schbench.csv"
+SCHBENCH_DIR="${HOMEDIR}/schbench"
+
+HACKBENCH_TYPE=("process.pipe" "process.socket" "thread.pipe" "thread.socket")
+
+mkdir -p $LOG_FOLDER
+
+. ${UTIL_FILE} || {
+	LogErr "Missing ${UTIL_FILE} file"
+	SetTestStateAborted
+	exit 0
+}
+
+#Schbench
+THREADS=$(grep -c ^processor /proc/cpuinfo)
+if [ ! "${MSG_THREADS}" ]; then
+	MSG_THREADS=(6 12)
+fi
+if [ ! "${RUNTIME}" ]; then
+	RUNTIME=300
+fi
+if [ ! "${SLEEPTIME}" ]; then
+	SLEEPTIME=30000
+fi
+if [ ! "${CPUTIME}" ]; then
+	CPUTIME=30000
+fi
+
+# hackbench
+if [ ! "${DATASIZE}" ]; then
+	DATASIZE=(128 256 512 1024 2048 4096)
+fi
+if [ ! "${LOOPS}" ]; then
+	LOOPS=2000
+fi
+GROUP_NR=$(grep -c ^processor /proc/cpuinfo)
+# If the number of FD is bigger,the time of running this test is much longer. We set the FDS 32 
+FDS=25
+
+# Install hackbench and schbench required packages
+function install_dependency_package () {
+	LogMsg "Detected $DISTRO_NAME $DISTRO_VERSION; installing required packages of hackbench and schbench"
+	update_repos
+	case "$DISTRO_NAME" in
+		oracle|rhel|centos)
+			install_epel
+			install_package "sysstat zip make gcc git numactl numactl-devel git"
+			;;
+		ubuntu|debian)
+			install_package "sysstat zip make gcc libnuma-dev git "
+			;;
+		sles|suse)
+			if [[ $DISTRO_VERSION =~ 12|15 ]]; then				
+				install_package "sysstat zip make gcc libnuma-devel git"
+			else
+				LogErr "Unsupported SLES version"
+				return 1
+			fi
+			;;
+		*)
+			LogErr "Unsupported distribution"
+			return 1
+	esac
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+}
+
+function build_hackbench () {
+	pkgVer=1.8
+	source="https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-${pkgVer}.tar.gz"
+	wget $source
+	tar -zxvf rt-tests-${pkgVer}.tar.gz
+	cd rt-tests-${pkgVer}
+	make && make install
+	if [ $? -ne 0 ]; then
+		LogErr "Build hackbench failed."
+		SetTestStateAborted
+		exit 0
+	fi
+	cd ..
+	export PATH=$PATH:/usr/local/bin
+}
+
+function build_schbench () {
+	git clone https://git.kernel.org/pub/scm/linux/kernel/git/mason/schbench.git
+	cd ./schbench
+	make
+	if [ $? -ne 0 ]; then
+		LogErr "Build schbench failed."
+		SetTestStateAborted
+		exit 0
+	fi
+	cd ..
+}
+
+function start_monitor () {
+	name=${1}
+	type=${2}
+	vmstat 1 2>&1 > /${LOG_FOLDER}/${name}.${type}.vmstat.log 2>&1 & 
+	sar -P ALL 1 2>&1 > /${LOG_FOLDER}/${name}.${type}.sar.cpu.log 2>&1 &
+}
+
+function stop_monitor () {
+	pkill -f vmstat
+	pkill -f sar
+}
+
+function run_hackbench () {
+#   -p, --pipe Sends the data via a pipe instead of the socket (default)
+#   -s, --datasize=<size in bytes> Sets the amount of data to send in each message
+#   -l, --loops=<number of loops> How many messages each sender/receiver pair should send
+#   -g, --groups=<number of groups> Defines how many groups  of  senders  and  receivers  should  be started
+#   -f, --fds=<number of file descriptors> Defines  how  many file descriptors each child should use
+#   -T, --threads Each sender/receiver child will be a POSIX thread of the parent.
+#   -P, --process Hackbench will use fork() on all children (default behaviour)
+	dataSize=${1}
+	LogMsg "hackbench with process mode start running with $GROUP_NR sender and receiver groups, sending the data via a pipe"
+	type="${dataSize}.process.pipe"
+	start_monitor "hackbench" "${type}"
+	hackbench -s ${dataSize} -l ${LOOPS} -g ${GROUP_NR} -f ${FDS} -P -p > /${LOG_FOLDER}/hackbench.${type}.log 2>&1
+	check_exit_status "Run hackbench" "failed"
+	stop_monitor
+	sleep 5
+
+	LogMsg "hackbench with thread mode start running with $GROUP_NR sender and receiver groups, sending the data via a pipe"
+	type="${dataSize}.thread.pipe"
+	start_monitor "hackbench" "${type}"
+	hackbench -s ${dataSize} -l ${LOOPS} -g ${GROUP_NR} -f ${FDS} -T -p > /${LOG_FOLDER}/hackbench.${type}.log 2>&1
+	check_exit_status "Run hackbench" "failed"
+	stop_monitor
+	sleep 5
+
+	LogMsg "hackbench with process mode start running with $GROUP_NR sender and receiver groups, sending the data via socket"
+	type="${dataSize}.process.socket"
+	start_monitor "hackbench" "${type}"
+	hackbench -s ${dataSize} -l ${LOOPS} -g ${GROUP_NR} -f ${FDS} -P > /${LOG_FOLDER}/hackbench.${type}.log 2>&1
+	check_exit_status "Run hackbench" "failed"
+	stop_monitor
+	sleep 5
+
+	LogMsg "hackbench with thread mode start running with $GROUP_NR sender and receiver groups, sending the data via socket"
+	type="${dataSize}.thread.socket"
+	start_monitor "hackbench" "${type}"
+	hackbench -s ${dataSize} -l ${LOOPS} -g ${GROUP_NR} -f ${FDS} -T > /${LOG_FOLDER}/hackbench.${type}.log 2>&1
+	check_exit_status "Run hackbench" "failed"
+	stop_monitor
+	sleep 5
+}
+
+function run_schbench () {
+#    -m (--message-threads): number of message threads (def: 2)
+#    -t (--threads): worker threads per message thread (def: 16)
+#    -r (--runtime): How long to run before exiting (seconds, def: 30)
+#    -s (--sleeptime): Message thread latency (usec, def: 10000
+#    -c (--cputime): How long to think during loop (usec, def: 10000
+#    -a (--auto): grow thread count until latencies hurt (def: off)
+#    -p (--pipe): transfer size bytes to simulate a pipe test (def: 0)
+#    -R (--rps): requests per second mode (count, def: 0)
+	currentMsgThreads=$1
+	LogMsg "schbench start running with $currentMsgThreads message threads."
+	start_monitor "schbench" "${currentMsgThreads}"
+	./schbench -c ${CPUTIME} -s ${SLEEPTIME} -m ${currentMsgThreads} -t ${THREADS} -r ${RUNTIME} > /${LOG_FOLDER}/schbench.${currentMsgThreads}.log 2>&1
+	check_exit_status "Run schbench" "failed"
+	stop_monitor
+	sleep 5
+}
+
+function parse_hackbench_log () {
+	echo "TestMode,DataSize_bytes,Loops,Groups,FDS,HackbenchType,Latency_sec" > "${HACKBENCH_RESULT}"
+	for type in "${HACKBENCH_TYPE[@]}"
+	do
+		for datasize in "${DATASIZE[@]}"
+		do
+			hackbench_log_file="${LOG_FOLDER}/hackbench.${datasize}.${type}.log"
+			latency=$(grep "Time:" "$hackbench_log_file" | tr ":" " " | awk '{print $NF}')
+			LogMsg "Test Results: "
+			LogMsg "---------------"
+			LogMsg "TestMode: hackbench"
+			LogMsg "DataSize_bytes: $datasize"
+			LogMsg "Loops: $LOOPS"
+			LogMsg "Groups: $GROUP_NR"
+			LogMsg "FDS: $FDS"
+			LogMsg "HackbenchType: $type"
+			LogMsg "Latency(seconds): $latency"
+			echo "hackbench,$datasize,$LOOPS,$GROUP_NR,$FDS,$type,$latency" >> "${HACKBENCH_RESULT}"
+		done
+	done
+}
+
+function parse_schbench_log () {
+	echo "TestMode,WorkerThreads,MessageThreads,Latency95thPercentile_us,Latency99thPercentile_us" > "${SCHBENCH_RESULT}"
+	for msg in "${MSG_THREADS[@]}"
+	do
+		schbench_log_file="${LOG_FOLDER}/schbench.${msg}.log"
+		latency95=$(grep "95.0th:" "$schbench_log_file" | tr ":" " " | awk '{print $NF}')
+		latency99=$(grep "99.0th:" "$schbench_log_file" | tr ":" " " | awk '{print $NF}')
+		LogMsg "Test Results: "
+		LogMsg "---------------"
+		LogMsg "TestMode: schbench"
+		LogMsg "WorkerThreads: $THREADS"
+		LogMsg "MessageThreads: $msg"
+		LogMsg "Latency of 95th Percentile(us): $latency95"
+		LogMsg "Latency of 99th Percentile(us): $latency99"
+		echo "schbench,$THREADS,$msg,$latency95,$latency99" >> "${SCHBENCH_RESULT}"
+	done
+}
+###############################################################################
+#
+# Main script body
+#
+###############################################################################
+LogMsg "Install required packages..."
+install_dependency_package
+if [ $? -ne 0 ]; then
+	LogErr "Dependency packages installation failed"
+	SetTestStateAborted
+	exit 0
+fi
+
+LogMsg "Build hackbench..."
+build_hackbench
+
+LogMsg "Run hackbench..."
+for datasize in "${DATASIZE[@]}"
+do
+	run_hackbench $datasize
+done
+parse_hackbench_log
+
+LogMsg "Build schbench..."
+build_schbench
+
+LogMsg "Run schbench..."
+cd ${SCHBENCH_DIR}
+for msg in "${MSG_THREADS[@]}"
+do
+    run_schbench ${msg}
+done
+cd $HOMEDIR
+parse_schbench_log
+
+column -s, -t "${HACKBENCH_RESULT}" > "${LOG_FOLDER}"/results_hackbench.log
+column -s, -t "${SCHBENCH_RESULT}" > "${LOG_FOLDER}"/results_schbench.log
+cat "${LOG_FOLDER}"/results_hackbench.log
+cat "${LOG_FOLDER}"/results_schbench.log
+
+cp "${LOG_FOLDER}"/* .
+SetTestStateCompleted

--- a/Testscripts/Windows/PERF-SCHEDULER.ps1
+++ b/Testscripts/Windows/PERF-SCHEDULER.ps1
@@ -1,0 +1,201 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+param(
+    [String] $TestParams,
+    [object] $AllVMData,
+    [object] $CurrentTestData
+)
+
+function Main {
+    param (
+        $TestParams,
+        $AllVMData
+    )
+    # Create test result
+    $CurrentTestResult = Create-TestResultObject
+    $resultArr = @()
+
+    try {
+        $testName="scheduler"
+        $myString = @"
+./perf_scheduler.sh &> schedulerConsoleLogs.txt
+. utils.sh
+collect_VM_properties
+"@
+        Set-Content "$LogDir\Start${testName}Test.sh" $myString
+        Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort `
+            -files "$constantsFile,$LogDir\Start${testName}Test.sh" -username $user -password $password -upload
+        Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort `
+            -files $currentTestData.files -username $user -password $password -upload
+
+        Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password `
+            -command "chmod +x *.sh" -runAsSudo | Out-Null
+        $testJob = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password `
+            -command "./Start${testName}Test.sh" -RunInBackground -runAsSudo
+
+        while ((Get-Job -Id $testJob).State -eq "Running") {
+            $currentStatus = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password `
+                -command "tail -2 ${testName}ConsoleLogs.txt | head -1"
+            Write-LogInfo "Current Test Status : $currentStatus"
+            Wait-Time -seconds 20
+        }
+        $finalStatus = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password `
+            -command "cat ./state.txt"
+
+        $filesTocopy = "${testName}ConsoleLogs.txt, hackbench.*.log, schbench.*.log, results*.log, results*.csv, VM_properties.csv"
+        Copy-RemoteFiles -download -downloadFrom $AllVmData.PublicIP -downloadTo $LogDir -Port $AllVmData.SSHPort `
+            -Username $user -password $password -files $filesTocopy
+
+        ##################################################################################################################
+        #region Parse log to obtain the test results
+        ##################################################################################################################
+        $uploadResults = $true
+        $hackbench_results = Get-Content -Path "$LogDir\results_hackbench.log"
+        $schbench_results = Get-Content -Path "$LogDir\results_schbench.log"
+
+        $connResult = "======================================="
+        $metadata = "Hackbench test results"
+        $currentTestResult.TestSummary += New-ResultSummary -testResult $connResult -metaData $metadata -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+        foreach ($line in $hackbench_results) {
+            if ($line -imatch "TestMode") {
+                continue;
+            }
+            try {
+                $datasize_bytes = ($line.Trim() -Replace " +"," ").Split(" ")[1]
+                $hackbenchType = ($line.Trim() -Replace " +"," ").Split(" ")[5]
+                $latency_sec = ($line.Trim() -Replace " +"," ").Split(" ")[6]
+                $connResult = "DataSize_bytes=$datasize_bytes Latency_sec=$latency_sec"
+                $metadata = "HackbenchType=$hackbenchType"
+                $currentTestResult.TestSummary += New-ResultSummary -testResult $connResult -metaData $metadata -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+
+                if ([float]$latency_sec -eq 0) {
+                    $uploadResults = $false
+                    $testResult = "FAIL"
+                }
+            } catch {
+                $ErrorMessage = $_.Exception.Message
+                $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+                Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+                $currentTestResult.TestSummary += New-ResultSummary -testResult "Error in parsing logs." -metaData "Hackbench" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+            }
+        }
+        $connResult = "======================================="
+        $metadata = "Schbench test results"
+        $currentTestResult.TestSummary += New-ResultSummary -testResult $connResult -metaData $metadata -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+        foreach ($line in $schbench_results) {
+            if ($line -imatch "TestMode") {
+                continue;
+            }
+            try {
+                $messageThreads = ($line.Trim() -Replace " +"," ").Split(" ")[2]
+                $latency95th_us = ($line.Trim() -Replace " +"," ").Split(" ")[3]
+                $latency99th_us = ($line.Trim() -Replace " +"," ").Split(" ")[4]
+                $connResult = "Latency95thPercentile_us=$latency95th_us Latency99thPercentile_us=$latency99th_us"
+                $metadata = "MessageThreads=$messageThreads"
+                $currentTestResult.TestSummary += New-ResultSummary -testResult $connResult -metaData $metadata -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+
+                if ([float]$latency95th_us -eq 0 -or [float]$latency99th_us -eq 0) {
+                    $uploadResults = $false
+                    $testResult = "FAIL"
+                }
+            } catch {
+                $ErrorMessage = $_.Exception.Message
+                $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+                Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+                $currentTestResult.TestSummary += New-ResultSummary -testResult "Error in parsing logs." -metaData "Schbench" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+            }
+        }
+        ##################################################################################################################
+        #endregion Parse log to obtain the test results
+        ##################################################################################################################
+
+        if ($finalStatus -imatch "TestFailed") {
+            Write-LogErr "Test failed. Last known status : $currentStatus."
+            $testResult = "FAIL"
+        } elseif ($finalStatus -imatch "TestAborted") {
+            Write-LogErr "Test Aborted. Last known status : $currentStatus."
+            $testResult = "ABORTED"
+        } elseif (($finalStatus -imatch "TestCompleted") -and $uploadResults) {
+            $testResult = "PASS"
+        } elseif ($finalStatus -imatch "TestRunning") {
+            Write-LogInfo "Powershell background job is completed but VM is reporting that test is still running. Please check $LogDir\ConsoleLogs.txt"
+            $testResult = "ABORTED"
+        }
+
+        #region Show results*.csv
+        $hackbenchDataCsv = Import-Csv -Path $LogDir\results_hackbench.csv
+        Write-LogInfo ("`n**************************************************************************`n"+$CurrentTestData.testName+" RESULTS...`n**************************************************************************")
+        Write-Host ($hackbenchDataCsv | Format-Table * | Out-String)
+        $schbenchDataCsv = Import-Csv -Path $LogDir\results_schbench.csv
+        Write-LogInfo ("`n**************************************************************************`n"+$CurrentTestData.testName+" RESULTS...`n**************************************************************************")
+        Write-Host ($schbenchDataCsv | Format-Table * | Out-String)
+        #endregion Show results*.csv
+
+        ##################################################################################################################
+        #region Parse log then upload the test results to database
+        ##################################################################################################################
+        $LogContents = @()
+        $LogContents += Get-Content -Path "$LogDir\results_hackbench.log"
+        $LogContents += Get-Content -Path "$LogDir\results_schbench.log"
+
+        if ($testResult -eq "PASS") {
+            $TestCaseName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.testTag
+            if (!$TestCaseName) {
+                $TestCaseName = $CurrentTestData.testName
+            }
+            $HostOs =  $(Get-Content "$LogDir\VM_properties.csv" | Select-String "Host Version"| ForEach-Object{$_ -replace ",Host Version,",""})
+            $GuestDistro = $(Get-Content "$LogDir\VM_properties.csv" | Select-String "OS type"| ForEach-Object{$_ -replace ",OS type,",""})
+            $KernelVersion = $(Get-Content "$LogDir\VM_properties.csv" | Select-String "Kernel version"| ForEach-Object{$_ -replace ",Kernel version,",""})
+            $TestDate = $(Get-Date -Format yyyy-MM-dd)
+
+            Write-LogInfo "Generating the performance data for database insertion"
+            foreach ($LogCon in $LogContents) {
+                for ($i = 1; $i -lt $LogCon.Count; $i++) {
+                    $Line = $LogCon[$i].Trim() -split '\s+'
+                    $resultMap = @{}
+                    $resultMap["TestCaseName"] = $TestCaseName
+                    $resultMap["TestDate"] = $TestDate
+                    $resultMap["HostType"] = $TestPlatform
+                    $resultMap["HostBy"] = $CurrentTestData.SetupConfig.TestLocation
+                    $resultMap["HostOS"] = $HostOs
+                    $resultMap["GuestOS"] = $GuestDistro
+                    $resultMap["InstanceSize"] = $clientVMData.InstanceSize
+                    $resultMap["KernelVersion"] = $KernelVersion
+                    $resultMap["TestMode"] = $($Line[0])
+                    if ($line[0] -imatch "hackbench") {
+                        $resultMap["DataSize_bytes"] = [Decimal]$($Line[1])
+                        $resultMap["Loops"] = [Decimal]$($Line[2])
+                        $resultMap["Groups"] = [Decimal]$($Line[3])
+                        $resultMap["HackbenchType"] = $($Line[5])
+                        $resultMap["Latency_sec"] = [Decimal]$($Line[6])
+                    } elseif ($line[0] -imatch "schbench") {
+                        $resultMap["WorkerThreads"] = [Decimal]$($Line[1])
+                        $resultMap["MessageThreads"] = [Decimal]$($Line[2])
+                        $resultMap["Latency95thPercentile_us"] = [Decimal]$($Line[3])
+                        $resultMap["Latency99thPercentile_us"] = [Decimal]$($Line[4])
+                    }
+                    $currentTestResult.TestResultData += $resultMap
+                }
+            }
+        }
+        ##################################################################################################################
+        #endregion Parse log then upload the test results to database
+        ##################################################################################################################
+        Write-LogInfo "Test result : $testResult"
+    } catch {
+        $ErrorMessage = $_.Exception.Message
+        $ErrorLine = $_.InvocationInfo.ScriptLineNumber
+        Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+    } finally {
+        $metaData = "${testName} RESULT"
+        if (!$testResult) {
+            $testResult = "Aborted"
+        }
+        $resultArr += $testResult
+    }
+
+    $currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+    return $currentTestResult
+}
+
+Main -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n")) -AllVMData $AllVmData

--- a/Testscripts/Windows/PERF-TWOVM-MIDDLEWARE-BENCHMARK.ps1
+++ b/Testscripts/Windows/PERF-TWOVM-MIDDLEWARE-BENCHMARK.ps1
@@ -187,8 +187,7 @@ collect_VM_properties
             $testResult = "PASS"
         } elseif ($finalStatus -imatch "TestRunning") {
             Write-LogInfo "Powershell background job is completed but VM is reporting that test is still running. Please check $LogDir\ConsoleLogs.txt"
-            Write-LogInfo "Contents of summary.log : $testSummary"
-            $testResult = "PASS"
+            $testResult = "ABORTED"
         }
 
         $DataCsv = Import-Csv -Path $LogDir\report.csv

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -488,6 +488,30 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>16</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>SCHBENCH_MSG_THREADS</ReplaceThis>
+		<ReplaceWith>(6 12)</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>SCHBENCH_RUNTIME</ReplaceThis>
+		<ReplaceWith>300</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>SCHBENCH_SLEEPTIME</ReplaceThis>
+		<ReplaceWith>30000</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>SCHBENCH_CPUTIME</ReplaceThis>
+		<ReplaceWith>30000</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>HACKBENCH_DATASIZE</ReplaceThis>
+		<ReplaceWith>(128 256 512 1024 2048 4096)</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>HACKBENCH_LOOPS</ReplaceThis>
+		<ReplaceWith>2000</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>STRESS_REBOOT_NUMBER</ReplaceThis>
 		<ReplaceWith>100</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -855,6 +855,28 @@
     </SetupConfig>
   </test>
   <test>
+    <testName>PERF-SCHEDULER</testName>
+    <testScript>PERF-SCHEDULER.ps1</testScript>
+    <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_scheduler.sh</files>
+    <TestParameters>
+      <param>MSG_THREADS=SCHBENCH_MSG_THREADS</param>
+      <param>RUNTIME=SCHBENCH_RUNTIME</param>
+      <param>SLEEPTIME=SCHBENCH_SLEEPTIME</param>
+      <param>CPUTIME=SCHBENCH_CPUTIME</param>
+      <param>DATASIZE=HACKBENCH_DATASIZE</param>
+      <param>LOOPS=HACKBENCH_LOOPS</param>
+    </TestParameters>
+    <Platform>Azure,HyperV</Platform>
+    <Category>Performance</Category>
+    <Area>BENCHMARK</Area>
+    <Tags>benchmark,scheduler</Tags>
+    <Priority>2</Priority>
+    <SetupConfig>
+      <SetupType>OneVM</SetupType>
+      <OverrideVMSize>Standard_D16s_v3</OverrideVMSize>
+    </SetupConfig>
+  </test>
+  <test>
     <testName>PERF-XDP-TCP-RX-DROP-SINGLECORE</testName>
     <testScript>PERF-XDP-RX-DROP.ps1</testScript>
     <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\XDPDumpSetup.sh,.\Testscripts\Linux\pktgenSetup.sh</files>


### PR DESCRIPTION
Bring up scheduler benchmark test case from lis-test to LISAv2.
There are two microbenchmarks, hackbench and schbench.
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 08/13/2020 11:00:11
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 BENCHMARK            PERF-SCHEDULER                                                                    PASS                19.66 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_D16s_v3, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
      Hackbench test results : =======================================
      HackbenchType=process.pipe : DataSize_bytes=128 Latency_sec=14.233
      HackbenchType=process.pipe : DataSize_bytes=256 Latency_sec=8.969
      HackbenchType=process.pipe : DataSize_bytes=512 Latency_sec=10.403
      HackbenchType=process.pipe : DataSize_bytes=1024 Latency_sec=12.396
      HackbenchType=thread.socket : DataSize_bytes=2048 Latency_sec=16.862
      HackbenchType=thread.socket : DataSize_bytes=4096 Latency_sec=12.880
      Schbench test results : =======================================
      MessageThreads=6 : Latency95thPercentile_us=35904 Latency99thPercentile_us=53696
      MessageThreads=12 : Latency95thPercentile_us=53696 Latency99thPercentile_us=94080
```