### PR TITLE
Fixing WALA-VERIFY-HOSTNAME-CHANGE test

### DIFF
--- a/Testscripts/Linux/WALA-VERIFY-HOSTNAME-CHANGE.py
+++ b/Testscripts/Linux/WALA-VERIFY-HOSTNAME-CHANGE.py
@@ -70,7 +70,8 @@ def ChangeHostName(expectedHost):
     expected_filter_string = "Detected hostname change: {0} -> {1}".format(expectedHost, changed_hostname)
     matchCount = Run("grep -i '"+expected_filter_string+"' /var/log/waagent.log | wc -l")
     RunLog.info('Get matchCount {0}'.format(matchCount))
-    if int(matchCount.rstrip()) == 1 and CheckHostName(changed_hostname) and int(fail_error_warn_count.rstrip()) == 0:
+    # Changed matchCount condition to be >= 1 since it showed up 4 times in waagent.log file.
+    if int(matchCount.rstrip()) >= 1 and CheckHostName(changed_hostname) and int(fail_error_warn_count.rstrip()) == 0:
         return True
     else:
         return False


### PR DESCRIPTION
This tets is failing for Ubuntu 18.0 and 20.04.