### PR TITLE
Support reboot in machine, and update test case

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -8,7 +8,7 @@ from lisa import schema
 from lisa.executable import Tools
 from lisa.feature import Features
 from lisa.operating_system import OperatingSystem
-from lisa.tools import Echo, Uname
+from lisa.tools import Echo, Reboot, Uname
 from lisa.util import (
     ContextMixin,
     InitializableMixin,
@@ -109,6 +109,9 @@ class Node(ContextMixin, InitializableMixin):
         self.shell = SshShell(self._connection_info)
         self.internal_address = address
         self.internal_port = port
+
+    def reboot(self) -> None:
+        self.tools[Reboot].reboot()
 
     def execute(
         self,

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -7,7 +7,9 @@ from .lscpu import Lscpu
 from .make import Make
 from .modinfo import Modinfo
 from .ntttcp import Ntttcp
+from .reboot import Reboot
 from .uname import Uname
+from .uptime import Uptime
 
 __all__ = [
     "Cat",
@@ -19,5 +21,7 @@ __all__ = [
     "Make",
     "Modinfo",
     "Ntttcp",
+    "Reboot",
     "Uname",
+    "Uptime",
 ]

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from spur.ssh import ConnectionError  # type: ignore
+
+from lisa.executable import Tool
+from lisa.util.perf_timer import create_timer
+
+from .uptime import Uptime
+
+
+class Reboot(Tool):
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        # timeout to wait
+        self.time_out: int = 300
+
+    @property
+    def command(self) -> str:
+        return "reboot"
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def reboot(self) -> None:
+        uptime = self.node.tools[Uptime]
+        timer = create_timer()
+        before_reboot_since_time = uptime.since_time()
+        current_since_time = before_reboot_since_time
+        self._log.debug(f"rebooting with current uptime: {before_reboot_since_time}")
+        self.node.execute(f"sudo {self.command}")
+        self.node.shell.close()
+        while (
+            before_reboot_since_time >= current_since_time
+            and timer.elapsed(False) < self.time_out
+        ):
+            self.node.shell.close()
+            try:
+                current_since_time = uptime.since_time()
+            except ConnectionError as identifier:
+                # error is ignorable, as ssh may be closed suddenly.
+                self._log.debug(f"ignorable ssh exception: {identifier}")
+                pass
+            self._log.debug(f"reconnected with uptime: {current_since_time}")

--- a/lisa/tools/uptime.py
+++ b/lisa/tools/uptime.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from lisa.executable import Tool
+from lisa.util import LisaException
+
+
+class Uptime(Tool):
+    @property
+    def command(self) -> str:
+        return "uptime"
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def since_time(self, no_error_log: bool = True) -> datetime:
+        command_result = self.run("-s", no_error_log=no_error_log)
+        if command_result.exit_code != 0:
+            raise LisaException(
+                f"get unexpected non-zero exit code {command_result.exit_code}"
+            )
+        return datetime.fromisoformat(command_result.stdout)

--- a/testsuites/basic/provisioning.py
+++ b/testsuites/basic/provisioning.py
@@ -1,6 +1,4 @@
 from lisa import TestCaseMetadata, TestSuite, TestSuiteMetadata
-from lisa.features import StartStop
-from lisa.testsuite import simple_requirement
 from lisa.tools import Dmesg
 from lisa.util.perf_timer import create_timer
 
@@ -20,18 +18,16 @@ class Provisioning(TestSuite):
         the case fails on any panic in kernel
         """,
         priority=0,
-        requirement=simple_requirement(supported_features=[StartStop]),
     )
-    def restart(self) -> None:
+    def smoke_test(self) -> None:
         node = self.environment.default_node
         dmesg = node.tools[Dmesg]
 
         dmesg.check_kernel_panic()
 
         timer = create_timer()
-        start_stop = node.features[StartStop]
         self.log.info(f"restarting {node.name}")
-        start_stop.restart()
+        node.reboot()
         self.log.info(f"node {node.name} rebooted in {timer}, trying connecting")
 
         dmesg.check_kernel_panic(force_run=True)


### PR DESCRIPTION
1. add reboot, uptime tools
2. add reboot method in node.
3. update current restart case to use internal reboot.
4. rename it to smoke_test