### PR TITLE
Add Check_lsvmbus in utils.sh and gpu-driver-install.sh

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -45,36 +45,12 @@ VCPU=$(nproc)
 LogMsg "Number of CPUs detected on VM: $VCPU"
 
 # check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
+Check_lsvmbus
 lsvmbus_path=$(which lsvmbus)
-if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
-    install_package wget
-    wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
-    chmod +x lsvmbus
-    if [[ "$DISTRO" =~ "coreos" ]]; then
-        export PATH=$PATH:/usr/share/oem/python/bin/
-        lsvmbus_path="./lsvmbus"
-    else
-        mv lsvmbus /usr/sbin
-        lsvmbus_path=$(which lsvmbus)
-    fi
-fi
-
-if [ -z "$lsvmbus_path" ]; then
-    LogErr "lsvmbus tool not found!"
-    SetTestStateFailed
-    exit 0
-fi
 
 GetGuestGeneration
 if [ "$os_GENERATION" -eq "1" ]; then
     tokens+=("Synthetic IDE Controller")
-fi
-
-# lsvmbus requires python
-which python || [ -f /usr/libexec/platform-python ] && ln -s /usr/libexec/platform-python /sbin/python || which python3 && ln -s $(which python3) /sbin/python
-if ! which python; then
-    update_repos
-    install_package python
 fi
 
 for token in "${tokens[@]}"; do

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -351,12 +351,7 @@ if [ $? -ne 0 ]; then
 	exit 0
 fi
 
-if [ -f /usr/libexec/platform-python ]; then
-	ln -s /usr/libexec/platform-python /sbin/python
-	wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
-	chmod +x lsvmbus
-	mv lsvmbus /usr/sbin
-fi
-
+# Check and install lsvmbus
+Check_lsvmbus
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3731,3 +3731,36 @@ function get_bootconfig_path() {
 	fi
 	echo "$config_path"
 }
+
+# check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
+# If lsvmbus doesn't exist, lsvmbus will be installed.
+# If installation is failed, the script will be exited.
+function Check_lsvmbus()
+{
+	lsvmbus_path=$(which lsvmbus)
+	if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
+		install_package wget
+		wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
+		chmod +x lsvmbus
+		if [[ "$DISTRO" =~ "coreos" ]]; then
+			export PATH=$PATH:/usr/share/oem/python/bin/
+			lsvmbus_path="./lsvmbus"
+		else
+			mv lsvmbus /usr/sbin
+			lsvmbus_path=$(which lsvmbus)
+		fi
+	fi
+
+	if [ -z "$lsvmbus_path" ]; then
+		LogErr "lsvmbus tool not found!"
+		SetTestStateFailed
+		exit 0
+	fi
+
+	# lsvmbus requires python
+	which python || [ -f /usr/libexec/platform-python ] && ln -s /usr/libexec/platform-python /sbin/python || which python3 && ln -s $(which python3) /sbin/python
+	if ! which python; then
+		update_repos
+		install_package python
+	fi
+}

--- a/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
+++ b/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
@@ -27,26 +27,7 @@ if [[ $? -gt 0 ]]; then
 fi
 
 # check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
-lsvmbus_path=$(which lsvmbus)
-if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
-    install_package wget
-    wget https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
-    chmod +x lsvmbus
-    if [[ "$DISTRO" =~ "coreos" ]]; then
-        export PATH=$PATH:/usr/share/oem/python/bin/
-        lsvmbus_path="./lsvmbus"
-    else
-        mv lsvmbus /usr/sbin
-        lsvmbus_path=$(which lsvmbus)
-    fi
-fi
-
-if [ -z "$lsvmbus_path" ]; then
-    LogErr "lsvmbus tool not found!"
-    SetTestStateFailed
-    exit 0
-fi
-
+Check_lsvmbus
 
 # Get the system path to the Heartbeat device on the VMBus
 sys_path=$(lsvmbus -vv | grep -A4 Heartbeat | grep path | awk '{ print $3 }')


### PR DESCRIPTION
If we run GPU area test cases against the custom kernel, the running kernel does not match installed version of linux-tools. So we need wget lsvmbus.

Before fix:
The GPU area test cases are failed for lack of lsvmbus tool when testing against backports kernel.

After fix:
The GPU area test cases are passed.

This is the same with PR of https://github.com/LIS/LISAv2/pull/952, which has conflicts. So I recreate a new PR

```
[LISAv2 Test Results Summary]
Test Run On           : 08/28/2020 08:26:21
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 4 (4 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:55

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_HEARTBEAT_PROPERTIES                                                 PASS                 0.87 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
    2 GPU                  NVIDIA-GRID-DRIVER-VALIDATION                                                     PASS                20.75 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_NV6, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
      Using nVidia driver : GRID
      lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS
      lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS
      lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS
      nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS
      
    3 GPU                  NVIDIA-CUDA-DRIVER-VALIDATION                                                     PASS                18.96 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_NC6s_v2, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
      Using nVidia driver : CUDA
      lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS
      lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS
      lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS
      nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS
      
    4 GPU                  GPU-PCI-RESCIND                                                                   PASS                 8.06 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_NC6s_v2, TestLocation: westus2, Kernel Version: 5.3.0-1035-azure
      Using nVidia driver : CUDA
      Successfully disabled and reenabled the PCI device. :
      lsvmbus: Expected "PCI Express pass-through" count: 1, count inside the VM: 1 : PASS
      lspci: Expected "3D controller: NVIDIA Corporation" count: 1, found inside the VM: 1 : PASS
      lshw: Expected Display adapters: 1, total adapters found in VM: 1 : PASS
      nvidia-smi: Expected GPU count: 1, found inside the VM: 1 : PASS
```