### PR TITLE
DPDK Fix: Remove mlx pmd config for meson build system

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -358,10 +358,6 @@ function Install_Dpdk () {
 		ssh ${1} "cd ${LIS_HOME}/${DPDK_DIR}/build && ninja && ninja install && ldconfig"
 		check_exit_status "dpdk build on ${1}" "exit"
 	else
-		ssh "${1}" "sed -i 's/^CONFIG_RTE_LIBRTE_MLX4_PMD=n/CONFIG_RTE_LIBRTE_MLX4_PMD=y/g' $RTE_SDK/config/common_base"
-		check_exit_status "${1} CONFIG_RTE_LIBRTE_MLX4_PMD=y" "exit"
-		ssh "${1}" "sed -i 's/^CONFIG_RTE_LIBRTE_MLX5_PMD=n/CONFIG_RTE_LIBRTE_MLX5_PMD=y/g' $RTE_SDK/config/common_base"
-		check_exit_status "${1} CONFIG_RTE_LIBRTE_MLX5_PMD=y" "exit"
 		if [[ ${DISTRO_NAME} == rhel ]] && ! [[ ${DISTRO_VERSION} == *"8."* ]]; then
 			ssh ${1} "cd ${LIS_HOME}/${DPDK_DIR} && PATH=$PATH:/opt/rh/rh-python36/root/usr/bin/ && meson ${RTE_TARGET}"
 		else


### PR DESCRIPTION
With Meson build system we no longer need to have mlx pmd config as meson build system already has it enabled by default.
```
[RedHat RHEL 7.5 latest] [LISAv2 Test Results Summary]
[RedHat RHEL 7.5 latest] Test Run On           : 10/21/2020 17:56:29
[RedHat RHEL 7.5 latest] ARM Image Under Test  : RedHat : RHEL : 7.5 : latest
[RedHat RHEL 7.5 latest] Test Priority         : 0,1,2,3
[RedHat RHEL 7.5 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[RedHat RHEL 7.5 latest] Total Time (dd:hh:mm) : 0:0:13
[RedHat RHEL 7.5 latest] 
[RedHat RHEL 7.5 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[RedHat RHEL 7.5 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[RedHat RHEL 7.5 latest]     1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                10.38 
[RedHat RHEL 7.5 latest]       ARMImageName: RedHat RHEL 7.5 latest, DiskType: Managed, Networking: SRIOV, TestLocation: westus2, Kernel Version: 3.10.0-862.51.1.el7.x86_64
[RedHat RHEL 7.5 latest] 
[RedHat RHEL 7.5 latest] 
[RedHat RHEL 7.5 latest] Logs can be found at C:\LISAv2\SE53-20201021175545\TestResults\2020-10-21-17-55-50-9507

[OpenLogic CentOS 7.5 latest] [LISAv2 Test Results Summary]
[OpenLogic CentOS 7.5 latest] Test Run On           : 10/21/2020 17:56:33
[OpenLogic CentOS 7.5 latest] ARM Image Under Test  : OpenLogic : CentOS : 7.5 : latest
[OpenLogic CentOS 7.5 latest] Test Priority         : 0,1,2,3
[OpenLogic CentOS 7.5 latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[OpenLogic CentOS 7.5 latest] Total Time (dd:hh:mm) : 0:0:9
[OpenLogic CentOS 7.5 latest] 
[OpenLogic CentOS 7.5 latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[OpenLogic CentOS 7.5 latest] -------------------------------------------------------------------------------------------------------------------------------------------
[OpenLogic CentOS 7.5 latest]     1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 7.42 
[OpenLogic CentOS 7.5 latest]       ARMImageName: OpenLogic CentOS 7.5 latest, DiskType: Managed, Networking: SRIOV, TestLocation: westus2, Kernel Version: 3.10.0-862.11.6.el7.x86_64
[OpenLogic CentOS 7.5 latest] 
[OpenLogic CentOS 7.5 latest] 
[OpenLogic CentOS 7.5 latest] Logs can be found at C:\LISAv2\JV73-20201021175550\TestResults\2020-10-21-17-55-55-8047

[Canonical UbuntuServer 18.04-LTS latest] [LISAv2 Test Results Summary]
[Canonical UbuntuServer 18.04-LTS latest] Test Run On           : 10/21/2020 17:56:20
[Canonical UbuntuServer 18.04-LTS latest] ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
[Canonical UbuntuServer 18.04-LTS latest] Test Priority         : 0,1,2,3
[Canonical UbuntuServer 18.04-LTS latest] Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
[Canonical UbuntuServer 18.04-LTS latest] Total Time (dd:hh:mm) : 0:0:9
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest]    ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
[Canonical UbuntuServer 18.04-LTS latest] -------------------------------------------------------------------------------------------------------------------------------------------
[Canonical UbuntuServer 18.04-LTS latest]     1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 6.75 
[Canonical UbuntuServer 18.04-LTS latest]       ARMImageName: Canonical UbuntuServer 18.04-LTS latest, DiskType: Managed, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] 
[Canonical UbuntuServer 18.04-LTS latest] Logs can be found at C:\LISAv2\ES21-20201021175535\TestResults\2020-10-21-17-55-40-6367
```