### PR TITLE
Add fix to get container and vhdname through OsVHD url

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -228,8 +228,8 @@ Function Assert-ResourceLimitationForDeployment($RGXMLData, [ref]$TargetLocation
 
 Function Move-OsVHDToStorageAccount($OriginalOsVHD, $TargetStorageAccount) {
 	$sourceStorageAccount = $OriginalOsVHD.Replace("https://", "").Replace("http://", "").Split(".")[0]
-	$sourceContainer = $OriginalOsVHD.Split("/")[$OriginalOsVHD.Split("/").Count - 2]
-	$vhdName = $OriginalOsVHD.Split("?")[0].split('/')[-1]
+	$sourceContainer = $OriginalOsVHD.Split("/")[3]
+	$vhdName = ($OriginalOsVHD.Split("?")[0] -split("/$sourceContainer/"))[-1]
 
 	$targetOsVHD = 'http://{0}.blob.core.windows.net/vhds/{1}' -f $TargetStorageAccount, $vhdName
 
@@ -298,7 +298,8 @@ Function Select-StorageAccountByTestLocation($CurrentTestData, [string]$Location
 			$CurrentTestData.SetupConfig.OsVHD = $updatedOsVHD
 		}
 		else {
-			$vhdName = $CurrentTestData.SetupConfig.OsVHD.Split("?")[0].split('/')[-1]
+			$sourceContainer = $CurrentTestData.SetupConfig.OsVHD.Split("/")[3]
+			$vhdName = ($CurrentTestData.SetupConfig.OsVHD.Split("?")[0] -split("/$sourceContainer/"))[-1]
 			Write-LogInfo "VHD '$vhdName' had ever been copied to '$targetStorageAccount', skip copying again"
 			$CurrentTestData.SetupConfig.OsVHD = 'http://{0}.blob.core.windows.net/vhds/{1}' -f $targetStorageAccount, $vhdName
 		}
@@ -1680,7 +1681,8 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 	Write-LogInfo "Current test setup: $($SetupTypeData.Name)"
 	$osVHDName = ""
 	if ($CurrentTestData.SetupConfig.OsVHD) {
-		$osVHDName = $CurrentTestData.SetupConfig.OsVHD.Split("?")[0].split('/')[-1]
+		$sourceContainer = $CurrentTestData.SetupConfig.OsVHD.Split("/")[3]
+		$osVHDName = ($CurrentTestData.SetupConfig.OsVHD.Split("?")[0] -split("/$sourceContainer/"))[-1]
 	}
 	$osImage = $CurrentTestData.SetupConfig.ARMImageName
 	$location = $CurrentTestData.SetupConfig.TestLocation


### PR DESCRIPTION
Before the fix, if the vhd url is "https://backuparmimages.blob.core.windows.net/vhds/Canonical/UbuntuServer/12.04.4-LTS/12.04.201407170.vhd", the vhdName and the SasUrl we got is wrong. This will cause test cases to fail when with this type of OsVHD.

After the fix, the test results are as below:
```
[LISAv2 Test Results Summary]
Test Run On           : 11/30/2020 13:48:34
VHD Under Test        : https://lisawestus2.blob.core.windows.net/vhds/EOSG-AUTOBUILT-Canonical-UbuntuServer-16.04-LTS-latest-IG31.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 2.09 
      OsVHD: http://lisawestus2.blob.core.windows.net/vhds/EOSG-AUTOBUILT-Canonical-UbuntuServer-16.04-LTS-latest-IG31.vhd, TestLocation: westus2, VMGeneration: 1, Kernel Version: 4.9.184-20201020t2145014214-custom
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
```
```
[LISAv2 Test Results Summary]
Test Run On           : 11/30/2020 13:20:34
VHD Under Test        : http://lisawestus2.blob.core.windows.net/vhds/microsoft-aks/aks/aks-ubuntu-1604-202002/2020.02.28.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 VERIFY-DEPLOYMENT-PROVISION                                                       PASS                 3.49 
      OsVHD: http://lisawestus2.blob.core.windows.net/vhds/microsoft-aks/aks/aks-ubuntu-1604-202002/2020.02.28.vhd, TestLocation: westus2, VMGeneration: 1, Kernel Version: 4.15.0-1071-azure
      FirstBoot : PASS
      FirstBoot : Call Trace Verification : PASS
      Reboot : PASS
      Reboot : Call Trace Verification : PASS
      
```