### PR TITLE
Fix "missing ]" issue in XDPDumpSetup.sh

### DIFF
--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-# This script installs XDP dump application 
+# This script installs XDP dump application
 
 repo_url="https://github.com/LIS/bpf-samples.git"
 

--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache License.
 
-# This script installs XDP dump application
+# This script installs XDP dump application 
 
 repo_url="https://github.com/LIS/bpf-samples.git"
 

--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -156,7 +156,7 @@ if [ -z ${ip} ] && [ ! -z "${1}" ]; then
     LogMsg "IP : ${ip}"
 fi
 
-if [ -z ${nicName}] && [ ! -z "${2}" ]; then
+if [ -z ${nicName} ] && [ ! -z "${2}" ]; then
     nicName=${2}
     LogMsg "nicName: ${2}"
 fi


### PR DESCRIPTION
With this issue, XDPDumpSetup.sh cannot work well. Add a space before ']' to fix this issue.

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>