### PR TITLE
Fix regression issue.

### DIFF
--- a/TestProviders/HyperVProvider.psm1
+++ b/TestProviders/HyperVProvider.psm1
@@ -165,7 +165,7 @@ Class HyperVProvider : TestProvider
 			}
 
 			([TestProvider]$this).RunTestCaseCleanup($AllVMData, $CurrentTestData, $CurrentTestResult, $CollectVMLogs, $RemoveFiles, $User, $Password, $SetupTypeData, $TestParameters)
-			if ($CurrentTestResult.TestResult -ne "PASS") {
+			if ($CurrentTestResult.TestResult -ne "PASS" -and $CurrentTestResult.TestResult -ne "SKIPPED") {
 				Create-HyperVCheckpoint -VMData $AllVMData -CheckpointName "$($CurrentTestData.TestName)-$($CurrentTestResult.TestResult)" `
 					-ShouldTurnOffVMBeforeCheckpoint $false -ShouldTurnOnVMAfterCheckpoint $false
 			}


### PR DESCRIPTION
- Set 1 as default value for $maxRetryCount.
- Use $sw.elapsed.TotalSeconds, otherwise some case will enter into dead loop.
- Not shutdown VM when case is skipped.
