### PR TITLE
Add optional LTP installation path

### DIFF
--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -184,7 +184,6 @@ fi
 
 # LTP can request input if missing users/groups
 # are detected, the yes command will handle the prompt.
-echo $LTP_PARAMS
 yes | ./runltp $LTP_PARAMS 2>/dev/null
 
 grep -A 5 "Total Tests" "$LTP_RESULTS" >> ~/summary.log

--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -31,13 +31,12 @@ LTP_OUTPUT="$HOMEDIR/ltp-output.log"
 LTP_LITE_TESTS="math,fsx,ipc,mm,sched,pty,fs"
 ltp_git_url="https://github.com/linux-test-project/ltp.git"
 
-# The LTPROOT is used by some tests, e.g, block_dev test
-export LTPROOT="/opt/ltp"
-
 if [[ ! -z "$CUSTOM_LTP_ROOT" ]]; then
 	TOP_BUILDDIR="$CUSTOM_LTP_ROOT"
-	export LTPROOT="$CUSTOM_LTP_ROOT"
 fi
+
+# The LTPROOT is used by some tests, e.g, block_dev test
+export LTPROOT=$TOP_BUILDDIR
 
 # Clear the old log
 rm -f $LTP_RESULTS $LTP_OUTPUT
@@ -136,7 +135,7 @@ if [[ $LTP_PACKAGE_URL == "" ]];then
     test -d "$TOP_BUILDDIR" || mkdir -p "$TOP_BUILDDIR"
     cd "$TOP_BUILDDIR" && "$TOP_SRCDIR/configure"
     cd "$TOP_SRCDIR"
-    ./configure --prefix=$LTPROOT 2>/dev/null
+    ./configure --prefix=$TOP_BUILDDIR 2>/dev/null
 
     LogMsg "Compiling LTP..."
     make -j $(nproc) all 2>/dev/null

--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -31,8 +31,13 @@ LTP_OUTPUT="$HOMEDIR/ltp-output.log"
 LTP_LITE_TESTS="math,fsx,ipc,mm,sched,pty,fs"
 ltp_git_url="https://github.com/linux-test-project/ltp.git"
 
-# The LTPROOT is used by some tests, e.g, block_dev test
-export LTPROOT="/opt/ltp"
+if [ -z "$CUSTOM_LTP_ROOT" ]; then
+    # The LTPROOT is used by some tests, e.g, block_dev test
+    export LTPROOT="/opt/ltp"
+else
+    TOP_BUILDDIR="$CUSTOM_LTP_ROOT"
+    export LTPROOT="$CUSTOM_LTP_ROOT"
+fi
 
 # Clear the old log
 rm -f $LTP_RESULTS $LTP_OUTPUT
@@ -128,6 +133,7 @@ if [[ $LTP_PACKAGE_URL == "" ]];then
     autoreconf -f 2>/dev/null
     make autotools 2>/dev/null
 
+    sed -i "s+/opt/ltp+$LTPROOT+g" "$TOP_SRCDIR/configure"
     test -d "$TOP_BUILDDIR" || mkdir -p "$TOP_BUILDDIR"
     cd "$TOP_BUILDDIR" && "$TOP_SRCDIR/configure"
     cd "$TOP_SRCDIR"

--- a/Testscripts/Linux/Linux-Test-Project-Tests.sh
+++ b/Testscripts/Linux/Linux-Test-Project-Tests.sh
@@ -31,12 +31,12 @@ LTP_OUTPUT="$HOMEDIR/ltp-output.log"
 LTP_LITE_TESTS="math,fsx,ipc,mm,sched,pty,fs"
 ltp_git_url="https://github.com/linux-test-project/ltp.git"
 
-if [ -z "$CUSTOM_LTP_ROOT" ]; then
-    # The LTPROOT is used by some tests, e.g, block_dev test
-    export LTPROOT="/opt/ltp"
-else
-    TOP_BUILDDIR="$CUSTOM_LTP_ROOT"
-    export LTPROOT="$CUSTOM_LTP_ROOT"
+# The LTPROOT is used by some tests, e.g, block_dev test
+export LTPROOT="/opt/ltp"
+
+if [[ ! -z "$CUSTOM_LTP_ROOT" ]]; then
+	TOP_BUILDDIR="$CUSTOM_LTP_ROOT"
+	export LTPROOT="$CUSTOM_LTP_ROOT"
 fi
 
 # Clear the old log
