### PR TITLE
make Linux Distro dectection extendable

### DIFF
--- a/lisa/notifier.py
+++ b/lisa/notifier.py
@@ -12,7 +12,7 @@ class MessageBase:
     elapsed: float = 0
 
 
-class Notifier(subclasses.BaseClassWithRunbook, InitializableMixin):
+class Notifier(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
     def __init__(self, runbook: schema.TypedSchema) -> None:
         super().__init__(runbook=runbook)
         self._log = get_logger("notifier", self.__class__.__name__)

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -20,7 +20,7 @@ class WaitMoreResourceError(Exception):
     pass
 
 
-class Platform(subclasses.BaseClassWithRunbook, InitializableMixin):
+class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
     def __init__(self, runbook: schema.Platform) -> None:
         super().__init__(runbook)
         self._log = get_logger("", self.type_name())

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -105,3 +105,13 @@ def find_patterns_in_lines(lines: str, patterns: List[Pattern[str]]) -> List[Lis
             if not results[index]:
                 results[index] = pattern.findall(line)
     return results
+
+
+def get_matched_str(content: str, pattern: Pattern[str]) -> str:
+    result: str = ""
+    if content:
+        matched_item = pattern.findall(content)
+        if matched_item:
+            # if something matched, it's like ['matched']
+            result = matched_item[0]
+    return result

--- a/lisa/util/subclasses.py
+++ b/lisa/util/subclasses.py
@@ -6,13 +6,13 @@ from lisa.util import InitializableMixin, LisaException
 from lisa.util.logger import get_logger
 
 
-class BaseClass:
+class BaseClassMixin:
     @classmethod
     def type_name(cls) -> str:
         raise NotImplementedError()
 
 
-class BaseClassWithRunbook(BaseClass):
+class BaseClassWithRunbookMixin(BaseClassMixin):
     def __init__(self, runbook: schema.TypedSchema) -> None:
         super().__init__()
         if self.type_schema() != type(runbook):
@@ -28,7 +28,7 @@ class BaseClassWithRunbook(BaseClass):
         raise NotImplementedError()
 
 
-T_BASECLASS = TypeVar("T_BASECLASS", bound=BaseClass)
+T_BASECLASS = TypeVar("T_BASECLASS", bound=BaseClassMixin)
 
 
 if TYPE_CHECKING:
@@ -77,10 +77,10 @@ class Factory(InitializableMixin, Generic[T_BASECLASS], SubClassTypeDict):
             raise LisaException(
                 f"cannot find subclass '{runbook.type}' for runbook {runbook}"
             )
-        sub_type_with_runbook = cast(Type[BaseClassWithRunbook], sub_type)
+        sub_type_with_runbook = cast(Type[BaseClassWithRunbookMixin], sub_type)
         sub_object = sub_type_with_runbook(runbook)
         assert isinstance(
-            sub_object, BaseClassWithRunbook
+            sub_object, BaseClassWithRunbookMixin
         ), f"actual: {type(sub_object)}"
 
         return cast(T_BASECLASS, sub_object)


### PR DESCRIPTION
Before this change, the detected OS must be defined in OperatingSystem class. With this change, a distro can be defined like an extension.