### PR TITLE
vmbus interrupt check test is no longer valid in big size Azure VM

### DIFF
--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -6,14 +6,17 @@
 #
 # Description:
 #    This script was created to automate the testing of a Linux
-#    Integration services. This script will verify if all the CPUs 
-#    inside a Linux VM are processing VMBus interrupts, by checking 
+#    Integration services. This script will verify if all the CPUs
+#    inside a Linux VM are processing VMBus interrupts, by checking
 #    the /proc/interrupts file.
 #
 #    The test performs the following steps:
 #        1. Looks for the Hyper-v timer property of each CPU under /proc/interrupts
 #        2. Verifies if each CPU has more than 0 interrupts processed.
-#     
+#   Note: There are 3 types of Hyper-v interrupts - Hypervisor callback interrupts,
+#       Hyper-V reenlightenment interrupts, and Hyper-V stimer0 interrupts
+#       Hypervisor callback interrupts - No need to have each CPU handle vmbus
+#       message or event in many CPU's VM.
 ################################################################
 
 # Source utils.sh
@@ -59,12 +62,15 @@ function verify_vmbus_interrupts() {
         fi
     done < "/proc/interrupts"
 
-    if [ $nonCPU0inter -ne "$cpu_count" ]; then
-        LogErr "Not all CPU cores are processing VMBUS interrupts!"
+    if [ $nonCPU0inter -eq 0 ]; then
+        LogErr "No CPU core is processing VMBUS interrupts!"
         SetTestStateFailed
         exit 0
     fi
 
+    if [[ $cpu_count -gt 4 && $nonCPU0inter -lt "$cpu_count" ]]; then
+        LogMsg "Some CPU cores are processing VMBUS interrupts, but it is ok to miss a few core not processing VMBUS interrupts because of big size VM"
+    fi
     UpdateSummary "All {$cpu_count} CPU cores are processing interrupts."
     SetTestStateCompleted
 }

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -50,9 +50,11 @@ function verify_vmbus_interrupts() {
     #
     while read -r line
     do
+        LogMsg "Debug - reading a line $line"
         if [[ ($line = *hyperv* ) || ( $line = *Hypervisor* ) ]]; then
-            for (( core=0; core<=${cpu_count-1}; core++ ))
+            for (( core=0; core<=$((cpu_count-1)); core++ ))
             do
+                LogMsg "Debug - checking the core count $core"
                 intrCount=$(echo "$line" | xargs echo | cut -f $(( $core+2 )) -d ' ')
                 if [ "$intrCount" -ne 0 ]; then
                     (( nonCPU0inter++ ))

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -53,7 +53,7 @@ function verify_vmbus_interrupts() {
         if [[ ($line = *hyperv* ) || ( $line = *Hypervisor* ) ]]; then
             for (( core=0; core<=${cpu_count-1}; core++ ))
             do
-                intrCount=$(echo "$line" | xargs echo | cut -f $(( ${core+2} )) -d ' ')
+                intrCount=$(echo "$line" | xargs echo | cut -f $(( $core+2 )) -d ' ')
                 if [ "$intrCount" -ne 0 ]; then
                     (( nonCPU0inter++ ))
                     UpdateSummary "CPU core ${core} is processing VMBUS interrupts."

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -39,7 +39,7 @@ function verify_vmbus_interrupts() {
     # It is not mandatory to have the Hyper-V interrupts present
     # Skip test execution if these are not showing up
     #
-    if ! [[ $(grep 'hyperv\|Hypervisor' /proc/interrupts) ]]; then
+    if ! [[ $(grep -q 'hyperv\|Hypervisor' /proc/interrupts) ]]; then
         UpdateSummary "Hyper-V interrupts are not recorded, abort test."
         SetTestStateAborted
         exit 0
@@ -48,12 +48,12 @@ function verify_vmbus_interrupts() {
     #
     # Verify if VMBUS interrupts are processed by all CPUs
     #
-    while read line
+    while read -r line
     do
         if [[ ($line = *hyperv* ) || ( $line = *Hypervisor* ) ]]; then
-            for (( core=0; core<=$cpu_count-1; core++ ))
+            for (( core=0; core<=${cpu_count-1}; core++ ))
             do
-                intrCount=$(echo "$line" | xargs echo |cut -f $(( $core+2 )) -d ' ')
+                intrCount=$(echo "$line" | xargs echo | cut -f $(( ${core+2} )) -d ' ')
                 if [ "$intrCount" -ne 0 ]; then
                     (( nonCPU0inter++ ))
                     UpdateSummary "CPU core ${core} is processing VMBUS interrupts."
@@ -62,7 +62,7 @@ function verify_vmbus_interrupts() {
         fi
     done < "/proc/interrupts"
 
-    if [ $nonCPU0inter -eq 0 ]; then
+    if [[ $nonCPU0inter -eq 0 ]]; then
         LogErr "No CPU core is processing VMBUS interrupts!"
         SetTestStateFailed
         exit 0

--- a/Testscripts/Linux/verify_vmbus_interrupts.sh
+++ b/Testscripts/Linux/verify_vmbus_interrupts.sh
@@ -39,7 +39,7 @@ function verify_vmbus_interrupts() {
     # It is not mandatory to have the Hyper-V interrupts present
     # Skip test execution if these are not showing up
     #
-    if ! [[ $(grep -q 'hyperv\|Hypervisor' /proc/interrupts) ]]; then
+    if ! [[ $(grep 'hyperv\|Hypervisor' /proc/interrupts) ]]; then
         UpdateSummary "Hyper-V interrupts are not recorded, abort test."
         SetTestStateAborted
         exit 0


### PR DESCRIPTION
Instead of deprecating it, change the condition for a big size VM allowing a few missing cores not to handle the vmbus interrupts.

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:04
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:54

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.65 
      ARMImageName: Canonical UbuntuServer 16.04-LTS latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 4.15.0-1096-azure
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.66 
      ARMImageName: Canonical UbuntuServer 16.04-LTS latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 4.15.0-1096-azure

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:07
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:48

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                  0.8 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 5.4.0-1026-azure
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.74 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 5.4.0-1026-azure

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:39
ARM Image Under Test  : OpenLogic : CentOS : 6.5 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:50

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.59 
      ARMImageName: OpenLogic CentOS 6.5 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 2.6.32-431.29.2.el6.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.57 
      ARMImageName: OpenLogic CentOS 6.5 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 2.6.32-431.29.2.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:45
ARM Image Under Test  : OpenLogic : CentOS : 7.7 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:54

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.68 
      ARMImageName: OpenLogic CentOS 7.7 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 3.10.0-1062.12.1.el7.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.67 
      ARMImageName: OpenLogic CentOS 7.7 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 3.10.0-1062.12.1.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:21
ARM Image Under Test  : RedHat : RHEL : 6.8 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:56

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.58 
      ARMImageName: RedHat RHEL 6.8 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 2.6.32-642.15.1.el6.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.59 
      ARMImageName: RedHat RHEL 6.8 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 2.6.32-642.15.1.el6.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:28
ARM Image Under Test  : RedHat : RHEL : 7.4 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:53

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.66 
      ARMImageName: RedHat RHEL 7.4 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 3.10.0-693.58.1.el7.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.66 
      ARMImageName: RedHat RHEL 7.4 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 3.10.0-693.58.1.el7.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:34
ARM Image Under Test  : RedHat : RHEL : 8.1 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:52

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.67 
      ARMImageName: RedHat RHEL 8.1 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 4.18.0-147.24.2.el8_1.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.67 
      ARMImageName: RedHat RHEL 8.1 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 4.18.0-147.24.2.el8_1.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:12
ARM Image Under Test  : SUSE : sles-12-sp5 : gen1 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:48

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.64 
      ARMImageName: SUSE sles-12-sp5 gen1 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 4.12.14-16.28-azure
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.63 
      ARMImageName: SUSE sles-12-sp5 gen1 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 4.12.14-16.28-azure

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 15:42:16
ARM Image Under Test  : SUSE : sles-15-sp2 : gen1 : latest
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:53

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.63 
      ARMImageName: SUSE sles-15-sp2 gen1 latest, DiskType: Managed, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 5.3.18-18.18-azure
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.62 
      ARMImageName: SUSE sles-15-sp2 gen1 latest, DiskType: Managed, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, Kernel Version: 5.3.18-18.18-azure



This is the result with the customized VHD with LIS.

[LISAv2 Test Results Summary]
Test Run On           : 09/25/2020 17:32:50
VHD Under Test        : https://lisawestus2.blob.core.windows.net/vhds/RDMA-LIS-4.3.5-CentOS68.vhd
Override VM size Under Test  : Standard_H16r
Override VM size Under Test  : Standard_B4ms
Test Priority         : 0,1,2,3
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:14

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.59 
      DiskType: Managed, OsVHD: http://lisasouthcentralus.blob.core.windows.net/vhds/RDMA-LIS-4.3.5-CentOS68.vhd, OverrideVMSize: Standard_B4ms, TestLocation: southcentralus, VMGeneration: 1, Kernel Version: 2.6.32-642.15.1.el6.x86_64
    2 CORE                 VMBUS_VERIFY_INTERRUPTS                                                           PASS                 0.58 
      DiskType: Managed, OsVHD: http://lisasouthcentralus.blob.core.windows.net/vhds/RDMA-LIS-4.3.5-CentOS68.vhd, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, VMGeneration: 1, Kernel Version: 2.6.32-642.15.1.el6.x86_64
