### PR TITLE
Just added the user friendly logging in TIME-CLOCKSOURCE

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -27,10 +27,10 @@ CheckSource()
 {
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
 
-	# Microsoft LIS installed version has lis_hv_clocksource_tsc_page
-	# Without Microsoft LIS, hv_clocksource_tsc_page
+	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page
+	# Without Microsoft LIS, hyperv_clocksource_tsc_page
 	# CentOS 6.8 or older versions, hyperv_clocksource
-	clocksource="hv_clocksource_tsc_page"
+	clocksource="hyperv_clocksource_tsc_page"
 	mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
 	mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
 	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel" ]] && [[ $mj -lt 7 && $mn -lt 9 ]]; then


### PR DESCRIPTION
Added the user-friendly logging because it was hard to identify the root-cause.

[LISAv2 Test Results Summary]
Test Run On           : 09/24/2020 00:41:47
ARM Image Under Test  : RedHat : RHEL : 6.10 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.32 
      ARMImageName: RedHat RHEL 6.10 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 2.6.32-754.15.3.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/24/2020 00:41:43
ARM Image Under Test  : RedHat : RHEL : 6.9 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.32 
      ARMImageName: RedHat RHEL 6.9 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 2.6.32-696.18.7.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/24/2020 00:41:52
ARM Image Under Test  : RedHat : RHEL : 7.3 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                  0.4 
      ARMImageName: RedHat RHEL 7.3 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 3.10.0-514.28.1.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/24/2020 00:41:55
ARM Image Under Test  : RedHat : RHEL : 7.6 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.35 
      ARMImageName: RedHat RHEL 7.6 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 3.10.0-957.35.2.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/24/2020 00:42:01
ARM Image Under Test  : RedHat : RHEL : 8 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:2

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.65 
      ARMImageName: RedHat RHEL 8 latest, DiskType: Managed, TestLocation: westus2, Kernel Version: 4.18.0-80.11.2.el8_0.x86_64