### PR TITLE
DPDK/netvsc: Adding Netvsc device setup reset

### DIFF
--- a/Testscripts/Linux/dpdk-testFWD.sh
+++ b/Testscripts/Linux/dpdk-testFWD.sh
@@ -174,14 +174,20 @@ function Run_Testcase() {
 
 	if [ ${pmd} = "netvsc" ]; then
 		LogMsg "Starting netvsc device setup"
-		. dpdkUtils.sh && NetvscDevice_Setup "${sender}"
-		. dpdkUtils.sh && NetvscDevice_Setup "${forwarder}"
-		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}"
+		. dpdkUtils.sh && NetvscDevice_Setup "${sender}" "set"
+		. dpdkUtils.sh && NetvscDevice_Setup "${forwarder}" "set"
+		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}" "set"
 	fi
 	for core in "${CORES[@]}"; do
 		Run_Testfwd ${core} ${TEST_DURATION} ${tx_rx_ips}
 	done
 
+	if [ ${pmd} = "netvsc" ]; then
+		LogMsg "Resetting netvsc device setup"
+		. dpdkUtils.sh && NetvscDevice_Setup "${sender}" "reset"
+		. dpdkUtils.sh && NetvscDevice_Setup "${forwarder}" "reset"
+		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}" "reset"
+	fi
 	LogMsg "Starting testfwd parser"
 	local csv_file=$(Create_Csv)
 	echo "dpdk_version,poll_mode_driver,test_mode,core,tx_pps_avg,fwdrx_pps_avg,fwdtx_pps_avg,rx_pps_avg,tx_bytes,rx_bytes,fwd_bytes,tx_packets,rx_packets,fwd_packets,tx_packet_size,rx_packet_size" > "${csv_file}"

--- a/Testscripts/Linux/dpdk-testPMD.sh
+++ b/Testscripts/Linux/dpdk-testPMD.sh
@@ -70,8 +70,8 @@ function Run_Testpmd() {
 
 	trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${receiver}")
 	if [ ${pmd} = "netvsc" ]; then
-		. dpdkUtils.sh && NetvscDevice_Setup "${sender}"
-		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}"
+		. dpdkUtils.sh && NetvscDevice_Setup "${sender}" "set"
+		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}" "set"
 	fi
 
 	for test_mode in ${modes}; do
@@ -105,6 +105,11 @@ function Run_Testpmd() {
 		LogMsg "TestPmd execution for ${test_mode} mode on ${core} core(s) is COMPLETED"
 		sleep 10
 	done
+	if [ ${pmd} = "netvsc" ]; then
+		LogMsg "Resetting netvsc device.."
+		. dpdkUtils.sh && NetvscDevice_Setup "${sender}" "reset"
+		. dpdkUtils.sh && NetvscDevice_Setup "${receiver}" "reset"
+	fi
 }
 
 # Requires

--- a/Testscripts/Linux/dpdkTestPmd.sh
+++ b/Testscripts/Linux/dpdkTestPmd.sh
@@ -76,8 +76,8 @@ runTestPmd()
 	LogMsg "pci_info_server $pci_info_server"
 	trx_rx_ips=$(Get_Trx_Rx_Ip_Flags "${server}")
 	if [ ${pmd} = "netvsc" ]; then
-		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${server}"
-		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${client}"
+		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${server}" "set"
+		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${client}" "set"
 		vdev=''
 	elif [ ${pmd} = "failsafe" ];then
 		vdev="--vdev=net_vdev_netvsc0,iface=eth1,force=1"
@@ -122,6 +122,11 @@ runTestPmd()
 		sleep 60
 		LogMsg "TestPmd execution for ${testmode} mode is COMPLETED"
 	done
+	if [ ${pmd} = "netvsc" ]; then
+		LogMsg "Resetting Netvsc device.."
+		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${server}" "reset"
+		. ${DPDK_UTIL_FILE} && NetvscDevice_Setup "${client}" "reset"
+	fi
 }
 
 testPmdParser ()


### PR DESCRIPTION
Added netvsc device setup reset, so tests running on same VM won't Fail due to device not found.
```
[LISAv2 Test Results Summary]
Test Run On           : 01/31/2021 05:18:10
ARM Image Under Test  : Canonical : UbuntuServer : 18.04-LTS : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:17

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes)
-------------------------------------------------------------------------------------------------------------------------------------------
    1 DPDK                 VERIFY-DPDK-BUILD-AND-NETVSCPMD-TEST                                              PASS                15.92
      ARMImageName: Canonical UbuntuServer 18.04-LTS latest, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1036-azure
```