### PR TITLE
fix bug of parsing SQLString for Kusto ingestion

### DIFF
--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -67,10 +67,10 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform, $TestLocation, $TestCategor
 	catch {
 		Write-LogErr "Get the SQL query of test results:  ERROR"
 		$line = $_.InvocationInfo.ScriptLineNumber
-		$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
+		$scriptName = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
 		$ErrorMessage = $_.Exception.Message
 		Write-LogInfo "EXCEPTION : $ErrorMessage"
-		Write-LogInfo "Source : Line $line in script $script_name."
+		Write-LogInfo "Source : Line $line in script $scriptName."
 	}
 }
 
@@ -122,7 +122,7 @@ Function Invoke-IngestKustoFromTSQL([string]$SQLString) {
 					foreach ($rowValue in $valueArr) {
 						$ingestValueArray = @($kustoTableColumns)
 						$cellValueIndex = 0
-						$cellValueArray = $rowValue.Split(",").Trim("' ")
+						$cellValueArray = @(($rowValue | Select-String -Pattern "\'([^\']*)\'" -AllMatches).Matches | ForEach-Object {$_.Groups[1].Value})
 						for ($tableColumnIndex = 0; $tableColumnIndex -lt $kustoTableColumns.Count; $tableColumnIndex++) {
 							if ($columns -contains $kustoTableColumns[$tableColumnIndex]) {
 								$ingestValueArray[$tableColumnIndex] = $cellValueArray[$cellValueIndex++].Replace(",", " ")
@@ -153,10 +153,10 @@ Function Invoke-IngestKustoFromTSQL([string]$SQLString) {
 	catch {
 		Write-LogErr "Ingest Kusto Data from TSQLString:  ERROR"
 		$line = $_.InvocationInfo.ScriptLineNumber
-		$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
+		$scriptName = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
 		$ErrorMessage = $_.Exception.Message
 		Write-LogInfo "EXCEPTION : $ErrorMessage `n when ingesting into '$kustoDatabase' by '$kustoClusterURI' with '$ingestInlineCmd'"
-		Write-LogInfo "Source : Line $line in script $script_name."
+		Write-LogInfo "Source : Line $line in script $scriptName."
 	}
 	finally {
 		if ($queryProvider) {$queryProvider.Dispose()}
@@ -193,10 +193,10 @@ Function Upload-TestResultToDatabase ([String]$SQLQuery) {
 					$uploadSucceeded = $false
 					Write-LogErr "Uploading test results to database: ERROR"
 					$line = $_.InvocationInfo.ScriptLineNumber
-					$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
+					$scriptName = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
 					$ErrorMessage = $_.Exception.Message
 					Write-LogErr "EXCEPTION : $ErrorMessage"
-					Write-LogErr "Source : Line $line in script $script_name."
+					Write-LogErr "Source : Line $line in script $scriptName."
 					if ($retry -lt $maxRetry) {
 						Start-Sleep -Seconds 1
 						Write-LogWarn "Retring, attempt $retry"
@@ -259,10 +259,10 @@ Function Upload-TestResultDataToDatabase ([Array] $TestResultData, [Object] $Dat
 		catch {
 			Write-LogErr "Fail to upload test results to database"
 			$line = $_.InvocationInfo.ScriptLineNumber
-			$script_name = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
+			$scriptName = ($_.InvocationInfo.ScriptName).Replace($PWD, ".")
 			$ErrorMessage = $_.Exception.Message
 			Write-LogInfo "EXCEPTION : $ErrorMessage"
-			Write-LogInfo "Source : Line $line in script $script_name."
+			Write-LogInfo "Source : Line $line in script $scriptName."
 			# throw from catch, in order to be caught by caller module/function
 			throw $_.Exception
 		}


### PR DESCRIPTION
fix bug of parsing SQLString for Kusto ingestion, no impact to normal LISAv2 testing flow.

=============Test logs  LISA ends expected, no failure/exception caused by DB and ingestion ===========
[LISAv2 Test Results Summary]
Test Run On           : 08/18/2020 10:02:22
Test Category         : Functional
Test Area             : CORE
Test Priority         : 0
Total Test Cases      : 12 (10 Passed, 1 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:33

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION-SRIOV                                                 PASS                 3.77 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, Networking: SRIOV, OverrideVMSize: Standard_DS13_v2, TestLocation: westus2, Kernel Version:
 5.3.0-1034-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    2 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.37 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
    3 CORE                 VERIFY-LINUX-CONFIGURATION                                                        PASS                 0.93 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    4 CORE                 LIS-MODULES-CHECK                                                                 PASS                 0.86 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    5 CORE                 VERIFY-LIS-MODULES-VERSION                                                     SKIPPED                 0.78 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    6 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        FAIL                 1.41 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    7 CORE                 VERIFY-VHD-PREREQUISITES                                                          PASS                 1.31 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    8 CORE                 TIMESYNC-NTP                                                                      PASS                 1.32 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
    9 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 1.03 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
   10 CORE                 VERIFY-LINUX-DISK-SETUP                                                           PASS                    1 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
   11 CORE                 RELOAD-MODULES-SMP                                                                PASS                 6.82 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure
   12 CORE                 LSVMBUS                                                                           PASS                 0.95 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.3.0-1034-azure


Logs can be found at C:\lisa\LISAv2\TestResults\2020-08-18-10-01-45-1052


08/18/2020 10:35:26 : [DEBUG] Creating 'C:\lisa\LISAv2\Azure-Functional-CORE-0-DC78-TestLogs.zip' from 'C:\lisa\LISAv2\TestResults\2020-08-18-10-01-45-1
052'
08/18/2020 10:35:26 : [DEBUG] C:\lisa\LISAv2\Azure-Functional-CORE-0-DC78-TestLogs.zip created successfully.
08/18/2020 10:35:26 : [INFO ] Analyzing test results ...
08/18/2020 10:35:26 : [INFO ] LISAv2 exit code: 1