### PR TITLE
Fix typo.

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -134,7 +134,7 @@ case $DISTRO in
 		LogMsg "WARNING: $DISTRO does not support unbinding the current clocksource, only check sourcing"
 		CheckSource
 		;;
-	redhat_8 |centos_8|fedora*|clear-linux-os|ubunut*|suse*|coreos*)
+	redhat_8 | centos_8 | fedora* | clear-linux-os | ubuntu* | suse* | coreos*)
 		CheckSource
 		UnbindCurrentSource
 		;;


### PR DESCRIPTION
Regression bring in by #1032.
Test results - 
```
[LISAv2 Test Results Summary]
Test Run On           : 10/10/2020 06:40:53
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-groovy-daily : 20_10-daily : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 TIME-CLOCKSOURCE                                                                  PASS                 0.49 
      ARMImageName: canonical 0001-com-ubuntu-server-groovy-daily 20_10-daily latest, TestLocation: westus2, Kernel Version: 5.8.0-1006-azure -> 5.8.0-1007-azure
```