### PR TITLE
Fix ETHTOOL-OFFLOADING-SETTING on RHEL8.3.

### DIFF
--- a/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
+++ b/Testscripts/Linux/ETHTOOL-OFFLOADING-SETTING.sh
@@ -133,7 +133,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Install iPerf3
-ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$VF_IP2" ". /home/${SUDO_USER}/utils.sh && update_repos && install_package iperf3"
+ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$VF_IP2" ". /home/${SUDO_USER}/utils.sh && update_repos && install_package iperf3 && stop_firewall"
 if [ $? -ne 0 ]; then
     LogErr "Could not install iPerf3 on VM2 (VF_IP: ${VF_IP2})"
     SetTestStateFailed
@@ -141,8 +141,8 @@ if [ $? -ne 0 ]; then
 fi
 
 update_repos
-install_package iperf3
-
+install_iperf3
+stop_firewall
 # Start iPerf server on dependency VM
 LogMsg "Start iPerf server on VM $VF_IP2."
 ssh -i "$HOME"/.ssh/"$SSH_PRIVATE_KEY" -o StrictHostKeyChecking=no "$remote_user"@"$VF_IP2" 'iperf3 -s -D > perfResults.log'

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2464,16 +2464,37 @@ function install_iperf3 () {
 			# For SUSE, keep iperf and iperf3 in the same way
 			ln -s /usr/bin/iperf3 /usr/bin/iperf
 			# iperf3 is not available in the repository of SLES 12
-			which iperf3
+			command -v iperf3
 			if [ $? -ne 0 ]; then
-				LogMsg "iperf3 is not installed. So, Installing iperf3 using rpm"
-				iperf_url="$PACKAGE_BLOB_LOCATION/iperf-sles-x86_64.rpm"
-				libiperf_url="$PACKAGE_BLOB_LOCATION/libiperf0-sles-x86_64.rpm"
-				rpm -ivh $iperf_url $libiperf_url
-				which iperf3
+				iperf3_version=3.2
+				iperf3_url=https://github.com/esnet/iperf/archive/$iperf3_version.tar.gz
+				update_repos
+				gcc -v
 				if [ $? -ne 0 ]; then
-					LogErr "Unable to install iperf3 from source/rpm"
-					SetTestStateAborted
+					install_package "gcc"
+				fi
+				make -v
+				if [ $? -ne 0 ]; then
+					install_package "make"
+				fi
+				rm -rf $iperf3_version.tar.gz
+				wget $iperf3_url
+				if [ $? -ne 0 ]; then
+					LogErr "Failed to download iperf3 from $iperf3_url"
+					return 1
+				fi
+				rm -rf iperf-$iperf3_version
+				tar xf $iperf3_version.tar.gz
+				pushd iperf-$iperf3_version
+
+				./configure; make; make install
+				# update shared libraries links
+				ldconfig
+				popd
+				PATH="$PATH:/usr/local/bin"
+				iperf3 -v > /dev/null 2>&1
+				if [ $? -ne 0 ]; then
+					LogErr "Unable to install iperf3 from $iperf3_url"
 					return 1
 				fi
 			else
@@ -2499,7 +2520,7 @@ function install_iperf3 () {
 	if [[ $(detect_linux_distribution) == coreos ]]; then
 		docker images | grep -i lisms/iperf3
 	else
-		which iperf3
+		command -v iperf3
 	fi
 	if [ $? -ne 0 ]; then
 		return 1


### PR DESCRIPTION
RHEL 8.3 enabled firewall by default, it will prevent connection between server and client.
After fix -
```
[LISAv2 Test Results Summary]
Test Run On           : 12/24/2020 04:05:45
ARM Image Under Test  : RedHat : RHEL : 8_3 : 8.3.2020111905
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                        PASS                 3.44 
      ARMImageName: RedHat RHEL 8_3 8.3.2020111905, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.18.0-240.1.1.el8_3.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 12/24/2020 05:38:07
ARM Image Under Test  : Oracle : Oracle-Linux : ol82 : 8.2.3
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                        PASS                 3.01 
      ARMImageName: Oracle Oracle-Linux ol82 8.2.3, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.17-2036.101.2.el8uek.x86_64

[LISAv2 Test Results Summary]
Test Run On           : 12/24/2020 05:38:45
ARM Image Under Test  : Canonical : UbuntuServer : 16.04-LTS : latest
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-groovy-daily : 20_10-daily : latest
Total Test Cases      : 3 (2 Passed, 0 Failed, 0 Aborted, 1 Skipped)
Total Time (dd:hh:mm) : 0:0:19

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                        PASS                 3.36 
      ARMImageName: canonical 0001-com-ubuntu-server-groovy-daily 20_10-daily 20.10.202012100, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.8.0-1012-azure
    2 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                     SKIPPED                 1.39 
      ARMImageName: Canonical UbuntuServer 16.04-LTS 16.04.202012100, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.15.0-1098-azure
    3 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                        PASS                  3.4 
      ARMImageName: Canonical UbuntuServer 18.04-LTS 18.04.202012111, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1031-azure
```