### PR TITLE
Enable AzureDataExplorer to log TestResults

### DIFF
--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -74,6 +74,96 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform, $TestLocation, $TestCategor
 	}
 }
 
+Function Invoke-IngestKustoFromTSQL([string]$SQLString) {
+	try {
+		$kustoClusterURI = $global:XmlSecrets.secrets.KustoClusterURI
+		$kustoDatabase = $global:XmlSecrets.secrets.KustoDatabase
+		$kustoDataDLLPath = $global:XmlSecrets.secrets.KustoDataDLLPath
+		if ($kustoClusterURI -and $kustoDatabase -and $kustoDataDLLPath) {
+			# Replace potential [''] in field value string
+			$SQLString = $SQLString -replace "(?<![,\(])\'\'(?![,\)])" , '"'
+			$insertTSQLPattern = "(?in:^\s*INSERT\s+INTO\s+(?<tablename>\w+)\s*\(\s*(?<columns>(\w+\s*,\s*)+\w+)\s*\)\s*VALUES\s*(\(\s*(?<values>(\'[^\']*\',)*\s*\'[^\']*\')\s*\)\s*,*\s*)+$)"
+			$allMatches = Select-String -Pattern $insertTSQLPattern -Input $SQLString -AllMatches
+			if ($allMatches.Matches) {
+				foreach ($matchGroup in $allMatches.Matches.Groups) {
+					if ($matchGroup.Name -eq "tablename") {
+						$tableName = $matchGroup.Value
+					}
+					elseif ($matchGroup.Name -eq "columns") {
+						$columns = @($matchGroup.Value.Split(',').Trim())
+					}
+					elseif ($matchGroup.Name -eq "values") {
+						$valueArr = @($matchGroup.Captures.Value | Where-Object {$_ -ne ""})
+					}
+				}
+				if ($tableName -and $columns -and $valueArr) {
+					$ingestInlineCmd = ".ingest inline into table $tableName "
+					$kcsb = New-Object Kusto.Data.KustoConnectionStringBuilder ("$kustoClusterURI;Fed=True", $kustoDatabase)
+					$azAccountType = $global:GlobalConfig.Global.Azure.Subscription.AccountType
+					if ($azAccountType -eq "ServicePrincipal") {
+						$applicationId = $global:XmlSecrets.secrets.SubscriptionServicePrincipalClientID
+						$authority = $global:XmlSecrets.secrets.SubscriptionServicePrincipalTenantID
+						$applicationKey = $global:XmlSecrets.secrets.SubscriptionServicePrincipalKey
+						$kcsb = $kcsb.WithAadApplicationKeyAuthentication($applicationId, $applicationKey, $authority)
+					}
+					elseif ($azAccountType -eq "ManagedService") {
+						$msiClientId = $global:XmlSecrets.secrets.MsiClientId
+						$kcsb = $kcsb.WithAadManagedIdentity($msiClientId)
+					}
+					$queryProvider = [Kusto.Data.Net.Client.KustoClientFactory]::CreateCslQueryProvider($kcsb)
+					# Query first to get table schema, and prepare ingest inline command
+					$crp = New-Object Kusto.Data.Common.ClientRequestProperties
+					$crp.ClientRequestId = "MyPowershellScript.ExecuteQuery." + [Guid]::NewGuid().ToString()
+					$crp.SetOption([Kusto.Data.Common.ClientRequestProperties]::OptionServerTimeout, [TimeSpan]::FromSeconds(30))
+					# Here may throw exception, when $tableName does not exist
+					$queryReader = $queryProvider.ExecuteQuery("$tableName | limit 1", $crp)
+					$queryDataTable = [Kusto.Cloud.Platform.Data.ExtendedDataReader]::ToDataSet($queryReader).Tables[0]
+					$kustoTableColumns = @($queryDataTable.Columns.ColumnName)
+					foreach ($rowValue in $valueArr) {
+						$ingestValueArray = @($kustoTableColumns)
+						$cellValueIndex = 0
+						$cellValueArray = $rowValue.Split(",").Trim("' ")
+						for ($tableColumnIndex = 0; $tableColumnIndex -lt $kustoTableColumns.Count; $tableColumnIndex++) {
+							if ($columns -contains $kustoTableColumns[$tableColumnIndex]) {
+								$ingestValueArray[$tableColumnIndex] = $cellValueArray[$cellValueIndex++].Replace(",", " ")
+							}
+							else {
+								$ingestValueArray[$tableColumnIndex] = ""
+							}
+						}
+						$ingestInlineCmd += " [ $($ingestValueArray -Join ',') ]"
+					}
+					# Execute ingest command with AdminProvider
+					$adminProvider = [Kusto.Data.Net.Client.KustoClientFactory]::CreateCslAdminProvider($kcsb)
+					# Here may throw exception, when schema does not match
+					$adminReader = $adminProvider.ExecuteControlCommand($ingestInlineCmd)
+					if ($adminReader.HasRows -and $adminReader["ExtentId"] -ne [Guid]::Empty) {
+						Write-LogInfo "Ingested successfully into '$kustoDatabase' of '$kustoClusterURI' with `n $ingestInlineCmd "
+					}
+				}
+				else {
+					Write-LogErr "Missing 'tablename' or 'columns' or 'values' from SQLString '$SQLString', hence skip Kusto ingestion"
+				}
+			}
+			else {
+				Write-LogErr "Failed to parse SQLString '$SQLString', hence skip Kusto ingestion"
+			}
+		}
+	}
+	catch {
+		Write-LogErr "Ingest Kusto Data from TSQLString:  ERROR"
+		$line = $_.InvocationInfo.ScriptLineNumber
+		$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
+		$ErrorMessage = $_.Exception.Message
+		Write-LogInfo "EXCEPTION : $ErrorMessage `n when ingesting into '$kustoDatabase' by '$kustoClusterURI' with '$ingestInlineCmd'"
+		Write-LogInfo "Source : Line $line in script $script_name."
+	}
+	finally {
+		if ($queryProvider) {$queryProvider.Dispose()}
+		if ($adminProvider) {$adminProvider.Dispose()}
+	}
+}
+
 Function Upload-TestResultToDatabase ([String]$SQLQuery) {
 	if ($XmlSecrets) {
 		$dataSource = $XmlSecrets.secrets.DatabaseServer
@@ -127,7 +217,7 @@ Function Upload-TestResultToDatabase ([String]$SQLQuery) {
 			Write-LogErr "Database details are not provided. Results will not be uploaded to database!!"
 		}
 	}
- else {
+	else {
 		Write-LogErr "Unable to send telemetry data to Azure. XML Secrets file not provided."
 	}
 }

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -259,10 +259,11 @@ Class AzureController : TestController
 		Write-LogInfo "------------------------------------------------------------------"
 
 		$SelectedSubscription = Set-AzContext -SubscriptionId $azureConfig.Subscription.SubscriptionID
+		$azureConfig.Subscription.AccountType = $SelectedSubscription.Account.Type
 		$subIDSplitted = ($SelectedSubscription.Subscription.SubscriptionId).Split("-")
 		Write-LogInfo "SubscriptionName       : $($SelectedSubscription.Subscription.Name)"
 		Write-LogInfo "SubscriptionId         : $($subIDSplitted[0])-xxxx-xxxx-xxxx-$($subIDSplitted[4])"
-		Write-LogInfo "User                   : $($SelectedSubscription.Account.Id)"
+		Write-LogInfo "AccountId              : $($SelectedSubscription.Account.Id)"
 		Write-LogInfo "ServiceEndpoint        : $($SelectedSubscription.Environment.ActiveDirectoryServiceEndpointResourceId)"
 		Write-LogInfo "CurrentStorageAccount  : $($azureConfig.Subscription.ARMStorageAccount)"
 

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -188,6 +188,10 @@ Class TestController
 				Get-LISAv2Tools -XMLSecretFile $XMLSecretFile
 				$this.UpdateXMLStringsFromSecretsFile()
 				$this.UpdateRegionAndStorageAccountsFromSecretsFile()
+				$kustoDataDLLPath = $this.XmlSecrets.secrets.KustoDataDLLPath
+				if ($kustoDataDllPath -and (Test-Path "$kustoDataDLLPath")) {
+					[System.Reflection.Assembly]::LoadFrom("$kustoDataDllPath") | Out-Null
+				}
 			} else {
 				Write-LogErr "The Secret file provided: '$XMLSecretFile' does not exist"
 			}
