### PR TITLE
Improve stability on smoke_test

### DIFF
--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -209,6 +209,7 @@ class Tool(ABC, InitializableMixin):
         no_error_log: bool = False,
         no_info_log: bool = True,
         cwd: Optional[pathlib.PurePath] = None,
+        timeout: int = 600,
     ) -> ExecutableResult:
         """
         Run a process and wait for result.
@@ -220,7 +221,7 @@ class Tool(ABC, InitializableMixin):
             no_info_log=no_info_log,
             cwd=cwd,
         )
-        return process.wait_result()
+        return process.wait_result(timeout=timeout)
 
     def get_tool_path(self) -> pathlib.PurePath:
         """
@@ -298,6 +299,7 @@ class CustomScript(Tool):
         no_error_log: bool = False,
         no_info_log: bool = True,
         cwd: Optional[pathlib.PurePath] = None,
+        timeout: int = 600,
     ) -> ExecutableResult:
         process = self.run_async(
             parameters=parameters,
@@ -306,7 +308,7 @@ class CustomScript(Tool):
             no_info_log=no_info_log,
             cwd=cwd,
         )
-        return process.wait_result()
+        return process.wait_result(timeout=timeout)
 
     @property
     def name(self) -> str:

--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -446,7 +446,7 @@ class Tools:
         if tool is None:
             # the Tool is not installed on current node, try to install it.
             tool_log = get_logger("tool", tool_key, self._node.log)
-            tool_log.debug(f"initializing {tool_key}")
+            tool_log.debug(f"initializing tool [{tool_key}]")
 
             if isinstance(tool_type, CustomScriptBuilder):
                 tool = tool_type.build(self._node)

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -127,6 +127,7 @@ class Node(ContextMixin, InitializableMixin):
         no_error_log: bool = False,
         no_info_log: bool = True,
         cwd: Optional[pathlib.PurePath] = None,
+        timeout: int = 600,
     ) -> ExecutableResult:
         process = self.execute_async(
             cmd,
@@ -135,7 +136,7 @@ class Node(ContextMixin, InitializableMixin):
             no_info_log=no_info_log,
             cwd=cwd,
         )
