### PR TITLE
remove 1 core vm sizes from default

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -50,8 +50,10 @@ AZURE_DEPLOYMENT_NAME = "lisa_default_deployment_script"
 AZURE_RG_NAME_KEY = "resource_group_name"
 
 VM_SIZE_FALLBACK_LEVELS = [
-    re.compile(r"Standard_DS(\d)+_v2"),
-    re.compile(r"Standard_A(\d)+"),
+    # exclude Standard_DS1_v2, because one core is too slow,
+    # and doesn't work in some distro
+    re.compile(r"Standard_DS((?!1)[\d]{1}|[\d]{2,})_v2"),
+    re.compile(r"Standard_A((?!1)[\d]{1}|[\d]{2,})"),
 ]
 LOCATIONS = ["westus2", "eastus2"]
 RESOURCE_GROUP_LOCATION = "westus2"

--- a/lisa/sut_orchestrator/azure/tests/azure_locations.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations.json
@@ -288,6 +288,157 @@
                     ],
                     "restrictions": []
                 }
+            },
+            {
+                "location": "westus2",
+                "vmSize": "Standard_DS2_v2",
+                "capability": {
+                    "type": "requirement",
+                    "name": "westus2_Standard_DS2_v2",
+                    "isDefault": false,
+                    "artifact": "",
+                    "nodeCount": 1,
+                    "coreCount": 2,
+                    "memoryMb": 7168,
+                    "diskCount": {
+                        "min": 0,
+                        "max": 8,
+                        "maxInclusive": true
+                    },
+                    "nicCount": {
+                        "min": 0,
+                        "max": 2,
+                        "maxInclusive": true
+                    },
+                    "gpuCount": 0,
+                    "features": {
+                        "isAllowSet": true,
+                        "items": [
+                            "StartStop"
+                        ]
+                    },
+                    "excludedFeatures": {
+                        "isAllowSet": false,
+                        "items": []
+                    }
+                },
+                "estimatedCost": 2,
+                "resourceSku": {
+                    "resource_type": "virtualMachines",
+                    "name": "Standard_DS2_v2",
+                    "tier": "Standard",
+                    "size": "DS2_v2",
+                    "family": "standardDSv2Family",
+                    "locations": [
+                        "westus2"
+                    ],
+                    "location_info": [
+                        {
+                            "location": "westus2",
+                            "zones": [
+                                "3",
+                                "2",
+                                "1"
+                            ],
+                            "zone_details": []
+                        }
+                    ],
+                    "capabilities": [
+                        {
+                            "name": "MaxResourceVolumeMB",
+                            "value": "14336"
+                        },
+                        {
+                            "name": "OSVhdSizeMB",
+                            "value": "1047552"
+                        },
+                        {
+                            "name": "vCPUs",
+                            "value": "2"
+                        },
+                        {
+                            "name": "HyperVGenerations",
+                            "value": "V1,V2"
+                        },
+                        {
+                            "name": "MemoryGB",
+                            "value": "7"
+                        },
+                        {
+                            "name": "MaxDataDiskCount",
+                            "value": "8"
+                        },
+                        {
+                            "name": "LowPriorityCapable",
+                            "value": "True"
+                        },
+                        {
+                            "name": "PremiumIO",
+                            "value": "True"
+                        },
+                        {
+                            "name": "VMDeploymentTypes",
+                            "value": "IaaS"
+                        },
+                        {
+                            "name": "vCPUsAvailable",
+                            "value": "2"
+                        },
+                        {
+                            "name": "ACUs",
+                            "value": "210"
+                        },
+                        {
+                            "name": "vCPUsPerCore",
+                            "value": "1"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedIOPS",
+                            "value": "8000"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedReadBytesPerSecond",
+                            "value": "67108864"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+                            "value": "67108864"
+                        },
+                        {
+                            "name": "CachedDiskBytes",
+                            "value": "92341796864"
+                        },
+                        {
+                            "name": "UncachedDiskIOPS",
+                            "value": "6400"
+                        },
+                        {
+                            "name": "UncachedDiskBytesPerSecond",
+                            "value": "100663296"
+                        },
+                        {
+                            "name": "EphemeralOSDiskSupported",
+                            "value": "True"
+                        },
+                        {
+                            "name": "EncryptionAtHostSupported",
+                            "value": "True"
+                        },
+                        {
+                            "name": "AcceleratedNetworkingEnabled",
+                            "value": "True"
+                        },
+                        {
+                            "name": "RdmaEnabled",
+                            "value": "False"
+                        },
+                        {
+                            "name": "MaxNetworkInterfaces",
+                            "value": "2"
+                        }
+                    ],
+                    "restrictions": []
+                }
             }
         ]
     },
