### PR TITLE
create storage account outside of arm template

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -8,6 +8,12 @@
                 "description": "resource group name"
             }
         },
+        "storageName": {
+            "type": "string",
+            "metadata": {
+                "description": "storage name for boot diagnosis"
+            }
+        },
         "location": {
             "type": "string",
             "metadata": {
@@ -58,7 +64,6 @@
         }
     },
     "variables": {
-        "storageName": "[concat('lisas', substring(parameters('location'),0,min(11, length(parameters('location')))), substring(subscription().id,sub(length(subscription().id),8),8))]",
         "sharedRGName": "lisa_shared_resource",
         "storageDeploymentName": "[concat('storage-deploy-', substring(parameters('resourceGroupName'),sub(length(parameters('resourceGroupName')),22),22))]"
     },
@@ -85,7 +90,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageName": {
-                        "value": "[variables('storageName')]"
+                        "value": "[parameters('storageName')]"
                     }
                 },
                 "mode": "Incremental",
@@ -161,7 +166,7 @@
                         "value": "[parameters('availabilitySetProperties')]"
                     },
                     "storageName": {
-                        "value": "[variables('storageName')]"
+                        "value": "[parameters('storageName')]"
                     },
                     "sharedRGName": {
                         "value": "[variables('sharedRGName')]"

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "resourceGroupName": {
@@ -18,12 +18,6 @@
             "type": "string",
             "metadata": {
                 "description": "location"
-            }
-        },
-        "resourceGroupLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "location of resource groups, fixed location prevents errors"
             }
         },
         "nodes": {
@@ -65,111 +59,87 @@
     },
     "variables": {
         "sharedRGName": "lisa_shared_resource",
-        "storageDeploymentName": "[concat('storage-deploy-', substring(parameters('resourceGroupName'),sub(length(parameters('resourceGroupName')),22),22))]"
+        "virtualNetworkName": "lisa-virtualNetwork",
+        "defaultSubnet": "lisa-subnetForPrimaryNIC",
+        "vnetId": "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "nodeCount": "[length(parameters('nodes'))]",
+        "availabilitySetName": "lisa-availabilitySet",
+        "defaultSubnetId": "[concat(variables('vnetId'),'/subnets/', variables('defaultSubnet'))]"
     },
     "resources": [
         {
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2020-06-01",
-            "name": "[variables('sharedRGName')]",
-            "location": "[parameters('resourceGroupLocation')]",
-            "properties": {}
+            "apiVersion": "2019-07-01",
+            "type": "Microsoft.Compute/availabilitySets",
+            "name": "[variables('availabilitySetName')]",
+            "location": "[parameters('location')]",
+            "tags": "[parameters('availabilitySetTags')]",
+            "sku": {
+                "name": "Aligned"
+            },
+            "properties": "[parameters('availabilitySetProperties')]"
         },
         {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2019-10-01",
-            "name": "[variables('storageDeploymentName')]",
-            "resourceGroup": "[variables('sharedRGName')]",
-            "dependsOn": [ "[variables('sharedRGName')]" ],
+            "apiVersion": "2020-05-01",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "location": "[parameters('location')]",
+            "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip')]",
+            "copy": {
+                "name": "vmCopy",
+                "count": "[variables('nodeCount')]"
+            },
             "properties": {
-                "expressionEvaluationOptions": {
-                    "scope": "inner"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[parameters('location')]"
-                    },
-                    "storageName": {
-                        "value": "[parameters('storageName')]"
-                    }
-                },
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "location": {
-                            "type": "string"
-                        },
-                        "storageName": {
-                            "type": "string"
-                        }
-                    },
-                    "resources": [
-                        {
-                            "name": "[parameters('storageName')]",
-                            "type": "Microsoft.Storage/storageAccounts",
-                            "apiVersion": "2019-06-01",
-                            "location": "[parameters('location')]",
-                            "kind": "StorageV2",
-                            "sku": {
-                                "name": "Standard_LRS"
-                            }
-                        }
-                    ]
-                }
+                "publicIPAllocationMethod": "Dynamic"
             }
         },
         {
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2020-06-01",
-            "name": "[parameters('resourceGroupName')]",
-            "location": "[parameters('resourceGroupLocation')]",
-            "properties": {}
+            "apiVersion": "2020-05-01",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.0.0.0/16"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('defaultSubnet')]",
+                        "properties": {
+                            "addressPrefix": "10.0.0.0/24"
+                        }
+                    }
+                ]
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2019-10-01",
-            "name": "lisa-deployment",
-            "resourceGroup": "[parameters('resourceGroupName')]",
+            "copy": {
+                "name": "vmCopy",
+                "count": "[variables('nodeCount')]"
+            },
+            "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]",
             "dependsOn": [
-                "[parameters('resourceGroupName')]",
-                "[variables('storageDeploymentName')]"
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip'))]",
+                "[variables('vnetId')]"
             ],
             "properties": {
                 "expressionEvaluationOptions": {
                     "scope": "inner"
                 },
                 "parameters": {
-                    "resourceGroupName": {
-                        "value": "[parameters('resourceGroupName')]"
+                    "vmName": {
+                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['name']]"
+                    },
+                    "nicCount": {
+                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]"
                     },
                     "location": {
                         "value": "[parameters('location')]"
                     },
-                    "nodes": {
-                        "value": "[parameters('nodes')]"
-                    },
-                    "adminUsername": {
-                        "value": "[parameters('adminUsername')]"
-                    },
-                    "adminPassword": {
-                        "value": "[parameters('adminPassword')]"
-                    },
-                    "adminKeyData": {
-                        "value": "[parameters('adminKeyData')]"
-                    },
-                    "availabilitySetTags": {
-                        "value": "[parameters('availabilitySetTags')]"
-                    },
-                    "availabilitySetProperties": {
-                        "value": "[parameters('availabilitySetProperties')]"
-                    },
-                    "storageName": {
-                        "value": "[parameters('storageName')]"
-                    },
-                    "sharedRGName": {
-                        "value": "[variables('sharedRGName')]"
+                    "defaultSubnetId": {
+                        "value": "[variables('defaultSubnetId')]"
                     }
                 },
                 "mode": "Incremental",
@@ -177,292 +147,51 @@
                     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
                     "parameters": {
-                        "resourceGroupName": {
+                        "vmName": {
                             "type": "string"
+                        },
+                        "nicCount": {
+                            "type": "int"
                         },
                         "location": {
                             "type": "string"
                         },
-                        "nodes": {
-                            "type": "array"
-                        },
-                        "adminUsername": {
-                            "type": "string"
-                        },
-                        "adminPassword": {
-                            "type": "string"
-                        },
-                        "adminKeyData": {
-                            "type": "string"
-                        },
-                        "availabilitySetTags": {
-                            "type": "object"
-                        },
-                        "availabilitySetProperties": {
-                            "type": "object"
-                        },
-                        "storageName": {
-                            "type": "string"
-                        },
-                        "sharedRGName": {
+                        "defaultSubnetId": {
                             "type": "string"
                         }
                     },
-                    "variables": {
-                        "virtualNetworkName": "lisa-virtualNetwork",
-                        "defaultSubnet": "lisa-subnetForPrimaryNIC",
-                        "vnetId": "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-                        "nodeCount": "[length(parameters('nodes'))]",
-                        "availabilitySetName": "lisa-availabilitySet",
-                        "defaultSubnetId": "[concat(variables('vnetId'),'/subnets/', variables('defaultSubnet'))]"
-                    },
                     "resources": [
                         {
-                            "apiVersion": "2019-07-01",
-                            "type": "Microsoft.Compute/availabilitySets",
-                            "name": "[variables('availabilitySetName')]",
-                            "location": "[parameters('location')]",
-                            "tags": "[parameters('availabilitySetTags')]",
-                            "sku": {
-                                "name": "Aligned"
-                            },
-                            "properties": "[parameters('availabilitySetProperties')]"
-                        },
-                        {
                             "apiVersion": "2020-05-01",
-                            "type": "Microsoft.Network/publicIPAddresses",
-                            "location": "[parameters('location')]",
-                            "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip')]",
+                            "type": "Microsoft.Network/networkInterfaces",
                             "copy": {
-                                "name": "vmCopy",
-                                "count": "[variables('nodeCount')]"
+                                "name": "nicCopy",
+                                "count": "[parameters('nicCount')]"
                             },
-                            "properties": {
-                                "publicIPAllocationMethod": "Dynamic"
-                            }
-                        },
-                        {
-                            "apiVersion": "2020-05-01",
-                            "type": "Microsoft.Network/virtualNetworks",
-                            "name": "[variables('virtualNetworkName')]",
+                            "name": "[concat(parameters('vmName'), '-nic-', copyIndex('nicCopy'))]",
                             "location": "[parameters('location')]",
                             "properties": {
-                                "addressSpace": {
-                                    "addressPrefixes": [
-                                        "10.0.0.0/16"
-                                    ]
-                                },
-                                "subnets": [
+                                "ipConfigurations": [
                                     {
-                                        "name": "[variables('defaultSubnet')]",
+                                        "name": "IPv4Config",
                                         "properties": {
-                                            "addressPrefix": "10.0.0.0/24"
+                                            "privateIPAddressVersion": "IPv4",
+                                            "publicIPAddress": "[if(equals(0, copyIndex('nicCopy')), network.getPublicIpAddress(parameters('vmName')), json('null'))]",
+                                            "subnet": {
+                                                "id": "[parameters('defaultSubnetId')]"
+                                            },
+                                            "privateIPAllocationMethod": "Dynamic"
                                         }
                                     }
                                 ]
-                            }
-                        },
-                        {
-                            "type": "Microsoft.Resources/deployments",
-                            "apiVersion": "2019-10-01",
-                            "copy": {
-                                "name": "vmCopy",
-                                "count": "[variables('nodeCount')]"
-                            },
-                            "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip'))]",
-                                "[variables('vnetId')]"
-                            ],
-                            "properties": {
-                                "expressionEvaluationOptions": {
-                                    "scope": "inner"
-                                },
-                                "parameters": {
-                                    "vmName": {
-                                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['name']]"
-                                    },
-                                    "nicCount": {
-                                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]"
-                                    },
-                                    "location": {
-                                        "value": "[parameters('location')]"
-                                    },
-                                    "defaultSubnetId": {
-                                        "value": "[variables('defaultSubnetId')]"
-                                    }
-                                },
-                                "mode": "Incremental",
-                                "template": {
-                                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                                    "contentVersion": "1.0.0.0",
-                                    "parameters": {
-                                        "vmName": {
-                                            "type": "string"
-                                        },
-                                        "nicCount": {
-                                            "type": "int"
-                                        },
-                                        "location": {
-                                            "type": "string"
-                                        },
-                                        "defaultSubnetId": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "resources": [
-                                        {
-                                            "apiVersion": "2020-05-01",
-                                            "type": "Microsoft.Network/networkInterfaces",
-                                            "copy": {
-                                                "name": "nicCopy",
-                                                "count": "[parameters('nicCount')]"
-                                            },
-                                            "name": "[concat(parameters('vmName'), '-nic-', copyIndex('nicCopy'))]",
-                                            "location": "[parameters('location')]",
-                                            "properties": {
-                                                "ipConfigurations": [
-                                                    {
-                                                        "name": "IPv4Config",
-                                                        "properties": {
-                                                            "privateIPAddressVersion": "IPv4",
-                                                            "publicIPAddress": "[if(equals(0, copyIndex('nicCopy')), network.getPublicIpAddress(parameters('vmName')), json('null'))]",
-                                                            "subnet": {
-                                                                "id": "[parameters('defaultSubnetId')]"
-                                                            },
-                                                            "privateIPAllocationMethod": "Dynamic"
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ],
-                                    "functions": [
-                                        {
-                                            "namespace": "network",
-                                            "members": {
-                                                "getPublicIpAddress": {
-                                                    "parameters": [
-                                                        {
-                                                            "name": "vmName",
-                                                            "type": "string"
-                                                        }
-                                                    ],
-                                                    "output": {
-                                                        "type": "object",
-                                                        "value": {
-                                                            "id": "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('vmName'),'-public-ip'))]"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "apiVersion": "2019-03-01",
-                            "type": "Microsoft.Compute/images",
-                            "copy": {
-                                "name": "imageCopy",
-                                "count": "[variables('nodeCount')]"
-                            },
-                            "condition": "[not(empty(parameters('nodes')[copyIndex('imageCopy')]['vhd']))]",
-                            "name": "[concat(parameters('nodes')[copyIndex('imageCopy')]['name'], '-image')]",
-                            "location": "[parameters('location')]",
-                            "properties": {
-                                "storageProfile": {
-                                    "osDisk": {
-                                        "osType": "Linux",
-                                        "osState": "Generalized",
-                                        "blobUri": "[parameters('nodes')[copyIndex('imageCopy')]['vhd']]",
-                                        "storageAccountType": "Standard_LRS"
-                                    }
-                                },
-                                "hyperVGeneration": "V1"
-                            }
-                        },
-                        {
-                            "apiVersion": "2019-07-01",
-                            "type": "Microsoft.Compute/virtualMachines",
-                            "copy": {
-                                "name": "vmCopy",
-                                "count": "[variables('nodeCount')]"
-                            },
-                            "name": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
-                            "location": "[parameters('nodes')[copyIndex('vmCopy')]['location']]",
-                            "tags": { "RG": "[parameters('resourceGroupName')]" },
-                            "plan": "[parameters('nodes')[copyIndex('vmCopy')]['purchasePlan']]",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]",
-                                "[resourceId('Microsoft.Compute/images', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-image'))]",
-                                "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]"
-                            ],
-                            "properties": {
-                                "availabilitySet": {
-                                    "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
-                                },
-                                "hardwareProfile": {
-                                    "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vmSize']]"
-                                },
-                                "osProfile": {
-                                    "computername": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
-                                    "adminUsername": "[parameters('adminUserName')]",
-                                    "adminPassword": "[if(empty(parameters('adminKeyData')), parameters('adminPassword'), json('null'))]",
-                                    "linuxConfiguration": "[if(empty(parameters('adminKeyData')), json('null'), lisa.getLinuxConfiguration(concat('/home/', parameters('adminUserName'), '/.ssh/authorized_keys'), parameters('adminKeyData')))]"
-                                },
-                                "storageProfile": {
-                                    "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), lisa.getOsDiskGallery(parameters('nodes')[copyIndex('vmCopy')]))]",
-                                    "osDisk": {
-                                        "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-osDisk')]",
-                                        "managedDisk": {
-                                            "storageAccountType": "Standard_LRS"
-                                        },
-                                        "caching": "ReadWrite",
-                                        "createOption": "FromImage"
-                                    }
-                                },
-                                "networkProfile": {
-                                    "copy": [
-                                        {
-                                            "name": "networkInterfaces",
-                                            "count": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]",
-                                            "input": {
-                                                "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-nic-', copyIndex('networkInterfaces')))]",
-                                                "properties": {
-                                                    "primary": "[if(equals(copyIndex('networkInterfaces'),0), json('true'), json('false'))]"
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "diagnosticsProfile": {
-                                    "bootDiagnostics": {
-                                        "enabled": true,
-                                        "storageUri": "[reference(resourceId(parameters('sharedRGName'), 'Microsoft.Storage/storageAccounts', parameters('storageName')), '2015-06-15').primaryEndpoints['blob']]"
-                                    }
-                                }
                             }
                         }
                     ],
                     "functions": [
                         {
-                            "namespace": "lisa",
+                            "namespace": "network",
                             "members": {
-                                "getOsDiskGallery": {
-                                    "parameters": [
-                                        {
-                                            "name": "node",
-                                            "type": "object"
-                                        }
-                                    ],
-                                    "output": {
-                                        "type": "object",
-                                        "value": "[parameters('node')['gallery']]"
-                                    }
-                                },
-                                "getOsDiskVhd": {
+                                "getPublicIpAddress": {
                                     "parameters": [
                                         {
                                             "name": "vmName",
@@ -472,40 +201,157 @@
                                     "output": {
                                         "type": "object",
                                         "value": {
-                                            "id": "[resourceId('Microsoft.Compute/images', concat(parameters('vmName'), '-image'))]"
-                                        }
-                                    }
-                                },
-                                "getLinuxConfiguration": {
-                                    "parameters": [
-                                        {
-                                            "name": "keyPath",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "name": "publicKeyData",
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "output": {
-                                        "type": "object",
-                                        "value": {
-                                            "disablePasswordAuthentication": true,
-                                            "ssh": {
-                                                "publicKeys": [
-                                                    {
-                                                        "path": "[parameters('keyPath')]",
-                                                        "keyData": "[parameters('publicKeyData')]"
-                                                    }
-                                                ]
-                                            },
-                                            "provisionVMAgent": true
+                                            "id": "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('vmName'),'-public-ip'))]"
                                         }
                                     }
                                 }
                             }
                         }
                     ]
+                }
+            }
+        },
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/images",
+            "copy": {
+                "name": "imageCopy",
+                "count": "[variables('nodeCount')]"
+            },
+            "condition": "[not(empty(parameters('nodes')[copyIndex('imageCopy')]['vhd']))]",
+            "name": "[concat(parameters('nodes')[copyIndex('imageCopy')]['name'], '-image')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "storageProfile": {
+                    "osDisk": {
+                        "osType": "Linux",
+                        "osState": "Generalized",
+                        "blobUri": "[parameters('nodes')[copyIndex('imageCopy')]['vhd']]",
+                        "storageAccountType": "Standard_LRS"
+                    }
+                },
+                "hyperVGeneration": "V1"
+            }
+        },
+        {
+            "apiVersion": "2019-07-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "copy": {
+                "name": "vmCopy",
+                "count": "[variables('nodeCount')]"
+            },
+            "name": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
+            "location": "[parameters('nodes')[copyIndex('vmCopy')]['location']]",
+            "tags": { "RG": "[parameters('resourceGroupName')]" },
+            "plan": "[parameters('nodes')[copyIndex('vmCopy')]['purchasePlan']]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]",
+                "[resourceId('Microsoft.Compute/images', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-image'))]",
+                "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]"
+            ],
+            "properties": {
+                "availabilitySet": {
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vmSize']]"
+                },
+                "osProfile": {
+                    "computername": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
+                    "adminUsername": "[parameters('adminUserName')]",
+                    "adminPassword": "[if(empty(parameters('adminKeyData')), parameters('adminPassword'), json('null'))]",
+                    "linuxConfiguration": "[if(empty(parameters('adminKeyData')), json('null'), lisa.getLinuxConfiguration(concat('/home/', parameters('adminUserName'), '/.ssh/authorized_keys'), parameters('adminKeyData')))]"
+                },
+                "storageProfile": {
+                    "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), lisa.getOsDiskGallery(parameters('nodes')[copyIndex('vmCopy')]))]",
+                    "osDisk": {
+                        "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-osDisk')]",
+                        "managedDisk": {
+                            "storageAccountType": "Standard_LRS"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "copy": [
+                        {
+                            "name": "networkInterfaces",
+                            "count": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]",
+                            "input": {
+                                "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-nic-', copyIndex('networkInterfaces')))]",
+                                "properties": {
+                                    "primary": "[if(equals(copyIndex('networkInterfaces'),0), json('true'), json('false'))]"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(resourceId(variables('sharedRGName'), 'Microsoft.Storage/storageAccounts', parameters('storageName')), '2015-06-15').primaryEndpoints['blob']]"
+                    }
+                }
+            }
+        }
+    ],
+    "functions": [
+        {
+            "namespace": "lisa",
+            "members": {
+                "getOsDiskGallery": {
+                    "parameters": [
+                        {
+                            "name": "node",
+                            "type": "object"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": "[parameters('node')['gallery']]"
+                    }
+                },
+                "getOsDiskVhd": {
+                    "parameters": [
+                        {
+                            "name": "vmName",
+                            "type": "string"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": {
+                            "id": "[resourceId('Microsoft.Compute/images', concat(parameters('vmName'), '-image'))]"
+                        }
+                    }
+                },
+                "getLinuxConfiguration": {
+                    "parameters": [
+                        {
+                            "name": "keyPath",
+                            "type": "string"
+                        },
+                        {
+                            "name": "publicKeyData",
+                            "type": "string"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": {
+                            "disablePasswordAuthentication": true,
+                            "ssh": {
+                                "publicKeys": [
+                                    {
+                                        "path": "[parameters('keyPath')]",
+                                        "keyData": "[parameters('publicKeyData')]"
+                                    }
+                                ]
+                            },
+                            "provisionVMAgent": true
+                        }
+                    }
                 }
             }
         }

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from azure.mgmt.compute import ComputeManagementClient  # type: ignore
 from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements  # type: ignore
+from azure.mgmt.storage import StorageManagementClient  # type: ignore
 
 from lisa.environment import Environment
 from lisa.node import Node
@@ -38,6 +39,21 @@ def get_compute_client(platform: Any) -> ComputeManagementClient:
         credential=azure_platform.credential,
         subscription_id=azure_platform.subscription_id,
     )
+
+
+def get_storage_client(platform: Any) -> ComputeManagementClient:
+    azure_platform: AzurePlatform = platform
+    return StorageManagementClient(
+        credential=azure_platform.credential,
+        subscription_id=azure_platform.subscription_id,
+    )
+
+
+def get_storage_account_name(platform: Any, location: str) -> str:
+    azure_platform: AzurePlatform = platform
+    subscription_id_postfix = azure_platform.subscription_id[-8:]
+    # name should be shorter than 24 charactor
+    return f"lisas{location[0:11]}{subscription_id_postfix}"
 
 
 def get_marketplace_ordering_client(platform: Any) -> MarketplaceOrderingAgreements:

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -28,6 +28,7 @@ from azure.mgmt.resource.resources.models import (  # type: ignore
     DeploymentMode,
     DeploymentProperties,
 )
+from azure.mgmt.storage.models import Sku, StorageAccountCreateParameters  # type:ignore
 from dataclasses_json import LetterCase, dataclass_json  # type: ignore
 from marshmallow import fields, validate
 from retry import retry  # type: ignore
@@ -56,11 +57,14 @@ from .common import (
     get_environment_context,
     get_marketplace_ordering_client,
     get_node_context,
+    get_storage_account_name,
+    get_storage_client,
     wait_operation,
 )
 
 # used by azure
 AZURE_RG_NAME_KEY = "resource_group_name"
+AZURE_SHARED_RG_NAME = "lisa_shared_resource"
 
 VM_SIZE_FALLBACK_PATTERNS = [
     # exclude Standard_DS1_v2, because one core is too slow,
@@ -196,6 +200,7 @@ class AzureNodeSchema:
 class AzureArmParameter:
     resource_group_name: str = ""
     resource_group_location: str = ""
+    storage_name: str = ""
     location: str = ""
     admin_username: str = ""
     admin_password: str = ""
@@ -779,6 +784,9 @@ class AzurePlatform(Platform):
             log.info(f"vm setting: {azure_node_runbook}")
 
         arm_parameters.nodes = nodes_parameters
+        arm_parameters.storage_name = get_storage_account_name(
+            self, arm_parameters.location
+        )
 
         # load template
         template = self._load_template()
@@ -797,7 +805,7 @@ class AzurePlatform(Platform):
             "deployment_name": f"lisa_deploy_"
             f"{environment_context.resource_group_name[-50:]}",
             "parameters": Deployment(
-                location=RESOURCE_GROUP_LOCATION, properties=deployment_properties
+                location=arm_parameters.location, properties=deployment_properties
             ),
         }
 
@@ -830,6 +838,10 @@ class AzurePlatform(Platform):
 
     def _deploy(self, deployment_parameters: Dict[str, Any], log: Logger) -> None:
         log.info("deployment is in progress...")
+
+        self._check_or_create_storage_account(
+            location=deployment_parameters["parameters"].location, log=log
+        )
 
         deployment_operation: Any = None
         deployments = self._rm_client.deployments
@@ -1059,3 +1071,32 @@ class AzurePlatform(Platform):
                 publisher=image_info.plan.publisher,
             )
         return plan
+
+    def _check_or_create_storage_account(self, location: str, log: Logger) -> None:
+        # check and deploy storage account.
+        # storage account can be deployed inside of arm template, but if the concurrent
+        # is too big, Azure may not able to delete deployment script on time. so there
+        # will be error like below
+        # Creating the deployment 'name' would exceed the quota of '800'.
+        storage_client = get_storage_client(self)
+        storage_account_exists = True
+        account_name = get_storage_account_name(platform=self, location=location)
+        try:
+            storage_client.storage_accounts.get_properties(
+                account_name=account_name,
+                resource_group_name=AZURE_SHARED_RG_NAME,
+            )
+            log.debug(f"found storage account: {account_name}")
+        except Exception:
+            storage_account_exists = False
+        if not storage_account_exists:
+            log.debug(f"creating storage account: {account_name}")
+            parameters = StorageAccountCreateParameters(
+                sku=Sku(name="Standard_LRS"), kind="StorageV2", location=location
+            )
+            operation = storage_client.storage_accounts.begin_create(
+                resource_group_name=AZURE_SHARED_RG_NAME,
+                account_name=account_name,
+                parameters=parameters,
+            )
+            wait_operation(operation)

--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,19 @@ azure-mgmt-core = ">=1.2.0,<2.0.0"
 msrest = ">=0.5.0"
 
 [[package]]
+name = "azure-mgmt-storage"
+version = "16.0.0"
+description = "Microsoft Azure Storage Management Client Library for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+azure-common = ">=1.1,<2.0"
+azure-mgmt-core = ">=1.2.0,<2.0.0"
+msrest = ">=0.5.0"
+
+[[package]]
 name = "bcrypt"
 version = "3.2.0"
 description = "Modern password hashing for your software and your servers"
@@ -964,7 +977,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "22e17ec78556ebdada79c492c967e90c6f4b3cec0489a4655f6a33d7066fbba8"
+content-hash = "a44f707696fdb38afd23be8723eccd02e6aa375323aafaf2a995b586901a2ac8"
 
 [metadata.files]
 adal = [
@@ -1017,6 +1030,10 @@ azure-mgmt-network = [
 azure-mgmt-resource = [
     {file = "azure-mgmt-resource-15.0.0.zip", hash = "sha256:80ecb69aa21152b924edf481e4b26c641f11aa264120bc322a14284811df9c14"},
     {file = "azure_mgmt_resource-15.0.0-py2.py3-none-any.whl", hash = "sha256:15bb46ef4b197426ce7ce8080a490c997111f3f3efe9f728cf8dc420982d54a2"},
+]
+azure-mgmt-storage = [
+    {file = "azure-mgmt-storage-16.0.0.zip", hash = "sha256:2f9d714d9722b1ef4bac6563676612e6e795c4e90f6f3cd323616fdadb0a99e5"},
+    {file = "azure_mgmt_storage-16.0.0-py2.py3-none-any.whl", hash = "sha256:a819e421d50c0b58416b551d3e9e9a9cf6029714cf977ffaaee86a37572e7113"},
 ]
 bcrypt = [
     {file = "bcrypt-3.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ azure-mgmt-resource = {version = "^15.0.0-beta.1", allow-prereleases = true}
 azure-mgmt-compute = {version = "^17.0.0-beta.1", allow-prereleases = true}
 azure-mgmt-marketplaceordering = {version = "^0.2.1", allow-prereleases = true}
 azure-mgmt-network = {version = "^16.0.0-beta.1", allow-prereleases = true}
+azure-mgmt-storage = {version = "^16.0.0", allow-prereleases = true}
 asserts = "^0.11.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
There are concurrent issues on Azure deployment script count. If too many deployments in progress in subscription level, the old scripts may not able to deleted on time. Deploy storage account outside of template to workaround it.