@@ -133,11 +133,10 @@ if [[ $LTP_PACKAGE_URL == "" ]];then
     autoreconf -f 2>/dev/null
     make autotools 2>/dev/null
 
-    sed -i "s+/opt/ltp+$LTPROOT+g" "$TOP_SRCDIR/configure"
     test -d "$TOP_BUILDDIR" || mkdir -p "$TOP_BUILDDIR"
     cd "$TOP_BUILDDIR" && "$TOP_SRCDIR/configure"
     cd "$TOP_SRCDIR"
-    ./configure 2>/dev/null
+    ./configure --prefix=$LTPROOT 2>/dev/null
 
     LogMsg "Compiling LTP..."
     make -j $(nproc) all 2>/dev/null
@@ -185,6 +184,7 @@ fi
 
 # LTP can request input if missing users/groups
 # are detected, the yes command will handle the prompt.
+echo $LTP_PARAMS
 yes | ./runltp $LTP_PARAMS 2>/dev/null
 
 grep -A 5 "Total Tests" "$LTP_RESULTS" >> ~/summary.log

--- a/Testscripts/Windows/Run-LtpSuite.ps1
+++ b/Testscripts/Windows/Run-LtpSuite.ps1
@@ -146,6 +146,11 @@ function Main {
     $currentTestResult = Create-TestResultObject
     $resultArr = @()
 
+    $ltpRoot = "/opt/ltp"
+    if ($TestParams["CUSTOM_LTP_ROOT"] -and $TestParams["CUSTOM_LTP_ROOT"] -ne "") {
+        $ltpRoot = $TestParams["CUSTOM_LTP_ROOT"]
+    }
+
     try {
         $null = Run-LinuxCmd -Command "bash ${TEST_SCRIPT} > LTP-summary.log 2>&1" `
             -Username $user -password $password -ip $AllVmData.PublicIP -Port $AllVmData.SSHPort `
@@ -162,7 +167,7 @@ function Main {
                 -Username $user -password $password -ip $AllVmData.PublicIP -Port $AllVmData.SSHPort `
                 -maxRetryCount 1 -runAsSudo -ignoreLinuxExitCode
 
-        $null = Run-LinuxCmd -Command "\cp -f /opt/ltp/VM_properties.csv /home/${user}" `
+        $null = Run-LinuxCmd -Command "\cp -f ${ltpRoot}/VM_properties.csv /home/${user}" `
                 -Username $user -password $password -ip $AllVmData.PublicIP -Port $AllVmData.SSHPort `
                 -maxRetryCount 1 -runAsSudo
 

--- a/Testscripts/Windows/Run-LtpSuite.ps1
+++ b/Testscripts/Windows/Run-LtpSuite.ps1
@@ -147,7 +147,7 @@ function Main {
     $resultArr = @()
 
     $ltpRoot = "/opt/ltp"
-    if ($TestParams["CUSTOM_LTP_ROOT"] -and $TestParams["CUSTOM_LTP_ROOT"] -ne "") {
+    if ($TestParams["CUSTOM_LTP_ROOT"]) {
         $ltpRoot = $TestParams["CUSTOM_LTP_ROOT"]
     }
 


### PR DESCRIPTION
Add optional LTP installation path as customized test parameter. User can install to and run from the customized path. 
No change for existing LTP tests whose default path is /opt/ltp. 
Test verification log
```
Test Run On           : 08/14/2020 15:35:11
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Test Category         : Community
Test Area             : LTP
Test Priority         : 2
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:8
ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
1 LTP                  LINUX-TEST-PROJECT-TESTS                                                          PASS                65.68 
ARMImageName: Canonical UbuntuServer 18.04-LTS latest, DiskType: Managed, OverrideVMSize: Standard_DS14_v2, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
```