### PR TITLE
Fix VERIFY-DPDK-NFF-GO

### DIFF
--- a/Testscripts/Linux/build_test_nff_go.sh
+++ b/Testscripts/Linux/build_test_nff_go.sh
@@ -54,7 +54,7 @@ function build_test_nff_go () {
 	check_exit_status "GO env downloaded from ${nffGoEnvSrcLink} on ${1}" "exit"
 
 	# Build NFF-GO using prebuilt DPDK
-	exported_vars="RTE_SDK=${RTE_SDK} RTE_TARGET=${RTE_TARGET} GOROOT=/opt/go GOPATH=/tmp/go-fork PATH=\$GOROOT/bin:$GOPATH/bin:\$PATH"
+	exported_vars="RTE_SDK=${RTE_SDK} RTE_TARGET=${RTE_TARGET} GOROOT=/opt/go GOPATH=/tmp/go-fork PATH=\$GOROOT/bin:$GOPATH/bin:\$PATH MAKE_PAUSE=n NFF_GO_NO_BPF_SUPPORT='UNEMPTY'"
 	ssh "${1}" "cd ${NFF_GO_DIR} && eval '${exported_vars} go mod download'"
 	check_exit_status "cd ${NFF_GO_DIR} && eval '${exported_vars} go mod download' on ${1}" "exit"
 	ssh "${1}" "cd ${NFF_GO_DIR} && eval '${exported_vars} make -j'"

--- a/XML/TestCases/FunctionalTests-DPDK.xml
+++ b/XML/TestCases/FunctionalTests-DPDK.xml
@@ -121,7 +121,7 @@
     <testScript>VERIFY-DPDK-NFF-GO.ps1</testScript>
     <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\dpdkSetup.sh,.\Testscripts\Linux\build_test_nff_go.sh,.\Testscripts\Linux\dpdkUtils.sh</files>
     <TestParameters>
-      <param>dpdkSrcLink="DPDK_SOURCE_URL"</param>
+      <param>dpdkSrcLink="https://github.com/DPDK/dpdk/archive/v19.08.tar.gz"</param>
       <param>nffGoSrcLink="NFF_GO_SOURCE_URL"</param>
       <param>nffGoSrcBranch="NFF_GO_SOURCE_BRANCH"</param>
       <param>nffGoEnvSrcLink="NFF_GO_ENV_SOURCE_URL"</param>


### PR DESCRIPTION
- nff-go current only works with v19.08.tar.gz
- it doesn't support meson
- AF_XDP support recently, but the default libbpf doesn't work, then try to build it from source, hit another build issue, it needs higher version of kernel header, so current build without this.

```error: 'XDP_RING_NEED_WAKEUP' undeclared```

Before fix, this test case will hung forever since make build is outdated in higher dpdk version.
```
[LISAv2 Test Results Summary]
Test Run On           : 08/18/2020 11:41:25
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:18

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-NFF-GO                                                                PASS                12.62 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, Networking: SRIOV, OverrideVMSize: Standard_D16s_v3, TestLocation: southcentralus, Kernel Version: 5.3.0-1034-azure
```