### PR TITLE
Add new test case for NTTTCP-MONITOR

### DIFF
--- a/Testscripts/Linux/ntttcp_monitor_throughput.sh
+++ b/Testscripts/Linux/ntttcp_monitor_throughput.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+########################################################################
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+#
+# In this script, we want to monitor the network throughput by ntttcp for running very long time, e.g. one month.
+# Any throughput churn that's upper/lower than (${tolerance} * ${throughput_baseline}) will be logged as Failed (out of tolerance).
+########################################################################
+
+# Source utils.sh
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
+    exit 0
+}
+# Source constants file and initialize most common variables
+UtilsInit
+
+function display_time_from_seconds {
+    local T=$1
+    local D=$((T/60/60/24))
+    local H=$((T/60/60%24))
+    local M=$((T/60%60))
+    local S=$((T%60))
+    (( $D > 0 )) && printf '%d days ' $D
+    (( $H > 0 )) && printf '%d hours ' $H
+    (( $M > 0 )) && printf '%d minutes ' $M
+    (( $D > 0 || $H > 0 || $M > 0 )) && printf 'and '
+    printf '%d seconds\n' $S
+}
+
+function main {
+    while true;do
+        case "$1" in
+            --log_dir)
+                log_dir="$2"
+                shift 2;;
+            --server_internal_ip)
+                server_internal_ip="$2"
+                shift 2;;
+            --) shift; break ;;
+            *) break ;;
+        esac
+    done
+
+    if [[ -z ${seconds_of_runtime} || -z ${monitor_interval} || -z ${tolerance} || -z ${ntttcp_version} ]]; then
+        LogMsg "Error: missing parameter 'seconds_of_runtime' or 'monitor_interval' or 'tolerance' or 'ntttcp_version' "
+        exit 1
+    elif (("${monitor_interval}" > 5)); then
+        LogMsg "Warning: interval larger than 5 seconds may cause testing result not correct"
+    fi
+
+    if [[ -s state.txt ]]; then
+        rm state.txt
+    fi
+
+    for ntttcp_pid in $(pidof ntttcp); do
+        kill $ntttcp_pid
+    done
+
+    if [[ -d "${log_dir}" ]]; then
+        rm -rf "${log_dir}"
+    fi
+    mkdir ${log_dir}
+    if [[ -s "constants.sh" ]]; then
+        cp -rf *.sh ${log_dir}
+    fi
+
+    update_repos
+    install_package "gcc make wget moreutils bc"
+    build_ntttcp ${ntttcp_version}
+
+    # start testing depending on role (10.0.0.4 is receiver/server, other ip is sender/client)
+    private_ip=$(hostname -I | awk '{print $1}')
+    if [[ "${private_ip}" = "${server_internal_ip}" ]]; then
+        nohup ntttcp -r -H &
+        sleep 10
+        SetTestStateRunning
+        echo "Ntttcp_Monitor_Server_Started"
+    else
+        # 5 seconds for ntttcp starting and cooling down buffer
+        end_time_readable=$(date -d "+$((${seconds_of_runtime} -5)) seconds" +"%Y-%m-%d %H:%M:%S")
+        end_time=$(date -d "+$((${seconds_of_runtime} -5)) seconds" +%s)
+        nohup ntttcp -s"${server_internal_ip}" -t ${seconds_of_runtime} | ts "%Y-%m-%d %H:%M:%S" > "${log_dir}"/monitor_ntttcp.log &
+        # waiting for ntttcp process to start and get a stable throughput
+        sleep $((${monitor_interval} + 10))
+
+        # start monitoring on client
+        while [ $end_time -gt $(date +%s) ]
+        do
+            date_back_interval=$(date -d "-${monitor_interval} seconds" +"%Y-%m-%d %H:%M:%S")
+            # TODO: should we use tail, or direct use ./monitor_ntttcp.log? need more testing to select the most efficient
+            # ntttcp log real-time throughput every 500ms, so interval
+            tail -$((2 * ${monitor_interval} + 5)) "${log_dir}"/monitor_ntttcp.log > "${log_dir}"/tail_throughput.log
+            sed -un '/'"${date_back_interval}"'/,$ s/.*/&/w '"${log_dir}"'/date_back_interval.log' "${log_dir}"/tail_throughput.log
+            # if ./date_back_interval.log is empty, means ntttcp aborted due to networking device broken
+            # exit and break from while loop
+            if [[ ! -s "${log_dir}/date_back_interval.log" ]]; then
+                break
+            fi
+            # also if "${log_dir}"/date_back_interval.log has some more columns that's not 'throughput|blank_space|unit' format
+            # means networking device broken or ntttcp running down, exit and break from while loop
+            # due to performance consideration, merge into above break for ./date_back_interval.log is empty
+            sed -uni 's/.*Real-time\sthroughput:\s\([0-9.]*\)\(.*bps\)/\1 \2/p' "${log_dir}"/date_back_interval.log
+
+            # average_throughput|blank_space|unit
+            now_state=($(awk 'BEGIN{sum = 0} {sum += $1; now_unit = $2 } END{average = sum / NR; print average,now_unit}' "${log_dir}"/date_back_interval.log))
+
+            if [[ (1 = $(echo "${now_state[0]} != 0" | bc)) && (-n "${now_state[1]}") ]]; then
+                if [[ -z ${initialized} ]]; then
+                    unit_baseline=${now_state[1]}
+                    throughput_baseline=${now_state[0]}
+                    throughput_max=${throughput_baseline}
+                    throughput_min=${throughput_baseline}
+                    threshold_upper=$(awk -v tol="${tolerance}" -v thr="${throughput_baseline}" "BEGIN {print (1 + tol) * thr}")
+                    threshold_lower=$(awk -v tol="${tolerance}" -v thr="${throughput_baseline}" "BEGIN {print (1 - tol) * thr}")
+                    initialized="initialized"
+                elif [[ (1 = $(echo "${now_state[0]} > ${threshold_upper} ||  ${now_state[0]} < ${threshold_lower}" | bc)) || (${now_state[1]} != ${unit_baseline}) ]]; then
+                    mv "${log_dir}"/date_back_interval.log "${log_dir}"/out_of_tolerance@${now_state[0]}_$(date +"%Y_%m_%d_%H_%M_%S")
+                fi
+                echo "TestRunning, EndTime: ${end_time_readable}, Baseline: ${throughput_baseline} ${unit_baseline},  Tolerance: +/- ${tolerance}, Now throughput: ${now_state[0]} ${now_state[1]}" > "${log_dir}"/state.txt
+                if [[ 1 = $(echo "${now_state[0]} > ${throughput_max} && ${now_state[1]} == ${unit_baseline}" | bc) ]]; then
+                    throughput_max=${now_state[0]}
+                fi
+                if [[ 1 = $(echo "${now_state[0]} < ${throughput_min} && ${now_state[1]} == ${unit_baseline}" | bc) ]]; then
+                    throughput_min=${now_state[0]}
+                fi
+            fi
+            # continue sleep interval even now_state (throughput) is under churn, until break the while for ./date_back_interval.log is empty
+            sleep ${monitor_interval}
+        done
+        if [ $end_time -gt $(date +%s) ]; then
+            LogMsg "Error: ntttcp aborted, which may be caused by network device error."
+            echo "Error: ntttcp aborted, which may be caused by network device error." >> "${log_dir}"/out_of_tolerance@$(date +"%Y_%m_%d_%H_%M_%S")
+        fi
+        out_tolerance_logs=($(find "${log_dir}" -name 'out_of_tolerance@*'))
+        if [[ ${#out_tolerance_logs[@]} -eq 0 ]]; then
+            echo "TestCompleted" > "${log_dir}"/state.txt
+            echo "Test Passed Successfully !" > "${log_dir}"/summary.log
+            echo "Total Runtime: $(display_time_from_seconds ${seconds_of_runtime})" >> "${log_dir}"/summary.log
+            echo "Monitor Interval: ${monitor_interval} seconds" >> "${log_dir}"/summary.log
+            echo "Throughput Baseline: ${throughput_baseline} ${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Tolerance: +/-${tolerance} of ${throughput_baseline} ${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Maximum throughput: ${throughput_max}${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Minimum throughput: ${throughput_min}${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Real-time throughput consistently upper than ${threshold_lower} ${unit_baseline} and lower than ${threshold_upper} ${unit_baseline}" >> "${log_dir}"/summary.log
+        else
+            echo "TestFailed" > "${log_dir}"/state.txt
+            echo "Test Passed Failed !" > "${log_dir}"/summary.log
+            echo "Total Runtime: $(display_time_from_seconds ${seconds_of_runtime})" >> "${log_dir}"/summary.log
+            echo "Monitor Interval: ${monitor_interval} seconds" >> "${log_dir}"/summary.log
+            echo "Tolerance: +/-${tolerance} of ${throughput_baseline} ${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Maximum throughput: ${throughput_max}${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Minimum throughput: ${throughput_min}${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Real-time throughput has ever been lower than ${threshold_lower} ${unit_baseline}, or upper than ${threshold_upper} ${unit_baseline}" >> "${log_dir}"/summary.log
+            echo "Please reference TestExecutionError.txt"
+            for log in "${out_tolerance_logs[@]}"; do
+                echo "" >> "${log_dir}"/TestExecutionError.txt
+                echo "$(basename $log)" | awk -F '@' '{print "out of tolerance at", $2}' >> "${log_dir}"/TestExecutionError.txt
+                awk '{print "\t\t\t", $0}' $log >> "${log_dir}"/TestExecutionError.txt
+            done
+        fi
+    fi
+}
+
+main $@

--- a/Testscripts/Windows/NTTTCP-MONITOR-THROUGHPUT.ps1
+++ b/Testscripts/Windows/NTTTCP-MONITOR-THROUGHPUT.ps1
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+param(
+	[String] $TestParams,
+	[object] $AllVMData,
+	[object] $CurrentTestData
+)
+
+function Main {
+	param (
+		$TestParams
+	)
+	$currentTestResult = Create-TestResultObject
+	$scriptFile = "./ntttcp_monitor_throughput.sh"
+	$log_dir = "/var/log/ntttcp_monitor"
+
+	$serverVMData = $allVMData | Select-Object -First 1
+	$server_internal_ip = $serverVMData.InternalIP
+	$serverResult = Run-LinuxCmd -ip $serverVMData.PublicIP -port $serverVMData.SSHPort -username $global:user `
+		-password $password -command "chmod +x *.sh && $scriptFile --log_dir '${log_dir}' --server_internal_ip '${server_internal_ip}'" -runAsSudo -ignoreLinuxExitCode
+	if ($serverResult -cmatch "Ntttcp_Monitor_Server_Started") {
+		$serverStartedSuccessfully = $true
+	}
+
+	if (!$serverStartedSuccessfully) {
+		Write-LogErr "Failed to start NTTTCP server"
+		$currentTestResult.TestResult = $global:ResultFail
+	}
+	else {
+		$clientVMData = $allVMData | Where-Object {$_.InternalIP -inotmatch "$server_internal_ip"} | Select-Object -First 1
+		$null = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username $global:user `
+				-password $global:password -command "rm -f state.txt && chmod +x *.sh && (nohup '${scriptFile}' --log_dir '${log_dir}' --server_internal_ip '${server_internal_ip}' & ); sleep 30" -runAsSudo -ignoreLinuxExitCode
+		$timeout = New-TimeSpan -Seconds 300
+		$sw = [System.Diagnostics.Stopwatch]::StartNew()
+		while ($clientNtttcpStatus -inotmatch "^TestRunning.*" -and $sw.Elapsed -lt $timeout) {
+			Start-Sleep -Seconds 5
+			$clientNtttcpStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username $global:user `
+				-password $password -command "cat ${log_dir}/state.txt" -runAsSudo -ignoreLinuxExitCode
+		}
+		if ($clientNtttcpStatus -imatch "^TestRunning.*") {
+			$currentTestResult.TestResult = $global:ResultPass
+			$connectionInfo = "Client Address: $($clientVMData.PublicIP):$($clientVMData.SSHPort), Server Address: $($serverVMData.PublicIP):$($serverVMData.SSHPort)"
+			$currentTestResult.TestSummary += New-ResultSummary -testResult $connectionInfo -metaData "Monitor NTTTCP Started Successfully" -testName $CurrentTestData.TestName
+			$currentTestResult.TestSummary += New-ResultSummary -testResult $clientNtttcpStatus -metaData "State" -testName $CurrentTestData.TestName
+			Write-LogInfo "Adding resource group tag: NTTTCP_MONITOR_THROUGHPUT=yes Started_Time=$(Get-Date)"
+			$resourceGroupName = $clientVMData.ResourceGroupName
+			if ($resourceGroupName) {
+				Add-ResourceGroupTag -ResourceGroup $resourceGroupName -TagName "NTTTCP_MONITOR_THROUGHPUT" -TagValue "yes" | Out-Null
+				Add-ResourceGroupTag -ResourceGroup $resourceGroupName -TagName "Started_Time" -TagValue "$(Get-Date)" | Out-Null
+				Write-LogInfo "Adding Timer Lock on the resource group $resourceGroupName"
+				New-AzResourceLock -LockName "Timer Lock" -LockLevel CanNotDelete -ResourceGroupName $resourceGroupName -Force | Out-Null
+			}
+		}
+		else {
+			Write-LogErr "Failed to start NTTTCP client"
+			$currentTestResult.TestResult = $global:ResultFail
+		}
+	}
+	return $currentTestResult
+}
+
+Main -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n"))

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -793,4 +793,16 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>NESTED_VHD_URL</ReplaceThis>
 		<ReplaceWith></ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>NTTTCP_MONITOR_SECS_RUNTIME</ReplaceThis>
+		<ReplaceWith>2592000</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>NTTTCP_MONITOR_INTERVAL</ReplaceThis>
+		<ReplaceWith>5</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>NTTTCP_MONITOR_TOLERANCE</ReplaceThis>
+		<ReplaceWith>0.3</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/Other.xml
+++ b/XML/TestCases/Other.xml
@@ -76,4 +76,22 @@
       <SetupType>long-term</SetupType>
     </SetupConfig>
   </test>
+  <test>
+    <testName>NTTTCP-MONITOR-THROUGHPUT</testName>
+    <testScript>NTTTCP-MONITOR-THROUGHPUT.ps1</testScript>
+    <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\ntttcp_monitor_throughput.sh</files>
+    <Platform>Azure</Platform>
+    <TestParameters>
+      <param>seconds_of_runtime=NTTTCP_MONITOR_SECS_RUNTIME</param>
+      <param>monitor_interval=NTTTCP_MONITOR_INTERVAL</param>
+      <param>tolerance=NTTTCP_MONITOR_TOLERANCE</param>
+      <param>ntttcp_version=master</param>
+    </TestParameters>
+    <Category></Category>
+    <Area></Area>
+    <Tags>ntttcp_monitor</Tags>
+    <SetupConfig>
+      <SetupType>TwoVM2Host</SetupType>
+    </SetupConfig>
+  </test>
 </TestCases>


### PR DESCRIPTION
- Add test case for long time (e.g., 30 days) running ntttcp and monitoring throughput, if out of tolerance (e.g., tolerance 0.3, if throughput < 0.7 * throughput_baseline, or throughput > 1.3 * throughput_baseline), Logging throughput failure with date time info, but testing will continue.  Eventually,  long running VM instance will generate summary reports at the end of testing (30 days later), and saved those logs and reports in the 'log_dir ' of VM instance.

- But once testing has been started successfully, LISA will return result of test case PASS. Otherwise,  LISA will report FAIL


============Test Log=================
[LISAv2 Test Results Summary]
Test Run On           : 11/06/2020 23:17:04
Override VM size Under Test  : Standard_DS2_v2
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1                      NTTTCP-MONITOR-THROUGHPUT                                                         PASS                 3.24 
      ARMImageName: Canonical UbuntuServer 18.04-LTS Latest, OverrideVMSize: Standard_DS2_v2, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
      Monitor NTTTCP Started Successfully : Client Address: xxxx:1112, Server Address: xxxx:1111
      State : TestRunning, EndTime: 2020-12-06 23:22:18, Baseline: 1.33 Gbps,  Tolerance: +/- 0.3, Now throughput: 1.33333 Gbps
      


Logs can be found at C:\LISAv2\DL64\TestResults\2020-11-06-23-16-25-3490


11/06/2020 23:23:13 : [DEBUG] Creating 'C:\LISAv2\DL64\Azure-DL64-TestLogs.zip' from 'C:\LISAv2\DL64\TestResults\2020-11-06-23-16-25-3490'
11/06/2020 23:23:14 : [DEBUG] C:\LISAv2\DL64\Azure-DL64-TestLogs.zip created successfully.
11/06/2020 23:23:14 : [INFO ] Analyzing test results ...
11/06/2020 23:23:14 : [INFO ] LISAv2 exit code: 0
