### PR TITLE
Restore 'OsVHD' to full storage URI, when '-TestLocation' is a single and same region as OsVHD's storage account region

### DIFF
--- a/Libraries/TestLogs.psm1
+++ b/Libraries/TestLogs.psm1
@@ -320,8 +320,9 @@ Function Trim-ErrorLogMessage($text) {
 		$splitByPeriod = $text.split(".")
 		if ($splitByPeriod.Count -gt 1) {
 			$maxLength -= $splitByPeriod[$splitByPeriod.Count - 1].Length
+			$text = $text.Substring(0,$maxLength) + ".."
 		}
-		$text = $text.Substring(0,$maxLength) + ".."
+		$text = $text.Replace("'","""")
 	}
 	return $text + "`r`n"
 }


### PR DESCRIPTION
Restore 'OsVHD' from a BaseName to full storage URI, when '-TestLocation' is a single region

Fix issue of 'Exception when using **vhd BaseName only** for '-OsVHD' which exist in the same region as '-TestLocation'  '

=============Previous TestLog with Exception ========================

08/14/2020 17:46:46 : [ERROR] Exception detected. Source : DeployVMs()
08/14/2020 17:46:46 : [ERROR] EXCEPTION : Cannot validate argument on parameter 'ResourceGroupName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.
08/14/2020 17:46:46 : [ERROR] Source : Line 2314 in script .\Libraries\Azure.psm1.
[LISAv2 Test Results Summary]
Test Run On           : 08/14/2020 17:46:39
VHD Under Test        : U1804-Mn4-BS.vhd
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:0

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 CPU-VERIFY-ONLINE                                                              ABORTED                    0 
      OsVHD: U1804-Mn4-BS.vhd, OverrideVMSize: Standard_DS3_v2, TestLocation: westus2, VMGeneration: 1, 
      Cannot validate argument on parameter 'ResourceGroupName'. The argument is null or empty...


Logs can be found at C:\LISAv2\EV72\TestResults\2020-08-14-17-46-01-9952


08/14/2020 17:46:50 : [DEBUG] Creating 'C:\LISAv2\EV72\Azure-EV72-TestLogs.zip' from 'C:\LISAv2\EV72\TestResults\2020-08-14-17-46-01-9952'
08/14/2020 17:46:50 : [DEBUG] C:\LISAv2\EV72\Azure-EV72-TestLogs.zip created successfully.
08/14/2020 17:46:50 : [INFO ] Analyzing test results ...
08/14/2020 17:46:50 : [INFO ] Forcefully exiting with exit code 0 as ExitWithZero flag was set to True
08/14/2020 17:46:50 : [INFO ] LISAv2 exit code: 0

=====================Fixed TestLog ========================

[LISAv2 Test Results Summary]
Test Run On           : 08/14/2020 19:42:46
VHD Under Test        : U1804-Mn4-BS.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 CPU-VERIFY-ONLINE                                                                 PASS                 1.87 
      OsVHD: http://lisawestus2x.blob.core.windows.net/vhds/U1804-Mn4-BS.vhd, OverrideVMSize: Standard_DS3_v2, StorageAccountType: Premium_LRS, TestLocation: westus2, VMGeneration: 1, Kernel Version: 5.0.0-1036-azure


Logs can be found at C:\LISAv2\AG95\TestResults\2020-08-14-19-42-09-1812


08/14/2020 19:47:18 : [DEBUG] Creating 'C:\LISAv2\AG95\Azure-AG95-TestLogs.zip' from 'C:\LISAv2\AG95\TestResults\2020-08-14-19-42-09-1812'
08/14/2020 19:47:18 : [DEBUG] C:\LISAv2\AG95\Azure-AG95-TestLogs.zip created successfully.
08/14/2020 19:47:18 : [INFO ] Analyzing test results ...
08/14/2020 19:47:18 : [INFO ] LISAv2 exit code: 0