@@ -569,6 +720,157 @@
                         {
                             "name": "AcceleratedNetworkingEnabled",
                             "value": "False"
+                        },
+                        {
+                            "name": "RdmaEnabled",
+                            "value": "False"
+                        },
+                        {
+                            "name": "MaxNetworkInterfaces",
+                            "value": "2"
+                        }
+                    ],
+                    "restrictions": []
+                }
+            },
+            {
+                "location": "eastus2",
+                "vmSize": "Standard_DS2_v2",
+                "capability": {
+                    "type": "requirement",
+                    "name": "eastus2_Standard_DS2_v2",
+                    "isDefault": false,
+                    "artifact": "",
+                    "nodeCount": 1,
+                    "coreCount": 2,
+                    "memoryMb": 7168,
+                    "diskCount": {
+                        "min": 0,
+                        "max": 8,
+                        "maxInclusive": true
+                    },
+                    "nicCount": {
+                        "min": 0,
+                        "max": 2,
+                        "maxInclusive": true
+                    },
+                    "gpuCount": 0,
+                    "features": {
+                        "isAllowSet": true,
+                        "items": [
+                            "StartStop"
+                        ]
+                    },
+                    "excludedFeatures": {
+                        "isAllowSet": false,
+                        "items": []
+                    }
+                },
+                "estimatedCost": 2,
+                "resourceSku": {
+                    "resource_type": "virtualMachines",
+                    "name": "Standard_DS2_v2",
+                    "tier": "Standard",
+                    "size": "DS2_v2",
+                    "family": "standardDSv2Family",
+                    "locations": [
+                        "eastus2"
+                    ],
+                    "location_info": [
+                        {
+                            "location": "eastus2",
+                            "zones": [
+                                "3",
+                                "1",
+                                "2"
+                            ],
+                            "zone_details": []
+                        }
+                    ],
+                    "capabilities": [
+                        {
+                            "name": "MaxResourceVolumeMB",
+                            "value": "14336"
+                        },
+                        {
+                            "name": "OSVhdSizeMB",
+                            "value": "1047552"
+                        },
+                        {
+                            "name": "vCPUs",
+                            "value": "2"
+                        },
+                        {
+                            "name": "HyperVGenerations",
+                            "value": "V1,V2"
+                        },
+                        {
+                            "name": "MemoryGB",
+                            "value": "7"
+                        },
+                        {
+                            "name": "MaxDataDiskCount",
+                            "value": "8"
+                        },
+                        {
+                            "name": "LowPriorityCapable",
+                            "value": "True"
+                        },
+                        {
+                            "name": "PremiumIO",
+                            "value": "True"
+                        },
+                        {
+                            "name": "VMDeploymentTypes",
+                            "value": "IaaS"
+                        },
+                        {
+                            "name": "vCPUsAvailable",
+                            "value": "2"
+                        },
+                        {
+                            "name": "ACUs",
+                            "value": "210"
+                        },
+                        {
+                            "name": "vCPUsPerCore",
+                            "value": "1"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedIOPS",
+                            "value": "8000"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedReadBytesPerSecond",
+                            "value": "67108864"
+                        },
+                        {
+                            "name": "CombinedTempDiskAndCachedWriteBytesPerSecond",
+                            "value": "67108864"
+                        },
+                        {
+                            "name": "CachedDiskBytes",
+                            "value": "92341796864"
+                        },
+                        {
+                            "name": "UncachedDiskIOPS",
+                            "value": "6400"
+                        },
+                        {
+                            "name": "UncachedDiskBytesPerSecond",
+                            "value": "100663296"
+                        },
+                        {
+                            "name": "EphemeralOSDiskSupported",
+                            "value": "True"
+                        },
+                        {
+                            "name": "EncryptionAtHostSupported",
+                            "value": "True"
+                        },
+                        {
+                            "name": "AcceleratedNetworkingEnabled",
+                            "value": "True"
                         },
                         {
                             "name": "RdmaEnabled",

--- a/lisa/sut_orchestrator/azure/tests/test_prepare.py
+++ b/lisa/sut_orchestrator/azure/tests/test_prepare.py
@@ -92,8 +92,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["westus2", "westus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS1_v2"],
-            expected_cost=2,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS2_v2"],
+            expected_cost=4,
             environment=env,
         )
 
@@ -102,8 +102,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS1_v2"],
-            expected_cost=2,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS2_v2"],
+            expected_cost=4,
             environment=env,
         )
 
@@ -114,13 +114,13 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_B1ls"],
-            expected_cost=2,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_B1ls"],
+            expected_cost=3,
             environment=env,
         )
 
     def test_predefined_with_3_nic(self) -> None:
-        # 3 nic cannot be met by Standard_DS1_v2, as it support at most 2 nics
+        # 3 nic cannot be met by Standard_DS2_v2, as it support at most 2 nics
         # the code path of predefined and normal is different, so test it twice
         env = self.load_environment(node_req_count=1)
         assert env.runbook.nodes_requirement
@@ -129,8 +129,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS15_v2"],
-            expected_cost=21,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS15_v2"],
+            expected_cost=22,
             environment=env,
         )
 
