### PR TITLE
dpdk-testFWD: Updates testcase with respect to change in DPDK code.

### DIFF
--- a/Testscripts/Linux/dpdk-testFWD.sh
+++ b/Testscripts/Linux/dpdk-testFWD.sh
@@ -133,19 +133,32 @@ function Testfwd_Parser() {
 		if [[ "${file}" =~ "receiver" ]]; then
 			local rx_pps_arr=($(grep Rx-pps: "${file}" | awk '{print $2}'))
 			local rx_pps_avg=$(( ($(printf '%b + ' "${rx_pps_arr[@]}"\\c)) / ${#rx_pps_arr[@]} ))
+			local rx_bytes_arr=($(cat "${file}" | grep TX-bytes: | rev | awk '{print $1}' | rev))
+			local rx_bytes_avg=$(($(expr $(printf '%b + ' "${rx_bytes_arr[@]::${#rx_bytes_arr[@]}}"\\c))/${#rx_bytes_arr[@]}))
+			local rx_packets_arr=($(cat "${file}" | grep TX-packets: | awk '{print $2}'))
+			local rx_packets_avg=$(($(expr $(printf '%b + ' "${rx_packets_arr[@]::${#rx_packets_arr[@]}}"\\c))/${#rx_packets_arr[@]}))
 		elif [[ "${file}" =~ "forwarder" ]]; then
 			local fwdrx_pps_arr=($(grep Rx-pps: "${file}" | awk '{print $2}'))
 			local fwdrx_pps_avg=$(( ($(printf '%b + ' "${fwdrx_pps_arr[@]}"\\c)) / ${#fwdrx_pps_arr[@]} ))
 
 			local fwdtx_pps_arr=($(grep Tx-pps: "${file}" | awk '{print $2}'))
 			local fwdtx_pps_avg=$(( ($(printf '%b + ' "${fwdtx_pps_arr[@]}"\\c)) / ${#fwdtx_pps_arr[@]} ))
+			local fwdtx_bytes_arr=($(cat "${file}" | grep TX-bytes: | rev | awk '{print $1}' | rev))
+			local fwdtx_bytes_avg=$(($(expr $(printf '%b + ' "${fwdtx_bytes_arr[@]::${#fwdtx_bytes_arr[@]}}"\\c))/${#fwdtx_bytes_arr[@]}))
+			local fwdtx_packets_arr=($(cat "${file}" | grep TX-packets: | awk '{print $2}'))
+			local fwdtx_packets_avg=$(($(expr $(printf '%b + ' "${fwdtx_packets_arr[@]::${#fwdtx_packets_arr[@]}}"\\c))/${#fwdtx_packets_arr[@]}))
 		elif [[ "${file}" =~ "sender" ]]; then
 			local tx_pps_arr=($(grep Tx-pps: "${file}" | awk '{print $2}'))
 			local tx_pps_avg=$(( ($(printf '%b + ' "${tx_pps_arr[@]}"\\c)) / ${#tx_pps_arr[@]} ))
+			local tx_bytes_arr=($(cat "${file}" | grep TX-bytes: | rev | awk '{print $1}' | rev))
+			local tx_bytes_avg=$(($(expr $(printf '%b + ' "${tx_bytes_arr[@]::${#tx_bytes_arr[@]}}"\\c))/${#tx_bytes_arr[@]}))
+			local tx_packets_arr=($(cat "${file}" | grep TX-packets: | awk '{print $2}'))
+			local tx_packets_avg=$(($(expr $(printf '%b + ' "${tx_packets_arr[@]::${#tx_packets_arr[@]}}"\\c))/${#tx_packets_arr[@]}))
 		fi
 	done
-
-	echo "${dpdk_version},${pmd},${core},${tx_pps_avg},${fwdrx_pps_avg},${fwdtx_pps_avg},${rx_pps_avg}" >> "${testfwd_csv_file}"
+	tx_packet_size=$((tx_bytes_avg/tx_packets_avg))
+	rx_packet_size=$((rx_bytes_avg/rx_packets_avg))
+	echo "${dpdk_version},${pmd},fwd,${core},${tx_pps_avg},${fwdrx_pps_avg},${fwdtx_pps_avg},${rx_pps_avg},${tx_bytes_avg},${rx_bytes_avg},${fwdtx_bytes_avg},${tx_packets_avg},${rx_packets_avg},${fwdtx_packets_avg},${tx_packet_size},${rx_packet_size}" >> "${testfwd_csv_file}"
 }
 
 function Run_Testcase() {
@@ -167,7 +180,7 @@ function Run_Testcase() {
 
 	LogMsg "Starting testfwd parser"
 	local csv_file=$(Create_Csv)
-	echo "dpdk_version,poll_mode_driver,core,tx_pps_avg,fwdrx_pps_avg,fwdtx_pps_avg,rx_pps_avg" > "${csv_file}"
+	echo "dpdk_version,poll_mode_driver,test_mode,core,tx_pps_avg,fwdrx_pps_avg,fwdtx_pps_avg,rx_pps_avg,tx_bytes,rx_bytes,fwd_bytes,tx_packets,rx_packets,fwd_packets,tx_packet_size,rx_packet_size" > "${csv_file}"
 	for core in "${CORES[@]}"; do
 		Testfwd_Parser ${core} "${csv_file}"
 	done

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -625,6 +625,7 @@ function Testpmd_Multiple_Tx_Flows_Setup() {
 function Testpmd_Macfwd_To_Dest() {
 	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
 	local dpdk_version_changed_mac_fwd="19.08"
+	local dpdk_version_changed_mac_fwd2="20.11"
 
 	local ptr_code="struct ipv4_hdr *ipv4_hdr;"
 	local offload_code="ol_flags |= PKT_TX_IP_CKSUM; ol_flags |= PKT_TX_IPV4;"
@@ -640,9 +641,15 @@ function Testpmd_Macfwd_To_Dest() {
 		LogMsg "Using legacy forwarding code insertion"
 	fi
 
+	# TODO: Replace line number updates with actual code
 	sed -i "53i ${ptr_code}" app/test-pmd/macfwd.c
-	sed -i "90i ${offload_code}" app/test-pmd/macfwd.c
-	sed -i "101i ${dst_addr_code}" app/test-pmd/macfwd.c
+	if [[ ! $(printf "${dpdk_version_changed_mac_fwd2}\n${dpdk_version}" | sort -V | head -n1) == "${dpdk_version}" ]]; then
+		sed -i "82i ${offload_code}" app/test-pmd/macfwd.c
+		sed -i "93i ${dst_addr_code}" app/test-pmd/macfwd.c
+	else
+		sed -i "90i ${offload_code}" app/test-pmd/macfwd.c
+		sed -i "101i ${dst_addr_code}" app/test-pmd/macfwd.c
+	fi
 }
 
 function Get_DPDK_Version() {


### PR DESCRIPTION
	1. Updated macfwd.c changes.
	2. Added more variables to dump into database.
	3. Added "fwd" mode to classify forwarding data.

```
[LISAv2 Test Results Summary]
Test Run On           : 11/21/2020 23:51:02
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:15

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-FWD-PPS-DS15                                                            FAIL                14.32
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
      dpdk_version poll_mode_driver test_mode core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg tx_bytes    rx_bytes
------------ ---------------- --------- ---- ---------- ------------- ------------- ---------- --------    --------
20.11.0-rc4  failsafe         fwd       2    22325958   15469899      10802585      10884728   86300436427 0
20.11.0-rc4  failsafe         fwd       4    21150359   15568233      10797837      10834460   82395471245 0
20.11.0-rc4  failsafe         fwd       8    20320062   19732693      5803484       5811362    77809894180 0



Logs can be found at C:\LISAv2\XS30\TestResults\2020-11-21-15-49-59-2678
```