### PR TITLE
Added functional tests to test TVM compatibility for Linux images

### DIFF
--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -23,8 +23,8 @@ case $DISTRO in
         release=$(lsb_release -c -s)
         echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ $release main" | sudo tee -a /etc/apt/sources.list.d/azure.list
 
-    wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add  -
-    wget -qO - https://packages.microsoft.com/keys/msopentech.asc | apt-key add -
+        wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+        wget -qO - https://packages.microsoft.com/keys/msopentech.asc | apt-key add -
     ;;
     suse*|opensuse*|sles*|sle_hpc*)
         zypper ar -t rpm-md -n "packages-microsoft-com-azurecore" --no-gpgcheck https://packages.microsoft.com/yumrepos/azurecore/ azurecore

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -53,9 +53,8 @@ fi
 
 
 sudo mbinfo
-rc=$?
 
-if [ rc == 0 ]; then
+if [ $? == 0 ]; then
     UpdateSummary "This OS image is compatible with TVM."
     SetTestStateCompleted
 else

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -34,8 +34,8 @@ case $DISTRO in
         zypper ar -t rpm-md -n "packages-microsoft-com-azurecore" --no-gpgcheck https://packages.microsoft.com/yumrepos/azurecore/ azurecore
     ;;
     *)
-        LogErr "Distro not supported. Aborting..."
-        UpdateSummary "Distro not supported. Aborting..."
+        LogErr "Distro not supported. Skipping..."
+        UpdateSummary "Distro not supported. Skipping..."
         SetTestStateAborted
         exit 0
     ;;

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -33,7 +33,7 @@ case $DISTRO in
     *)
         LogErr "Distro not supported. Skipping test case..."
         UpdateSummary "Distro not supported. Skipping test case..."
-        SetTestStateAborted
+        SetTestStateSkipped
         exit 0
     ;;
 esac
@@ -50,9 +50,10 @@ fi
 
 
 output=$(sudo mbinfo)
+ret=$?
 LogMsg "$output"
 
-if [ $? == 0 ]; then
+if [ $ret == 0 ]; then
     UpdateSummary "This OS image is compatible with TVM."
     SetTestStateCompleted
 else

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -23,8 +23,8 @@ case $DISTRO in
         release=$(lsb_release -c -s)
         echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ $release main" | sudo tee -a /etc/apt/sources.list.d/azure.list
 
-        wget -qO https://packages.microsoft.com/keys/microsoft.asc | apt-key add microsoft.asc
-        wget -qO https://packages.microsoft.com/keys/msopentech.asc | apt-key add msopentech.asc
+        wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add microsoft.asc
+        wget -qO - https://packages.microsoft.com/keys/msopentech.asc | apt-key add msopentech.asc
 
     ;;
     suse*|opensuse*|sles*|sle_hpc*)

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -4,24 +4,58 @@
 
 . utils.sh || {
     echo "Error: unable to source utils.sh!"
+    echo "TestAborted" > state.txt
     exit 0
 }
 
 UtilsInit
-homeDir=$(dirname "$0")
 
-if [ ! -e "$homeDir"/tvminfo ]; then
-    LogErr "tvminfo tool is not on the system"
+GetDistro
+case $DISTRO in
+    redhat*|centos*|oracle*)
+        echo "[packages-microsoft-com-azurecore]" | tee -a /etc/yum.repos.d/azurecore.repo
+        echo "name=packages-microsoft-com-azurecore" | tee -a /etc/yum.repos.d/azurecore.repo
+        echo "baseurl=https://packages.microsoft.com/yumrepos/azurecore/" | tee -a /etc/yum.repos.d/azurecore.repo
+        echo "enabled=1" | tee -a /etc/yum.repos.d/azurecore.repo
+        echo "gpgcheck=0" | tee -a /etc/yum.repos.d/azurecore.repo
+    ;;
+    ubuntu*|debian*)
+        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ trusty main" | sudo tee -a /etc/apt/sources.list.d/azure.list
+        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ xenial main" | sudo tee -a /etc/apt/sources.list.d/azure.list
+        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ bionic main" | sudo tee -a /etc/apt/sources.list.d/azure.list
+
+        wget https://packages.microsoft.com/keys/microsoft.asc
+        wget https://packages.microsoft.com/keys/msopentech.asc
+
+        apt-key add microsoft.asc
+        apt-key add msopentech.asc
+    ;;
+    suse*|opensuse*|sles*|sle_hpc*)
+        zypper ar -t rpm-md -n "packages-microsoft-com-azurecore" --no-gpgcheck https://packages.microsoft.com/yumrepos/azurecore/ azurecore
+    ;;
+    *)
+        LogErr "Distro not supported. Aborting..."
+        UpdateSummary "Distro not supported. Aborting..."
+        SetTestStateAborted
+        exit 0
+    ;;
+esac
+
+LogMsg "Trying to install azure-compatscanner package..."
+update_repos
+install_package "azure-compatscanner"
+
+if [ ! -e /usr/bin/mbinfo ]; then
+    LogErr "mbinfo tool is not on the system"
     SetTestStateAborted
     exit 0
 fi
 