@@ -153,8 +153,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["westus2"],
-            expected_vm_sizes=["Standard_DS1_v2"],
-            expected_cost=1,
+            expected_vm_sizes=["Standard_DS2_v2"],
+            expected_cost=2,
             environment=env,
         )
 
@@ -188,8 +188,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_A8_v2", "Standard_DS1_v2"],
-            expected_cost=10,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_A8_v2", "Standard_DS2_v2"],
+            expected_cost=12,
             environment=env,
         )
 
@@ -200,8 +200,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS1_v2"],
-            expected_cost=2,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS2_v2"],
+            expected_cost=4,
             environment=env,
         )
 
@@ -211,8 +211,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["westus2", "westus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS1_v2"],
-            expected_cost=2,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS2_v2"],
+            expected_cost=4,
             environment=env,
         )
 
@@ -226,8 +226,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS15_v2"],
-            expected_cost=21,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS15_v2"],
+            expected_cost=22,
             environment=env,
         )
 
@@ -241,13 +241,13 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_A8_v2"],
-            expected_cost=9,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_A8_v2"],
+            expected_cost=10,
             environment=env,
         )
 
     def test_normal_with_3_nic(self) -> None:
-        # 3 nic cannot be met by Standard_DS1_v2, as it support at most 2 nics
+        # 3 nic cannot be met by Standard_DS2_v2, as it support at most 2 nics
         # the code path of predefined and normal is different, so test it twice
         env = self.load_environment(node_req_count=1)
         assert env.runbook.nodes_requirement
@@ -255,8 +255,8 @@ class AzurePrepareTestCase(TestCase):
         self.verify_prepared_nodes(
             expected_result=True,
             expected_locations=["eastus2", "eastus2"],
-            expected_vm_sizes=["Standard_DS1_v2", "Standard_DS15_v2"],
-            expected_cost=21,
+            expected_vm_sizes=["Standard_DS2_v2", "Standard_DS15_v2"],
+            expected_cost=22,
             environment=env,
         )
 


### PR DESCRIPTION
1 core is slow, and there is no special coverage need it. So by default,
use 2 cores VM for test cases.

Update UTs also.