### PR TITLE
Support remote ssh on Windows

### DIFF
--- a/lisa/tools/echo.py
+++ b/lisa/tools/echo.py
@@ -4,10 +4,7 @@ from lisa.executable import Tool
 class Echo(Tool):
     @property
     def command(self) -> str:
-        command = "echo"
-        if not self.node.is_linux:
-            command = "cmd /c echo"
-        return command
+        return "echo"
 
     @property
     def _is_installed_internal(self) -> bool:

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -78,7 +78,7 @@ class WindowsShellType(object):
             update_env_commands = [
                 "set {0}={1}".format(key, value) for key, value in update_env.items()
             ]
-            commands += f"{'; '.join(update_env_commands)}; "
+            commands += f"{'& '.join(update_env_commands)}& "
 
         if cwd is not None:
             commands.append(f"pushd {cwd} & ")

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -135,7 +135,7 @@ class SshShell:
             shell_type = WindowsShellType()
         else:
             self.is_linux = True
-            shell_type = spur.SshShell.ShellTypes.sh
+            shell_type = spur.ssh.ShellTypes.sh
 
         spur_ssh_shell = spur.SshShell(shell_type=shell_type, **spur_kwargs)
         sftp = spurplus.sftp.ReconnectingSFTP(


### PR DESCRIPTION
spur supports only remote Linux. Rrewrite a WindowsShellType, it can supports most functionality now. kill doesn't work yet, if it's needed, will overwrite spur.SshShell to support it.