### PR TITLE
Do not set ExitWithZero if RunInParallel

### DIFF
--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -147,7 +147,6 @@ $params["Verbose"] = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 
 try {
 	if ($RunInParallel) {
-#		$params["ExitWithZero"] = $params.RunInParallel
 		Start-LISAv2 @params -ParamsInParallel $params
 	}
 	else {

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -147,7 +147,7 @@ $params["Verbose"] = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 
 try {
 	if ($RunInParallel) {
-		$params["ExitWithZero"] = $params.RunInParallel
+#		$params["ExitWithZero"] = $params.RunInParallel
 		Start-LISAv2 @params -ParamsInParallel $params
 	}
 	else {

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -460,6 +460,7 @@ Class TestController {
 		try {
 			# Prepare test case log folder
 			$currentTestName = $($CurrentTestData.testName)
+			Write-LogInfo "Start running test case: $currentTestName"
 			$CurrentTestLogDir = "$global:LogDir\$currentTestName"
 
 			New-Item -Type Directory -Path $CurrentTestLogDir -ErrorAction SilentlyContinue | Out-Null

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -460,7 +460,6 @@ Class TestController {
 		try {
 			# Prepare test case log folder
 			$currentTestName = $($CurrentTestData.testName)
-			Write-LogInfo "Start running test case: $currentTestName"
 			$CurrentTestLogDir = "$global:LogDir\$currentTestName"
 
 			New-Item -Type Directory -Path $CurrentTestLogDir -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION
We still need to get the overall succeeded/failed status, even if RunInParallel is set. Instead we can set the ExitWithZero explictly.