### PR TITLE
DPDK Fix: Netvsc pmd device setup and testpmd options change

### DIFF
--- a/Testscripts/Linux/dpdkPmdsBasicCheck.sh
+++ b/Testscripts/Linux/dpdkPmdsBasicCheck.sh
@@ -59,7 +59,7 @@ function checkCmdExitStatus ()
 		SetTestStateAborted
 		exit $exit_status
 	else
-		echo "$cmd: SUCCESS" 
+		echo "$cmd: SUCCESS"
 	fi
 }
 
@@ -67,7 +67,7 @@ runTestPmd()
 {
 	pmd=$1
 	LogMsg "*********INFO: Starting TestPmd test execution with ${pmd} PMD*********"
-	whitelist="-w ${bus_info}"
+	whitelist="-a ${bus_info}"
 	case "$pmd" in
 		mlx*)
 			vdev=""

--- a/Testscripts/Linux/dpdkPmdsBasicCheck.sh
+++ b/Testscripts/Linux/dpdkPmdsBasicCheck.sh
@@ -67,7 +67,14 @@ runTestPmd()
 {
 	pmd=$1
 	LogMsg "*********INFO: Starting TestPmd test execution with ${pmd} PMD*********"
-	whitelist="-a ${bus_info}"
+
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
+	local pci_param="-w ${bus_info}"
+	local dpdk_version_changed="20.11"
+	if [[ ! $(printf "${dpdk_version_changed}\n${dpdk_version}" | sort -V | head -n1) == "${dpdk_version}" ]]; then
+		pci_param="-a ${bus_info}"
+	fi
+
 	case "$pmd" in
 		mlx*)
 			vdev=""
@@ -97,7 +104,6 @@ runTestPmd()
 			mac=$(cat /sys/class/net/eth1/address)
 			chmod +x ${FAILSAFE_FILE}
 			vdev='$('${FAILSAFE_FILE}' '${mac}')'
-			whitelist=""
 			;;
 		*)
 			LogMsg "Not supported PMD $pmd. Abort."
@@ -114,7 +120,7 @@ runTestPmd()
 		SetTestStateAborted
 		exit 0
 	}
-	cmd="echo 'stop' | $testpmd_cmd -l 0-1 ${whitelist} ${vdev} -- -i --port-topology=chained --nb-cores 1"
+	cmd="echo 'stop' | $testpmd_cmd -l 0-1 ${pci_param} ${vdev} -- -i --port-topology=chained --nb-cores 1"
 	LogMsg "$cmd"
 	eval "$cmd" > $LOGDIR/$pmd.log 2>&1
 	checkCmdExitStatus "TestPmd with ${pmd} execution"

--- a/Testscripts/Linux/dpdkTestPmd.sh
+++ b/Testscripts/Linux/dpdkTestPmd.sh
@@ -59,6 +59,13 @@ runTestPmd()
 	cores=1
 	ssh "${server}" "mkdir -p $LOGDIR"
 
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
+	local pci_param="-w"
+	local dpdk_version_changed="20.11"
+	if [[ ! $(printf "${dpdk_version_changed}\n${dpdk_version}" | sort -V | head -n1) == "${dpdk_version}" ]]; then
+		pci_param="-a"
+	fi
+
 	. ${DPDK_UTIL_FILE} && Hugepage_Setup ${client}
 	. ${DPDK_UTIL_FILE} && Hugepage_Setup ${server}
 	vf_name_client=$(ssh "${client}" ". utils.sh && get_vf_name 'eth1'")
@@ -88,18 +95,18 @@ runTestPmd()
 	for testmode in $modes; do
 		LogMsg "TestPmd is starting on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs"
 		Hugepage_Setup ${server} "set"
-		serverTestPmdCmd="modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} dpdk-testpmd -l 0-1 -a $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
+		serverTestPmdCmd="modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} dpdk-testpmd -l 0-1 ${pci_param} $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
 		LogMsg "Server Testpmd Command: $serverTestPmdCmd"
 		ssh "${server}" "$serverTestPmdCmd" 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-receiver-$(date +"%m%d%Y-%H%M%S").log &
 		check_exit_status "TestPmd started on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs" "aborted"
 
 		LogMsg "TestPmd is starting on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
