### PR TITLE
Add Hyper-V platform for case VERIFY-BOOT-ERROR-WARNINGS

### DIFF
--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -96,7 +96,7 @@
     <testName>VERIFY-BOOT-ERROR-WARNINGS</testName>
     <testScript>VERIFY-BOOT-ERROR-WARNINGS.py</testScript>
     <files>.\Testscripts\Linux\azuremodules.py,.\Testscripts\Linux\VERIFY-BOOT-ERROR-WARNINGS.py,.\XML\Other\ignorable-boot-errors.xml,.\XML\Other\ignorable-walalog-errors.xml</files>
-    <Platform>Azure,WSL</Platform>
+    <Platform>Azure,HyperV,WSL</Platform>
     <Category>Functional</Category>
     <Area>CORE</Area>
     <Tags>provision</Tags>


### PR DESCRIPTION
The test case VERIFY-BOOT-ERROR-WARNINGS also can run in the Hyper-V platform, but maybe need to update ignore list in LISAv2/XML/Other/ignorable-boot-errors.xml based on test result on Hyper-V. 
Locally we have checked current error/warning/fail list and maintain a downstream ignorable-boot-errors.xml file.

If any new error/warning/fail is found when you use RHEL VM in the Hyper-V host, we can check whether they are already in our local list, mainly for some issues that already have bugzilla and knowledge base documents.

Thank you.

Test Result:

09/28/2020 07:56:38 : [INFO ] Hyper-V VM LISAv2-OneVM-202009-TX67-637369051856-role-0 removed!
09/28/2020 07:56:39 : [INFO ] Hyper-V VM group LISAv2-OneVM-202009-TX67-637369051856 removed!
09/28/2020 07:56:39 : [INFO ] Successfully delete HyperV group LISAv2-OneVM-202009-TX67-637369051856.
09/28/2020 07:56:39 : [INFO ] Cleanup test environment if required ...
09/28/2020 07:56:39 : [INFO ] Test TX67 finished
09/28/2020 07:56:39 : [INFO ] 
[LISAv2 Test Results Summary]
Test Run On           : 09/28/2020 07:53:05
VHD Under Test        : D:\lisav2-RHEL.xxx.n.0-gen2--psi.vhdx
Test Category         : Functional
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:3

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-BOOT-ERROR-WARNINGS                                                        PASS                 1.84 
      OsVHD: D:\lisav2-RHEL-xxxx.vhdx, TestLocation: localhost, VMGeneration: 2, Kernel Version: 4.18.0-xxx.el8.x86_64
