### PR TITLE
Fix test issues on SLES15 SP1.

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -136,7 +136,7 @@ function Install_Dpdk_Dependencies() {
 		fi
 		ssh ${install_ip} "yum install --nogpgcheck ${yum_flags} --setopt=skip_missing_names_on_install=False -y gcc make git tar wget dos2unix psmisc kernel-devel-$(uname -r) numactl-devel.x86_64 librdmacm-devel libmnl-devel meson"
 
-	elif [[ "${distro}" == "sles15" ]]; then
+	elif [[ "${distro}" =~ sles15* ]]; then
 		local kernel=$(uname -r)
 		dependencies_install_command="zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install gcc make git tar wget dos2unix psmisc libnuma-devel numactl librdmacm1 rdma-core-devel libmnl-devel meson"
 		if [[ "${kernel}" == *azure ]]; then
@@ -147,7 +147,7 @@ function Install_Dpdk_Dependencies() {
 		fi
 
 		ssh "${install_ip}" "${dependencies_install_command}"
-		ssh ${install_ip} "ln -sf /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
+		ssh "${install_ip}" "ln -sf /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
 	else
 		LogErr "ERROR: unsupported distro ${distro} for DPDK on Azure"
 		SetTestStateAborted
@@ -244,6 +244,7 @@ function Install_Dpdk () {
 			# default meson in SUSE 15-SP1 is 0.46 & required is 0.47. Installing it separately
 			ssh "${1}" ". utils.sh && install_package ninja"
 			ssh "${1}" "rpm -ivh https://download.opensuse.org/repositories/openSUSE:/Leap:/15.2/standard/noarch/meson-0.54.2-lp152.1.1.noarch.rpm"
+			ssh "${1}" "ln -sf /usr/include/libmnl/libmnl/libmnl.h /usr/include/libmnl/libmnl.h"
 			;;
 		*)
 			echo "Unknown distribution"

--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -46,6 +46,12 @@ Install_KVM_Dependencies()
         SetTestStateSkipped
         exit 0
     fi
+    lscpu | grep -i vt
+    if [ $? != 0 ]; then
+        LogMsg "CPU type is not VT-x. Skip the test."
+        SetTestStateSkipped
+        exit 0
+    fi
     update_repos
     install_package qemu-kvm
     check_package "bridge-utils"


### PR DESCRIPTION
VERIFY-DPDK-RING-LATENCY 

```
[LISAv2 Test Results Summary]
Test Run On           : 11/05/2020 15:19:54
ARM Image Under Test  : suse : sles-15-sp1 : gen2 : latest
Override VM size Under Test  : Standard_M208s_v2
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-RING-LATENCY                                                          PASS                 4.32 
      ARMImageName: suse sles-15-sp1 gen2 latest, Networking: SRIOV, OverrideVMSize: Standard_M208s_v2, TestLocation: westus2, Kernel Version: 4.12.14-8.33-azure
```

NESTED-KVM-BASIC-VERIFICATION - skip when CPU Virtualization type is not vt-x.
```
Test Run On           : 11/05/2020 15:29:19
ARM Image Under Test  : suse : sles-15-sp1 : gen2 : latest
Override VM size Under Test  : Standard_M208s_v2
Total Test Cases      : 1 (0 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-BASIC-VERIFICATION                                                  SKIPPED                 1.33 
      ARMImageName: suse sles-15-sp1 gen2 latest, OverrideVMSize: Standard_M208s_v2, TestLocation: westus2, Kernel Version: 4.12.14-8.33-azure
```