### PR TITLE
Fix Kdump and DPDK test case issues.

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2178,7 +2178,7 @@ Function Get-AllDeploymentData([string]$ResourceGroups, [string]$PatternOfResour
 		$RGVMs = Get-AzResource -ResourceGroupName $ResourceGroup -ResourceType "Microsoft.Compute/virtualMachines" -Verbose `
 		| Where-Object {!$PatternOfResourceNamePrefix -or $_.Name -imatch $PatternOfResourceNamePrefix}
 		$retryCount = 0
-		while (!$RGVMs -and $retryCount -lt 5) {
+		while (!$RGVMs -and $retryCount -lt 60) {
 			Write-LogWarn "    No available Microsoft.Compute/virtualMachines resources, retry..."
 			Start-Sleep -Seconds 2
 			$retryCount++

--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -215,7 +215,7 @@ function Install_Dpdk () {
 				fi
 			else
 				if [[ "${DISTRO_NAME}" = "centos" && ${DISTRO_VERSION} == *"8."* ]]; then
-					dnf --enablerepo=PowerTools install -y meson
+					ssh "${1}" "dnf --enablerepo=PowerTools install -y meson"
 				else
 					packages+=(meson)
 				fi
@@ -232,7 +232,7 @@ function Install_Dpdk () {
 			fi
 			ssh "${1}" ". utils.sh && CheckInstallLockUbuntu && add-apt-repository 'deb http://cz.archive.ubuntu.com/ubuntu eoan main universe' "
 			ssh "${1}" ". utils.sh && CheckInstallLockUbuntu && update_repos"
-			packages+=(librdmacm-dev librdmacm1 build-essential libnuma-dev libmnl-dev libelf-dev dpkg-dev meson pkg-config)
+			packages+=(librdmacm-dev librdmacm1 build-essential libnuma-dev libmnl-dev libelf-dev dpkg-dev meson pkg-config python3-pip)
 			;;
 		suse|opensuse|sles)
 			ssh "${1}" ". utils.sh && add_sles_network_utilities_repo"
@@ -348,6 +348,15 @@ function Install_Dpdk () {
 		check_exit_status "DST IP configuration on ${1}" "exit"
 	else
 		LogMsg "dpdk build with default DST IP ADDR on ${1}"
+	fi
+
+	# meson version on Ubuntu 16.04 is 0.29.0, on Ubuntu 18.04 is 0.45.1.
+	# dpdk meson version needs at least 0.47.1.
+	if [[ ${DISTRO_NAME} == ubuntu ]]; then
+		ssh "${1}" "pip3 install --upgrade meson"
+		ssh "${1}" "mv /usr/bin/meson /usr/bin/meson.bak"
+		ssh "${1}" "ln -s /usr/local/bin/meson /usr/bin/meson"
+		ssh "${1}" "pip3 install --upgrade ninja"
 	fi
 
 	LogMsg "MLX_PMD flag enabling on ${1}"

--- a/Testscripts/Linux/nvme_blkdiscard.sh
+++ b/Testscripts/Linux/nvme_blkdiscard.sh
@@ -53,7 +53,11 @@ Run_Blkdiscard() {
             LogMsg "Unmounted ${namespace}"
         fi
         # Run blkdiscard on partition
-        blkdiscard  -v "/dev/${namespace}p1"
+        if [ "${DISTRO_NAME}" = "ubuntu" ] && [ ${DISTRO_VERSION} = "20.10" ]; then
+            blkdiscard -f -v "/dev/${namespace}p1"
+        else
+            blkdiscard -v "/dev/${namespace}p1"
+        fi
         if [ $? -ne 0 ]; then
             LogErr "Failed to run blkdiscard on ${namespace}"
             SetTestStateFailed

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -643,7 +643,7 @@
     <TestParameters>
       <param>vmCpuNumber=2</param>
       <param>vmMemory=2GB</param>
-      <param>crashkernel=256M</param>
+      <param>crashkernel=512M</param>
       <param>kexecVersion=KEXEC_VERSION</param>
     </TestParameters>
     <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
1. Fix in Azure.psm1 to extend waiting time when get deployed VM info, this issue was found in DA pipeline.
2. Fix meson version is too low to build dpdk on Ubuntu 16.04 and Ubuntu 18.04.
3. Fix blkdiscard run failed against focal.
4. Fix 256M crash memory is too low to load kdump kernel.