-		LogMsg "timeout ${testDuration} dpdk-testpmd -l 0-1 -a $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
+		LogMsg "timeout ${testDuration} dpdk-testpmd -l 0-1 ${pci_param} $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
 
 		Hugepage_Setup ${client} "set"
 		# Replace modprobe command with Modprobe_setup
 		modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib
-		timeout "${testDuration}" dpdk-testpmd -l 0-1 -a ${pci_info_client} ${vdev} -- \
+		timeout "${testDuration}" dpdk-testpmd -l 0-1 ${pci_param} ${pci_info_client} ${vdev} -- \
 			--port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 \
 			--forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-sender-$(date +"%m%d%Y-%H%M%S").log &
 		check_exit_status "TestPmd started on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs" "aborted"

--- a/Testscripts/Linux/dpdkTestPmd.sh
+++ b/Testscripts/Linux/dpdkTestPmd.sh
@@ -88,18 +88,18 @@ runTestPmd()
 	for testmode in $modes; do
 		LogMsg "TestPmd is starting on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs"
 		Hugepage_Setup ${server} "set"
-		serverTestPmdCmd="modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} dpdk-testpmd -l 0-1 -w $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
+		serverTestPmdCmd="modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib;timeout ${testDuration} dpdk-testpmd -l 0-1 -a $pci_info_server ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=${testmode}  --stats-period 1"
 		LogMsg "Server Testpmd Command: $serverTestPmdCmd"
 		ssh "${server}" "$serverTestPmdCmd" 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-receiver-$(date +"%m%d%Y-%H%M%S").log &
 		check_exit_status "TestPmd started on ${serverNIC1ip} with ${testmode} mode, duration ${testDuration} secs" "aborted"
 
 		LogMsg "TestPmd is starting on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs"
-		LogMsg "timeout ${testDuration} dpdk-testpmd -l 0-1 -w $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
+		LogMsg "timeout ${testDuration} dpdk-testpmd -l 0-1 -a $pci_info_client ${vdev} -- --port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 --forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 >> $LOGDIR/dpdk-testpmd-${testmode}-sender.log &"
 
 		Hugepage_Setup ${client} "set"
 		# Replace modprobe command with Modprobe_setup
 		modprobe -a ib_uverbs mlx4_en mlx4_core mlx4_ib
-		timeout "${testDuration}" dpdk-testpmd -l 0-1 -w ${pci_info_client} ${vdev} -- \
+		timeout "${testDuration}" dpdk-testpmd -l 0-1 -a ${pci_info_client} ${vdev} -- \
 			--port-topology=chained --nb-cores 1 --txq 1 --rxq 1 --mbcache=512 --txd=4096 --rxd=4096 \
 			--forward-mode=txonly --stats-period 1 ${trx_rx_ips} 2>&1 > "$LOGDIR"/dpdk-testpmd-"${testmode}"-sender-$(date +"%m%d%Y-%H%M%S").log &
 		check_exit_status "TestPmd started on ${clientNIC1ip} with txonly mode, duration ${testDuration} secs" "aborted"

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -524,6 +524,7 @@ function Create_Testpmd_Cmd() {
 	# partial strings to concat
 	local testpmd="dpdk-testpmd"
 	local eal_opts=""
+	local eal_debug_opts="--log-level=eal,debug --log-level=mlx,debug"
 	case "$pmd" in
 		netvsc)
 			DEV_UUID=$(basename $(readlink /sys/class/net/eth1/device))
@@ -532,10 +533,10 @@ function Create_Testpmd_Cmd() {
 			echo $NET_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/hv_netvsc/unbind &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/bind &>/dev/null
-			eal_opts="-l 0-${core} -a ${busaddr} --"
+			eal_opts="-l 0-${core} -a ${busaddr} ${eal_debug_opts} --log-level=netvsc,debug --"
 			;;
 		failsafe)
