### PR TITLE
Update pattern for checking panic and call trace from dmesg.

### DIFF
--- a/testsuites/basic/provisioning.py
+++ b/testsuites/basic/provisioning.py
@@ -23,11 +23,11 @@ class Provisioning(TestSuite):
         node = self.environment.default_node
         dmesg = node.tools[Dmesg]
 
-        dmesg.check_kernel_panic()
+        dmesg.check_kernel_errors()
 
         timer = create_timer()
         self.log.info(f"restarting {node.name}")
         node.reboot()
         self.log.info(f"node {node.name} rebooted in {timer}, trying connecting")
 
-        dmesg.check_kernel_panic(force_run=True)
+        dmesg.check_kernel_errors(force_run=True)


### PR DESCRIPTION
1. When VM is in connected status, we can check call trace by run dmesg directly. (Remove check timestamp part)
2. When VM is in disconnected status for a while, we need download serial console and check panic from there. (not included in this PR)

Two images tested for this change.
OpenLogic CentOS 6.10 6.10.20180709 - no call trace, not panic, but we get failure using current code. => Now, it pass using updated code.
`failed: dmesg error with 26099 lines, first line: 'Initializing cgroup subsys cpuset'`

abiquo abiquo-hybrid-cloud-34 abiquo-340-monolithic 4.0.1 - has call trace. => Current code can catch call trace and test fail.
Previous result - fail with `failed: dmesg error with 552 lines, first line: 'Initializing cgroup subsys cpuset'`
Current result - fail with `failed: dmesg error with 1 lines, first line: 'Call Trace:'`

