### PR TITLE
Install meson on CentOS 8

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -202,7 +202,7 @@ function Install_Dpdk () {
 			if [ $? -eq 0 ]; then
 				packages+=("elfutils-libelf-devel")
 			fi
-			if [ "${DISTRO_NAME}" = "rhel" ]; then
+			if [[ "${DISTRO_NAME}" = "rhel" ]]; then
 				# meson requires ninja-build and python-devel to be installed. [ninja-build ref: https://pkgs.org/download/ninja-build]
 				if [[ ${DISTRO_VERSION} == *"8."* ]]; then
 					ssh "${1}" ". utils.sh && install_package python3-devel"
@@ -214,7 +214,11 @@ function Install_Dpdk () {
 					ssh "${1}" 'PATH=$PATH:/opt/rh/rh-python36/root/usr/bin/ && pip install --upgrade pip && pip install meson'
 				fi
 			else
-				packages+=(meson)
+				if [[ "${DISTRO_NAME}" = "centos" && ${DISTRO_VERSION} == *"8."* ]]; then
+					dnf --enablerepo=PowerTools install -y meson
+				else
+					packages+=(meson)
+				fi
 			fi
 			;;
 		ubuntu|debian)


### PR DESCRIPTION
Before fix, dpdk build failed on CentOS 8.*
```
[LISAv2 Test Results Summary]
Test Run On           : 12/01/2020 10:07:11
ARM Image Under Test  : OpenLogic : CentOS : 8_1 : 8.1.2020111900
ARM Image Under Test  : OpenLogic : CentOS : 7.5 : latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                  6.8 
      ARMImageName: OpenLogic CentOS 7.5 7.5.201808150, Networking: SRIOV, TestLocation: westus2, Kernel Version: 3.10.0-862.11.6.el7.x86_64
    2 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 5.72 
      ARMImageName: OpenLogic CentOS 8_1 8.1.2020111900, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.18.0-147.8.1.el8_1.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 12/01/2020 10:54:59
ARM Image Under Test  : OpenLogic : CentOS : 8_2 : 8.2.2020111800
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 4.92 
      ARMImageName: OpenLogic CentOS 8_2 8.2.2020111800, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.18.0-193.28.1.el8_2.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 12/01/2020 10:37:36
ARM Image Under Test  : OpenLogic : CentOS : 8.0 : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-COMPLIANCE                                                            PASS                 5.15 
      ARMImageName: OpenLogic CentOS 8.0 8.0.201912060, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.18.0-80.11.2.el8_0.x86_64
```