### PR TITLE
Add serial log into smoke test, and improve SSH timeout

### DIFF
--- a/lisa/features/__init__.py
+++ b/lisa/features/__init__.py
@@ -1,3 +1,4 @@
+from .serial_console import SerialConsole
 from .startstop import StartStop
 
-__all__ = ["StartStop"]
+__all__ = ["SerialConsole", "StartStop"]

--- a/lisa/features/serial_console.py
+++ b/lisa/features/serial_console.py
@@ -1,0 +1,62 @@
+import re
+from pathlib import Path
+from typing import Any, List, Optional, Pattern
+
+from lisa.feature import Feature
+from lisa.util import LisaException, find_patterns_in_lines, get_datetime_path
+
+FEATURE_NAME_SERIAL_CONSOLE = "SerialConsole"
+
+
+class SerialConsole(Feature):
+    panic_patterns: List[Pattern[str]] = [
+        re.compile(r"^(.*Kernel panic - not syncing:.*)$", re.MULTILINE),
+        re.compile(r"^(.*RIP:.*)$", re.MULTILINE),
+        re.compile(r"^(.*grub>.*)$", re.MULTILINE),
+    ]
+
+    @classmethod
+    def name(cls) -> str:
+        return FEATURE_NAME_SERIAL_CONSOLE
+
+    @classmethod
+    def enabled(cls) -> bool:
+        # most platform support shutdown
+        return True
+
+    @classmethod
+    def can_disable(cls) -> bool:
+        # no reason to disable it, it can not be used
+        return False
+
+    def _get_console_log(self, saved_path: Optional[Path]) -> bytes:
+        """
+        there may be another logs like screenshot can be saved, so pass path into
+        """
+        raise NotImplementedError()
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self._cached_console_log: Optional[bytes] = None
+
+    def get_console_log(
+        self, saved_path: Optional[Path], force_run: bool = False
+    ) -> str:
+        self._node.log.debug("downloading serial log...")
+        if saved_path:
+            saved_path = saved_path.joinpath(get_datetime_path())
+            saved_path.mkdir()
+        if self._cached_console_log is None or force_run:
+            self._cached_console_log = self._get_console_log(saved_path=saved_path)
+        if saved_path:
+            log_file_name = saved_path.joinpath("serial_console.log")
+            with open(log_file_name, mode="wb") as f:
+                f.write(self._cached_console_log)
+        return self._cached_console_log.decode("utf-8")
+
+    def check_panic(self, saved_path: Optional[Path], force_run: bool = False) -> None:
+        self._node.log.debug("checking panic in serial log...")
+        content: str = self.get_console_log(saved_path=saved_path, force_run=force_run)
+        result = find_patterns_in_lines(content, self.panic_patterns)
+        errors = [x for x in result if x]
+        if errors:
+            raise LisaException(f"found panic in serial log: {errors}")

--- a/lisa/main.py
+++ b/lisa/main.py
@@ -8,16 +8,17 @@ from pathlib import Path
 from retry import retry  # type: ignore
 
 from lisa.parameter_parser.argparser import parse_args
-from lisa.util import constants
+from lisa.util import constants, get_datetime_path
 from lisa.util.logger import get_logger, set_level, set_log_file
 from lisa.util.perf_timer import create_timer
 
 
 @retry(FileExistsError, tries=10, delay=0)  # type: ignore
 def create_run_path(root_path: Path) -> Path:
-    date = datetime.utcnow().strftime("%Y%m%d")
-    time = datetime.utcnow().strftime("%H%M%S-%f")[:-3]
-    run_path = Path(f"{date}/{date}-{time}")
+    current_time = datetime.utcnow()
+    date = current_time.strftime("%Y%m%d")
+    date_time = get_datetime_path(current_time)
+    run_path = Path(f"{date}/{date_time}")
     local_path = root_path.joinpath(run_path)
     if local_path.exists():
         raise FileExistsError(f"{local_path} exists, and not found an unique path.")

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1,11 +1,22 @@
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 
-from lisa.features import StartStop as BaseStartStop
+import requests
+
+from lisa import features
+from lisa.node import Node
 
 from .common import get_compute_client, get_node_context, wait_operation
 
 
-class StartStop(BaseStartStop):
+class AzureFeatureMixin:
+    def _initialize_information(self, node: Node) -> None:
+        node_context = get_node_context(node)
+        self._vm_name = node_context.vm_name
+        self._resource_group_name = node_context.resource_group_name
+
+
+class StartStop(AzureFeatureMixin, features.StartStop):
     def _stop(self, wait: bool = True) -> Any:
         return self._execute(wait, "begin_stop")
 
