### PR TITLE
Updated IB tests with ND support scenario.

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -86,13 +86,13 @@ function Main() {
 		echo 8 > /etc/yum/vars/releasever
 		LogMsg "$?: Applied a mitigation for $DISTRO to /etc/yum/vars/releasever"
 	fi
-	# CentOS-HPC 7.6 or older versions only support ND device.
+	# CentOS-HPC 7.5 or older versions only support ND device. This lis-next has a bug.
 	# https://github.com/LIS/lis-next/blob/master/hv-rhel7.x/hv/Makefile#L20
 	mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
 	mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
 
-	if [[ $is_nd == "yes" && $DISTRO == 'centos_7' && $mj -eq 7 && $mn -gt 6 ]]; then
-		LogErr "ND test only support CentOS-HPC 7.6 or earlier version. Abort!"
+	if [[ $is_nd == "yes" && $DISTRO == 'centos_7' && $mj -eq 7 && $mn -gt 5 ]]; then
+		LogErr "ND test only support CentOS-HPC 7.5 or earlier version. Abort!"
 		SetTestStateAborted
 		exit 0
 	fi

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -629,7 +629,7 @@ function Main() {
 		Verify_File $benchmark_bin
 	fi
 
-	if [[ $benchmark_type == "OMB" && $$mpi_type != "mvapich" ]]; then
+	if [[ $benchmark_type == "OMB" && $mpi_type != "mvapich" ]]; then
 		currentDir=$(pwd)
 		cd ~
 		LogMsg "Proceeding OSU MPI Benchmark (OMB) test installation"

--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -86,6 +86,17 @@ function Main() {
 		echo 8 > /etc/yum/vars/releasever
 		LogMsg "$?: Applied a mitigation for $DISTRO to /etc/yum/vars/releasever"
 	fi
+	# CentOS-HPC 7.6 or older versions only support ND device.
+	# https://github.com/LIS/lis-next/blob/master/hv-rhel7.x/hv/Makefile#L20
+	mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
+	mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
+
+	if [[ $is_nd == "yes" && $DISTRO == 'centos_7' && $mj -eq 7 && $mn -gt 6 ]]; then
+		LogErr "ND test only support CentOS-HPC 7.6 or earlier version. Abort!"
+		SetTestStateAborted
+		exit 0
+	fi
+
 	LogMsg "Starting RDMA required packages and software setup in VM"
 	update_repos
 	# Install common packages
@@ -618,7 +629,7 @@ function Main() {
 		Verify_File $benchmark_bin
 	fi
 
-	if [ $benchmark_type == "OMB" && $$mpi_type != "mvapich" ]; then
+	if [[ $benchmark_type == "OMB" && $$mpi_type != "mvapich" ]]; then
 		currentDir=$(pwd)
 		cd ~
 		LogMsg "Proceeding OSU MPI Benchmark (OMB) test installation"

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -488,23 +488,27 @@ function Main() {
 	# It's safer to obtain pkeys in the test script because some distros
 	# may require a reboot after the IB setup is completed
 	# Find the correct partition key for IB communicating with other VM
-	if [ -z ${MPI_IB_PKEY+x} ]; then
-		firstkey=$(cat /sys/class/infiniband/mlx5_0/ports/1/pkeys/0)
-		LogMsg "Getting the first key $firstkey"
-		secondkey=$(cat /sys/class/infiniband/mlx5_0/ports/1/pkeys/1)
-		LogMsg "Getting the second key $secondkey"
+	if [[ $is_nd == "no" ]]; then
+		if [ -z ${MPI_IB_PKEY+x} ]; then
+			firstkey=$(cat /sys/class/infiniband/mlx5_0/ports/1/pkeys/0)
+			LogMsg "Getting the first key $firstkey"
+			secondkey=$(cat /sys/class/infiniband/mlx5_0/ports/1/pkeys/1)
+			LogMsg "Getting the second key $secondkey"
 
-		# Assign the bigger number to MPI_IB_PKEY
-		if [ $((firstkey - secondkey)) -gt 0 ]; then
-			export MPI_IB_PKEY=$firstkey
-			echo "MPI_IB_PKEY=$firstkey" >> /root/constants.sh
+			# Assign the bigger number to MPI_IB_PKEY
+			if [ $((firstkey - secondkey)) -gt 0 ]; then
+				export MPI_IB_PKEY=$firstkey
+				echo "MPI_IB_PKEY=$firstkey" >> /root/constants.sh
+			else
+				export MPI_IB_PKEY=$secondkey
+				echo "MPI_IB_PKEY=$secondkey" >> /root/constants.sh
+			fi
+			LogMsg "Setting MPI_IB_PKEY to $MPI_IB_PKEY and copying it into constants.sh file"
 		else
-			export MPI_IB_PKEY=$secondkey
-			echo "MPI_IB_PKEY=$secondkey" >> /root/constants.sh
+			LogMsg "pkey is already present in constants.sh"
 		fi
-		LogMsg "Setting MPI_IB_PKEY to $MPI_IB_PKEY and copying it into constants.sh file"
 	else
-		LogMsg "pkey is already present in constants.sh"
+		LogMsg "Skipped MPI_IB_PKEY query step in ND device"
 	fi
 
 	for vm in $master $slaves_array; do
@@ -543,7 +547,11 @@ function Main() {
 	# ib kernel modules verification
 	# mlx5_ib, rdma_cm, rdma_ucm, ib_ipoib, ib_umad shall be loaded in kernel
 	final_module_load_status=0
-	kernel_modules="mlx5_ib rdma_cm rdma_ucm ib_ipoib ib_umad"
+	if [[ $is_nd == "yes" ]]; then
+		kernel_modules="rdma_cm rdma_ucm ib_ipoib ib_umad"
+	else
+		kernel_modules="mlx5_ib rdma_cm rdma_ucm ib_ipoib ib_umad"
+	fi
 
 	for vm in $master $slaves_array; do
 	LogMsg "Checking kernel modules in $vm"
@@ -565,14 +573,19 @@ function Main() {
 	# ############################################################################################################
 	# ibv_devinfo verifies PORT STATE
 	# PORT_ACTIVE (4) is expected. If PORT_DOWN (1), it fails
+	# wait 5-second for port establishment
+	if [[ $is_nd == "yes" ]]; then
+		# ND device loading takes time.
+		LogMsg "Waiting 60 seconds for ND interface load"
+		sleep 60
+	fi
 	ib_port_state_down_cnt=0
 	min_port_state_up_cnt=0
 	for vm in $master $slaves_array; do
 		min_port_state_up_cnt=$(($min_port_state_up_cnt + 1))
 		ssh root@${vm} "ibv_devinfo > /root/IMB-PORT_STATE_${vm}.txt"
 		port_state=$(ssh root@${vm} "ibv_devinfo | grep -i state")
-		port_state=$(echo $port_state | cut -d ' ' -f2)
-		if [ "$port_state" == "PORT_ACTIVE" ]; then
+		if [[ "$port_state" == *"PORT_ACTIVE"* ]]; then
 			LogMsg "$vm ib port is up - Succeeded; $port_state"
 		else
 			LogErr "$vm ib port is down; $port_state"
@@ -649,82 +662,91 @@ function Main() {
 	final_pingpong_state=0
 	found_ib0_interface=1
 
-	# Getting ib0 interface address and store in constants.sh
-	slaves_array=$(echo ${slaves} | tr ',' ' ')
-	for vm in $master $slaves_array; do
-		ib0=$(ssh root@${vm} ip addr show ib0 | awk -F ' *|:' '/inet /{print $3}' | cut -d / -f 1)
-		if [[ $? -eq 0 && $ib0 ]]; then
-			LogMsg "Successfully queried ib0 interface address, $ib0 from ${vm}."
-		else
-			LogErr "Failed to query ib0 interface address, $ib0 from ${vm}."
-			final_pingpong_state=$(($final_pingpong_state + 1))
-			found_ib0_interface=0
-		fi
-		LogMsg "Logging ib0_$vm value: $ib0"
-		vm_id=$(echo $vm | sed -r 's!/.*!!; s!.*\.!!')
-		echo ib0_$vm_id=$ib0 >> /root/constants.sh
-		export ib0_$vm_id=$ib0
-	done
+	if [[ $is_nd == "no" ]]; then
+		# Getting ib0 interface address and store in constants.sh
+		slaves_array=$(echo ${slaves} | tr ',' ' ')
+		ib_name=ib0
+		for vm in $master $slaves_array; do
+			ib0=$(ssh root@${vm} ip addr show $ib_name | awk -F ' *|:' '/inet /{print $3}' | cut -d / -f 1)
+			if [[ $? -eq 0 && $ib0 ]]; then
+				LogMsg "Successfully queried $ib_name interface address, $ib0 from ${vm}."
+			else
+				LogErr "Failed to query $ib_name interface address, $ib0 from ${vm}."
+				final_pingpong_state=$(($final_pingpong_state + 1))
+				found_ib0_interface=0
+			fi
+			LogMsg "Logging ib0_$vm value: $ib0"
+			vm_id=$(echo $vm | sed -r 's!/.*!!; s!.*\.!!')
+			echo ib0_$vm_id=$ib0 >> /root/constants.sh
+			export ib0_$vm_id=$ib0
+		done
 
-	# Define ibv_ pingpong commands in the array
-	declare -a ping_cmds=("ibv_rc_pingpong" "ibv_uc_pingpong" "ibv_ud_pingpong")
+		# Define ibv_ pingpong commands in the array
+		declare -a ping_cmds=("ibv_rc_pingpong" "ibv_uc_pingpong" "ibv_ud_pingpong")
 
-	if [ $found_ib0_interface = 1 ]; then
-		for ping_cmd in "${ping_cmds[@]}"; do
-			for vm1 in $master $slaves_array; do
-				for vm2 in $slaves_array $master; do
-					if [[ "$vm1" == "$vm2" ]]; then
-						# Skip self-ping test case
-						break
-					fi
-					# Define pingpong test log file name
-					log_file=IMB-"$ping_cmd"-output-$vm1-$vm2.txt
-					LogMsg "Run $ping_cmd from $vm2 to $vm1"
-					LogMsg "  Start $ping_cmd in server VM $vm1 first"
-					retries=0
-					while [ $retries -lt 3 ]; do
-						ssh root@${vm1} "$ping_cmd" &
-						LogMsg "  $?"
-						sleep 1
-						vm1_id=ib0_$(echo $vm1 | sed -r 's!/.*!!; s!.*\.!!')
-						LogMsg "  Start $ping_cmd in client VM, $vm2 to ${!vm1_id}"
-						ssh root@${vm2} "$ping_cmd ${!vm1_id} > /root/$log_file"
-						pingpong_state=$?
-						LogMsg "  $pingpong_state"
+		if [ $found_ib0_interface = 1 ]; then
+			for ping_cmd in "${ping_cmds[@]}"; do
+				for vm1 in $master $slaves_array; do
+					for vm2 in $slaves_array $master; do
+						if [[ "$vm1" == "$vm2" ]]; then
+							# Skip self-ping test case
+							break
+						fi
+						# Define pingpong test log file name
+						log_file=IMB-"$ping_cmd"-output-$vm1-$vm2.txt
+						LogMsg "Run $ping_cmd from $vm2 to $vm1"
+						LogMsg "  Start $ping_cmd in server VM $vm1 first"
+						retries=0
+						while [ $retries -lt 3 ]; do
+							ssh root@${vm1} "$ping_cmd" &
+							LogMsg "  $?"
+							sleep 1
+							vm1_id=ib0_$(echo $vm1 | sed -r 's!/.*!!; s!.*\.!!')
+							LogMsg "  Start $ping_cmd in client VM, $vm2 to ${!vm1_id}"
+							ssh root@${vm2} "$ping_cmd ${!vm1_id} > /root/$log_file"
+							pingpong_state=$?
+							LogMsg "  $pingpong_state"
 
-						sleep 1
-						scp root@${vm2}:/root/$log_file .
-						pingpong_result=$(cat $log_file | grep -i Mbit | cut -d ' ' -f7)
-						if [ $pingpong_state -eq 0 ] && [ $pingpong_result > 0 ]; then
-							LogMsg "$ping_cmd test execution successful"
-							LogMsg "$ping_cmd result $pingpong_result in $vm1-$vm2 - Succeeded."
-							retries=4
-						else
-							sleep 10
-							let retries=retries+1
+							sleep 1
+							scp root@${vm2}:/root/$log_file .
+							pingpong_result=$(cat $log_file | grep -i Mbit | cut -d ' ' -f7)
+							if [ $pingpong_state -eq 0 ] && [ $pingpong_result > 0 ]; then
+								LogMsg "$ping_cmd test execution successful"
+								LogMsg "$ping_cmd result $pingpong_result in $vm1-$vm2 - Succeeded."
+								retries=4
+							else
+								sleep 10
+								let retries=retries+1
+							fi
+						done
+						if [ $pingpong_state -ne 0 ] || (($(echo "$pingpong_result <= 0" | bc -l))); then
+							LogErr "$ping_cmd test execution failed"
+							LogErr "$ping_cmd result $pingpong_result in $vm1-$vm2 - Failed"
+							final_pingpong_state=$(($final_pingpong_state + 1))
 						fi
 					done
-					if [ $pingpong_state -ne 0 ] || (($(echo "$pingpong_result <= 0" | bc -l))); then
-						LogErr "$ping_cmd test execution failed"
-						LogErr "$ping_cmd result $pingpong_result in $vm1-$vm2 - Failed"
-						final_pingpong_state=$(($final_pingpong_state + 1))
-					fi
 				done
 			done
-		done
-	fi
+		fi
 
-	if [ $final_pingpong_state -ne 0 ]; then
-		LogErr "ibv_ping_pong test failed in some VMs. Aborting further tests."
-		SetTestStateFailed
-		Collect_Logs
-		LogErr "INFINIBAND_VERIFICATION_FAILED_IBV_PINGPONG"
-		exit 0
+		if [ $final_pingpong_state -ne 0 ]; then
+			LogErr "ibv_ping_pong test failed in some VMs. Aborting further tests."
+			SetTestStateFailed
+			Collect_Logs
+			LogErr "INFINIBAND_VERIFICATION_FAILED_IBV_PINGPONG"
+			exit 0
+		else
+			LogMsg "INFINIBAND_VERIFICATION_SUCCESS_IBV_PINGPONG"
+		fi
 	else
-		LogMsg "INFINIBAND_VERIFICATION_SUCCESS_IBV_PINGPONG"
+		LogMsg "ND test skipped ibv_ping_pong test"
 	fi
 
-	non_shm_mpi_settings=$(echo $mpi_settings | sed 's/shm://')
+	if [[ $is_nd == "no" ]]; then
+		non_shm_mpi_settings=$(echo $mpi_settings | sed 's/shm://')
+	else
+		non_shm_mpi_settings=$mpi_settings
+	fi
 	imb_ping_pong_path=$(find / -name ping_pong)
 	imb_mpi1_path=$(find / -name IMB-MPI1 | head -n 1)
 	imb_rma_path=$(find / -name IMB-RMA | head -n 1)

--- a/Testscripts/Linux/TestRDMA_MultiVM.sh
+++ b/Testscripts/Linux/TestRDMA_MultiVM.sh
@@ -742,11 +742,7 @@ function Main() {
 		LogMsg "ND test skipped ibv_ping_pong test"
 	fi
 
-	if [[ $is_nd == "no" ]]; then
-		non_shm_mpi_settings=$(echo $mpi_settings | sed 's/shm://')
-	else
-		non_shm_mpi_settings=$mpi_settings
-	fi
+	non_shm_mpi_settings=$(echo $mpi_settings | sed 's/shm://')
 	imb_ping_pong_path=$(find / -name ping_pong)
 	imb_mpi1_path=$(find / -name IMB-MPI1 | head -n 1)
 	imb_rma_path=$(find / -name IMB-RMA | head -n 1)

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -155,7 +155,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_ND</ReplaceThis>
-		<ReplaceWith>-env I_MPI_FABRICS ofi -env SECS_PER_SAMPLE=600</ReplaceWith>
+		<ReplaceWith>-env I_MPI_FABRICS dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env SECS_PER_SAMPLE=600</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_MPI_SETTINGS_TCP</ReplaceThis>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -151,7 +151,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_IB</ReplaceThis>
-		<ReplaceWith>-env I_MPI_FABRICS shm:dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env SECS_PER_SAMPLE=600</ReplaceWith>
+		<ReplaceWith>-env I_MPI_FABRICS dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env SECS_PER_SAMPLE=600</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_ND</ReplaceThis>

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -151,6 +151,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_IB</ReplaceThis>
+		<ReplaceWith>-env I_MPI_FABRICS shm:dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env SECS_PER_SAMPLE=600</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_INTEL_MPI_SETTINGS_ND</ReplaceThis>
 		<ReplaceWith>-env I_MPI_FABRICS ofi -env SECS_PER_SAMPLE=600</ReplaceWith>
 	</Parameter>
 	<Parameter>
@@ -196,6 +200,10 @@ Scenario 2 : You need to run all the performance tests quickly.
 	<Parameter>
 		<ReplaceThis>INFINIBAND_INTEL_MPI_TESTNAMES</ReplaceThis>
 		<ReplaceWith>allreduce</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>INFINIBAND_INTEL_MPI_ND_TESTNAMES</ReplaceThis>
+		<ReplaceWith>pingpong</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>INFINIBAND_IBM_MPI_TESTNAMES</ReplaceThis>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -436,4 +436,51 @@
       <OverrideVMSize>Standard_HC44rs</OverrideVMSize>
     </SetupConfig>
   </test>
+  <!-- ND with Intel MPI -->
+  <test>
+    <testName>INFINIBAND-INTEL-MPI-ND</testName>
+    <testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
+    <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
+    <Priority>3</Priority>
+    <TestParameters>
+      <param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+      <param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
+      <param>num_reboot="INFINIBAND_INTEL_TOTAL_REBOOT_COUNT"</param>
+      <param>mpi_settings="INFINIBAND_INTEL_MPI_SETTINGS_IB"</param>
+      <param>ib_nic="INFINIBAND_IB_NIC"</param>
+      <param>imb_mpi1_tests="INFINIBAND_INTEL_MPI_ND_TESTNAMES"</param>
+      <param>mpi1_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_mpi1_tests_iterations=INFINIBAND_MPI_TEST_COUNT</param>
+      <param>imb_rma_tests="INFINIBAND_INTEL_RMA_TESTNAMES"</param>
+      <param>rma_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_rma_tests_iterations=INFINIBAND_INTEL_RMA_TEST_COUNT</param>
+      <param>imb_nbc_tests="INFINIBAND_INTEL_NBC_TESTNAMES"</param>
+      <param>nbc_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_nbc_tests_iterations=INFINIBAND_INTEL_NBC_TEST_COUNT</param>
+      <param>p2p_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_p2p_tests_iterations=INFINIBAND_INTEL_P2P_TEST_COUNT</param>
+      <param>io_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_io_tests_iterations=INFINIBAND_INTEL_IO_TEST_COUNT</param>
+      <param>mpi_type="intel"</param>
+      <param>benchmark_type="IMB"</param>
+      <param>mlx_ofed_partial_link=MLX_OFED_PARTIAL_LINK</param>
+      <param>ibm_platform_mpi=IBM_PLATFORM_MPI_DOWNLOAD</param>
+      <param>intel_mpi=INTEL_MPI_DOWNLOAD</param>
+      <param>open_mpi=OPEN_MPI_DOWNLOAD</param>
+      <param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
+      <param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
+      <param>walaagent_repo=WALAAgent_REPO</param>
+      <param>quicktest_only=yes</param> <!-- Do not change this param -->
+      <param>is_nd=yes</param>
+    </TestParameters>
+    <Platform>Azure</Platform>
+    <Category>Functional</Category>
+    <Area>INFINIBAND</Area>
+    <Tags>rdma</Tags>
+    <SetupConfig>
+      <SetupType>TwoVM1Dep</SetupType>
+      <OverrideVMSize>Standard_H16r,=~Standard_A[8-9],=~Standard_H16(r|mr)*$</OverrideVMSize>
+      <ARMImageName>=~CentOS-HPC\s7\.[0-6],=~CentOS-HPC\s6\.(5|8)</ARMImageName>
+    </SetupConfig>
+  </test>
 </TestCases>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -446,7 +446,7 @@
       <param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
       <param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
       <param>num_reboot="INFINIBAND_INTEL_TOTAL_REBOOT_COUNT"</param>
-      <param>mpi_settings="INFINIBAND_INTEL_MPI_SETTINGS_IB"</param>
+      <param>mpi_settings="INFINIBAND_INTEL_MPI_SETTINGS_ND"</param>
       <param>ib_nic="INFINIBAND_IB_NIC"</param>
       <param>imb_mpi1_tests="INFINIBAND_INTEL_MPI_ND_TESTNAMES"</param>
       <param>mpi1_ppn=INFINIBAND_INTEL_PPN</param>

--- a/XML/TestCases/FunctionalTests-InfiniBand.xml
+++ b/XML/TestCases/FunctionalTests-InfiniBand.xml
@@ -438,7 +438,7 @@
   </test>
   <!-- ND with Intel MPI -->
   <test>
-    <testName>INFINIBAND-INTEL-MPI-ND</testName>
+    <testName>INFINIBAND-INTEL-MPI-ND-2VM</testName>
     <testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
     <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
     <Priority>3</Priority>
@@ -479,6 +479,52 @@
     <Tags>rdma</Tags>
     <SetupConfig>
       <SetupType>TwoVM1Dep</SetupType>
+      <OverrideVMSize>Standard_H16r,=~Standard_A[8-9],=~Standard_H16(r|mr)*$</OverrideVMSize>
+      <ARMImageName>=~CentOS-HPC\s7\.[0-6],=~CentOS-HPC\s6\.(5|8)</ARMImageName>
+    </SetupConfig>
+  </test>
+  <test>
+    <testName>INFINIBAND-INTEL-MPI-ND-32VM</testName>
+    <testScript>VERIFY-INFINIBAND-MultiVM.ps1</testScript>
+    <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\TestRDMA_MultiVM.sh,.\Testscripts\Linux\SetupRDMA.sh</files>
+    <Priority>3</Priority>
+    <TestParameters>
+      <param>install_ofed="INFINIBAND_INSTALL_OFED"</param>
+      <param>install_ofed_from_extension="INFINIBAND_INSTALL_OFED_FROM_EXTENSION"</param>
+      <param>num_reboot="INFINIBAND_INTEL_TOTAL_REBOOT_COUNT"</param>
+      <param>mpi_settings="INFINIBAND_INTEL_MPI_SETTINGS_ND"</param>
+      <param>ib_nic="INFINIBAND_IB_NIC"</param>
+      <param>imb_mpi1_tests="INFINIBAND_INTEL_MPI_ND_TESTNAMES"</param>
+      <param>mpi1_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_mpi1_tests_iterations=INFINIBAND_MPI_TEST_COUNT</param>
+      <param>imb_rma_tests="INFINIBAND_INTEL_RMA_TESTNAMES"</param>
+      <param>rma_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_rma_tests_iterations=INFINIBAND_INTEL_RMA_TEST_COUNT</param>
+      <param>imb_nbc_tests="INFINIBAND_INTEL_NBC_TESTNAMES"</param>
+      <param>nbc_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_nbc_tests_iterations=INFINIBAND_INTEL_NBC_TEST_COUNT</param>
+      <param>p2p_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_p2p_tests_iterations=INFINIBAND_INTEL_P2P_TEST_COUNT</param>
+      <param>io_ppn=INFINIBAND_INTEL_PPN</param>
+      <param>imb_io_tests_iterations=INFINIBAND_INTEL_IO_TEST_COUNT</param>
+      <param>mpi_type="intel"</param>
+      <param>benchmark_type="IMB"</param>
+      <param>mlx_ofed_partial_link=MLX_OFED_PARTIAL_LINK</param>
+      <param>ibm_platform_mpi=IBM_PLATFORM_MPI_DOWNLOAD</param>
+      <param>intel_mpi=INTEL_MPI_DOWNLOAD</param>
+      <param>open_mpi=OPEN_MPI_DOWNLOAD</param>
+      <param>mvapich_mpi=MVAPICH_MPI_DOWNLOAD</param>
+      <param>intel_mpi_benchmark=INTEL_MPI_BENCHMARK_DOWNLOAD</param>
+      <param>walaagent_repo=WALAAgent_REPO</param>
+      <param>quicktest_only=yes</param> <!-- Do not change this param -->
+      <param>is_nd=yes</param>
+    </TestParameters>
+    <Platform>Azure</Platform>
+    <Category>Functional</Category>
+    <Area>INFINIBAND</Area>
+    <Tags>rdma</Tags>
+    <SetupConfig>
+      <SetupType>RDMA32VMs</SetupType>
       <OverrideVMSize>Standard_H16r,=~Standard_A[8-9],=~Standard_H16(r|mr)*$</OverrideVMSize>
       <ARMImageName>=~CentOS-HPC\s7\.[0-6],=~CentOS-HPC\s6\.(5|8)</ARMImageName>
     </SetupConfig>


### PR DESCRIPTION
Summary of the changes

- Adjusted the time for ND device loading
- Opt-ed out ibv_pingpong result analysis, because ibv_pingpong does not support IB over ND.
- Set ND supporting VM size - Standard A8, A9, H16, H16r and H16mr only
- Marked do not change in Update FunctionalTests-InfiniBand.xml

1) Test result with Standard_H16r

> [LISAv2 Test Results Summary]
> Test Run On           : 10/06/2020 18:04:34
> ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.3 : latest
> Override VM size Under Test  : Standard_H16r
> Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
> Total Time (dd:hh:mm) : 0:0:13
> 
>    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
> -------------------------------------------------------------------------------------------------------------------------------------------
>     1 INFINIBAND           INFINIBAND-INTEL-MPI-ND                                                           PASS                11.15 
>       ARMImageName: OpenLogic CentOS-HPC 7.3 latest, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 3.10.0-514.26.2.el7.x86_64
>       InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
>       InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : SKIPPED
>       InfiniBand-Verification-1-FirstBoot :IMB PingPong Intranode : PASS
>       InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
>       InfiniBand-Verification-1-FirstBoot : IMB-IO : SKIPPED
>       InfiniBand-Verification-1-FirstBoot : IMB-RMA : SKIPPED
>       InfiniBand-Verification-1-FirstBoot : IMB-NBC : SKIPPED
>       InfiniBand-Verification-2-Reboot : eth0 IP : PASS
>       InfiniBand-Verification-2-Reboot : IBV_PINGPONG : SKIPPED
>       InfiniBand-Verification-2-Reboot :IMB PingPong Intranode : PASS
>       InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
>       InfiniBand-Verification-2-Reboot : IMB-IO : SKIPPED
>       InfiniBand-Verification-2-Reboot : IMB-RMA : SKIPPED
>       InfiniBand-Verification-2-Reboot : IMB-NBC : SKIPPED

2) Test result with default VM size from XML def. Expected to abort.
```
[LISAv2 Test Results Summary]
Test Run On           : 10/06/2020 18:48:26
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.3 : latest
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-ND                                                        ABORTED                 2.32 
      ARMImageName: OpenLogic CentOS-HPC 7.3 latest, TestLocation: southcentralus, Kernel Version: 3.10.0-514.26.2.el7.x86_64
```

Go to details error inside -> 
`10/06/2020 18:52:19 : [ERROR] EXCEPTION : @{ServiceName=; ResourceGroupName=LISAv2-TwoVM1Dep-juhlee-YV93-20201006184831; Location=southcentralus; RoleName=controller-vm; PublicIP=104.215.74.61; PublicIPv6=; InternalIP=10.0.0.4; SecondInternalIP=; URL=ica42438v4.southcentralus.cloudapp.azure.com; URLv6=; Status=Succeeded; InstanceSize=Standard_DS1_v2; SSHPort=1110; IsWindows=False}.InstanceSize does not support ND test at line: 182`

3) Test results with HB60rs (IB over SR-IOV VM size) Expected to abort.

```
[LISAv2 Test Results Summary]
Test Run On           : 10/06/2020 17:56:42
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.3 : latest
Override VM size Under Test  : Standard_HB60rs
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-ND                                                        ABORTED                 2.39 
      ARMImageName: OpenLogic CentOS-HPC 7.3 latest, OverrideVMSize: Standard_HB60rs, TestLocation: southcentralus, Kernel Version: 3.10.0-514.26.2.el7.x86_64
```

Go to the details log ->
`10/06/2020 18:01:53 : [ERROR] EXCEPTION : @{ServiceName=; ResourceGroupName=LISAv2-TwoVM1Dep-juhlee-WO31-20201006175647; Location=southcentralus; RoleName=controller-vm; PublicIP=65.52.35.88; PublicIPv6=; InternalIP=10.0.0.5; SecondInternalIP=; URL=ica38724v4.southcentralus.cloudapp.azure.com; URLv6=; Status=Succeeded; InstanceSize=Standard_HB60rs; SSHPort=1110; IsWindows=False}.InstanceSize does not support ND test at line: 182
`
4) Test results with an un-support HPC image. (7.7). Expect Abort.
```
[LISAv2 Test Results Summary]
Test Run On           : 10/06/2020 21:53:09
ARM Image Under Test  : OpenLogic : CentOS-HPC : 7.7 : latest
Override VM size Under Test  : Standard_H16r
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-ND                                                        ABORTED                 3.13 
      ARMImageName: OpenLogic CentOS-HPC 7.7 latest, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 3.10.0-1127.el7.x86_64
```

5) Test results with non-CentOS image. Expects Abort.

```
[LISAv2 Test Results Summary]
Test Run On           : 10/06/2020 23:44:13
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Override VM size Under Test  : Standard_H16r
Total Test Cases      : 1 (0 Passed, 0 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-INTEL-MPI-ND                                                        ABORTED                 2.57 
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, OverrideVMSize: Standard_H16r, TestLocation: southcentralus, Kernel Version: 5.4.0-1026-azure

```

Go to the detail log -> 10/06/2020 23:50:17 : [ERROR] EXCEPTION : Non CentOS-HPC VM, UBUNTU, support ND test. at line: 186