### PR TITLE
TIME_CLOCKSOURCE now accepts both types - hyperv_clocksource and hv_clocksource

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -17,7 +17,7 @@
 	exit 0
 }
 
-# Source constants file and initialize most common variables
+# Source constants file and initialize most common variables.
 UtilsInit
 
 #
@@ -27,10 +27,10 @@ CheckSource()
 {
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
 
-	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page,
-	#	lis_hv_clocksource_tsc_page
-	# Without Microsoft LIS, hyperv_clocksource_tsc_page or hv_clocksource_tsc_page
-	# CentOS 7.0 or older versions has hyperv_clocksource
+	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page or
+	#	lis_hv_clocksource_tsc_page.
+	# Without Microsoft LIS, hyperv_clocksource_tsc_page or hv_clocksource_tsc_page.
+	# CentOS 7.0 or older versions has hyperv_clocksource.
 	clocksource="v_clocksource_tsc_page"
 	source /etc/os-release
 	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel" ]] && (($(echo "$VERSION_ID < 7.1" | bc -l))) || [[ $DISTRO == "redhat_6" || $DISTRO == "centos_6" ]]; then

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -25,6 +25,7 @@ UtilsInit
 #
 CheckSource()
 {
+	LogMsg "Running CheckSource"
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
 
 	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page or
@@ -83,6 +84,7 @@ CheckSource()
 }
 function UnbindCurrentSource()
 {
+	LogMsg "Running UnbindCurrentSource"
 	unbind_file="/sys/devices/system/clocksource/clocksource0/unbind_clocksource"
 	LogMsg "Assign $clocksource to $unbind_file"
 	if echo $clocksource > $unbind_file
@@ -120,7 +122,7 @@ function UnbindCurrentSource()
 #
 case $DISTRO in
 	redhat_6 | centos_6 | redhat_7 | centos_7 | debian*)
-		LogMsg "WARNING: $DISTRO does not support unbind current clocksource, only check"
+		LogMsg "WARNING: $DISTRO does not support unbinding the current clocksource, only check sourcing"
 		CheckSource
 		;;
 	redhat_8 |centos_8|fedora*|clear-linux-os|ubunut*|suse*|coreos*)

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -123,19 +123,7 @@ case $DISTRO in
 		LogMsg "WARNING: $DISTRO does not support unbind current clocksource, only check"
 		CheckSource
 		;;
-	redhat_8 |centos_8|fedora*|clear-linux-os)
-		CheckSource
-		UnbindCurrentSource
-		;;
-	ubuntu*)
-		CheckSource
-		UnbindCurrentSource
-		;;
-	suse*)
-		CheckSource
-		UnbindCurrentSource
-		;;
-	coreos*)
+	redhat_8 |centos_8|fedora*|clear-linux-os|ubunut*|suse*|coreos*)
 		CheckSource
 		UnbindCurrentSource
 		;;

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -27,16 +27,16 @@ CheckSource()
 {
 	current_clocksource="/sys/devices/system/clocksource/clocksource0/current_clocksource"
 
-	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page
-	# Without Microsoft LIS, hyperv_clocksource_tsc_page
-	# CentOS 6.8 or older versions, hyperv_clocksource
-	clocksource="hyperv_clocksource_tsc_page"
-	mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
-	mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
-	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel" ]] && [[ $mj -lt 7 && $mn -lt 9 ]]; then
+	# Microsoft LIS installed version has lis_hyperv_clocksource_tsc_page,
+	#	lis_hv_clocksource_tsc_page
+	# Without Microsoft LIS, hyperv_clocksource_tsc_page or hv_clocksource_tsc_page
+	# CentOS 7.0 or older versions has hyperv_clocksource
+	clocksource="v_clocksource_tsc_page"
+	source /etc/os-release
+	if [[ $DISTRO_NAME == "centos" || $DISTRO_NAME == "rhel" ]] && (($(echo "$VERSION_ID < 7.1" | bc -l))) || [[ $DISTRO == "redhat_6" || $DISTRO == "centos_6" ]]; then
 		clocksource="hyperv_clocksource"
 	fi
-	LogMsg "clocksource: $clocksource"
+	LogMsg "Temporary clocksource: $clocksource"
 
 	if ! [[ $(find $current_clocksource -type f -size +0M) ]]; then
 		LogErr "Test Failed. No file was found current_clocksource greater than 0M."
@@ -45,8 +45,9 @@ CheckSource()
 	else
 		__file_content=$(cat $current_clocksource)
 		LogMsg "Found currect_clocksource $__file_content in $current_clocksource"
-		if [[ $__file_content == *"$clocksource" ]]; then
+		if [[ $__file_content == *"$clocksource"* ]]; then
 			LogMsg "Test successful. Proper file was found. Clocksource file content is $__file_content"
+			clocksource=$__file_content
 		else
 			LogErr "Test failed. Proper file was NOT found. Expected $clocksource, found $__file_content"
 			SetTestStateFailed
@@ -83,7 +84,7 @@ CheckSource()
 function UnbindCurrentSource()
 {
 	unbind_file="/sys/devices/system/clocksource/clocksource0/unbind_clocksource"
-	clocksource="hyperv_clocksource_tsc_page"
+	LogMsg "Assign $clocksource to $unbind_file"
 	if echo $clocksource > $unbind_file
 	then
 		_clocksource=$(cat /sys/devices/system/clocksource/clocksource0/current_clocksource)
@@ -117,9 +118,8 @@ function UnbindCurrentSource()
 #
 # MAIN SCRIPT
 #
-GetDistro
 case $DISTRO in
-	redhat_6 | centos_6 | redhat_7 | centos_7)
+	redhat_6 | centos_6 | redhat_7 | centos_7 | debian*)
 		LogMsg "WARNING: $DISTRO does not support unbind current clocksource, only check"
 		CheckSource
 		;;
@@ -127,15 +127,15 @@ case $DISTRO in
 		CheckSource
 		UnbindCurrentSource
 		;;
-	ubuntu*|debian*)
+	ubuntu*)
 		CheckSource
 		UnbindCurrentSource
 		;;
-	suse* )
+	suse*)
 		CheckSource
 		UnbindCurrentSource
 		;;
-	coreos* )
+	coreos*)
 		CheckSource
 		UnbindCurrentSource
 		;;

--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -128,9 +128,8 @@ case $DISTRO in
 		UnbindCurrentSource
 		;;
 	*)
-		msg="ERROR: Distro '$DISTRO' not supported"
-		LogMsg "${msg}"
-		SetTestStateFailed
+		LogErr "Distro '$DISTRO' not supported"
+		SetTestStateAborted
 		exit 0
 		;;
 esac


### PR DESCRIPTION
Changed the condition for broadening distros with its older versions.

Lazy to post 12 results here, but do the screenshot.
![image](https://user-images.githubusercontent.com/23069399/94384027-7a600500-00f6-11eb-827a-262d170911aa.png)
