### PR TITLE
Added a new test for HPC VM inside.

### DIFF
--- a/Testscripts/Linux/check_IB_SRIOV.sh
+++ b/Testscripts/Linux/check_IB_SRIOV.sh
@@ -57,7 +57,7 @@ function Main() {
 		fi
 
 		if [ $_type == "1" ]; then
-			LogMsg "The waagent detects IB over SR-ION because of no Nd driver version. Verify it loads inbox or MLX out-of-tree driver loading for IB interface"
+			LogMsg "The waagent detects IB over SR-IOV because of no Nd driver version. Verify it loads inbox or MLX out-of-tree driver loading for IB interface"
 			output=$(dmesg | grep 'Mellanox Connect-IB Infiniband driver')
 			if [ -z "$output" ]; then
 				LogErr "Failed to find SR-IOV driver for IB interface"

--- a/Testscripts/Linux/check_IB_SRIOV.sh
+++ b/Testscripts/Linux/check_IB_SRIOV.sh
@@ -31,7 +31,7 @@ function Main() {
 
 	if [ $_type == "2" ]; then
 		LogMsg "This VM is non-HPC VM. No further testing."
-		SetTestStateAborted
+		SetTestStateSkipped
 		exit 0
 	fi
 

--- a/Testscripts/Linux/check_IB_SRIOV.sh
+++ b/Testscripts/Linux/check_IB_SRIOV.sh
@@ -21,7 +21,7 @@ function Main() {
 	is_hpc_vm
 	_type=$?
 	if [ $_type == "3" ]; then
-		LogMsg "Could not determine VM type is HPC or non-HPC."
+		LogMsg "Could not determine VM type is either HPC or non-HPC."
 		SetTestStateFailed
 		exit 0
 	fi
@@ -32,9 +32,42 @@ function Main() {
 		exit 0
 	fi
 
-	if [ $_type == "0" || $_type == "1" ]; then
-		LogMsg "This VM is HPC type. Check out "
-	
+	if [ $_type == "0" ] || [ $_type == "1" ]; then
+		LogMsg "This is HPC VM. Check out the waagent config parameter - OS.EnableRDMA"
+		output=$(cat /etc/waagent.conf | grep ^OS.EnableRDMA=y)
+		if [ $output == "OS.EnableRDMA=y" ]; then
+			LogMsg "Verified waagent config OS.EnableRDMA=y set successfully"
+		else
+			LogErr "Found waagent configuration of OS.EnableRDMA=y was missing or commented out"
+			SetTestStateFailed
+			exit 0
+		fi
+
+		if [ $_type == "0" ]; then
+			LogMsg "This VM has IB over ND. Check out the ND driver files."
+			m=$(echo $DISTRO_VERSION | cut -d "." -f 1)
+			n=$(echo $DISTRO_VERSION | cut -d "." -f 2)
+			if [ -d /opt/microsoft/rdma/rhel$m$n/ ]; then
+				LogMsg "Verified Microsoft ND driver in /opt/microsoft/rdma/rhel$m$n"
+			else
+				LogErr "Failed to find ND driver in /opt/microsoft/rdma/"
+				SetTestStateFailed
+				exit 0
+			fi
+		fi
+
+		if [ $_type == "1" ]; then
+			LogMsg "The waagent detects IB over SR-ION because of no Nd driver version. Verify it loads inbox or MLX out-of-tree driver loading for IB interface"
+			output=$(dmesg | grep 'Mellanox Connect-IB Infiniband driver')
+			if [ -z "$output" ]; then
+				LogErr "Failed to find SR-IOV driver for IB interface"
+				SetTestStateFailed
+				exit 0
+			else
+				LogMsg "Successfully found the SR-IOV driver for IB interface - $output"
+			fi
+		fi
+	fi
 
 }
 

--- a/Testscripts/Linux/check_IB_SRIOV.sh
+++ b/Testscripts/Linux/check_IB_SRIOV.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+########################################################################################################
+# Source utils.sh
+. utils.sh || {
+	echo "Error: unable to source utils.sh!"
+	echo "TestAborted" > state.txt
+	exit 0
+}
+# Source constants file and initialize most common variables
+UtilsInit
+
+# Constants/Globals
+# Get distro information
+GetDistro
+
+function Main() {
+
+	is_hpc_vm
+	_type=$?
+	if [ $_type == "3" ]; then
+		LogMsg "Could not determine VM type is HPC or non-HPC."
+		SetTestStateFailed
+		exit 0
+	fi
+
+	if [ $_type == "2" ]; then
+		LogMsg "This VM is non-HPC VM. No further testing."
+		SetTestStateAborted
+		exit 0
+	fi
+
+	if [ $_type == "0" || $_type == "1" ]; then
+		LogMsg "This VM is HPC type. Check out "
+	
+
+}
+
+# main body
+Main
+SetTestStateCompleted
+exit 0

--- a/Testscripts/Linux/check_IB_SRIOV.sh
+++ b/Testscripts/Linux/check_IB_SRIOV.sh
@@ -2,6 +2,9 @@
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
+# This script checks HPC VM prerequitions like waagent config, IB over ND HPC VM and IB over SR-IOV HPC
+# VM have different conditions to prove their setting right. Use the common library function call, and
+# get the HPC VM type. It also checks if there is anything missing in HPC VM requirements.
 ########################################################################################################
 # Source utils.sh
 . utils.sh || {

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3769,8 +3769,10 @@ function check_lsvmbus() {
 # Return 1, if VM is IB over SR-IOV.
 # Return 2, if VM is non HPC VM.
 # Return 3, if unknown.
+# Ubuntu is used for HPC SKU but manual configuration required. It's exceptional.
 function is_hpc_vm() {
-	if [ -d /sys/class/infiniband/ ]; then
+	GetDistro
+	if [ -d /sys/class/infiniband/ ] && [[ $DISTRO != "ubuntu"* ]]; then
 		if [ -n "$(lspci | grep "Virtual Function")" ] && [ -n "$(dmesg | grep "IB Infiniband driver")" ]; then
 			return 1
 		elif [ -n "$(dmesg | grep hvnd_try_bind_nic)" ]; then

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -21,7 +21,6 @@ param([object] $AllVmData, [string]$TestParams)
 
 function Main {
 	param($AllVMData, $TestParams)
-	$currentTestResult = Create-TestResultObject
 	try {
 		#region Generate constants.sh
 		Write-LogInfo "Generating constants.sh ..."

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+	
+
+.Description
+	
+#>
+
+param([object] $AllVmData, [string]$TestParams)
+
+function Main {
+	param($AllVMData, $TestParams)
+	$currentTestResult = Create-TestResultObject
+	try {
+		$testResult = $resultFail
+		
+		#region Generate constants.sh
+		Write-LogInfo "Generating constants.sh ..."
+		$constantsFile = "$LogDir\constants.sh"
+		foreach ($TestParam in $CurrentTestData.TestParameters.param) {
+			Add-Content -Value "$TestParam" -Path $constantsFile
+			Write-LogInfo "$TestParam added to constants.sh"
+		}
+		Write-LogInfo "constants.sh created successfully..."
+		#endregion
+
+		# Getting queue counts and interrupt counts after resuming.
+		$vfname = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash /home/$user/getvf.sh" -runAsSudo
+		if ($vfname -ne '') {
+			$tx_queue_count2 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "ethtool -l ${vfname} | grep -i tx | tail -n 1 | cut -d ':' -f 2 | tr -d '[:space:]'" -runAsSudo
+			$interrupt_count2 = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "cat /proc/interrupts | grep -i mlx | grep -i msi | wc -l" -runAsSudo
+		}
+		if ($tx_queue_count1 -ne $tx_queue_count2) {
+			Write-LogErr "Before hibernation, Tx queue count - $tx_queue_count1. After waking up, Tx queue count - $tx_queue_count2"
+			throw "Tx queue counts changed after waking up."
+		} else {
+			Write-LogInfo "Successfully verified Tx queue count matching in Current hardware settings."
+		}
+
+		if ($interrupt_count1 -ne $interrupt_count2) {
+			Write-LogErr "Before hibernation, MSI interrupts of mlx driver - $interrupt_count1. After waking up, MSI interrupts of mlx driver - $interrupt_count2"
+			throw "MSI interrupt counts changed after waking up."
+		} else {
+			Write-LogInfo "Successfully verified MSI interrupt counts matching"
+		}
+
+		$testResult = $resultPass
+		Copy-RemoteFiles -downloadFrom $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log" -runAsSudo
+	} catch {
+		$ErrorMessage =  $_.Exception.Message
+		$ErrorLine = $_.InvocationInfo.ScriptLineNumber
+		Write-LogErr "EXCEPTION : $ErrorMessage at line: $ErrorLine"
+	} finally {
+		if (!$testResult) {
+			$testResult = $resultAborted
+		}
+		$resultArr = $testResult
+	}
+
+	$currentTestResult.TestResult = Get-FinalResultHeader -resultarr $resultArr
+	return $currentTestResult
+}
+
+Main -AllVmData $AllVmData -CurrentTestData $CurrentTestData

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -53,7 +53,6 @@ function Main {
 		}
 	}
 
-	#Write-LogInfo "Test result: $testResult"
 	return $testResult
 }
 

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -31,7 +31,11 @@ function Main {
 		if ($result -eq "TestCompleted") {
 			Write-LogInfo "Verified HPC driver and its requirement in the VM"
 			$testResult = $resultPass
+		} elseif ( $result -eq "TestSkipped" ) {
+			$testResult = $resultSkipped
+			Write-LogInfo "This VM is non-HPC VM. No further testing."
 		} else {
+			$testResult = $resultFailed
 			throw "check_IB_SRIOV.sh did not finish successfully. Please check out the log for details."
 		}
 		Copy-RemoteFiles -downloadFrom $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log"

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -22,16 +22,6 @@ param([object] $AllVmData, [string]$TestParams)
 function Main {
 	param($AllVMData, $TestParams)
 	try {
-		#region Generate constants.sh
-		Write-LogInfo "Generating constants.sh ..."
-		$constantsFile = "$LogDir\constants.sh"
-		foreach ($TestParam in $CurrentTestData.TestParameters.param) {
-			Add-Content -Value "$TestParam" -Path $constantsFile
-			Write-LogInfo "$TestParam added to constants.sh"
-		}
-		Write-LogInfo "constants.sh created successfully..."
-		#end region
-
 		Copy-RemoteFiles -uploadTo $AllVMData.PublicIP -port $AllVMData.SSHPort -files $currentTestData.files -username $user -password $password -upload
 		Start-Sleep -Seconds 3
 		$result = Run-LinuxCmd -ip $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -command "bash ./check_IB_SRIOV.sh" -runAsSudo

--- a/Testscripts/Windows/VERIFY-HPC-VM.ps1
+++ b/Testscripts/Windows/VERIFY-HPC-VM.ps1
@@ -31,6 +31,8 @@ function Main {
 		if ($result -eq "TestCompleted") {
 			Write-LogInfo "Verified HPC driver and its requirement in the VM"
 			$testResult = $resultPass
+		} else {
+			throw "check_IB_SRIOV.sh did not finish successfully. Please check out the log for details."
 		}
 		Copy-RemoteFiles -downloadFrom $AllVMData.PublicIP -port $AllVMData.SSHPort -username $user -password $password -download -downloadTo $LogDir -files "*.log"
 	} catch {

--- a/XML/TestCases/FunctionalTests-KernelDebug.xml
+++ b/XML/TestCases/FunctionalTests-KernelDebug.xml
@@ -12,4 +12,17 @@
             <SetupType>OneVM</SetupType>
         </SetupConfig>
     </test>
+    <test>
+        <testName>VERIFY-HPC-VM</testName>
+        <testScript>VERIFY-HPC-VM.ps1</testScript>
+        <files>.\Testscripts\Linux\check_IB_SRIOV.sh,.\Testscripts\Linux\utils.sh</files>
+        <Platform>Azure</Platform>
+        <Category>Functional</Category>
+        <Area>CORE</Area>
+        <Tags>rdma</Tags>
+        <Priority>1</Priority>
+        <SetupConfig>
+            <SetupType>OneVM</SetupType>
+        </SetupConfig>
+    </test>
 </TestCases>


### PR DESCRIPTION
This test improves the HPC VM verification in 2 different cases - IB over ND and IB over SR-IOV. And the 3rd case was non-HPC VM size. 
HPC VM waagent config should have below condition in /etc/waagent.conf. Should not comment out.
OS.EnableRDMA=y

If VM has IB over ND, it verifies Nd driver installation/location. ib_ipoib module is optional, so I removed this verification here.

The 3rd case is IB over SR-IOV. Verify it loads inbox or out-of-tree driver loading for IB interface. Originally I wanted to add those verifications to the VM provision test, but keep them separate because of more future verifications like LIS, VMbus verifications.

**Non-HPC VM case**
[LISAv2 Test Results Summary]
Test Run On           : 09/15/2020 06:25:22
ARM Image Under Test  : OpenLogic : CentOS : 7.4 : latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-HPC-VM                                                                     FAIL                 0.77
      ARMImageName: OpenLogic CentOS 7.4 latest, TestLocation: westus2, Kernel Version: 3.10.0-693.21.1.el7.x86_64

Tue Sep 15 06:27:54 2020 : Successfully initialized testscript!                                                                                     OS family: Rhel                                                                                                                                     Tue Sep 15 06:27:54 2020 : This VM is non-HPC VM. No further testing. 

**IB over SR-IOV case. VM size should be joint condition.**
[LISAv2 Test Results Summary]
Test Run On           : 09/15/2020 07:41:11
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.7 : latest
Override VM size Under Test  : Standard_HC44rs
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-HPC-VM                                                                     PASS                 0.47
      ARMImageName: OpenLogic CentOS-HPC 7.7 latest, OverrideVMSize: Standard_HC44rs, TestLocation: westus2, Kernel Version: 3.10.0-1127.el7.x86_64

**IB over ND case**
[LISAv2 Test Results Summary]
Test Run On           : 09/15/2020 07:55:54
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.4 : latest
Override VM size Under Test  : Standard_H16mr
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-HPC-VM                                                                     PASS                 0.73
      ARMImageName: OpenLogic CentOS-HPC 7.4 latest, OverrideVMSize: Standard_H16mr, TestLocation: southcentralus, Kernel Version: 3.10.0-693.21.1.el7.x86_64