### PR TITLE
Fix issue of Waiting VM start up with relative timeout according to VM size

### DIFF
--- a/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Parallel.ps1
@@ -10,11 +10,19 @@ function Main {
     $resultArr = @()
     try {
         $testResult = $null
+        $count = 0
         $diskSizeinGB = $TestParams.DiskSize
         $allDiskNames = @()
         $allUnmanagedDataDisks = @()
         $virtualMachine = Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName
-        $diskCount = (Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}).MaxDataDiskCount
+        $azVmSize = Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}
+        if (!$azVmSize) {
+            throw "Could not find VM Size information for $($AllVMData.InstanceSize)."
+        }
+        $diskCount = $azVmSize.MaxDataDiskCount
+        if (!$diskCount -or $diskCount -eq 0) {
+            throw "MaxDataDiskCount of current VM Size $($AllVMData.InstanceSize) is not acceptable."
+        }
         Write-Debug "Found max data disk size $diskCount in the system"
         $storageProfile = (Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName).StorageProfile
         Write-LogInfo "Parallel Addition of Data Disks to the VM "

--- a/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
+++ b/Testscripts/Windows/DiskHotAddRemove-Serial.ps1
@@ -11,9 +11,17 @@ function Main {
     $resultArr = @()
     try {
         $testResult = $null
+        $count = 0
         $diskSizeinGB = $TestParams.DiskSize
         $virtualMachine = Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName
-        $diskCount = (Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}).MaxDataDiskCount
+        $azVmSize = Get-AzVMSize -Location $AllVMData.Location | Where-Object {$_.Name -eq $AllVMData.InstanceSize}
+        if (!$azVmSize) {
+            throw "Could not find VM Size information for $($AllVMData.InstanceSize)."
+        }
+        $diskCount = $azVmSize.MaxDataDiskCount
+        if (!$diskCount -or $diskCount -eq 0) {
+            throw "MaxDataDiskCount of current VM Size $($AllVMData.InstanceSize) is not acceptable."
+        }
         $storageProfile = (Get-AzVM -ResourceGroupName $AllVMData.ResourceGroupName -Name $AllVMData.RoleName).StorageProfile
         Write-Debug "Found max data disk $diskCount in the system"
         Write-LogInfo "Serial Addition and Removal of Data Disks"

--- a/XML/TestCases/FunctionalTests-SRIOV.xml
+++ b/XML/TestCases/FunctionalTests-SRIOV.xml
@@ -176,6 +176,7 @@
     <Tags>network</Tags>
     <Priority>1</Priority>
     <SetupConfig>
+      <Networking>SRIOV</Networking>
       <SetupType>OneVM</SetupType>
       <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
     </SetupConfig>


### PR DESCRIPTION
Previously, starting a very big VM size will timeout, which cause test case fail/pass improperly.  Now fix with a reasonable timeout methodology.

Fix test issues in test cases:  "NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION" and "SRIOV-ADD-MAX-NICS-AFTER-PROVISION"

===================Test Logs========================

[LISAv2 Test Results Summary]
Test Run On           : 08/27/2020 07:51:34
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              NETWORK-ADD-MAX-SYNTHETIC-NICS-AFTER-PROVISION                                    PASS                 7.11 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_B16ms, TestLocation: australiaeast, Kernel Version: 5.3.0-1035-azure


Logs can be found at C:\LISAv2\TestResults\2020-08-27-00-49-27-1681


08/27/2020 08:01:46 : [DEBUG] Creating 'C:\LISAv2\Azure-MZ76-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-08-27-00-49-27-1681'
08/27/2020 08:01:46 : [DEBUG] C:\LISAv2\Azure-MZ76-TestLogs.zip created successfully.
08/27/2020 08:01:46 : [INFO ] Analyzing test results ...
08/27/2020 08:01:46 : [INFO ] LISAv2 exit code: 0

========================Another Log for SRIOV-ADD-MAX-NICS-AFTER-PROVISION ============
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2020 08:07:24
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-ADD-MAX-NICS-AFTER-PROVISION                                                PASS                 6.95 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure


Logs can be found at C:\LISAv2\TestResults\2020-08-27-01-05-55-7865


08/27/2020 08:16:49 : [DEBUG] Creating 'C:\LISAv2\Azure-MT89-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-08-27-01-05-55-7865'
08/27/2020 08:16:49 : [DEBUG] C:\LISAv2\Azure-MT89-TestLogs.zip created successfully.
08/27/2020 08:16:49 : [INFO ] Analyzing test results ...
08/27/2020 08:16:49 : [INFO ] LISAv2 exit code: 0

=====================Test Logs =========================

[LISAv2 Test Results Summary]
Test Run On           : 08/27/2020 08:46:17
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              STORAGE-HOT-ADD-DISK-SERIAL                                                       PASS                 5.65 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
    2 STORAGE              STORAGE-HOT-ADD-DISK-PARALLEL                                                     PASS                 1.78 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure


Logs can be found at C:\LISAv2\TestResults\2020-08-27-01-45-33-5431


08/27/2020 08:55:44 : [DEBUG] Creating 'C:\LISAv2\Azure-MG81-TestLogs.zip' from 'C:\LISAv2\TestResults\2020-08-27-01-45-33-5431'
08/27/2020 08:55:44 : [DEBUG] C:\LISAv2\Azure-MG81-TestLogs.zip created successfully.
08/27/2020 08:55:44 : [INFO ] Analyzing test results ...
08/27/2020 08:55:44 : [INFO ] LISAv2 exit code: 0