### PR TITLE
Return environment information in test result message

### DIFF
--- a/lisa/lisarunner.py
+++ b/lisa/lisarunner.py
@@ -103,7 +103,7 @@ class LisaRunner(Action):
                 for new_env_result in new_env_can_run_results:
                     if new_env_result.check_environment(environment, True):
                         await self._run_suite(
-                            environment=environment, cases=[new_env_result]
+                            environment=environment, results=[new_env_result]
                         )
                         break
 
@@ -123,7 +123,7 @@ class LisaRunner(Action):
                         ):
                             # run last batch cases
                             await self._run_suite(
-                                environment=environment, cases=grouped_cases
+                                environment=environment, results=grouped_cases
                             )
                             grouped_cases = []
 
@@ -132,7 +132,9 @@ class LisaRunner(Action):
                         grouped_cases.append(test_result)
 
                 if grouped_cases:
-                    await self._run_suite(environment=environment, cases=grouped_cases)
+                    await self._run_suite(
+                        environment=environment, results=grouped_cases
+                    )
             finally:
                 if environment and environment.is_ready:
                     platform.delete_environment(environment)
@@ -176,18 +178,18 @@ class LisaRunner(Action):
         super().close()
 
     async def _run_suite(
-        self, environment: Environment, cases: List[TestResult]
+        self, environment: Environment, results: List[TestResult]
     ) -> None:
 
-        assert cases
-        suite_metadata = cases[0].runtime_data.metadata.suite
+        assert results
+        suite_metadata = results[0].runtime_data.metadata.suite
         test_suite: TestSuite = suite_metadata.test_class(
             environment,
-            cases,
+            results,
             suite_metadata,
         )
-        for case in cases:
-            case.env = environment.name
+        for result in results:
+            result.environment = environment
         await test_suite.start()
 
     def _create_test_results(

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -173,7 +173,7 @@ class Node(ContextMixin, InitializableMixin):
             assert self.shell
             assert (
                 self._connection_info
-            ), "call setConnectionInfo before use remote node"
+            ), "don't call setConnectionInfo before use remote node"
 
             if self.is_linux:
                 remote_root_path = pathlib.Path("$HOME")
@@ -237,7 +237,6 @@ class Nodes:
                 else:
                     default = self._list[0]
             self._default = default
-        self._default.initialize()
         return self._default
 
     def list(self) -> Iterable[Node]:
@@ -260,7 +259,6 @@ class Nodes:
         if not found:
             raise KeyError(f"cannot find node {key}")
 
-        found.initialize()
         return found
 
     def __setitem__(self, key: Union[int, str], v: Node) -> None:

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -33,7 +33,14 @@ from lisa.feature import Feature
 from lisa.node import Node
 from lisa.platform_ import Platform
 from lisa.secret import PATTERN_GUID, PATTERN_HEADTAIL, add_secret
-from lisa.util import LisaException, constants, get_public_key_data, set_filtered_fields
+from lisa.tools import Dmesg, Modinfo
+from lisa.util import (
+    LisaException,
+    constants,
+    find_patterns_in_lines,
+    get_public_key_data,
+    set_filtered_fields,
+)
 from lisa.util.logger import Logger
 
 from . import features
@@ -197,6 +204,23 @@ class AzurePlatformSchema:
 
         if not self.locations:
             self.locations = LOCATIONS
+
+
+HOST_VERSION_PATTERN = re.compile(r"Hyper-V Host Build:([^\n;]*)")
+
+
+def _get_node_information(node: Node, information: Dict[str, str]) -> None:
+    if node.is_linux:
+        dmesg = node.tools[Dmesg]
+        matched_host_version = find_patterns_in_lines(
+            dmesg.get_output(), [HOST_VERSION_PATTERN]
+        )
+        information["host_version"] = (
+            matched_host_version[0][0] if matched_host_version[0] else ""
+        )
+
+        modinfo = node.tools[Modinfo]
+        information["lis_version"] = modinfo.get_version("hv_vmbus")
 
 
 class AzurePlatform(Platform):