-chmod +x "$homeDir"/tvminfo
 
-sudo "$homeDir"/tvminfo
+sudo mbinfo
 rc=$?
 
-if [ rc == 0]; then
+if [ rc == 0 ]; then
     UpdateSummary "This OS image is compatible with TVM."
     SetTestStateCompleted
 else

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -23,9 +23,8 @@ case $DISTRO in
         release=$(lsb_release -c -s)
         echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ $release main" | sudo tee -a /etc/apt/sources.list.d/azure.list
 
-        wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add microsoft.asc
-        wget -qO - https://packages.microsoft.com/keys/msopentech.asc | apt-key add msopentech.asc
-
+    wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add  -
+    wget -qO - https://packages.microsoft.com/keys/msopentech.asc | apt-key add -
     ;;
     suse*|opensuse*|sles*|sle_hpc*)
         zypper ar -t rpm-md -n "packages-microsoft-com-azurecore" --no-gpgcheck https://packages.microsoft.com/yumrepos/azurecore/ azurecore

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -20,22 +20,19 @@ case $DISTRO in
         echo "gpgcheck=0" | tee -a /etc/yum.repos.d/azurecore.repo
     ;;
     ubuntu*|debian*)
-        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ trusty main" | sudo tee -a /etc/apt/sources.list.d/azure.list
-        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ xenial main" | sudo tee -a /etc/apt/sources.list.d/azure.list
-        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ bionic main" | sudo tee -a /etc/apt/sources.list.d/azure.list
+        release=$(lsb_release -c -s)
+        echo "deb [arch=amd64] http://packages.microsoft.com/repos/azurecore/ $release main" | sudo tee -a /etc/apt/sources.list.d/azure.list
 
-        wget https://packages.microsoft.com/keys/microsoft.asc
-        wget https://packages.microsoft.com/keys/msopentech.asc
+        wget -qO https://packages.microsoft.com/keys/microsoft.asc | apt-key add microsoft.asc
+        wget -qO https://packages.microsoft.com/keys/msopentech.asc | apt-key add msopentech.asc
 
-        apt-key add microsoft.asc
-        apt-key add msopentech.asc
     ;;
     suse*|opensuse*|sles*|sle_hpc*)
         zypper ar -t rpm-md -n "packages-microsoft-com-azurecore" --no-gpgcheck https://packages.microsoft.com/yumrepos/azurecore/ azurecore
     ;;
     *)
-        LogErr "Distro not supported. Skipping..."
-        UpdateSummary "Distro not supported. Skipping..."
+        LogErr "Distro not supported. Skipping test case..."
+        UpdateSummary "Distro not supported. Skipping test case..."
         SetTestStateAborted
         exit 0
     ;;
@@ -52,7 +49,8 @@ if [ ! -e /usr/bin/mbinfo ]; then
 fi
 
 
-sudo mbinfo
+output=$(sudo mbinfo)
+LogMsg "$output"
 
 if [ $? == 0 ]; then
     UpdateSummary "This OS image is compatible with TVM."

--- a/Testscripts/Linux/TVM-TestCompatibility.sh
+++ b/Testscripts/Linux/TVM-TestCompatibility.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache License.
+
+. utils.sh || {
+    echo "Error: unable to source utils.sh!"
+    exit 0
+}
+
+UtilsInit
+homeDir=$(dirname "$0")
+
+if [ ! -e "$homeDir"/tvminfo ]; then
+    LogErr "tvminfo tool is not on the system"
+    SetTestStateAborted
+    exit 0
+fi
+
+chmod +x "$homeDir"/tvminfo
+
+sudo "$homeDir"/tvminfo
+rc=$?
+
+if [ rc == 0]; then
+    UpdateSummary "This OS image is compatible with TVM."
+    SetTestStateCompleted
+else
+    UpdateSummary "This OS image is not compatible with TVM."
+    SetTestStateFailed
+fi
+
+exit 0