@@ -16,9 +27,8 @@ class StartStop(BaseStartStop):
         return self._execute(wait, "begin_restart")
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
-        node_context = get_node_context(self._node)
-        self._vm_name = node_context.vm_name
-        self._resource_group_name = node_context.resource_group_name
+        super()._initialize(*args, **kwargs)
+        self._initialize_information(self._node)
 
     def _execute(self, wait: bool, operator: str) -> Any:
         compute_client = get_compute_client(self._platform)
@@ -29,3 +39,28 @@ class StartStop(BaseStartStop):
         if wait:
             result = wait_operation(result)
         return result
+
+
+class SerialConsole(AzureFeatureMixin, features.SerialConsole):
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        super()._initialize(*args, **kwargs)
+        self._initialize_information(self._node)
+
+    def _get_console_log(self, saved_path: Optional[Path]) -> bytes:
+        compute_client = get_compute_client(self._platform)
+        diagnostic_data = (
+            compute_client.virtual_machines.retrieve_boot_diagnostics_data(
+                resource_group_name=self._resource_group_name, vm_name=self._vm_name
+            )
+        )
+        if saved_path:
+            screenshot_name = saved_path.joinpath("serial_console.bmp")
+            screenshot_response = requests.get(
+                diagnostic_data.console_screenshot_blob_uri
+            )
+            with open(screenshot_name, mode="wb") as f:
+                f.write(screenshot_response.content)
+
+        log_response = requests.get(diagnostic_data.serial_console_log_blob_uri)
+
+        return log_response.content

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -322,7 +322,7 @@ class AzurePlatform(Platform):
 
     @classmethod
     def supported_features(cls) -> List[Type[Feature]]:
-        return [features.StartStop]
+        return [features.StartStop, features.SerialConsole]
 
     def _prepare_environment(  # noqa: C901
         self, environment: Environment, log: Logger
@@ -987,7 +987,9 @@ class AzurePlatform(Platform):
 
         # all node support start/stop
         node_space.features = search_space.SetSpace[str](is_allow_set=True)
-        node_space.features.add(features.StartStop.name())
+        node_space.features.update(
+            [features.StartStop.name(), features.SerialConsole.name()]
+        )
 
         return node_space
 

--- a/lisa/tests/test_testsuite.py
+++ b/lisa/tests/test_testsuite.py
@@ -71,19 +71,19 @@ class MockTestSuite(TestSuite):
         if self.fail_on_after_case:
             raise LisaException("failed")
 
-    def mock_ut1(self) -> None:
+    def mock_ut1(self, *args: Any, **kwargs: Any) -> None:
         if self.partial_pass:
             raise PartialPassedException("mock_ut1 partial passed")
         while self.fail_case_count > 0:
             self.fail_case_count -= 1
             raise LisaException("mock_ut1 failed")
 
-    def mock_ut2(self) -> None:
+    def mock_ut2(self, *args: Any, **kwargs: Any) -> None:
         pass
 
 
 class MockTestSuite2(TestSuite):
-    def mock_ut3(self) -> None:
+    def mock_ut3(self, *args: Any, **kwargs: Any) -> None:
         pass
 
 

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -255,8 +255,12 @@ class TestCaseMetadata:
         _add_case_metadata(self)
 
         @wraps(self._func)
-        def wrapper(*args: object) -> None:
-            func(*args)
+        def wrapper(*args: Any, **kwargs: Any) -> None:
+            parameters: Dict[str, Any] = dict()
+            for name in kwargs.keys():
+                if name in func.__annotations__:
+                    parameters[name] = kwargs[name]
+            func(*args, **parameters)
 
         return wrapper
 

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -1,5 +1,6 @@
+from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Pattern, Type, TypeVar
+from typing import Any, Dict, Iterable, List, Optional, Pattern, Type, TypeVar
 
 T = TypeVar("T")
 
@@ -54,6 +55,14 @@ class InitializableMixin:
             except Exception as identifier:
                 self._is_initialized = False
                 raise identifier
+
+
+def get_datetime_path(current: Optional[datetime] = None) -> str:
+    if current is None:
+        current = datetime.now()
+    date = current.utcnow().strftime("%Y%m%d")
+    time = current.utcnow().strftime("%H%M%S-%f")[:-3]
+    return f"{date}-{time}"
 
 
 def get_public_key_data(private_key_file_path: str) -> str:


### PR DESCRIPTION

1. Implement serial console feature and azure implementaiton.
1. update smoke_test to check serial console log if tcp port cannot be connected.
1. use tcp ping before ssh connection, it makes ssh timeout predicable, and message is more simple.
1. other improvement related to e2e works, like setup test case path, refactor for sharing code.
