### PR TITLE
Fixed the Clock Source information in different CentOS/RHEL versions

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -33,7 +33,7 @@ CheckSource()
 		exit 0
 	else
 		__file_content=$(cat $current_clocksource)
-		if [[ $__file_content == "$clocksource" ]]; then
+		if [[ $__file_content == *"$clocksource" ]]; then
 			LogMsg "Test successful. Proper file was found. Clocksource file content is $__file_content"
 		else
 			LogErr "Test failed. Proper file was NOT found."
@@ -105,11 +105,11 @@ function UnbindCurrentSource()
 #
 GetDistro
 case $DISTRO in
-	redhat_6 | centos_6)
+	redhat_6 | centos_6 | redhat_7 | centos_7)
 		LogMsg "WARNING: $DISTRO does not support unbind current clocksource, only check"
 		CheckSource
 		;;
-	redhat_7|redhat_8|centos_7|centos_8|fedora*|clear-linux-os)
+	redhat_8 |centos_8|fedora*|clear-linux-os)
 		CheckSource
 		UnbindCurrentSource
 		;;

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -32,7 +32,7 @@ CheckSource()
 	clocksource="hyperv_clocksource_tsc_page"
 	mj=$(echo $DISTRO_VERSION | cut -d '.' -f 1)
 	mn=$(echo $DISTRO_VERSION | cut -d '.' -f 2)
-	if [[ $mj == 6 && $mn < 9 ]]; then
+	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel"]] && [[$mj == 6 && $mn < 9 ]]; then
 		clocksource="hyperv_clocksource"
 	fi
 	if ! [[ $(find $current_clocksource -type f -size +0M) ]]; then

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -30,9 +30,9 @@ CheckSource()
 	# Without Microsoft LIS, hyperv_clocksource_tsc_page
 	# CentOS 6.8 or older versions, hyperv_clocksource 
 	clocksource="hyperv_clocksource_tsc_page"
-	mj=$(echo $DISTRO_VERSION | cut -d '.' -f 1)
-	mn=$(echo $DISTRO_VERSION | cut -d '.' -f 2)
-	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel"]] && [[$mj == 6 && $mn < 9 ]]; then
+	mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
+	mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
+	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel" ]] && [[ $mj -lt 7 && $mn -lt 9 ]]; then
 		clocksource="hyperv_clocksource"
 	fi
 	if ! [[ $(find $current_clocksource -type f -size +0M) ]]; then

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -26,7 +26,15 @@ UtilsInit
 CheckSource()
 {
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
+	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page
+	# Without Microsoft LIS, hyperv_clocksource_tsc_page
+	# CentOS 6.8 or older versions, hyperv_clocksource 
 	clocksource="hyperv_clocksource_tsc_page"
+	mj=$(echo $DISTRO_VERSION | cut -d '.' -f 1)
+	mn=$(echo $DISTRO_VERSION | cut -d '.' -f 2)
+	if [[ $mj == 6 && $mn < 9 ]]; then
+		clocksource="hyperv_clocksource"
+	fi
 	if ! [[ $(find $current_clocksource -type f -size +0M) ]]; then
 		LogErr "Test Failed. No file was found current_clocksource greater than 0M."
 		SetTestStateFailed


### PR DESCRIPTION
The current clock source is stored in /sys/devices/system/clocksource/clocksource0/current_clocksource. The context is different from the version of Distros.
For RHEL and CentOS, 

- Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page
- Without Microsoft LIS, hyperv_clocksource_tsc_page
- CentOS 6.8 or older versions, hyperv_clocksource 

**TEST RESULTS**

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:50:58
ARM Image Under Test  : OpenLogic : CentOS : 6.8 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                  0.3 
      ARMImageName: OpenLogic CentOS 6.8 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 2.6.32-642.15.1.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:51:05
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.42 
      ARMImageName: OpenLogic CentOS 7.5 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 3.10.0-862.11.6.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:51:11
ARM Image Under Test  : OpenLogic : CentOS : 8_2 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.53 
      ARMImageName: OpenLogic CentOS 8_2 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 4.18.0-193.6.3.el8_2.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:50:37
ARM Image Under Test  : RedHat : RHEL : 6.9 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.32 
      ARMImageName: RedHat RHEL 6.9 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 2.6.32-696.18.7.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:50:43
ARM Image Under Test  : RedHat : RHEL : 7.4 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.49 
      ARMImageName: RedHat RHEL 7.4 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 3.10.0-693.58.1.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:50:50
ARM Image Under Test  : RedHat : RHEL : 7.8 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.61 
      ARMImageName: RedHat RHEL 7.8 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 3.10.0-1127.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/18/2020 21:50:55
ARM Image Under Test  : RedHat : RHEL : 8 : latest
Test Priority         : 0,1,2,3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.58 
      ARMImageName: RedHat RHEL 8 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 4.18.0-80.11.2.el8_0.x86_64