### PR TITLE
revert check kernel log

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -479,7 +479,7 @@ Class TestController {
 				Write-LogInfo "==> Run test setup script if defined."
 				$this.TestProvider.RunSetup($VmData, $CurrentTestData, $testParameters, $ApplyCheckpoint)
 
-				if (($CurrentTestData.SetupConfig.OSType -notcontains "Windows") -and ($this.CustomParams.VerifyKernelLogs -eq "True")) {
+				if ($CurrentTestData.SetupConfig.OSType -notcontains "Windows") {
 					Write-LogInfo "==> Check the target machine kernel log."
 					$this.GetAndCompareOsLogs($VmData, "Initial")
 				}
@@ -541,9 +541,9 @@ Class TestController {
 			}
 
 			if ($CurrentTestData.SetupConfig.OSType -notcontains "Windows") {
-				if ($this.CustomParams.VerifyKernelLogs -eq "True") {
+				if ($testParameters["SkipVerifyKernelLogs"] -ne "True") {
 					$ret = $this.GetAndCompareOsLogs($VmData, "Final")
-					if (($ret -eq $false) -and ($currentTestResult.TestResult -eq $global:ResultPass)) {
+					if (($testParameters["FailForLogCheck"] -eq "True") -and ($ret -eq $false) -and ($currentTestResult.TestResult -eq $global:ResultPass)) {
 						$currentTestResult.TestResult = $global:ResultFail
 						Write-LogErr "Test $($CurrentTestData.TestName) fails for log check"
 						$currentTestResult.testSummary += New-ResultSummary -testResult "Test fails for log check"


### PR DESCRIPTION
Revert to previous checking kernel log.

====================Test Log========================
[LISAv2 Test Results Summary]
Test Run On           : 11/29/2020 21:55:48
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.61 
      ARMImageName: Canonical UbuntuServer 18.04-LTS 18.04.202011230, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      


Logs can be found at C:\LISAv2OL\TestResults\2020-11-29-13-54-59-YN88


11/29/2020 22:03:06 : [DEBUG] Creating 'C:\LISAv2OL\Azure-YN88-TestLogs.zip' from 'C:\LISAv2OL\TestResults\2020-11-29-13-54-59-YN88'
11/29/2020 22:03:06 : [DEBUG] C:\LISAv2OL\Azure-YN88-TestLogs.zip created successfully.
11/29/2020 22:03:06 : [INFO ] Analyzing test results ...
11/29/2020 22:03:06 : [INFO ] LISAv2 exit code: 0