### PR TITLE
Add ignore warning message of WALA

### DIFF
--- a/XML/Other/ignorable-boot-errors.xml
+++ b/XML/Other/ignorable-boot-errors.xml
@@ -70,5 +70,6 @@
             <keywords>Proceeding WITHOUT firewalling in effect!</keywords>
             <keywords>urandom warning\(s\) missed due to ratelimiting</keywords>
             <keywords>kdumpctl.*: Warning: There might not be enough space to save a vmcore</keywords>
+            <keywords>WARNING ExtHandler ExtHandler cgroups v2 mounted at</keywords>
         </warnings>
 </messages>


### PR DESCRIPTION
Confirm with WALA team, they said

![image](https://user-images.githubusercontent.com/10083705/90625033-892be000-e24b-11ea-9988-d412a550ae0f.png)

https://github.com/Azure/WALinuxAgent/issues/1982

```
08/19/2020 10:35:39 AM : INFO : Ignorable ERROR/WARNING/FAILURE message: /var/log/syslog:995:Aug 19 10:34:49 LISAv2-OneVM-lili-PY60-20200819103300-role-0 python3[1051]: 2020-08-19T10:34:49.780309Z WARNING ExtHandler ExtHandler cgroups v2 mounted at /sys/fs/cgroup/unified.  Controllers: []

[LISAv2 Test Results Summary]
Test Run On           : 08/19/2020 10:32:57
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : 18.04.202008120
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 1.05 
      ARMImageName: Canonical UbuntuServer 18.04-LTS 18.04.202008120, TestLocation: eastus2, Kernel Version: 5.3.0-1034-azure
```