### PR TITLE
Add new case about FIPS enable

### DIFF
--- a/Testscripts/Windows/FIPS-ENABLE.ps1
+++ b/Testscripts/Windows/FIPS-ENABLE.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+<#
+.Synopsis
+    This script tests the enable fips (Federal Information Processing Standard) mode.
+
+.Description
+    The script will enable fips mode and reboot vm to check whether fips mode is enabled
+#>
+param([String] $TestParams,
+      [object] $AllVmData)
+
+function Main {
+
+    if ( ( $global:detectedDistro -imatch "CENTOS") -or ($global:detectedDistro -imatch "REDHAT") ) {
+        Write-LogInfo "Test on DISTRO $($global:detectedDistro)"
+    }
+    else {
+        Write-LogWarn "Do not support this DISTRO $($global:detectedDistro)."
+        return "SKIPPED"
+    }
+    $cmd = "command -v fips-mode-setup"
+    try {
+        $null = Run-LinuxCmd -username $global:user -password $global:password -ip $AllVMData.PublicIP `
+        -port $AllVMData.SSHPort -command $cmd -runAsSudo
+    }
+    catch {
+        Write-LogWarn "fips-mode-setup does not exist in the VM, skip test"
+        return "SKIPPED"
+    }
+
+    Write-LogInfo "fips-mode-setup command exists in the VM"
+
+    $cmd = "fips-mode-setup --enable"
+    $null = Run-LinuxCmd -username $global:user -password $global:password -ip $AllVMData.PublicIP `
+    -port $AllVMData.SSHPort -command $cmd -runAsSudo
+
+    # Rebooting the VM
+    $TestProvider.RestartAllDeployments($AllVMData)
+
+    Write-LogInfo "VM boots up successfully after reboot..."
+
+    $sts = Run-LinuxCmd -username $global:user -password $global:password -ip $AllVMData.PublicIP `
+        -port $AllVMData.SSHPort -command "fips-mode-setup --check | grep enabled" -ignoreLinuxExitCode
+
+    if (-not $sts) {
+        Write-LogErr "VM fails to boot up with fips mode enabled!"
+        return "FAIL"
+    }
+    else {
+        Write-LogInfo "VM boots up with the fips mode enabled successfully..."
+        return "PASS"
+    }
+}
+Main

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -991,4 +991,16 @@
       <SetupType>OneVM</SetupType>
     </SetupConfig>
   </test>
+  <test>
+    <testName>FIPS-ENABLE</testName>
+    <testScript>FIPS-ENABLE.ps1</testScript>
+    <Platform>Azure,HyperV</Platform>
+    <Category>Functional</Category>
+    <Area>CORE</Area>
+    <Tags>boot</Tags>
+    <Priority>2</Priority>
+    <SetupConfig>
+      <SetupType>OneVM</SetupType>
+    </SetupConfig>
+  </test>
 </TestCases>


### PR DESCRIPTION
Add a new test case for FIPS - Federal Information Processing Standard (FIPS) enable test.

In RHEL 8, there is command "fips-mode-setup" to set FIPS mode easily, please refer to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening.
But for RHEL 7, it is more complex to set up. Since there is less change for RHEL 7.9 (only some update there, prefer to not covering RHEL 7 release test for this case)

Also not sure how to set up FIPS mode in other distro, skip other distro.


[LISAv2 Test Results Summary]
Test Run On           : 11/23/2020 08:18:18
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:4

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 FIPS-ENABLE                                                                       PASS                 3.06
      TestLocation: xxxxx, Kernel Version: 4.18.0-xxxx.el8.x86_64