-        return process.wait_result()
+        return process.wait_result(timeout=timeout)
 
     def execute_async(
         self,

--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -20,5 +20,8 @@ class Waagent(Tool):
 
     def get_version(self) -> str:
         result = self.run("-version")
+        if result.exit_code != 0:
+            self._command = "/usr/sbin/waagent"
+            result = self.run("-version")
         found_version = find_patterns_in_lines(result.stdout, [self.__version_pattern])
         return found_version[0][0] if found_version[0] else ""

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -1,4 +1,5 @@
 from .cat import Cat
+from .date import Date
 from .dmesg import Dmesg
 from .echo import Echo
 from .gcc import Gcc
@@ -13,6 +14,7 @@ from .who import Who
 
 __all__ = [
     "Cat",
+    "Date",
     "Dmesg",
     "Echo",
     "Gcc",

--- a/lisa/tools/date.py
+++ b/lisa/tools/date.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from lisa.executable import Tool
+from lisa.util import LisaException
+
+
+class Date(Tool):
+    @property
+    def command(self) -> str:
+        return "date"
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def current(self, no_error_log: bool = True) -> datetime:
+        command_result = self.run(no_error_log=no_error_log, timeout=10)
+        if command_result.exit_code != 0:
+            raise LisaException(
+                f"'Date' return non-zero exit code: {command_result.stderr}"
+            )
+        # Mon Nov 23 00:21:02 UTC 2020
+        result = datetime.strptime(command_result.stdout, "%a %b %d %H:%M:%S %Z %Y")
+        return result

--- a/lisa/tools/modinfo.py
+++ b/lisa/tools/modinfo.py
@@ -36,7 +36,9 @@ class Modinfo(Tool):
                 # CentOS may not include the path when started,
                 # specify path and try again.
                 self._command = "/usr/sbin/modinfo"
-                cached_result = self.run(mod_name)
+                cached_result = self.run(
+                    mod_name, no_info_log=no_info_log, no_error_log=no_error_log
+                )
             self._cached_result[mod_name] = cached_result
         return cached_result.stdout
 

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -27,13 +27,14 @@ class Reboot(Tool):
         timer = create_timer()
         last_boot_time = who.last_boot()
         current_boot_time = last_boot_time
-        date = self.node.tools[Date]
 
         # who -b returns time without seconds.
         # so if the node rebooted in one minute, the who -b is not changed.
         # The reboot will wait forever.
         # in this case, verify the time is wait enough to prevent this problem.
+        date = self.node.tools[Date]
         current_delta = date.current() - current_boot_time
+        self._log.debug(f"delta time since last boot: {current_delta}")
         while current_delta < timedelta(minutes=1):
             # wait until one minute
             wait_seconds = 60 - current_delta.seconds + 1

--- a/lisa/tools/who.py
+++ b/lisa/tools/who.py
@@ -27,6 +27,7 @@ class Who(Tool):
             result = datetime.fromisoformat(datetime_output)
         except ValueError:
             # ValueError: Invalid isoformat string: 'Nov 10 20:54'
-            result = datetime.strptime(datetime_output, "%b %d %H:%M")
+            datetime_with_year = f"{datetime_output} {datetime.utcnow().year}"
+            result = datetime.strptime(datetime_with_year, "%b %d %H:%M %Y")
 
         return result

--- a/lisa/tools/who.py
+++ b/lisa/tools/who.py
@@ -17,7 +17,7 @@ class Who(Tool):
         return False
 
     def last_boot(self, no_error_log: bool = True) -> datetime:
-        command_result = self.run("-b", no_error_log=no_error_log)
+        command_result = self.run("-b", no_error_log=no_error_log, timeout=10)
         if command_result.exit_code != 0:
             raise LisaException(
                 f"'last' return non-zero exit code: {command_result.stderr}"

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -141,6 +141,7 @@ def try_connect(connection_info: ConnectionInfo) -> Any:
         username=connection_info.username,
         password=connection_info.password,
         key_filename=connection_info.private_key_file,
+        banner_timeout=10,
     )
     _, stdout, _ = paramiko_client.exec_command("cmd")
     paramiko_client.close()

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -28,12 +28,11 @@ def wait_tcp_port_ready(
     """
     is_ready: bool = False
     # TODO: may need to support IPv6.
-    tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     times: int = 0
 
     timout_timer = create_timer()
     while timout_timer.elapsed(False) < timeout:
-        try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as tcp_socket:
             result = tcp_socket.connect_ex((address, port))
             if result == 0:
                 is_ready = True
@@ -41,13 +40,11 @@ def wait_tcp_port_ready(
             else:
                 if times % 10 == 0 and log:
                     log.debug(
-                        f"TCP port {port} connection failed, and retrying... "
+                        f"TCP port {port} connection failed({result}), and retrying... "
                         f"Tried times: {times}, elapsed: {timout_timer}"
                     )
                 sleep(1)
                 times += 1
-        finally:
-            tcp_socket.close()
     return is_ready
 
 

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -218,7 +218,7 @@ class SshShell(InitializableMixin):
         stdout: Any = None,
         stderr: Any = None,
         encoding: str = "utf-8",
-        use_pty: bool = False,
+        use_pty: bool = True,
         allow_error: bool = True,
     ) -> spur.ssh.SshProcess:
         self.initialize()


### PR DESCRIPTION
1. fix the unintented reused socket object, to prevent 10038 error.
2. fix sometime reboot happens too fast in one minute with last boot. Since the `who -b` doesn't return seconds, so it may not detected the system is rebooted. Check by `date` and wait to prevent it happens in one minute.
3. expose timeout to high level tools.

Improve some log