### PR TITLE
Bring up Mariadb test into LISAv2

### DIFF
--- a/Testscripts/Linux/perf_mariadb.sh
+++ b/Testscripts/Linux/perf_mariadb.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+
+#######################################################################
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+#######################################################################
+
+#######################################################################
+#
+# perf_mariadb.sh
+# Description:
+#    Install mariadb and sysbench.
+#    Run performance test of MariaDB using sysbench.
+#    This script needs to be run on client VM.
+#
+# Supported Distros:
+#    Ubuntu/Centos/RedHat/Debian
+#    TODO: We will support SUSE and other distros in the future.
+#######################################################################
+CONSTANTS_FILE="./constants.sh"
+UTIL_FILE="./utils.sh"
+HOMEDIR=$(pwd)
+LOG_FOLDER="${HOMEDIR}/mariadb_log"
+MARIADB_RESULT="${LOG_FOLDER}/report.csv"
+MARIADB_LOG_NAME="mariadb.bench.log"
+COMMON_LOG_FILE="${LOG_FOLDER}/common.log"
+SYSBENCH_VERSION=1.0.20
+
+db_path="/maria/db"
+db_parent_path="/maria"
+escaped_path=$(echo "${db_path}" | sed 's/\//\\\//g')
+user="lisa"
+
+. ${CONSTANTS_FILE} || {
+	LogErr "Error: missing ${CONSTANTS_FILE} file"
+	SetTestStateAborted
+	exit 0
+}
+
+. ${UTIL_FILE} || {
+	LogErr "Missing ${UTIL_FILE} file"
+	SetTestStateAborted
+	exit 0
+}
+
+if [ ! "${server}" ]; then
+	LogErr "Please add/provide value for server in constants.sh. server=<server ip>"
+	SetTestStateAborted
+	exit 0
+fi
+if [ ! "${client}" ]; then
+	LogErr "Please add/provide value for client in constants.sh. client=<client ip>"
+	SetTestStateAborted
+	exit 0
+fi
+
+if [ ! "${THREADS}" ]; then
+	THREADS=(1 2 4 8 16 32 64 128 256)
+fi
+
+if [ ! "${MAX_TIME}" ]; then
+	MAX_TIME=300
+fi
+
+function install_sysbench () {
+	LogMsg "Getting sysbench"
+	wget https://github.com/akopytov/sysbench/archive/${SYSBENCH_VERSION}.tar.gz
+	if [ $? -gt 0 ]; then
+		LogErr "Failed to download sysbench"
+		SetTestStateAborted
+		exit 0
+	fi
+
+	tar -xzvf ${SYSBENCH_VERSION}.tar.gz
+	if [ $? -gt 0 ]; then
+		LogErr "Failed to unzip sysbench"
+		SetTestStateAborted
+		exit 0
+	fi
+
+	LogMsg "Building sysbench"
+	pushd "${HOMEDIR}/sysbench-${SYSBENCH_VERSION}"
+	./autogen.sh && ./configure && make && make install
+	if [ $? -gt 0 ]; then
+		LogErr "Failed to build sysbench"
+		SetTestStateAborted
+		exit 0
+	fi
+	popd
+	export PATH="/usr/local/bin:${PATH}"
+	LogMsg "Sysbench installed successfully"
+}
+
+function create_data_dir () {
+	disks=$(ssh "${server}" ". $UTIL_FILE && get_AvailableDisks")
+	# We just use only one disk
+	for disk in ${disks}
+	do
+		Run_SSHCommand "${server}" "mkdir -p ${db_path}"
+		Run_SSHCommand "${server}" "yes | mkfs.ext4 /dev/${disk}"
+		Run_SSHCommand "${server}" "mount /dev/${disk} ${db_path}"
+		Run_SSHCommand "${server}" "cp -rf /var/lib/mysql/* ${db_path}"
+		Run_SSHCommand "${server}" "chown -R mysql:mysql ${db_path}"
+		Run_SSHCommand "${server}" "chmod 0755 -R ${db_path}"
+		# We also need to ensure that all the parent directories of the datadir upwards 
+		# have "x" (execute) permissions for all (user, group, and other)
+		# Refer to https://mariadb.com/kb/en/what-to-do-if-mariadb-doesnt-start/#cant-create-test-file
+		Run_SSHCommand "${server}" "chmod 0755 -R ${db_parent_path}"
+		break
+	done
+}
+
+function config_mariadb () {
+	case "$DISTRO_NAME" in
+		oracle|rhel|centos)
+			# Mariadb is not enabled by default
+			Run_SSHCommand "${server}" "service mariadb stop"
+			Run_SSHCommand "${server}" "echo datadir = ${db_path} | sudo tee --append /etc/my.cnf.d/mariadb-server.cnf"
+			Run_SSHCommand "${server}" "echo bind-address = 0.0.0.0 | sudo tee --append /etc/my.cnf.d/mariadb-server.cnf"
+			Run_SSHCommand "${server}" "echo max_connections = 1024 | sudo tee --append /etc/my.cnf.d/mariadb-server.cnf"
+			# Config the systemd service to set the open files limit as infinity
+			# Refer to https://mariadb.com/kb/en/systemd/
+			Run_SSHCommand "${server}" "echo LimitNOFILE=infinity | sudo tee --append /lib/systemd/system/mariadb.service"
+			Run_SSHCommand "${server}" "systemctl daemon-reload"
+			# Config selinux to set enforcing to permissive
+			# Refer to https://blogs.oracle.com/jsmyth/selinux-and-mysql
+			Run_SSHCommand "${server}" "setenforce 0"
+			;;
+		ubuntu|debian)
+			Run_SSHCommand "${server}" "service mysql stop"
+			Run_SSHCommand "${server}" "sed -i '/datadir/c\datadir = ${escaped_path}' /etc/mysql/mariadb.conf.d/50-server.cnf"
+			Run_SSHCommand "${server}" "sed -i '/bind-address/c\bind-address = 0\.0\.0\.0' /etc/mysql/mariadb.conf.d/50-server.cnf"
+			Run_SSHCommand "${server}" "sed -i '/max_connections/c\max_connections = 1024' /etc/mysql/mariadb.conf.d/50-server.cnf"
+			;;
+		*)
+			LogErr "Unsupported distribution"
+			return 1
+	esac
+	Run_SSHCommand "${server}" "service mariadb start"
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+}
+
+function config_mariadb_for_remote_access () {
+	# We can refer to https://webdock.io/en/docs/how-guides/how-enable-remote-access-your-mariadbmysql-database
+	# to get the meaning of these sql commands.
+	Run_SSHCommand "${server}" "mysql -e \"GRANT ALL PRIVILEGES ON *.* TO '${user}'@'${client}' IDENTIFIED BY 'lisapassword' WITH GRANT OPTION;\""
+	Run_SSHCommand "${server}" "mysql -e \"DROP DATABASE sbtest;\""
+	Run_SSHCommand "${server}" "mysql -e \"CREATE DATABASE sbtest;\""
+	Run_SSHCommand "${server}" "mysql -e \"FLUSH PRIVILEGES;\""
+}
+
+function start_monitor()
+{
+	lteration=${1}
+	mpstat_cmd="mpstat"
+	iostat_cmd="iostat"
+	sar_cmd="sar"
+	vmstat_cmd="vmstat"
+	Run_SSHCommand "${server}" "${iostat_cmd} -x -d 1 ${MAX_TIME}" > "${LOG_FOLDER}/${lteration}.iostat.server.log" &
+	Run_SSHCommand "${server}" "${sar_cmd} -n DEV 1 ${MAX_TIME}" > "${LOG_FOLDER}/${lteration}.sar.server.log" &
+	Run_SSHCommand "${server}" "${mpstat_cmd} -P ALL 1 ${MAX_TIME}" > "${LOG_FOLDER}/${lteration}.mpstat.server.log" &
+	Run_SSHCommand "${server}" "${vmstat_cmd} 1 ${MAX_TIME}" > "${LOG_FOLDER}/${lteration}.vmstat.server.log" &
+
+	${iostat_cmd} -x -d 1 ${MAX_TIME} > ${LOG_FOLDER}/${lteration}.iostat.client.log &
+	${sar_cmd} -n DEV 1 ${MAX_TIME} > ${LOG_FOLDER}/${lteration}.sar.client.log &
+	${mpstat_cmd} -P ALL 1 ${MAX_TIME} > ${LOG_FOLDER}/${lteration}.mpstat.client.log &
+	${vmstat_cmd} 1 ${MAX_TIME} > ${LOG_FOLDER}/${lteration}.vmstat.client.log &
+}
+
+function parse_log () {
+	threads=${1}
+	mariadb_log_file="${LOG_FOLDER}/${threads}.${MARIADB_LOG_NAME}"
+	Threads=$(grep "Number of threads:" $mariadb_log_file | awk '{print $NF}')
+	TotalQueries=$(grep "total:" $mariadb_log_file | awk '{print $NF}')
+	TransactionsPerSec=$(grep "transactions:" $mariadb_log_file | awk -F '(' '{print $2}' | awk '{print $1}')
+	Latency95Percentile_ms=$(grep "95th percentile:" $mariadb_log_file | awk '{print $NF}')
+
+	LogMsg "Test Results: "
+	LogMsg "---------------"
+	LogMsg "Threads: $Threads"
+	LogMsg "Total Queries: $TotalQueries"
+	LogMsg "Transactions Per Sec: $TransactionsPerSec"
+	LogMsg "95 Percentile latency(ms): $Latency95Percentile_ms"
+
+	echo "$Threads,$TotalQueries,$TransactionsPerSec,$Latency95Percentile_ms" >> "${MARIADB_RESULT}"
+}
+
+function run_mariadb () {
+	threads=$1
+
+	LogMsg "======================================"
+	LogMsg "Running mariadb test with current threads: ${threads}"
+	LogMsg "======================================"
+	start_monitor ${threads}
+
+	sysbench ${oltp_path} --mysql-host=${server} --mysql-user=${user} --mysql-password=lisapassword \
+--mysql-db=sbtest --time=${MAX_TIME} --oltp-test-mode=complex --mysql-table-engine=innodb --oltp-read-only=off \
+--max-requests=1000000 --num-threads=${threads} run > "${LOG_FOLDER}/${threads}.${MARIADB_LOG_NAME}"
+
+	parse_log ${threads}
+}
+
+Run_SSHCommand "${server}" "rm -rf ${LOG_FOLDER}"
+Run_SSHCommand "${server}" "mkdir -p ${LOG_FOLDER}"
+rm -rf ${LOG_FOLDER}
+mkdir -p ${LOG_FOLDER}
+
+# Install mariadb in client and server machine
+LogMsg "Configuring client ${client}..."
+install_mariadb
+if [ $? -ne 0 ]; then
+	LogErr "Mariadb installation failed in ${client}.."
+	SetTestStateAborted
+	exit 0
+fi
+
+LogMsg "Configuring server ${server}..."
+Run_SSHCommand "${server}" ". $UTIL_FILE && install_mariadb"
+if [ $? -ne 0 ]; then
+	LogErr "Mariadb installation failed in ${server}..."
+	SetTestStateAborted
+	exit 0
+fi
+
+# Install sysbench in client machine
+LogMsg "Installing sysbench in client ${client}..."
+install_sysbench
+
+# Create data directory of mysql on server machine
+LogMsg "Creating data directory of mysql in server ${server}..."
+create_data_dir
+if [ $? -ne 0 ]; then
+	LogErr "Creating data directory of mysql failed in server ${server}.."
+	SetTestStateAborted
+	exit 0
+fi
+
+# Config MariaDB
+LogMsg "Configing MariaDB in server ${server}..."
+config_mariadb
+if [ $? -ne 0 ]; then
+	LogErr "Configing MarinaDB failed in server ${server}.."
+	SetTestStateAborted
+	exit 0
+fi
+
+# Config MariaDB for remote access
+LogMsg "Configuring MariaDB for remote access in server ${server}..."
+config_mariadb_for_remote_access
+if [ $? -ne 0 ]; then
+	LogErr "Configuring MarinaDB for remote access failed in server ${server}.."
+	SetTestStateAborted
+	exit 0
+fi
+
+# Prepare for mariadb test
+LogMsg "Prepare for MarinaDB test in client ${client}..."
+oltp_path="${HOMEDIR}/sysbench-${SYSBENCH_VERSION}/tests/include/oltp_legacy/oltp.lua"
+sysbench ${oltp_path} --mysql-host=${server} --mysql-user=${user} --mysql-password=lisapassword \
+--mysql-db=sbtest --oltp-table-size=1000000 prepare >> ${COMMON_LOG_FILE}
+
+echo "Threads,TotalQueries,TransactionsPerSec,Latency95Percentile_ms" > "${MARIADB_RESULT}"
+
+# Run mariadb test
+LogMsg "Running MariaDB performance test using sysbench in client ${client}..."
+for threads in "${THREADS[@]}"
+do
+    run_mariadb ${threads}
+done
+
+sysbench ${oltp_path} --mysql-host=${server} --mysql-user=${user} --mysql-password=lisapassword --mysql-db=sbtest cleanup >> ${COMMON_LOG_FILE}
+
+LogMsg "Kernel Version : $(uname -r)"
+LogMsg "Guest OS : ${distro}"
+
+column -s, -t "${MARIADB_RESULT}" > "${LOG_FOLDER}"/report.log
+cp "${LOG_FOLDER}"/* .
+cat report.log
+SetTestStateCompleted

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -480,6 +480,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>(1 2 4 8 16 32 64 128 256 512 1024)</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>MARIADB_THREADS</ReplaceThis>
+		<ReplaceWith>(1 2 4 8 16 32 64 128 256)</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>MAX_CONCURRENCY_PER_AB</ReplaceThis>
 		<ReplaceWith>4</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -769,6 +769,26 @@
     </SetupConfig>
   </test>
   <test>
+    <testName>PERF-MARIADB-BENCHMARK</testName>
+    <testScript>PERF-TWOVM-MIDDLEWARE-BENCHMARK.ps1</testScript>
+    <runSetupScriptOnlyOnce>yes</runSetupScriptOnlyOnce>
+    <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\perf_mariadb.sh</files>
+    <TestParameters>
+        <param>THREADS=MARIADB_THREADS</param>
+        <param>MAX_TIME=300</param>
+    </TestParameters>
+    <Platform>Azure,HyperV</Platform>
+    <Category>Performance</Category>
+    <Area>BENCHMARK</Area>
+    <Tags>benchmark,mariadb,sriov</Tags>
+    <Priority>2</Priority>
+    <SetupConfig>
+      <Networking>SRIOV</Networking>
+      <SetupType>TwoVM2Host1Disk</SetupType>
+      <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
+    </SetupConfig>
+  </test>
+  <test>
     <testName>PERF-APACHE-BENCHMARK-SRIOV</testName>
     <testScript>PERF-TWOVM-MIDDLEWARE-BENCHMARK.ps1</testScript>
     <runSetupScriptOnlyOnce>yes</runSetupScriptOnlyOnce>

--- a/XML/VMConfigurations/TwoVMs.xml
+++ b/XML/VMConfigurations/TwoVMs.xml
@@ -138,6 +138,42 @@
             </VirtualMachine>
         </ResourceGroup>
     </TwoVM2Host>
+    <TwoVM2Host1Disk>
+        <isDeployed>NO</isDeployed>
+        <ResourceGroup>
+            <VirtualMachine>
+                <InstanceSize>Standard_DS15_v2</InstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>SSH</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>22</LocalPort>
+                    <PublicPort>1111</PublicPort>
+                </EndPoints>
+                <DataDisk>
+                    <LUN>0</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
+            </VirtualMachine>
+            <VirtualMachine>
+                <DeployOnDifferentHyperVHost>yes</DeployOnDifferentHyperVHost>
+                <InstanceSize>Standard_DS15_v2</InstanceSize>
+                <RoleName></RoleName>
+                <EndPoints>
+                    <Name>SSH</Name>
+                    <Protocol>tcp</Protocol>
+                    <LocalPort>22</LocalPort>
+                    <PublicPort>1112</PublicPort>
+                </EndPoints>
+                <DataDisk>
+                    <LUN>0</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
+            </VirtualMachine>
+        </ResourceGroup>
+    </TwoVM2Host1Disk>
     <TwoVM2Host1Dep>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>


### PR DESCRIPTION
Bring up Mariadb test case from lis-test into LISAv2. 
This test case supports Centos and Ubuntu distros. For SUSE and other distros, I will add support later.
Test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2020 07:54:04
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:56

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 BENCHMARK            PERF-MARIADB-BENCHMARK                                                            PASS                52.86 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
      Threads=1 : TotalQueries=330240 TransactionsPerSec=55.04 Latency95Percentile_ms=36.24
      Threads=2 : TotalQueries=456080 TransactionsPerSec=76.01 Latency95Percentile_ms=43.39
      Threads=4 : TotalQueries=790661 TransactionsPerSec=131.75 Latency95Percentile_ms=61.08
      Threads=8 : TotalQueries=1346945 TransactionsPerSec=224.40 Latency95Percentile_ms=80.03
      Threads=16 : TotalQueries=3172911 TransactionsPerSec=528.37 Latency95Percentile_ms=56.84
      Threads=32 : TotalQueries=4243723 TransactionsPerSec=706.11 Latency95Percentile_ms=75.82
      Threads=64 : TotalQueries=7415793 TransactionsPerSec=1231.95 Latency95Percentile_ms=92.42
      Threads=128 : TotalQueries=10752939 TransactionsPerSec=1763.82 Latency95Percentile_ms=150.29
      Threads=256 : TotalQueries=7259421 TransactionsPerSec=789.48 Latency95Percentile_ms=816.63
```
```
[LISAv2 Test Results Summary]
Test Run On           : 08/27/2020 08:07:05
ARM Image Under Test  : OpenLogic : CentOS : 8_1 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:55

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 BENCHMARK            PERF-MARIADB-BENCHMARK                                                            PASS                51.86 
      ARMImageName: OpenLogic CentOS 8_1 latest, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.18.0-147.8.1.el8_1.x86_64
      Threads=1 : TotalQueries=275840 TransactionsPerSec=45.96 Latency95Percentile_ms=50.11
      Threads=2 : TotalQueries=368000 TransactionsPerSec=61.33 Latency95Percentile_ms=57.87
      Threads=4 : TotalQueries=798999 TransactionsPerSec=133.14 Latency95Percentile_ms=58.92
      Threads=8 : TotalQueries=1766797 TransactionsPerSec=294.29 Latency95Percentile_ms=48.34
      Threads=16 : TotalQueries=3269966 TransactionsPerSec=544.34 Latency95Percentile_ms=58.92
      Threads=32 : TotalQueries=6289009 TransactionsPerSec=1045.18 Latency95Percentile_ms=69.29
      Threads=64 : TotalQueries=13024687 TransactionsPerSec=2159.76 Latency95Percentile_ms=70.55
      Threads=128 : TotalQueries=20064614 TransactionsPerSec=3305.54 Latency95Percentile_ms=112.67
      Threads=256 : TotalQueries=9682188 TransactionsPerSec=1025.91 Latency95Percentile_ms=682.06
```