### PR TITLE
Add Hyper-V test case for gnome-shell check

### DIFF
--- a/Testscripts/Linux/GUI-GNOME-SHELL.sh
+++ b/Testscripts/Linux/GUI-GNOME-SHELL.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+# This script verifies gnome-shell process in running or not
+
+UTIL_FILE="./utils.sh"
+
+# Source utils.sh
+. ${UTIL_FILE} || {
+		echo "ERROR: unable to source ${UTIL_FILE}!"
+		echo "TestAborted" > state.txt
+		exit 0
+}
+
+# Source constants file and initialize most common variables
+UtilsInit
+
+# Script start from here
+LogMsg "*********INFO: Script Execution Started********"
+
+target=$(systemctl get-default)
+if [ "${target}" != "graphical.target" ]; then
+	LogMsg "Skip test case since VM does not set graphical as default target"
+	SetTestStateSkipped
+	exit 0
+fi
+
+ps -aux | grep "gnome-shell" | grep -v grep
+
+if [ $? -eq 0 ]; then
+	LogMsg "Find the gnome-shell process after VM boots up"
+	SetTestStateCompleted
+	exit 0
+else
+	LogErr "ERROR: Fail to find the gnome-shell process, maybe GUI cannot login"
+	SetTestStateFailed
+	exit 1
+fi

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -978,4 +978,17 @@
       <setupScript>.\Testscripts\Windows\SETUP-NET-Add-NIC.ps1</setupScript>
     </SetupConfig>
   </test>
+  <test>
+    <testName>GUI-GNOME-SHELL</testName>
+    <testScript>GUI-GNOME-SHELL.sh</testScript>
+    <files>.\TestScripts\Linux\GUI-GNOME-SHELL.sh,.\TestScripts\Linux\utils.sh</files>
+    <Platform>HyperV</Platform>
+    <Category>Functional</Category>
+    <Area>CORE</Area>
+    <Tags>boot</Tags>
+    <Priority>2</Priority>
+    <SetupConfig>
+      <SetupType>OneVM</SetupType>
+    </SetupConfig>
+  </test>
 </TestCases>


### PR DESCRIPTION
Add a test case for gnome-shell process check, mainly to check whether GUI can login or not, recently we have two major regression issues about fail to login GUI, this checking 'gnome-shell' method can detect the two bugs.

We have installed "Server with GUI" by default, if you also need to add an installation related script in GUI-GNOME-SHELL.sh, will add later. Maybe different linux distributions have different methods to install GUI, I only can verify on RHEL VM locally.

Thank you.

[LISAv2 Test Results Summary]
Test Run On           : 10/21/2020 01:51:00
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:1

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 GUI-GNOME-SHELL                                                                   PASS                  0.8 
      TestLocation: xxxx, Kernel Version: xxx