### PR TITLE
Detect data device name dynamicly instead of hardcode /dev/sdc

### DIFF
--- a/Testscripts/Linux/SetupHbKernel.sh
+++ b/Testscripts/Linux/SetupHbKernel.sh
@@ -48,7 +48,9 @@ function Main() {
 	done
 	LogMsg "Generated the keys.txt file for fdisk commanding"
 
-	cat keys.txt | fdisk /dev/sdc
+	# Get the latest device name which should be the new attached data disk
+	data_dev=$(ls /dev/sd*[a-z] | sort -r | head -1)
+	cat keys.txt | fdisk ${data_dev}
 	LogMsg "$?: Executed fdisk command"
 	# Need to wait for system complete the swap disk update.
 	LogMsg "Waiting 10 seconds for swap disk update"
@@ -56,10 +58,10 @@ function Main() {
 	ret=$(ls /dev/sd*)
 	LogMsg "$?: List out /dev/sd* - $ret"
 
-	mkswap /dev/sdc1
+	mkswap ${data_dev}1
 	LogMsg "$?: Set up the swap space"
 
-	swapon /dev/sdc1
+	swapon ${data_dev}1
 	LogMsg "$?: Enabled the swap space"
 	# Wait 2 seconds for swap disk enabling
 	sleep 2


### PR DESCRIPTION
This fix get the latest device name as the data disk name instead of the hardcode /dev/sdc in the SetupHbKernel.sh script.
It's a small fix to fit for the VM sizes that have no temporary disk, such as Standard_E8s_v4.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>