### PR TITLE
Add -y to avoid manual interaction.

### DIFF
--- a/Testscripts/Linux/docker_dotnet_app.sh
+++ b/Testscripts/Linux/docker_dotnet_app.sh
@@ -45,7 +45,7 @@ InstallDotnetSDK() {
             if CheckDotnetSDKSupport $package;then
                 wget ${package} -O ${package_name}
                 dpkg -i ${package_name}
-                add-apt-repository universe
+                add-apt-repository -y universe
                 apt-get update
                 apt-get install apt-transport-https
                 apt-get update


### PR DESCRIPTION
Currently it waits for an input during testing.