-			eal_opts="-l 0-${core} -a ${busaddr} --vdev='net_vdev_netvsc0,iface=${iface}' --"
+			eal_opts="-l 0-${core} -a ${busaddr} --vdev='net_vdev_netvsc0,iface=${iface}' ${eal_debug_opts} --log-level=failsafe,debug --"
 			;;
 		*)
 			LogMsg "Not supported PMD $pmd. Abort."

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -507,8 +507,8 @@ function Create_Testpmd_Cmd() {
 		exit 1
 	fi
 
-	if [ -z "${DPDK_DIR}" ]; then
-		LogErr "ERROR: DPDK_DIR must be defined before calling Create_Testpmd_Cmd()"
+	if [ -z "${LIS_HOME}" -o -z "${DPDK_DIR}" ]; then
+		LogErr "ERROR: DPDK_DIR and LIS_HOME must be defined before calling Create_Testpmd_Cmd()"
 		SetTestStateAborted
 		exit 1
 	fi
@@ -520,7 +520,12 @@ function Create_Testpmd_Cmd() {
 	local pmd="${5}"
 	local additional_params="${6}"
 
-
+	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
+	local pci_param="-w ${busaddr}"
+	local dpdk_version_changed="20.11"
+	if [[ ! $(printf "${dpdk_version_changed}\n${dpdk_version}" | sort -V | head -n1) == "${dpdk_version}" ]]; then
+		pci_param="-a ${busaddr}"
+	fi
 	# partial strings to concat
 	local testpmd="dpdk-testpmd"
 	local eal_opts=""
@@ -533,10 +538,10 @@ function Create_Testpmd_Cmd() {
 			echo $NET_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/hv_netvsc/unbind &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/bind &>/dev/null
-			eal_opts="-l 0-${core} -a ${busaddr} ${eal_debug_opts} --log-level=netvsc,debug --"
+			eal_opts="-l 0-${core} ${pci_param} ${eal_debug_opts} --log-level=netvsc,debug --"
 			;;
 		failsafe)
-			eal_opts="-l 0-${core} -a ${busaddr} --vdev='net_vdev_netvsc0,iface=${iface}' ${eal_debug_opts} --log-level=failsafe,debug --"
+			eal_opts="-l 0-${core} ${pci_param} --vdev='net_vdev_netvsc0,iface=${iface}' ${eal_debug_opts} --log-level=failsafe,debug --"
 			;;
 		*)
 			LogMsg "Not supported PMD $pmd. Abort."

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -532,10 +532,10 @@ function Create_Testpmd_Cmd() {
 			echo $NET_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/new_id &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/hv_netvsc/unbind &>/dev/null
 			echo $DEV_UUID > /sys/bus/vmbus/drivers/uio_hv_generic/bind &>/dev/null
-			eal_opts="-l 0-${core} -w ${busaddr} --"
+			eal_opts="-l 0-${core} -a ${busaddr} --"
 			;;
 		failsafe)
-			eal_opts="-l 0-${core} -w ${busaddr} --vdev='net_vdev_netvsc0,iface=${iface}' --"
+			eal_opts="-l 0-${core} -a ${busaddr} --vdev='net_vdev_netvsc0,iface=${iface}' --"
 			;;
 		*)
 			LogMsg "Not supported PMD $pmd. Abort."


### PR DESCRIPTION
Two changes:

> 1. Collect VM IPs before configuring NETVSC device as it won't be available later

> 2. Replace -w / --pci-whitelist deprecated testpmd option with -a / --allow

```
[LISAv2 Test Results Summary]
Test Run On           : 11/30/2020 23:13:32
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 3 (1 Passed, 1 Failed, 1 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:27

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-TESTPMD-TEST                                                PASS                21.33
      ARMImageName: Canonical UbuntuServer 18.04-LTS 18.04.202011230, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure

[LISAv2 Test Results Summary]
Test Run On           : 12/01/2020 00:24:51
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (0 Passed, 1 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:22

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 PERF-DPDK-FWD-PPS-NETVSCPMD                                                       FAIL                15.87
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
      dpdk_version poll_mode_driver test_mode core tx_pps_avg fwdrx_pps_avg fwdtx_pps_avg rx_pps_avg tx_bytes    rx_bytes
------------ ---------------- --------- ---- ---------- ------------- ------------- ---------- --------    --------
20.11.0      netvsc           fwd       2    21578997   13257858      12934256      12922305   84148893416 0
20.11.0      netvsc           fwd       4    22549446   10951705      10951705      10935061   85975338882 0
20.11.0      netvsc           fwd       8    20677824   6873384       6873384       6871793    78749587495 0
```