### PR TITLE
Add CODEOWNERS file to setup default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+* @andschwa @squirrelsc @lpereira


### PR DESCRIPTION
This adds support for GitHub’s CODEOWNERS, which is a file indicating
which GitHub users should be automatically added as reviewers to new
Pull Requests. It’s per-branch, meaning it applies only for changes made
in a branch which includes this file, so this will not affect ‘master’.
It is setup currently to add Chi, Leandro, and myself to all PRs to
‘main’ for LISAv3.