### PR TITLE
Add one more panic pattern.

### DIFF
--- a/lisa/features/serial_console.py
+++ b/lisa/features/serial_console.py
@@ -13,6 +13,7 @@ class SerialConsole(Feature):
         re.compile(r"^(.*Kernel panic - not syncing:.*)$", re.MULTILINE),
         re.compile(r"^(.*RIP:.*)$", re.MULTILINE),
         re.compile(r"^(.*grub>.*)$", re.MULTILINE),
+        re.compile(r"^The operating system has halted.$", re.MULTILINE),
     ]
 
     # ignore some return lines, which shouldn't be a panic line.


### PR DESCRIPTION
Test against 'publisher': 'netapp', 'offer': 'netapp-ontap-cloud', 'sku': 'ontap_cloud_byol_ha', 'version': '9.5.20190717'
Result -
```
Provisioning.smoke_test: FAILED   failed: bootup found panic in serial log: ['The operating system has halted.']
```