@@ -788,6 +792,9 @@ Class TestController
 					-ARMImageName $CurrentTestData.SetupConfig.ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL -TableName $dataTableName
 
 				Upload-TestResultToDatabase -SQLQuery $SQLQuery
+
+				# IngestKusto may throw exceptions or log error messages, in that case, manual configuration is needed from kusto cluster service for its table schemas mapping to exising SQL database
+				Invoke-IngestKustoFromTSQL -SQLString $SQLQuery
 			}
 			catch {
 				$line = $_.InvocationInfo.ScriptLineNumber

--- a/UnitTests/PowerShell/LISAv2-Framework.Tests.ps1
+++ b/UnitTests/PowerShell/LISAv2-Framework.Tests.ps1
@@ -34,7 +34,8 @@ Describe "Test if ${moduleName} Run-LISAv2 fails with no test cases found" {
 		Mock Select-AzSubscription -Verifiable -ModuleName "AzureController" {
 			return @{
 				"Account" = @{
-					"Id" = "Id"
+					"Id" = "Id";
+					"Type" = "User"
 				};
 				"Subscription" = @{
 					"SubscriptionId" = "SubscriptionId";
@@ -61,7 +62,8 @@ Describe "Test if ${moduleName} Run-LISAv2 fails to parse report results on Azur
 		Mock Select-AzSubscription -Verifiable -ModuleName "AzureController" {
 			return @{
 				"Account" = @{
-					"Id" = "Id"
+					"Id" = "Id";
+					"Type" = "User"
 				};
 				"Subscription" = @{
 					"SubscriptionId" = "SubscriptionId";

--- a/UnitTests/PowerShell/TestControllers/AzureController.Tests.ps1
+++ b/UnitTests/PowerShell/TestControllers/AzureController.Tests.ps1
@@ -91,7 +91,8 @@ Describe "Test if module ${moduleName} PrepareTestEnvironment is valid" {
 		Mock Set-AzContext -Verifiable -ModuleName $moduleName {
 			return @{
 				"Account" = @{
-					"Id" = "Id"
+					"Id" = "Id";
+					"Type" = "User"
 				};
 				"Subscription" = @{
 					"SubscriptionId" = "SubscriptionId";

--- a/XML/GlobalConfigurations.xml
+++ b/XML/GlobalConfigurations.xml
@@ -5,6 +5,7 @@
             <SubscriptionName>YOUR_SUBSCRIPTION_NAME</SubscriptionName>
             <Environment>AzureCloud</Environment>
             <ARMStorageAccount>ExistingStorage_Standard</ARMStorageAccount>
+            <AccountType></AccountType>
         </Subscription>
         <DefaultARMImageName>Canonical UbuntuServer 18.04-LTS Latest</DefaultARMImageName>
         <ResultsDatabase>


### PR DESCRIPTION
Enable AzureDataExplorer to log TestResults

If any of `<KustoClusterURI> <KustoDatabase> <KustoDataDLLPath>` from secret file is NOT provided, this change will not impact the original telemetry logging.  In that case, same console logs as before.   If Kusto info are sufficient from secret file, test log will looks like below:

==============Test Log=================

08/15/2020 17:56:25 : [INFO ] Get the SQL query of test results: done
08/15/2020 17:56:26 : [INFO ] SQLQuery: INSERT INTO LISAv2Results
...
08/15/2020 17:56:26 : [INFO ] Uploading test results to database: DONE
08/15/2020 17:58:15 : [INFO ] Ingested successfully into 'LISAv2Results ' of 'xxx' with
'.ingest inline into table LISAv2Results <|
....
08/15/2020 18:02:02 : [INFO ] ==> Run test cleanup script if defined.
08/15/2020 18:02:02 : [INFO ] Start to do cleanup for case VERIFY-DEPLOYMENT-PROVISION
08/15/2020 18:02:02 : [INFO ] Removing Background Job 19...
08/15/2020 18:02:02 : [INFO ] Removing all files logs from IP : 52.175.235.49 PORT : 22
08/15/2020 18:02:02 : [DEBUG] dos2unix: converting file C:\LISAv2\TestResults\2020-08-15-10-50-41-1238\VERIFY-DEPLOYMENT-PROVISION\runtest-SD83.sh to Unix format...
08/15/2020 18:02:02 : [DEBUG] Uploading C:\LISAv2\TestResults\2020-08-15-10-50-41-1238\VERIFY-DEPLOYMENT-PROVISION\runtest-SD83.sh to lisa : 52.175.235.49, port 22 using PrivateKey authentication
08/15/2020 18:02:03 : [DEBUG] Upload successful after 1 attempt
08/15/2020 18:02:03 : [DEBUG] .\Tools\plink.exe -ssh -t -i ppkfile -P 22 lisa@xxx "sudo -S rm -rf *"
08/15/2020 18:02:05 : [DEBUG] rm -rf * executed successfully in 1.21 seconds.
08/15/2020 18:02:05 : [INFO ] All files removed from current user lisa home folder successfully. VM IP : 52.175.235.49 PORT : 22
08/15/2020 18:02:05 : [INFO ] End of testing: VERIFY-DEPLOYMENT-PROVISION with SetupConfig: { ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2 }, result: PASS
08/15/2020 18:02:05 : [INFO ] PASS - 1
08/15/2020 18:02:05 : [INFO ] SKIPPED - 0
08/15/2020 18:02:05 : [INFO ] FAIL - 0
08/15/2020 18:02:05 : [INFO ] ABORTED - 0
08/15/2020 18:02:05 : [INFO ] PENDING - 0

08/15/2020 18:02:05 : [INFO ] Delete deployed target machine ...
08/15/2020 18:02:05 : [INFO ] Try to delete resource group LISAv2-OneVM-harzTestKusto-SD83-20200815105223...
08/15/2020 18:02:07 : [INFO ] Triggering delete operation for Resource Group LISAv2-OneVM-harzTestKusto-SD83-20200815105223
08/15/2020 18:02:07 : [INFO ] Checking for any unmanaged disks in LISAv2-OneVM-harzTestKusto-SD83-20200815105223 ...
08/15/2020 18:02:07 : [INFO ] No any unmanaged VHDs found. Proceeding resource group cleanup.
08/15/2020 18:02:09 : [INFO ] Retrying 'Remove-AzResourceGroup -ResourceGroupName LISAv2-OneVM-harzTestKusto-SD83-20200815105223'. Remaining attempts : 9
08/15/2020 18:02:13 : [INFO ] Successfully triggered delete operation for Resource Group LISAv2-OneVM-harzTestKusto-SD83-20200815105223
08/15/2020 18:02:13 : [INFO ] Successfully started clean up for RG LISAv2-OneVM-harzTestKusto-SD83-20200815105223..
08/15/2020 18:02:13 : [INFO ] Cleanup test environment if required ...
08/15/2020 18:02:14 : [INFO ] Test SD83 finished
08/15/2020 18:02:14 : [INFO ]
[LISAv2 Test Results Summary]
Test Run On : 08/15/2020 17:52:13
Total Test Cases : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

ID TestArea TestCaseName TestResult TestDuration(in minutes)
1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 7.78 
  ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
  FirstBoot : PASS
  FirstBoot : Call Trace Verification : PASS
  Reboot : PASS
  Reboot : Call Trace Verification : PASS
Logs can be found at C:\LISAv2\TestResults\2020-08-15-10-50-41-1238

08/15/2020 18:02:14 : [DEBUG] Creating 'C:\LISAv2\Azure-SD83-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-08-15-10-50-41-1238'
08/15/2020 18:02:14 : [DEBUG] C:\LISAv2\Azure-SD83-TestLogs.zip created successfully.
08/15/2020 18:02:14 : [INFO ] Analyzing test results ...
08/15/2020 18:02:14 : [INFO ] LISAv2 exit code: 0