### PR TITLE
DPDK - Load needed modules before testing.

### DIFF
--- a/Testscripts/Linux/dpdkPmdsBasicCheck.sh
+++ b/Testscripts/Linux/dpdkPmdsBasicCheck.sh
@@ -67,7 +67,8 @@ runTestPmd()
 {
 	pmd=$1
 	LogMsg "*********INFO: Starting TestPmd test execution with ${pmd} PMD*********"
-
+	LogMsg "Load module ib_uverbs mlx4_ib mlx5_ib"
+	modprobe -a ib_uverbs mlx4_ib mlx5_ib
 	local dpdk_version=$(Get_DPDK_Version "${LIS_HOME}/${DPDK_DIR}")
 	local pci_param="-w ${bus_info}"
 	local dpdk_version_changed="20.11"


### PR DESCRIPTION
Before fix, test failed on U1604 for not loading the modules.
```
Mon Jan 25 01:48:08 2021 : ERROR: Unexpected logs are found in failsafe PMD:
EAL: Detected 16 lcore(s)
EAL: Detected 1 NUMA nodes
Option -w, --pci-whitelist is deprecated, use -a, --allow option instead
EAL: Multi-process socket /var/run/dpdk/rte/mp_socket
EAL: Selected IOVA mode 'PA'
EAL: Probing VFIO support...
EAL: Probe PCI driver: net_mlx4 (15b3:1004) device: 6b7d:00:02.0 (socket 0)
net_mlx4: cannot list devices, is ib_uverbs loaded?
EAL: Requested device 6b7d:00:02.0 cannot be used
EAL: Bus (pci) probe failed.
EAL: Probe PCI driver: net_mlx4 (15b3:1004) device: 6b7d:00:02.0 (socket 0)
net_mlx4: cannot list devices, is ib_uverbs loaded?
EAL: Driver cannot attach the device (6b7d:00:02.0)
EAL: Failed to attach device on primary process
net_failsafe: sub_device 0 probe failed (Function not implemented)
```
After fix.
```
DPDK                 DPDK-PMDS-BASIC-CHECK                                                             PASS                 5.31 
      ARMImageName: Canonical UbuntuServer 16.04-LTS 16.04.202101190, Networking: SRIOV, TestLocation: westus2, Kernel Version: 4.15.0-1103-azure -> 4.15.0-1106-azure
```