### PR TITLE
DPDK: Change DPDK_SOURCE_URL from 18.11.9 to 20.11

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -39,7 +39,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 <ReplaceableTestParameters>
 	<Parameter>
 		<ReplaceThis>DPDK_SOURCE_URL</ReplaceThis>
-		<ReplaceWith>https://git.dpdk.org/dpdk-stable/snapshot/dpdk-stable-18.11.9.tar.gz</ReplaceWith>
+		<ReplaceWith>https://git.dpdk.org/dpdk-stable/snapshot/dpdk-stable-20.11.tar.gz</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_PERF_CORES</ReplaceThis>


### PR DESCRIPTION
DPDK-stable won't be updating 18.11 any more as it has reached it's end of life.
We will be moving forward with 20.11 as default DPDK source as it has new features and NETVSC pmd fixes.