### PR TITLE
Fix bug of using OsVHD with Sasl

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -209,7 +209,7 @@ Function Add-SetupConfig {
             if (!$test.SetupConfig.$ConfigName) {
                 # use CDATA when the value contains XML escaped characters
                 if ($ConfigValue -imatch "&|<|>|'|""") {
-                    $test.SetupConfig.InnerXml += "<$ConfigName><![CDATA['$ConfigValue']]></$ConfigName>"
+                    $test.SetupConfig.InnerXml += "<$ConfigName><![CDATA[$ConfigValue]]></$ConfigName>"
                 }
                 else {
                     $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -333,11 +333,16 @@ Class AzureController : TestController
 		}
 
 		foreach ($test in $AllTests) {
+			$testOsVHDString = $test.SetupConfig.OsVHD
+			# SetupConfig.OsVHD may be wrapped within <![CDATA['$OsVHD']]> for escaping &|<|>|'|", in that case, we use InnerText
+			if ($test.SetupConfig.OsVHD.InnerText) {
+				$testOsVHDString = $test.SetupConfig.OsVHD.InnerText
+			}
 			# Put test case to hashtable, per setupType,OverrideVMSize,networking,diskType,osDiskType,switchName
 			$key = "$($test.SetupConfig.SetupType),$($test.SetupConfig.OverrideVMSize),$($test.SetupConfig.Networking),$($test.SetupConfig.DiskType)," +
 				"$($test.SetupConfig.OSDiskType),$($test.SetupConfig.SwitchName),$($test.SetupConfig.ImageType)," +
 				"$($test.SetupConfig.OSType),$($test.SetupConfig.StorageAccountType),$($test.SetupConfig.TestLocation)," +
-				"$($test.SetupConfig.ARMImageName),$($test.SetupConfig.OsVHD),$($test.SetupConfig.VMGeneration)"
+				"$($test.SetupConfig.ARMImageName),$testOsVHDString,$($test.SetupConfig.VMGeneration)"
 			if ($test.SetupConfig.SetupType) {
 				if ($SetupTypeToTestCases.ContainsKey($key)) {
 					$SetupTypeToTestCases[$key] += $test

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -156,11 +156,16 @@ Class HyperVController : TestController
 		Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
 
 		foreach ($test in $AllTests) {
+			$testOsVHDString = $test.SetupConfig.OsVHD
+			# SetupConfig.OsVHD may be wrapped within <![CDATA['$OsVHD']]> for escaping &|<|>|'|", in that case, we use InnerText
+			if ($test.SetupConfig.OsVHD.InnerText) {
+				$testOsVHDString = $test.SetupConfig.OsVHD.InnerText
+			}
 			# Put test case to hashtable, per setupType,OverrideVMSize,networking,diskType,osDiskType,switchName
 			$key = "$($test.SetupConfig.SetupType),$($test.SetupConfig.OverrideVMSize),$($test.SetupConfig.Networking),$($test.SetupConfig.DiskType)," +
 				"$($test.SetupConfig.OSDiskType),$($test.SetupConfig.SwitchName),$($test.SetupConfig.ImageType)," +
 				"$($test.SetupConfig.OSType),$($test.SetupConfig.StorageAccountType),$($test.SetupConfig.TestLocation)," +
-				"$($test.SetupConfig.OsVHD),$($test.SetupConfig.VMGeneration)"
+				"$testOsVHDString,$($test.SetupConfig.VMGeneration)"
 			if ($test.SetupConfig.SetupType) {
 				if ($SetupTypeToTestCases.ContainsKey($key)) {
 					$SetupTypeToTestCases[$key] += $test

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -234,8 +234,13 @@ Class TestController
 		}
 
 		foreach ($test in $AllTests) {
+			$testOsVHDString = $test.SetupConfig.OsVHD
+			# SetupConfig.OsVHD may be wrapped within <![CDATA['$OsVHD']]> for escaping &|<|>|'|", in that case, we use InnerText
+			if ($test.SetupConfig.OsVHD.InnerText) {
+				$testOsVHDString = $test.SetupConfig.OsVHD.InnerText
+			}
 			# Put test case to hashtable, per setupType, TestLocation, OsVHD
-			$key = "$($test.SetupConfig.SetupType),$($test.SetupConfig.TestLocation),$($test.SetupConfig.OsVHD)"
+			$key = "$($test.SetupConfig.SetupType),$($test.SetupConfig.TestLocation),$testOsVHDString"
 			if ($test.SetupConfig.SetupType) {
 				if ($SetupTypeToTestCases.ContainsKey($key)) {
 					$SetupTypeToTestCases[$key] += $test
@@ -270,7 +275,7 @@ Class TestController
 					$this.SetupTypeTable[$setupTypeXml.LocalName] = $setupTypeXml
 				}
 				else {
-					Throw "Duplicate setup type defined with the same name: $($setupTypeXml.LocalName) from $file"
+					Throw "Conflicts in SetupType '$($setupTypeXml.LocalName)' from '$file', which has the same name defined in other TestSetup files, please check all other TestSetup Xml files"
 				}
 			}
 		}


### PR DESCRIPTION
Fix bug of testing with OsVHD that has Sasl provided from Run-LISAv2 command line

```
==================Test Log==========
.\Run-LisaV2.ps1 -TestLocation '' -RGIdentifier 'harz-sasl' -TestPlatform 'Azure' -StorageAccount 'ExistingStorage_Standard' -VMGeneration '1' -EnableTelemetry -DeployVMPerEachTest -OsVHD 'https://susetestimage.blob.core.windows.net/images/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd?xxxx' -TestNames 'LSVMBUS' -ResourceCleanup 'Default' -XMLSecretFile '****' -ForceCustom -ExitWithZero
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2020 10:30:51
VHD Under Test        : https://susetestimage.blob.core.windows.net/images/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd?...
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 LSVMBUS                                                                           PASS                 0.84 
      OsVHD: http://lisav2eastus2.blob.core.windows.net/vhds/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd, OverrideVMSize: Standard_DS4_v2, TestLocation: eastus2, VMGeneration: 1, Kernel Version: 5.3.18-18.12-azure


Logs can be found at C:\LISAv2\IK57\TestResults\2020-08-20-10-30-18-6353


08/20/2020 10:38:08 : [DEBUG] Creating 'C:\LISAv2\IK57\Azure-IK57-TestLogs.zip' from 'C:\LISAv2\IK57\TestResults\2020-08-20-10-30-18-6353'
08/20/2020 10:38:08 : [DEBUG] C:\LISAv2\IK57\Azure-IK57-TestLogs.zip created successfully.
08/20/2020 10:38:08 : [INFO ] Analyzing test results ...
08/20/2020 10:38:08 : [INFO ] LISAv2 exit code: 0 
```