### PR TITLE
Added new common function, is_hpc_vm

### DIFF
--- a/Testscripts/Linux/LSVMBUS.sh
+++ b/Testscripts/Linux/LSVMBUS.sh
@@ -45,7 +45,7 @@ VCPU=$(nproc)
 LogMsg "Number of CPUs detected on VM: $VCPU"
 
 # check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
-Check_lsvmbus
+check_lsvmbus
 lsvmbus_path=$(which lsvmbus)
 
 GetGuestGeneration

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -352,6 +352,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Check and install lsvmbus
-Check_lsvmbus
+check_lsvmbus
 SetTestStateCompleted
 exit 0

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3735,8 +3735,7 @@ function get_bootconfig_path() {
 # check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
 # If lsvmbus doesn't exist, lsvmbus will be installed.
 # If installation is failed, the script will be exited.
-function Check_lsvmbus()
-{
+function check_lsvmbus() {
 	lsvmbus_path=$(which lsvmbus)
 	if [[ -z "$lsvmbus_path" ]] || ! $lsvmbus_path > /dev/null 2>&1; then
 		install_package wget
@@ -3762,5 +3761,24 @@ function Check_lsvmbus()
 	if ! which python; then
 		update_repos
 		install_package python
+	fi
+}
+
+# Check if this VM is IB over ND, IB over SR-IOV or non-HPC VM.
+# Return 0, if VM is IB over ND.
+# Return 1, if VM is IB over SR-IOV.
+# Return 2, if VM is non HPC VM.
+# Return 3, if unknown.
+function is_hpc_vm() {
+	if [ -d /sys/class/infiniband/ ]; then
+		if [ -n "$(lspci | grep "Virtual Function")" ] && [ -n "$(dmesg | grep "IB Infiniband driver")" ]; then
+			return 1
+		elif [ -n "$(dmesg | grep hvnd_try_bind_nic)" ]; then
+			return 0
+		else
+			return 3
+		fi
+	else
+		return 2
 	fi
 }

--- a/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
+++ b/Testscripts/Linux/verify_vmbus_heartbeat_properties.sh
@@ -27,7 +27,7 @@ if [[ $? -gt 0 ]]; then
 fi
 
 # check if lsvmbus exists, or the running kernel does not match installed version of linux-tools
-Check_lsvmbus
+check_lsvmbus
 
 # Get the system path to the Heartbeat device on the VMBus
 sys_path=$(lsvmbus -vv | grep -A4 Heartbeat | grep path | awk '{ print $3 }')


### PR DESCRIPTION
Check if this VM is IB over ND, IB over SR-IOV or non-HPC VM.

> Return 0 for IB over ND.
> Return 1for IB over SR-IOV.
> Return 2 for non HPC VM.
> Return 3 for unknown.

Also renamed the function name in a consistent format.

<Test Results>
[lisa@juhlee-**ib-nd** ~]$ source t.sh

0

[lisa@juhlee-**ib-sriov** ~]$ source t.sh
1

[lisa@juhlee-**noIB** ~]$ source t.sh
2