@@ -839,6 +863,7 @@ class AzurePlatform(Platform):
                 password=node_context.password,
                 private_key_file=node_context.private_key_file,
             )
+            node.add_node_information_hook(_get_node_information)
 
     def _resource_sku_to_capability(
         self, location: str, resource_sku: ResourceSku

--- a/lisa/tests/test_lisarunner.py
+++ b/lisa/tests/test_lisarunner.py
@@ -415,7 +415,10 @@ class LisaRunnerTestCase(TestCase):
     ) -> None:
         self.assertListEqual(
             expected_envs,
-            [x.env for x in test_results],
+            [
+                x.environment.name if x.environment is not None else ""
+                for x in test_results
+            ],
         )
         self.assertListEqual(
             expected_status,

--- a/lisa/tests/test_platform.py
+++ b/lisa/tests/test_platform.py
@@ -71,6 +71,9 @@ class MockPlatform(Platform):
             requirements = environment.runbook.nodes_requirement
             for node_space in requirements:
                 environment.nodes.from_requirement(node_requirement=node_space)
+        for node in environment.nodes.list():
+            # prevent real calls
+            node._node_information_hooks.clear()
         deployed_envs.append(environment.name)
         environment._is_initialized = True
         environment.is_ready = self.deploy_is_ready

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -56,6 +56,9 @@ class TestResult:
     def can_run(self) -> bool:
         return self.status == TestStatus.NOTRUN
 
+    def __post_init__(self, *args: Any, **kwargs: Any) -> None:
+        self._send_result_message()
+
     def set_status(
         self, new_status: TestStatus, message: Union[str, List[str]]
     ) -> None:
@@ -67,20 +70,7 @@ class TestResult:
             self.message = "\n".join(message)
         if self.status != new_status:
             self.status = new_status
-
-            fields = ["status", "elapsed", "message"]
-            result_message = TestResultMessage()
-            set_filtered_fields(self, result_message, fields=fields)
-
-            # get information of default node, and send to notifier.
-            if self.environment:
-                environment_information = (
-                    self.environment.default_node.get_node_information()
-                )
-                result_message.environment_information.update(environment_information)
-                result_message.environment_information["name"] = self.environment.name
-            result_message.name = self.runtime_data.metadata.full_name
-            notifier.notify(result_message)
+            self._send_result_message()
 
     def check_environment(
         self, environment: Environment, save_reason: bool = False
@@ -106,6 +96,21 @@ class TestResult:
             else:
                 self.check_results = check_result
         return check_result.result
+
+    def _send_result_message(self) -> None:
+        fields = ["status", "elapsed", "message"]
+        result_message = TestResultMessage()
+        set_filtered_fields(self, result_message, fields=fields)
+
+        # get information of default node, and send to notifier.
+        if self.environment:
+            environment_information = (
+                self.environment.default_node.get_node_information()
+            )
+            result_message.environment_information.update(environment_information)
+            result_message.environment_information["name"] = self.environment.name
+        result_message.name = self.runtime_data.metadata.full_name
+        notifier.notify(result_message)
 
 
 @dataclass

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -37,6 +37,7 @@ class SkipTestCaseException(LisaException):
 @dataclass
 class TestResultMessage(notifier.MessageBase):
     type: str = "TestResult"
+    name: str = ""
     status: TestStatus = TestStatus.NOTRUN
     message: str = ""
     environment_information: Dict[str, str] = field(default_factory=dict)
@@ -78,6 +79,7 @@ class TestResult:
                 )
                 result_message.environment_information.update(environment_information)
                 result_message.environment_information["name"] = self.environment.name
+            result_message.name = self.runtime_data.metadata.full_name
             notifier.notify(result_message)
 
     def check_environment(

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -5,7 +5,19 @@ from .gcc import Gcc
 from .git import Git
 from .lscpu import Lscpu
 from .make import Make
+from .modinfo import Modinfo
 from .ntttcp import Ntttcp
 from .uname import Uname
 
-__all__ = ["Cat", "Dmesg", "Echo", "Gcc", "Git", "Lscpu", "Make", "Ntttcp", "Uname"]
+__all__ = [
+    "Cat",
+    "Dmesg",
+    "Echo",
+    "Gcc",
+    "Git",
+    "Lscpu",
+    "Make",
+    "Modinfo",
+    "Ntttcp",
+    "Uname",
+]

--- a/lisa/tools/dmesg.py
+++ b/lisa/tools/dmesg.py
@@ -33,6 +33,10 @@ class Dmesg(Tool):
     def _check_exists(self) -> bool:
         return True
 
+    def get_output(self, force_run: bool = False) -> str:
+        command_output = self._run(force_run=force_run)
+        return command_output.stdout
+
     def check_kernel_panic(
         self, force_run: bool = False, throw_error: bool = True
     ) -> str:

--- a/lisa/tools/modinfo.py
+++ b/lisa/tools/modinfo.py
@@ -1,0 +1,38 @@
+import re
+from typing import Any, Dict
+
+from lisa.executable import Tool
+from lisa.util import find_patterns_in_lines
+from lisa.util.process import ExecutableResult
+
+
+class Modinfo(Tool):
+    __version_pattern = re.compile(r"^vermagic:[ \t]*([^ \n]*)")
+
+    @property
+    def command(self) -> str:
+        return self._command
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self._command = "modinfo"
+        self._cached_result: Dict[str, ExecutableResult] = {}
+
+    def get_info(self, mod_name: str, force_run: bool = False) -> str:
+        cached_result = self._cached_result.get(mod_name)
+        if cached_result is None or force_run:
+            cached_result = self.run(mod_name)
+            if cached_result.exit_code != 0:
+                # CentOS may not include the path when started,
+                # specify path and try again.
+                self._command = "/usr/sbin/modinfo"
+                cached_result = self.run(mod_name)
+            self._cached_result[mod_name] = cached_result
+        return cached_result.stdout
+
+    def get_version(self, mod_name: str, force_run: bool = False) -> str:
+        output = self.get_info(mod_name=mod_name, force_run=force_run)
+        found_version = find_patterns_in_lines(output, [self.__version_pattern])
+        return found_version[0][0] if found_version[0] else ""

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Type, TypeVar
+from typing import Any, Dict, Iterable, List, Pattern, Type, TypeVar
 
 T = TypeVar("T")
 
@@ -96,3 +96,12 @@ def set_filtered_fields(src: Any, dest: Any, fields: List[str]) -> None:
             raise LisaException(f"field {field_name} doesn't exist on src")
         if field_value is not None:
             setattr(dest, field_name, field_value)
+
+
+def find_patterns_in_lines(lines: str, patterns: List[Pattern[str]]) -> List[List[str]]:
+    results: List[List[str]] = [list()] * len(patterns)
+    for line in lines.splitlines(keepends=False):
+        for index, pattern in enumerate(patterns):
+            if not results[index]:
+                results[index] = pattern.findall(line)
+    return results

--- a/lisa/variable.py
+++ b/lisa/variable.py
@@ -125,7 +125,7 @@ def load_from_variable_entry(
 
     assert isinstance(name, str), f"actual: {type(name)}"
     mask_pattern_name = ""
-    if type(raw_value) in [str, int, bool]:
+    if type(raw_value) in [str, int, bool, float]:
         value = raw_value
     else:
         if isinstance(raw_value, dict):


### PR DESCRIPTION
1. replace original env string to environment_information dict in
  TestResultMessage.
2. Add  node_info hooks on node, so that different component can return
  customized environment information.
3. add hooks in lisarunner and azure platform to get linux information.
4. add modinfo tool.
5. some minor refactoring.