### PR TITLE
Smoke test enhancement.

### DIFF
--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -23,5 +23,11 @@ class Waagent(Tool):
         if result.exit_code != 0:
             self._command = "/usr/sbin/waagent"
             result = self.run("-version")
+        # When the default command python points to python2,
+        # we need specify python3 clearly.
+        # e.g. bt-americas-inc diamondip-sapphire-v5 v5-9 9.0.53.
+        if result.exit_code != 0:
+            self._command = "python3 /usr/sbin/waagent"
+            result = self.run("-version")
         found_version = find_patterns_in_lines(result.stdout, [self.__version_pattern])
         return found_version[0][0] if found_version[0] else ""


### PR DESCRIPTION
Fix three issues -

- There are python and python3 installed by default in some images, need specify python3, can get expected waagent version. e.g. bt-americas-inc diamondip-sapphire-v5 v5-9 9.0.53.
- Run reboot, didn't return issue, use execute_async, e.g. SUSE sles-15-sp1-sapcal gen1 2020.10.23
- Reboot path doesn't exist issue, e.g. teradata teradata-data-mover teradata-data-mover-agent-byol 5.1.1 - (need run some testing to confirm this)




