### PR TITLE
Fix OsVHD with Sasl problem

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -207,13 +207,11 @@ Function Add-SetupConfig {
         param ([System.Collections.ArrayList]$TestCollections, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
         foreach ($test in $TestCollections) {
             if (!$test.SetupConfig.$ConfigName) {
-                # use CDATA when the value contains XML escaped characters
+                # if the $ConfigValue contains certain characters as below, use [System.Security.SecurityElement]::Escape() to avoid exception
                 if ($ConfigValue -imatch "&|<|>|'|""") {
-                    $test.SetupConfig.InnerXml += "<$ConfigName><![CDATA['$ConfigValue']]></$ConfigName>"
+                    $ConfigValue = [System.Security.SecurityElement]::Escape($ConfigValue)
                 }
-                else {
-                    $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
-                }
+                $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
             }
             elseif ($Force) {
                 $test.SetupConfig.$ConfigName = $ConfigValue


### PR DESCRIPTION
Previously, if Run-LISAv2 using OsVHD with a sasl string, the test will be aborted, due to exception in LISAv2 deployment.  (While using the normal Storage URL without sasl query string, or a single *.vhd file name in the target test location's storage container vhds, is OK).
This fix is for sasl scenario using for OsVHD.

=========Test Log **with normal OSVHD .vhd file in the same storage account as test location** ============
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2020 20:35:38
VHD Under Test        : suse-sles-15-sp2-test-scheduler-none-v20200808.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 LSVMBUS                                                                           PASS                 0.85 
      OsVHD: http://lisav2eastus2.blob.core.windows.net/vhds/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd, OverrideVMSize: Standard_DS4_v2, TestLocation: eastus2, VMGeneration: 1, Kernel Version: 5.3.18-18.12-azure


Logs can be found at C:\LISAv2\HT83\TestResults\2020-08-20-20-35-07-0139


08/20/2020 20:40:01 : [DEBUG] Creating 'C:\LISAv2\HT83\Azure-HT83-TestLogs.zip' from 'C:\LISAv2\HT83\TestResults\2020-08-20-20-35-07-0139'
08/20/2020 20:40:01 : [DEBUG] C:\LISAv2\HT83\Azure-HT83-TestLogs.zip created successfully.
08/20/2020 20:40:01 : [INFO ] Analyzing test results ...
08/20/2020 20:40:01 : [INFO ] LISAv2 exit code: 0


====================Another test log **using SASL in OsVHD** ===================
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2020 20:20:40
VHD Under Test        : https://susetestimage.blob.core.windows.net/images/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd?xxxxx
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 LSVMBUS                                                                           PASS                  0.9 
      OsVHD: http://lisav2eastus2.blob.core.windows.net/vhds/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd, OverrideVMSize: Standard_DS4_v2, TestLocation: eastus2, VMGeneration: 1, Kernel Version: 5.3.18-18.12-azure


Logs can be found at C:\LISAv2\TX91-20200820202002\TestResults\2020-08-20-20-20-06-7098


08/20/2020 20:28:37 : [DEBUG] Creating 'C:\LISAv2\TX91-20200820202002\Azure-TX91-TestLogs.zip' from 'C:\LISAv2\TX91-20200820202002\TestResults\2020-08-20-20-20-06-7098'
08/20/2020 20:28:37 : [DEBUG] C:\LISAv2\TX91-20200820202002\Azure-TX91-TestLogs.zip created successfully.
08/20/2020 20:28:37 : [INFO ] Analyzing test results ...
08/20/2020 20:28:37 : [INFO ] LISAv2 exit code: 0

===============Another Log for **OsVHD with full storage URL, but no SASL string** =======================
[LISAv2 Test Results Summary]
Test Run On           : 08/20/2020 20:46:50
VHD Under Test        : https://lisaeastus2.blob.core.windows.net/vhds/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 LSVMBUS                                                                           PASS                 0.66 
      OsVHD: http://lisasouthcentralus.blob.core.windows.net/vhds/suse-sles-15-sp2-test-scheduler-none-v20200808.vhd, OverrideVMSize: Standard_DS4_v2, TestLocation: southcentralus, VMGeneration: 1, Kernel Version: 5.3.18-18.12-azure


Logs can be found at C:\LISAv2\IR52\TestResults\2020-08-20-20-46-12-4561


08/20/2020 20:55:42 : [DEBUG] Creating 'C:\LISAv2\IR52\Azure-IR52-TestLogs.zip' from 'C:\LISAv2\IR52\TestResults\2020-08-20-20-46-12-4561'
08/20/2020 20:55:42 : [DEBUG] C:\LISAv2\IR52\Azure-IR52-TestLogs.zip created successfully.
08/20/2020 20:55:42 : [INFO ] Analyzing test results ...
08/20/2020 20:55:42 : [INFO ] LISAv2 exit code: 0