### PR TITLE
Removed rhel5.x version check as 5.x EOL

### DIFF
--- a/Testscripts/Linux/LIS-VERSION-CHECK.sh
+++ b/Testscripts/Linux/LIS-VERSION-CHECK.sh
@@ -71,7 +71,8 @@ then
     exit 0
 else
     version=$(modinfo "hv_vmbus" | grep version: | head -1 | awk '{print $2}')
-    for i in 5 6 7
+	# no verification of LIS version in RHEL 5.x or CentOS 5.x. EOL in Azure.
+    for i in 6 7
     do
         rm -rf hv_compat.h
         wget https://raw.githubusercontent.com/LIS/lis-next/"$version"/hv-rhel$i.x/hv/include/linux/hv_compat.h


### PR DESCRIPTION
LIS rhel5.x source code commit has an old bug and it caught the LIS testing in 4.2.6. This problem has been fixed in the later version. However, rhel 5.x version does not exist in Azure. I propose to delete rhel5.x version check in LIS-DRIVER-VERSION-CHECK

