### PR TITLE
Fix LIS-VERSION-CHECK.sh

### DIFF
--- a/Testscripts/Linux/LIS-VERSION-CHECK.sh
+++ b/Testscripts/Linux/LIS-VERSION-CHECK.sh
@@ -21,7 +21,7 @@ function check_lis_version
 		LogMsg "Detected version and Source version are same"
 	else
 		LogMsg "Detected version and Source version are different"
-		updateSummary "LIS version check is failed"
+		UpdateSummary "LIS version check is failed"
 		SetTestStateFailed
 		exit 0
 	fi
@@ -40,7 +40,7 @@ function check_lis_version_hex()
 		LogMsg "Detected version and Source version are same for hex value"
 	else
 		LogMsg "Detected version and Source version are different for hex value"
-		updateSummary "LIS hex version check failed"
+		UpdateSummary "LIS hex version check failed"
 		SetTestStateFailed
 		exit 0
 	fi


### PR DESCRIPTION
The function in `utils.sh` is actually `UpdateSummary` (note the capitalized `U`) and Bash cannot find this function when it's incorrectly cased. I tested this fix against a CentOS machine. I'm a little confused as to how this bug exists because it should mean this test doesn't work properly when it fails for anyone. My only guess is that it's only ever passed so these two logical branches weren't executed until I tested them on a CentOS machine _without_ the LIS module.