--- a/XML/TestCases/FunctionalTests-TVM.xml
+++ b/XML/TestCases/FunctionalTests-TVM.xml
@@ -10,8 +10,28 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D2s_v3,=~.*</OverrideVMSize>
+      <OverrideVMSize>Standard_D2s_v3,=~Standard_D[0-9]+s_v3</OverrideVMSize>
       <VMGeneration>2</VMGeneration>
+      <ARMImageName>Canonical 0003-com-ubuntu-server-trusted-vm 18_04-gen2 latest,RedHat RHEL 78-gen2 latest,RedHat RHEL 82gen2 latest,OpenLogic CentOS 7_8-gen2 latest,OpenLogic CentOS 8_2-gen2 latest,=~0003-com-ubuntu-server-trusted-vm\s18_04-gen2,=~RHEL\s78-gen2,=~RHEL\s82gen2,=~CentOS\s7_8-gen2,=~CentOS\s8_2-gen2</ARMImageName>
+    </SetupConfig>
+  </test>
+  <test>
+    <testName>TVM-TEST-COMPATIBILITY</testName>
+    <testScript>TVM-TestCompatibility.sh</testScript>
+    <files>.\Testscripts\Linux\TVM-TestCompatibility.sh,.\Testscripts\Linux\utils.sh,.\Tools\tvminfo</files>
+    <Platform>Azure</Platform>
+    <Category>Functional</Category>
+    <Area>TVM</Area>
+    <Tags>tvm</Tags>
+    <Priority>1</Priority>
+    <SetupConfig>
+      <TestLocation>eastus2euap</TestLocation>
+      <SetupType>OneVM</SetupType>
+      <SecureBoot>true</SecureBoot>
+      <vTPM>true</vTPM>
+      <OverrideVMSize>Standard_D2s_v3,=~Standard_D[0-9]+s_v3</OverrideVMSize>
+      <VMGeneration>2</VMGeneration>
+      <ARMImageName>=~0003-com-ubuntu-server-trusted-vm\s18_04-gen2</ARMImageName>
     </SetupConfig>
   </test>
 </TestCases>

--- a/XML/TestCases/FunctionalTests-TVM.xml
+++ b/XML/TestCases/FunctionalTests-TVM.xml
@@ -10,9 +10,8 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D2s_v3,=~Standard_D[0-9]+s_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D2s_v3,=~.*</OverrideVMSize>
       <VMGeneration>2</VMGeneration>
-      <ARMImageName>Canonical 0003-com-ubuntu-server-trusted-vm 18_04-gen2 latest,RedHat RHEL 78-gen2 latest,RedHat RHEL 82gen2 latest,OpenLogic CentOS 7_8-gen2 latest,OpenLogic CentOS 8_2-gen2 latest,=~0003-com-ubuntu-server-trusted-vm\s18_04-gen2,=~RHEL\s78-gen2,=~RHEL\s82gen2,=~CentOS\s7_8-gen2,=~CentOS\s8_2-gen2</ARMImageName>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/FunctionalTests-TVM.xml
+++ b/XML/TestCases/FunctionalTests-TVM.xml
@@ -17,7 +17,7 @@
   <test>
     <testName>TVM-TEST-COMPATIBILITY</testName>
     <testScript>TVM-TestCompatibility.sh</testScript>
-    <files>.\Testscripts\Linux\TVM-TestCompatibility.sh,.\Testscripts\Linux\utils.sh,.\Tools\tvminfo</files>
+    <files>.\Testscripts\Linux\TVM-TestCompatibility.sh,.\Testscripts\Linux\utils.sh</files>
     <Platform>Azure</Platform>
     <Category>Functional</Category>
     <Area>TVM</Area>


### PR DESCRIPTION
Added test case to test TVM compatibility of gallery images and OS VHDs of distro images that wish to onboard to TVM.

Attaching a test summary indicating that the tests run fine and does not cause regressions.
[TVM-TEST-COMPATIBILITY_summary.log](https://github.com/microsoft/lisa/files/5691676/TVM-TEST-COMPATIBILITY_summary.log)
