### PR TITLE
Enhance Install-CustomScript.ps1, if ResourceGroupName is NULL then exit.

### DIFF
--- a/Utilities/Install-CustomScript.ps1
+++ b/Utilities/Install-CustomScript.ps1
@@ -8,8 +8,8 @@
 
 .PARAMETER
 	-AzureSecretsFile, the path of Azure secrets file
-	-VmName, the name of the VM to install the CustomScript extension, if no VmName is provided, it will be installed on all VMs
-	-ResourceGroupName, the resource group name of the VMs to install the CustomScript extension, if no ResourceGroupName is provided, it will be installed on all VMs in the subscription
+	-VmName, the name of the VM to install the CustomScript extension, if no VmName is provided, it will be installed on all VMs in the ResourceGroup
+	-ResourceGroupName, the resource group name of the VMs to install the CustomScript extension.
 	-FileUris, comma separated Uris of the custom scripts
 	-CommandToRun, the command to run on the VM
 	-Timeout, the longest time that current job wait for command running on the VM, if no Timeout is provided, it will be 360s
@@ -94,7 +94,8 @@ Function Install-CustomScript($AzureSecretsFile, $FileUris, $CommandToRun, $Time
 	} elseif ($ResourceGroupName) {
 		$vms = Get-AzVM -ResourceGroupName $ResourceGroupName | Where-Object {$_.StorageProfile.OsDisk.OsType -eq $OSType}
 	} else {
-		$vms = Get-AzVM | Where-Object {$_.StorageProfile.OsDisk.OsType -eq $OSType}
+		Write-LogInfo "Resource Group Name is NULL. Exiting."
+		exit 1
 	}
 	$jobs = @()
 	$jobIdToVM = @{}


### PR DESCRIPTION
Before enhancement, if parameter ResourceGroupName and VmName is all NULL, the custom script will be installed on all VMs in the subscription. This is not good. 

After enhancement, if the parameter ResourceGroupName is NULL, error will be reported and the script will be exited.

Test result:
```
 .\Utilities\Install-CustomScript.ps1 -AzureSecretsFile "E:\Baihua\AzureSecretsTESTONLY.xml" -VmName $vmName `
-ResourceGroupName "" `
-FileUris "https://lisawestus2.blob.core.windows.net/guest-pipeline/build-kernel-with-HyperV-Backports.sh" `
-CommandToRun "bash build-kernel-with-HyperV-Backports.sh" `
-Timeout 3000 -StorageAccountName "lisawestus2" -StorageAccountKey $key  -OSType Linux
08/31/2020 01:21:30 : [INFO ] Secrets file found.
08/31/2020 01:21:31 : [INFO ] Using provided secrets file: E:\Baihua\AzureSecretsTESTONLY.xml
08/31/2020 01:21:31 : [INFO ] E:\Baihua\AzureSecretsTESTONLY.xml found.
08/31/2020 01:21:31 : [INFO ] ------------------------------------------------------------------
08/31/2020 01:21:31 : [INFO ] Authenticating Azure PS session using Service Principal...
WARNING: The provided service principal secret will be included in the 'AzureRmContext.json' file found in the user profile ( C:\Users\balu\.Azure ). Please ensure that this directory has appropriate protections.
08/31/2020 01:21:33 : [INFO ] Current Subscription : 0cc2a67a-xxxx-xxxx-xxxx-bfa46a28e896.
08/31/2020 01:21:33 : [INFO ] ------------------------------------------------------------------
08/31/2020 01:21:33 : [INFO ] Resource Group Name is NULL. Exiting.
```