### PR TITLE
Yaml: change Camel case to snake_case in yaml

### DIFF
--- a/examples/runbook/hello_world_azure.yml
+++ b/examples/runbook/hello_world_azure.yml
@@ -4,12 +4,12 @@ extension:
     - "../testsuites"
 platform:
   - type: azure
-    adminPrivateKeyFile: $(adminPrivateKeyFile)
+    admin_private_key_file: $(admin_private_key_file)
     azure:
-      servicePrincipalTenantId: $(servicePrincipalTenantId)
-      servicePrincipalClientId: $(servicePrincipalClientId)
-      servicePrincipalKey: $(servicePrincipalKey)
-      subscriptionId: $(subscriptionId)
+      service_principal_tenant_id: $(service_principal_tenant_id)
+      service_principal_client_id: $(service_principal_client_id)
+      service_principal_key: $(service_principal_key)
+      subscription_id: $(subscription_id)
 testcase:
   - criteria:
       area: demo

--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -7,7 +7,7 @@ from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, List, Optional
 
-from dataclasses_json import LetterCase, dataclass_json  # type: ignore
+from dataclasses_json import dataclass_json  # type: ignore
 from marshmallow import validate
 
 from lisa import schema, search_space
@@ -40,7 +40,7 @@ EnvironmentStatus = Enum(
 )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class EnvironmentSpace(search_space.RequirementMixin):
     """

--- a/lisa/notifiers/console.py
+++ b/lisa/notifiers/console.py
@@ -2,13 +2,13 @@ import logging
 from dataclasses import dataclass
 from typing import List, Type, cast
 
-from dataclasses_json import LetterCase, dataclass_json  # type: ignore
+from dataclasses_json import dataclass_json  # type: ignore
 
 from lisa import notifier, schema
 from lisa.testsuite import TestResultMessage
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class ConsoleSchema(schema.TypedSchema):
     log_level: str = logging.getLevelName(logging.DEBUG)

--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -166,10 +166,10 @@ class Runner(Action):
         self._latest_test_results = test_results
 
     async def stop(self) -> None:
-        super().stop()
+        await super().stop()
 
     async def close(self) -> None:
-        super().close()
+        await super().close()
 
     def _pick_one_result_on_environment(
         self, environment: Environment, results: List[TestResult]

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, ca
 from dataclasses_json import (  # type: ignore
     CatchAll,
     DataClassJsonMixin,
-    LetterCase,
     Undefined,
     config,
     dataclass_json,
@@ -105,7 +104,7 @@ class ListableValidator(validate.Validator):
         return value
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class ExtendableSchemaMixin:
     extended_schemas: CatchAll = field(default_factory=dict)
@@ -145,13 +144,13 @@ class ExtendableSchemaMixin:
         return result
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class TypedSchema:
     type: str = ""
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Strategy:
     """
@@ -178,7 +177,7 @@ class Strategy:
     )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Parent:
     """
@@ -192,7 +191,7 @@ class Parent:
     )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Extension:
     """
@@ -204,7 +203,7 @@ class Extension:
     paths: List[str] = field(default_factory=list, metadata=metadata(required=True))
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class VariableEntry:
     is_secret: bool = False
@@ -212,7 +211,7 @@ class VariableEntry:
     value: Union[str, bool, int] = ""
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Variable:
     """
@@ -256,7 +255,7 @@ class Variable:
             self.value = self.value_raw
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class ArtifactLocation(TypedSchema):
     type: str = field(
@@ -269,7 +268,7 @@ class ArtifactLocation(TypedSchema):
         add_secret(self.path)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Artifact(TypedSchema):
     # name is optional. artifacts can be referred by name or index.
@@ -277,7 +276,7 @@ class Artifact(TypedSchema):
     locations: List[ArtifactLocation] = field(default_factory=list)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class Notifier(TypedSchema):
     """
@@ -288,7 +287,7 @@ class Notifier(TypedSchema):
     delay_parsed: CatchAll = field(default_factory=dict)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixin):
     type: str = field(
@@ -304,40 +303,33 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
     artifact: str = field(default="")
     node_count: search_space.CountSpace = field(
         default=search_space.IntRange(min=1),
-        metadata=metadata(
-            data_key="nodeCount", decoder=search_space.decode_count_space
-        ),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     core_count: search_space.CountSpace = field(
         default=search_space.IntRange(min=1),
-        metadata=metadata(
-            data_key="coreCount", decoder=search_space.decode_count_space
-        ),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     memory_mb: search_space.CountSpace = field(
         default=search_space.IntRange(min=512),
-        metadata=metadata(data_key="memoryMb", decoder=search_space.decode_count_space),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     disk_count: search_space.CountSpace = field(
         default=search_space.IntRange(min=1),
-        metadata=metadata(
-            data_key="diskCount", decoder=search_space.decode_count_space
-        ),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     nic_count: search_space.CountSpace = field(
         default=search_space.IntRange(min=1),
-        metadata=metadata(data_key="nicCount", decoder=search_space.decode_count_space),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     gpu_count: search_space.CountSpace = field(
         default=search_space.IntRange(min=0),
-        metadata=metadata(data_key="gpuCount", decoder=search_space.decode_count_space),
+        metadata=metadata(decoder=search_space.decode_count_space),
     )
     # all features on requirement should be included.
     # all features on capability can be included.
     features: Optional[search_space.SetSpace[str]] = field(
         default=None,
         metadata=metadata(
-            data_key="features",
             decoder=search_space.decode_set_space,
             allow_none=True,
         ),
@@ -347,7 +339,6 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
     excluded_features: Optional[search_space.SetSpace[str]] = field(
         default=None,
         metadata=metadata(
-            data_key="excludedFeatures",
             decoder=search_space.decode_set_space,
             allow_none=True,
         ),
@@ -527,7 +518,7 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
         return min_value
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Capability(NodeSpace):
     type: str = constants.ENVIRONMENTS_NODES_REQUIREMENT
@@ -537,7 +528,7 @@ class Capability(NodeSpace):
         self.node_count = 1
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class LocalNode(TypedSchema):
     type: str = field(
@@ -552,7 +543,7 @@ class LocalNode(TypedSchema):
     capability: Capability = field(default_factory=Capability)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class RemoteNode(TypedSchema):
     type: str = field(
@@ -571,9 +562,7 @@ class RemoteNode(TypedSchema):
     public_address: str = ""
     public_port: int = field(
         default=22,
-        metadata=metadata(
-            data_key="publicPort", validate=validate.Range(min=1, max=65535)
-        ),
+        metadata=metadata(validate=validate.Range(min=1, max=65535)),
     )
     username: str = field(default="", metadata=metadata(required=True))
     password: str = ""
@@ -589,7 +578,7 @@ class RemoteNode(TypedSchema):
 
         if not self.address and not self.public_address:
             raise LisaException(
-                "at least one of address and publicAddress need to be set"
+                "at least one of address and public_address need to be set"
             )
         elif not self.address:
             self.address = self.public_address
@@ -597,7 +586,7 @@ class RemoteNode(TypedSchema):
             self.public_address = self.address
 
         if not self.port and not self.public_port:
-            raise LisaException("at least one of port and publicPort need to be set")
+            raise LisaException("at least one of port and public_port need to be set")
         elif not self.port:
             self.port = self.public_port
         elif not self.public_port:
@@ -609,7 +598,7 @@ class RemoteNode(TypedSchema):
             )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Environment:
     name: str = field(default="")
@@ -656,19 +645,19 @@ class Environment:
             self.nodes_raw = None
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class EnvironmentRoot:
     max_concurrency: int = field(
         default=1,
-        metadata=metadata(data_key="maxConcurrency", validate=validate.Range(min=1)),
+        metadata=metadata(validate=validate.Range(min=1)),
     )
     allow_create: bool = True
     warn_as_error: bool = field(default=False)
     environments: List[Environment] = field(default_factory=list)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL, undefined=Undefined.INCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class Platform(TypedSchema, ExtendableSchemaMixin):
     type: str = field(
@@ -707,7 +696,7 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
                 )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Criteria:
     """
@@ -732,7 +721,7 @@ class Criteria:
     )
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class TestCase:
     """
@@ -780,7 +769,7 @@ class TestCase:
     environment: str = ""
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class Runbook:
     # run name prefix to help grouping results and put it in title.

--- a/lisa/search_space.py
+++ b/lisa/search_space.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Iterable, List, Optional, Set, TypeVar, Union
 
-from dataclasses_json import LetterCase, dataclass_json  # type: ignore
+from dataclasses_json import dataclass_json  # type: ignore
 
 from lisa.util import LisaException
 
@@ -67,7 +67,7 @@ class RequirementMixin:
 T_SEARCH_SPACE = TypeVar("T_SEARCH_SPACE", bound=RequirementMixin)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class IntRange(RequirementMixin):
     min: int = 0
@@ -203,7 +203,7 @@ def _one_of_matched(requirement: Any, capabilities: List[Any]) -> ResultReason:
     return result
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class SetSpace(RequirementMixin, Set[T]):
     is_allow_set: bool = False

--- a/lisa/search_space.py
+++ b/lisa/search_space.py
@@ -188,9 +188,7 @@ def decode_count_space(data: Any) -> Any:
     return decoded_data
 
 
-def _one_of_matched(
-    requirement: Any, capabilities: List[T_SEARCH_SPACE]
-) -> ResultReason:
+def _one_of_matched(requirement: Any, capabilities: List[Any]) -> ResultReason:
     result = ResultReason()
     supported = False
     assert isinstance(requirement, RequirementMixin), f"actual: {type(requirement)}"

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -2,13 +2,13 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "resourceGroupName": {
+        "resource_group_name": {
             "type": "string",
             "metadata": {
                 "description": "resource group name"
             }
         },
-        "storageName": {
+        "storage_name": {
             "type": "string",
             "metadata": {
                 "description": "storage name for boot diagnosis"
@@ -26,31 +26,31 @@
                 "description": "all nodes"
             }
         },
-        "adminUsername": {
+        "admin_username": {
             "type": "string",
             "metadata": {
                 "description": "user name"
             }
         },
-        "adminPassword": {
+        "admin_password": {
             "type": "string",
             "metadata": {
                 "description": "password"
             }
         },
-        "adminKeyData": {
+        "admin_key_data": {
             "type": "string",
             "metadata": {
                 "description": "public key data"
             }
         },
-        "availabilitySetTags": {
+        "availability_set_tags": {
             "type": "object",
             "metadata": {
                 "description": "tags of availability set"
             }
         },
-        "availabilitySetProperties": {
+        "availability_set_properties": {
             "type": "object",
             "metadata": {
                 "description": "properties of availability set"
@@ -58,25 +58,25 @@
         }
     },
     "variables": {
-        "sharedRGName": "lisa_shared_resource",
-        "virtualNetworkName": "lisa-virtualNetwork",
-        "defaultSubnet": "lisa-subnetForPrimaryNIC",
-        "vnetId": "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-        "nodeCount": "[length(parameters('nodes'))]",
-        "availabilitySetName": "lisa-availabilitySet",
-        "defaultSubnetId": "[concat(variables('vnetId'),'/subnets/', variables('defaultSubnet'))]"
+        "shared_rg_name": "lisa_shared_resource",
+        "virtual_network_name": "lisa-virtualNetwork",
+        "default_subnet": "lisa-subnetForPrimaryNIC",
+        "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtual_network_name'))]",
+        "node_count": "[length(parameters('nodes'))]",
+        "availability_set_name": "lisa-availabilitySet",
+        "default_subnetId": "[concat(variables('vnet_id'),'/subnets/', variables('default_subnet'))]"
     },
     "resources": [
         {
             "apiVersion": "2019-07-01",
             "type": "Microsoft.Compute/availabilitySets",
-            "name": "[variables('availabilitySetName')]",
+            "name": "[variables('availability_set_name')]",
             "location": "[parameters('location')]",
-            "tags": "[parameters('availabilitySetTags')]",
+            "tags": "[parameters('availability_set_tags')]",
             "sku": {
                 "name": "Aligned"
             },
-            "properties": "[parameters('availabilitySetProperties')]"
+            "properties": "[parameters('availability_set_properties')]"
         },
         {
             "apiVersion": "2020-05-01",
@@ -85,7 +85,7 @@
             "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip')]",
             "copy": {
                 "name": "vmCopy",
-                "count": "[variables('nodeCount')]"
+                "count": "[variables('node_count')]"
             },
             "properties": {
                 "publicIPAllocationMethod": "Dynamic"
@@ -94,7 +94,7 @@
         {
             "apiVersion": "2020-05-01",
             "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
+            "name": "[variables('virtual_network_name')]",
             "location": "[parameters('location')]",
             "properties": {
                 "addressSpace": {
@@ -104,7 +104,7 @@
                 },
                 "subnets": [
                     {
-                        "name": "[variables('defaultSubnet')]",
+                        "name": "[variables('default_subnet')]",
                         "properties": {
                             "addressPrefix": "10.0.0.0/24"
                         }
@@ -117,12 +117,12 @@
             "apiVersion": "2019-10-01",
             "copy": {
                 "name": "vmCopy",
-                "count": "[variables('nodeCount')]"
+                "count": "[variables('node_count')]"
             },
             "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-public-ip'))]",
-                "[variables('vnetId')]"
+                "[variables('vnet_id')]"
             ],
             "properties": {
                 "expressionEvaluationOptions": {
@@ -132,14 +132,14 @@
                     "vmName": {
                         "value": "[parameters('nodes')[copyIndex('vmCopy')]['name']]"
                     },
-                    "nicCount": {
-                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]"
+                    "nic_count": {
+                        "value": "[parameters('nodes')[copyIndex('vmCopy')]['nic_count']]"
                     },
                     "location": {
                         "value": "[parameters('location')]"
                     },
-                    "defaultSubnetId": {
-                        "value": "[variables('defaultSubnetId')]"
+                    "default_subnetId": {
+                        "value": "[variables('default_subnetId')]"
                     }
                 },
                 "mode": "Incremental",
@@ -150,13 +150,13 @@
                         "vmName": {
                             "type": "string"
                         },
-                        "nicCount": {
+                        "nic_count": {
                             "type": "int"
                         },
                         "location": {
                             "type": "string"
                         },
-                        "defaultSubnetId": {
+                        "default_subnetId": {
                             "type": "string"
                         }
                     },
@@ -166,7 +166,7 @@
                             "type": "Microsoft.Network/networkInterfaces",
                             "copy": {
                                 "name": "nicCopy",
-                                "count": "[parameters('nicCount')]"
+                                "count": "[parameters('nic_count')]"
                             },
                             "name": "[concat(parameters('vmName'), '-nic-', copyIndex('nicCopy'))]",
                             "location": "[parameters('location')]",
@@ -178,7 +178,7 @@
                                             "privateIPAddressVersion": "IPv4",
                                             "publicIPAddress": "[if(equals(0, copyIndex('nicCopy')), network.getPublicIpAddress(parameters('vmName')), json('null'))]",
                                             "subnet": {
-                                                "id": "[parameters('defaultSubnetId')]"
+                                                "id": "[parameters('default_subnetId')]"
                                             },
                                             "privateIPAllocationMethod": "Dynamic"
                                         }
@@ -216,7 +216,7 @@
             "type": "Microsoft.Compute/images",
             "copy": {
                 "name": "imageCopy",
-                "count": "[variables('nodeCount')]"
+                "count": "[variables('node_count')]"
             },
             "condition": "[not(empty(parameters('nodes')[copyIndex('imageCopy')]['vhd']))]",
             "name": "[concat(parameters('nodes')[copyIndex('imageCopy')]['name'], '-image')]",
@@ -238,29 +238,31 @@
             "type": "Microsoft.Compute/virtualMachines",
             "copy": {
                 "name": "vmCopy",
-                "count": "[variables('nodeCount')]"
+                "count": "[variables('node_count')]"
             },
             "name": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
             "location": "[parameters('nodes')[copyIndex('vmCopy')]['location']]",
-            "tags": { "RG": "[parameters('resourceGroupName')]" },
-            "plan": "[parameters('nodes')[copyIndex('vmCopy')]['purchasePlan']]",
+            "tags": {
+                "RG": "[parameters('resource_group_name')]"
+            },
+            "plan": "[parameters('nodes')[copyIndex('vmCopy')]['purchase_plan']]",
             "dependsOn": [
-                "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]",
+                "[resourceId('Microsoft.Compute/availabilitySets', variables('availability_set_name'))]",
                 "[resourceId('Microsoft.Compute/images', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-image'))]",
                 "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-networkInterfaces')]"
             ],
             "properties": {
                 "availabilitySet": {
-                    "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetName'))]"
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availability_set_name'))]"
                 },
                 "hardwareProfile": {
-                    "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vmSize']]"
+                    "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vm_size']]"
                 },
                 "osProfile": {
                     "computername": "[parameters('nodes')[copyIndex('vmCopy')]['name']]",
-                    "adminUsername": "[parameters('adminUserName')]",
-                    "adminPassword": "[if(empty(parameters('adminKeyData')), parameters('adminPassword'), json('null'))]",
-                    "linuxConfiguration": "[if(empty(parameters('adminKeyData')), json('null'), lisa.getLinuxConfiguration(concat('/home/', parameters('adminUserName'), '/.ssh/authorized_keys'), parameters('adminKeyData')))]"
+                    "adminUsername": "[parameters('admin_username')]",
+                    "adminPassword": "[if(empty(parameters('admin_key_data')), parameters('admin_password'), json('null'))]",
+                    "linuxConfiguration": "[if(empty(parameters('admin_key_data')), json('null'), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')))]"
                 },
                 "storageProfile": {
                     "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), lisa.getOsDiskGallery(parameters('nodes')[copyIndex('vmCopy')]))]",
@@ -277,7 +279,7 @@
                     "copy": [
                         {
                             "name": "networkInterfaces",
-                            "count": "[parameters('nodes')[copyIndex('vmCopy')]['nicCount']]",
+                            "count": "[parameters('nodes')[copyIndex('vmCopy')]['nic_count']]",
                             "input": {
                                 "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-nic-', copyIndex('networkInterfaces')))]",
                                 "properties": {
@@ -290,7 +292,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(resourceId(variables('sharedRGName'), 'Microsoft.Storage/storageAccounts', parameters('storageName')), '2015-06-15').primaryEndpoints['blob']]"
+                        "storageUri": "[reference(resourceId(variables('shared_rg_name'), 'Microsoft.Storage/storageAccounts', parameters('storage_name')), '2015-06-15').primaryEndpoints['blob']]"
                     }
                 }
             }

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -29,7 +29,7 @@ from azure.mgmt.resource.resources.models import (  # type: ignore
     DeploymentProperties,
 )
 from azure.mgmt.storage.models import Sku, StorageAccountCreateParameters  # type:ignore
-from dataclasses_json import LetterCase, dataclass_json  # type: ignore
+from dataclasses_json import dataclass_json  # type: ignore
 from marshmallow import fields, validate
 from retry import retry  # type: ignore
 
@@ -99,7 +99,7 @@ RESOURCE_ID_NIC_PATTERN = re.compile(r"([\w]+-[\d]+)-nic-0")
 RESOURCE_ID_PUBLIC_IP_PATTERN = re.compile(r"([\w]+-[\d]+)-public-ip")
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureCapability:
     location: str
@@ -109,7 +109,7 @@ class AzureCapability:
     resource_sku: Dict[str, Any]
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureLocation:
     updated_time: datetime = field(
@@ -118,7 +118,6 @@ class AzureLocation:
             fields.DateTime,
             encoder=datetime.isoformat,
             decoder=datetime.fromisoformat,
-            data_key="updatedTime",
             format="iso",
         ),
     )
@@ -126,7 +125,7 @@ class AzureLocation:
     capabilities: List[AzureCapability] = field(default_factory=list)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureVmGallerySchema:
     publisher: str = "Canonical"
@@ -135,7 +134,7 @@ class AzureVmGallerySchema:
     version: str = "Latest"
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureVmPurchasePlanSchema:
     name: str
@@ -143,7 +142,7 @@ class AzureVmPurchasePlanSchema:
     publisher: str
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureNodeSchema:
     name: str = ""
@@ -214,7 +213,7 @@ class AzureNodeSchema:
         return result
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzureArmParameter:
     resource_group_name: str = ""
@@ -239,20 +238,18 @@ class AzureArmParameter:
             }
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class AzurePlatformSchema:
     service_principal_tenant_id: str = field(
         default="",
         metadata=schema.metadata(
-            data_key="servicePrincipalTenantId",
             validate=validate.Regexp(constants.GUID_REGEXP),
         ),
     )
     service_principal_client_id: str = field(
         default="",
         metadata=schema.metadata(
-            data_key="servicePrincipalClientId",
             validate=validate.Regexp(constants.GUID_REGEXP),
         ),
     )
@@ -260,7 +257,6 @@ class AzurePlatformSchema:
     subscription_id: str = field(
         default="",
         metadata=schema.metadata(
-            data_key="subscriptionId",
             validate=validate.Regexp(constants.GUID_REGEXP),
         ),
     )
@@ -273,7 +269,6 @@ class AzurePlatformSchema:
     log_level: str = field(
         default=logging.getLevelName(logging.WARN),
         metadata=schema.metadata(
-            data_key="logLevel",
             validate=validate.OneOf(
                 [
                     logging.getLevelName(logging.ERROR),
@@ -670,7 +665,9 @@ class AzurePlatform(Platform):
             except Exception as identifier:
                 # if schema changed, There may be exception, remove cache and retry
                 # Note: retry on this method depends on decorator
-                log.debug("error on loading cache, delete cache and retry.")
+                log.debug(
+                    f"error on loading cache, delete cache and retry. {identifier}"
+                )
                 cached_file_name.unlink()
                 raise identifier
         return loaded_obj

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_australiaeast.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_australiaeast.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_brazilsouth.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_brazilsouth.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_eastus.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_eastus.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_eastus2.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_eastus2.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:46.895330",
+    "updated_time": "9999-09-21T12:16:46.895330",
     "location": "eastus2",
     "capabilities": [
         {
             "location": "eastus2",
-            "vmSize": "Standard_B1ls",
+            "vm_size": "Standard_B1ls",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_B1ls",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 512,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 512,
+                "disk_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_B1ls",
                 "tier": "Standard",
@@ -144,35 +144,35 @@
         },
         {
             "location": "eastus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -291,39 +291,39 @@
         },
         {
             "location": "eastus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",
@@ -442,35 +442,35 @@
         },
         {
             "location": "eastus2",
-            "vmSize": "Standard_DS15_v2",
+            "vm_size": "Standard_DS15_v2",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_DS15_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 20,
-                "memoryMb": 143360,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 20,
+                "memory_mb": 143360,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 20,
-            "resourceSku": {
+            "estimated_cost": 20,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS15_v2",
                 "tier": "Standard",
@@ -607,35 +607,35 @@
         },
         {
             "location": "eastus2",
-            "vmSize": "Standard_A8_v2",
+            "vm_size": "Standard_A8_v2",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_A8_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 8,
-                "memoryMb": 16384,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 8,
+                "memory_mb": 16384,
+                "disk_count": {
                     "min": 0,
                     "max": 16,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 8,
-            "resourceSku": {
+            "estimated_cost": 8,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_A8_v2",
                 "tier": "Standard",
@@ -742,35 +742,35 @@
         },
         {
             "location": "eastus2",
-            "vmSize": "Standard_NV48s_v3",
+            "vm_size": "Standard_NV48s_v3",
             "capability": {
                 "type": "requirement",
                 "name": "eastus2_Standard_NV48s_v3",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 48,
-                "memoryMb": 458752,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 48,
+                "memory_mb": 458752,
+                "disk_count": {
                     "min": 0,
                     "max": 32,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 4,
+                "gpu_count": 4,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 448,
-            "resourceSku": {
+            "estimated_cost": 448,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_NV48s_v3",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_northeurope.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_northeurope.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_notreal.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_notreal.json
@@ -1,5 +1,5 @@
 {
-    "updatedTime": "9999-09-21T12:16:46.895330",
+    "updated_time": "9999-09-21T12:16:46.895330",
     "location": "notreal",
     "capabilities": []
 }

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_southcentralus.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_southcentralus.json
@@ -1,5 +1,5 @@
 {
-    "updatedTime": "9999-09-21T12:16:46.895330",
+    "updated_time": "9999-09-21T12:16:46.895330",
     "location": "southeastasia",
     "capabilities": []
 }

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_southeastasia.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_southeastasia.json
@@ -1,5 +1,5 @@
 {
-    "updatedTime": "9999-09-21T12:16:46.895330",
+    "updated_time": "9999-09-21T12:16:46.895330",
     "location": "southeastasia",
     "capabilities": []
 }

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_uksouth.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_uksouth.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_westeurope.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_westeurope.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/sut_orchestrator/azure/tests/azure_locations_westus2.json
+++ b/lisa/sut_orchestrator/azure/tests/azure_locations_westus2.json
@@ -1,38 +1,38 @@
 {
-    "updatedTime": "9999-09-21T12:16:43.682968",
+    "updated_time": "9999-09-21T12:16:43.682968",
     "location": "westus2",
     "capabilities": [
         {
             "location": "westus2",
-            "vmSize": "Standard_M208ms_v2",
+            "vm_size": "Standard_M208ms_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_M208ms_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 208,
-                "memoryMb": 5836800,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 208,
+                "memory_mb": 5836800,
+                "disk_count": {
                     "min": 0,
                     "max": 64,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 208,
-            "resourceSku": {
+            "estimated_cost": 208,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_M208ms_v2",
                 "tier": "Standard",
@@ -143,35 +143,35 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS1_v2",
+            "vm_size": "Standard_DS1_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS1_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 1,
-                "memoryMb": 3584,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 1,
+                "memory_mb": 3584,
+                "disk_count": {
                     "min": 0,
                     "max": 4,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true
+                    "is_allow_set": true
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false
+                "excluded_features": {
+                    "is_allow_set": false
                 }
             },
-            "estimatedCost": 1,
-            "resourceSku": {
+            "estimated_cost": 1,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS1_v2",
                 "tier": "Standard",
@@ -290,39 +290,39 @@
         },
         {
             "location": "westus2",
-            "vmSize": "Standard_DS2_v2",
+            "vm_size": "Standard_DS2_v2",
             "capability": {
                 "type": "requirement",
                 "name": "westus2_Standard_DS2_v2",
                 "isDefault": false,
                 "artifact": "",
-                "nodeCount": 1,
-                "coreCount": 2,
-                "memoryMb": 7168,
-                "diskCount": {
+                "node_count": 1,
+                "core_count": 2,
+                "memory_mb": 7168,
+                "disk_count": {
                     "min": 0,
                     "max": 8,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "nicCount": {
+                "nic_count": {
                     "min": 0,
                     "max": 2,
-                    "maxInclusive": true
+                    "max_inclusive": true
                 },
-                "gpuCount": 0,
+                "gpu_count": 0,
                 "features": {
-                    "isAllowSet": true,
+                    "is_allow_set": true,
                     "items": [
                         "StartStop"
                     ]
                 },
-                "excludedFeatures": {
-                    "isAllowSet": false,
+                "excluded_features": {
+                    "is_allow_set": false,
                     "items": []
                 }
             },
-            "estimatedCost": 2,
-            "resourceSku": {
+            "estimated_cost": 2,
+            "resource_sku": {
                 "resource_type": "virtualMachines",
                 "name": "Standard_DS2_v2",
                 "tier": "Standard",

--- a/lisa/tests/test_env_requirement.py
+++ b/lisa/tests/test_env_requirement.py
@@ -90,39 +90,39 @@ class RequirementTestCase(SearchSpaceTestCase):
         n1 = schema.NodeSpace()
         n1 = n1.generate_min_capability(n1)
         n4 = schema.NodeSpace.schema().load(  # type:ignore
-            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "coreCount": 4}
+            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "core_count": 4}
         )
         n4 = n4.generate_min_capability(n4)
         n4g1 = schema.NodeSpace.schema().load(  # type:ignore
             {
                 "type": constants.ENVIRONMENTS_NODES_REQUIREMENT,
-                "coreCount": 4,
-                "gpuCount": 1,
+                "core_count": 4,
+                "gpu_count": 1,
             }
         )
         n4g1 = n4g1.generate_min_capability(n4g1)
         n6 = schema.NodeSpace.schema().load(  # type:ignore
-            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "coreCount": 6}
+            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "core_count": 6}
         )
         n6 = n6.generate_min_capability(n6)
         n6g2 = schema.NodeSpace.schema().load(  # type:ignore
             {
                 "type": constants.ENVIRONMENTS_NODES_REQUIREMENT,
-                "coreCount": 6,
-                "gpuCount": 2,
+                "core_count": 6,
+                "gpu_count": 2,
             }
         )
         n6g2 = n6g2.generate_min_capability(n6g2)
         n6g1 = schema.NodeSpace.schema().load(  # type:ignore
             {
                 "type": constants.ENVIRONMENTS_NODES_REQUIREMENT,
-                "coreCount": 6,
-                "gpuCount": 1,
+                "core_count": 6,
+                "gpu_count": 1,
             }
         )
         n6g1 = n6g1.generate_min_capability(n6g1)
         n10 = schema.NodeSpace.schema().load(  # type:ignore
-            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "coreCount": 10}
+            {"type": constants.ENVIRONMENTS_NODES_REQUIREMENT, "core_count": 10}
         )
         n10 = n10.generate_min_capability(n10)
 

--- a/lisa/tests/test_environment.py
+++ b/lisa/tests/test_environment.py
@@ -19,7 +19,7 @@ def generate_runbook(
         nodes.append(
             {
                 constants.TYPE: constants.ENVIRONMENTS_NODES_LOCAL,
-                constants.ENVIRONMENTS_NODES_CAPABILITY: {"coreCount": {"min": 4}},
+                constants.ENVIRONMENTS_NODES_CAPABILITY: {"core_count": {"min": 4}},
             }
         )
     if remote:
@@ -28,8 +28,8 @@ def generate_runbook(
                 constants.TYPE: constants.ENVIRONMENTS_NODES_REMOTE,
                 constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS: "internal_address",
                 constants.ENVIRONMENTS_NODES_REMOTE_PORT: 22,
-                "publicAddress": "public_address",
-                "publicPort": 10022,
+                "public_address": "public_address",
+                "public_port": 10022,
                 constants.ENVIRONMENTS_NODES_REMOTE_USERNAME: "name_of_user",
                 constants.ENVIRONMENTS_NODES_REMOTE_PASSWORD: "dont_use_it",
             }
@@ -38,10 +38,10 @@ def generate_runbook(
         nodes.append(
             {
                 constants.TYPE: constants.ENVIRONMENTS_NODES_REQUIREMENT,
-                "nodeCount": 2,
-                "coreCount": 8,
-                "diskCount": {"min": 1},
-                "nicCount": {"min": 1, "max": 1},
+                "node_count": 2,
+                "core_count": 8,
+                "disk_count": {"min": 1},
+                "nic_count": {"min": 1, "max": 1},
             }
         )
     if is_single_env:
@@ -50,7 +50,7 @@ def generate_runbook(
         for node in nodes:
             environments.append({"nodes": [node]})
 
-    data = {"maxConcurrency": 2, constants.ENVIRONMENTS: environments}
+    data = {"max_concurrency": 2, constants.ENVIRONMENTS: environments}
     return schema.EnvironmentRoot.schema().load(data)  # type: ignore
 
 

--- a/lisa/tests/test_platform.py
+++ b/lisa/tests/test_platform.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, List, Optional, Type, Union
 from unittest.case import TestCase
 
-from dataclasses_json import LetterCase, dataclass_json  # type: ignore
+from dataclasses_json import dataclass_json  # type: ignore
 
 from lisa import schema
 from lisa.environment import (
@@ -25,7 +25,7 @@ class MockPlatformTestData:
     deleted_envs: List[str] = field(default_factory=list)
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class MockPlatformSchema:
     # for other UT to set value
@@ -111,9 +111,9 @@ def generate_platform(
 ) -> MockPlatform:
     runbook_data = {
         constants.TYPE: constants.PLATFORM_MOCK,
-        "reserveEnvironment": reserve_environment,
-        "adminPassword": admin_password,
-        "adminPrivateKeyFile": admin_key_file,
+        "reserve_environment": reserve_environment,
+        "admin_password": admin_password,
+        "admin_private_key_file": admin_key_file,
     }
     runbook = schema.Platform.schema().load(runbook_data)  # type: ignore
     platform = load_platform([runbook])

--- a/lisa/tests/test_variable.py
+++ b/lisa/tests/test_variable.py
@@ -13,33 +13,33 @@ class VariableTestCase(TestCase):
         secret.reset()
 
     def test_in_env(self) -> None:
-        os.environ["LISA_normalValue"] = "value_from_env"
-        os.environ["S_LISA_normalEntry"] = "s_value_from_env"
+        os.environ["LISA_normal_value"] = "value_from_env"
+        os.environ["S_LISA_normal_entry"] = "s_value_from_env"
         variables = self._get_default_variables()
         variable.load_from_env(variables)
-        data = self._replace_and_validate(variables, {"normalEntry": "******"})
+        data = self._replace_and_validate(variables, {"normal_entry": "******"})
         self.assertEqual("value_from_env", data["nested"]["normal_value"])
-        self.assertEqual("s_value_from_env", data["normalEntry"])
+        self.assertEqual("s_value_from_env", data["normal_entry"])
 
     def test_in_pair(self) -> None:
-        pair1 = "normalValue:nv_from_pair"
-        pair2 = "S:normalEntry:s_value_from_env"
+        pair1 = "normal_value:nv_from_pair"
+        pair2 = "S:normal_entry:s_value_from_env"
         variables = self._get_default_variables()
         variable.load_from_pairs([pair1, pair2], variables)
-        data = self._replace_and_validate(variables, {"normalEntry": "******"})
+        data = self._replace_and_validate(variables, {"normal_entry": "******"})
         self.assertEqual("nv_from_pair", data["nested"]["normal_value"])
-        self.assertEqual("s_value_from_env", data["normalEntry"])
+        self.assertEqual("s_value_from_env", data["normal_entry"])
 
     def test_in_normal_file_outside_secret(self) -> None:
         self._test_files(
             "variable_normal.yml",
             True,
             {
-                "normalValue": "******",
-                "normalEntry": "******",
-                "secretGuid": "12345678-****-****-****-********90ab",
-                "secretInt": "1****0",
-                "secretHeadTail": "a****h",
+                "normal_value": "******",
+                "normal_entry": "******",
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
             },
         )
 
@@ -48,9 +48,9 @@ class VariableTestCase(TestCase):
             "variable_normal.yml",
             False,
             {
-                "secretGuid": "12345678-****-****-****-********90ab",
-                "secretInt": "1****0",
-                "secretHeadTail": "a****h",
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
             },
         )
 
@@ -59,11 +59,11 @@ class VariableTestCase(TestCase):
             "variable_secret.yml",
             True,
             {
-                "normalValue": "******",
-                "normalEntry": "******",
-                "secretGuid": "12345678-****-****-****-********90ab",
-                "secretInt": "1****0",
-                "secretHeadTail": "a****h",
+                "normal_value": "******",
+                "normal_entry": "******",
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
             },
         )
 
@@ -79,43 +79,43 @@ class VariableTestCase(TestCase):
         data = self._test_runbook_file_entry(
             runbook_data,
             {
-                "secretGuid": "12345678-****-****-****-********90ab",
-                "secretInt": "1****0",
-                "secretHeadTail": "a****h",
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
             },
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
         self.assertEqual(1234567890, data["list"][1]["dictInList"])
         self.assertEqual("abcdefgh", data["headtail"])
         self.assertEqual("normal_value", data["nested"]["normal_value"])
-        self.assertEqual("entry_value", data["normalEntry"])
+        self.assertEqual("entry_value", data["normal_entry"])
 
     def test_in_runbook_format_variable(self) -> None:
         runbook_data: Dict[str, Any] = {
             "variable": [
-                {"name": "normalValue", "value": "normal_value"},
-                {"name": "normalEntry", "value": {"value": "entry_value"}},
+                {"name": "normal_value", "value": "normal_value"},
+                {"name": "normal_entry", "value": {"value": "entry_value"}},
                 {
-                    "name": "secretGuid",
+                    "name": "secret_guid",
                     "value": {
                         "value": "12345678-abcd-efab-cdef-1234567890ab",
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "guid",
                     },
                 },
                 {
-                    "name": "secretInt",
+                    "name": "secret_int",
                     "value": {
                         "value": 1234567890,
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "headtail",
                     },
                 },
                 {
-                    "name": "secretHeadTail",
+                    "name": "secret_head_tail",
                     "value": {
                         "value": "abcdefgh",
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "headtail",
                     },
                 },
@@ -124,44 +124,44 @@ class VariableTestCase(TestCase):
         data = self._test_runbook_file_entry(
             runbook_data,
             {
-                "secretGuid": "12345678-****-****-****-********90ab",
-                "secretInt": "1****0",
-                "secretHeadTail": "a****h",
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
             },
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
         self.assertEqual(1234567890, data["list"][1]["dictInList"])
         self.assertEqual("abcdefgh", data["headtail"])
         self.assertEqual("normal_value", data["nested"]["normal_value"])
-        self.assertEqual("entry_value", data["normalEntry"])
+        self.assertEqual("entry_value", data["normal_entry"])
 
     def test_in_runbook_ordered(self) -> None:
         runbook_data: Dict[str, Any] = {
             "variable": [
                 {"file": "variable_normal.yml"},
-                {"name": "normalValue", "value": "normal_value1"},
-                {"name": "normalEntry", "value": {"value": "entry_value1"}},
+                {"name": "normal_value", "value": "normal_value1"},
+                {"name": "normal_entry", "value": {"value": "entry_value1"}},
                 {
-                    "name": "secretGuid",
+                    "name": "secret_guid",
                     "value": {
                         "value": "12345678-abcd-efab-cdef-1234567890ac",
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "guid",
                     },
                 },
                 {
-                    "name": "secretInt",
+                    "name": "secret_int",
                     "value": {
                         "value": 1234567891,
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "headtail",
                     },
                 },
                 {
-                    "name": "secretHeadTail",
+                    "name": "secret_head_tail",
                     "value": {
                         "value": "abcdefgi",
-                        "isSecret": True,
+                        "is_secret": True,
                         "mask": "headtail",
                     },
                 },
@@ -170,16 +170,16 @@ class VariableTestCase(TestCase):
         data = self._test_runbook_file_entry(
             runbook_data,
             {
-                "secretGuid": "12345678-****-****-****-********90ac",
-                "secretInt": "1****1",
-                "secretHeadTail": "a****i",
+                "secret_guid": "12345678-****-****-****-********90ac",
+                "secret_int": "1****1",
+                "secret_head_tail": "a****i",
             },
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ac", data["list"][0])
         self.assertEqual(1234567891, data["list"][1]["dictInList"])
         self.assertEqual("abcdefgi", data["headtail"])
         self.assertEqual("normal_value1", data["nested"]["normal_value"])
-        self.assertEqual("entry_value1", data["normalEntry"])
+        self.assertEqual("entry_value1", data["normal_entry"])
 
     def test_variable_not_found(self) -> None:
         variables = self._get_default_variables()
@@ -192,10 +192,10 @@ class VariableTestCase(TestCase):
         variables = self._get_default_variables()
         variables["unused"] = variable.VariableEntry("value")
         self.assertFalse(variables["unused"].is_used)
-        self.assertFalse(variables["normalvalue"].is_used)
-        self._replace_and_validate(variables, {"normalEntry": "original"})
+        self.assertFalse(variables["normal_value"].is_used)
+        self._replace_and_validate(variables, {"normal_entry": "original"})
         self.assertFalse(variables["unused"].is_used)
-        self.assertTrue(variables["normalvalue"].is_used)
+        self.assertTrue(variables["normal_value"].is_used)
 
     def test_invalid_file_extension(self) -> None:
         variables = self._get_default_variables()
@@ -221,7 +221,7 @@ class VariableTestCase(TestCase):
         variable.load_from_file(file_name, variables, is_secret=all_secret)
         data = self._replace_and_validate(variables, secret_variables)
         self.assertEqual("normal_value", data["nested"]["normal_value"])
-        self.assertEqual("entry_value", data["normalEntry"])
+        self.assertEqual("entry_value", data["normal_entry"])
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
         self.assertEqual(1234567890, data["list"][1]["dictInList"])
         self.assertEqual("abcdefgh", data["headtail"])
@@ -255,11 +255,11 @@ class VariableTestCase(TestCase):
 
     def _get_default_variables(self) -> Dict[str, variable.VariableEntry]:
         data = {
-            "normalvalue": variable.VariableEntry("original"),
-            "normalentry": variable.VariableEntry("original"),
-            "secretguid": variable.VariableEntry("original"),
-            "secretint": variable.VariableEntry("original"),
-            "secretheadtail": variable.VariableEntry("original"),
+            "normal_value": variable.VariableEntry("original"),
+            "normal_entry": variable.VariableEntry("original"),
+            "secret_guid": variable.VariableEntry("original"),
+            "secret_int": variable.VariableEntry("original"),
+            "secret_head_tail": variable.VariableEntry("original"),
         }
         return data
 
@@ -271,12 +271,12 @@ class VariableTestCase(TestCase):
         self.assertDictEqual(
             {
                 "keep": "normal",
-                "normalEntry": variables["normalentry"].data,
-                "headtail": variables["secretheadtail"].data,
-                "nested": {"normal_value": variables["normalvalue"].data},
+                "normal_entry": variables["normal_entry"].data,
+                "headtail": variables["secret_head_tail"].data,
+                "nested": {"normal_value": variables["normal_value"].data},
                 "list": [
-                    variables["secretguid"].data,
-                    {"dictInList": variables["secretint"].data},
+                    variables["secret_guid"].data,
+                    {"dictInList": variables["secret_int"].data},
                 ],
             },
             data,
@@ -288,9 +288,9 @@ class VariableTestCase(TestCase):
     def _get_default_data(self) -> Dict[str, Any]:
         data = {
             "keep": "normal",
-            "normalEntry": "$(normalEntry)",
-            "headtail": "$(secretHeadTail)",
-            "nested": {"normal_value": "$(normalValue)"},
-            "list": ["$(secretGuid)", {"dictInList": "$(secretInt)"}],
+            "normal_entry": "$(normal_entry)",
+            "headtail": "$(secret_head_tail)",
+            "nested": {"normal_value": "$(normal_value)"},
+            "list": ["$(secret_guid)", {"dictInList": "$(secret_int)"}],
         }
         return data

--- a/lisa/tests/variable_normal.yml
+++ b/lisa/tests/variable_normal.yml
@@ -1,15 +1,15 @@
-normalValue: normal_value
-normalEntry:
+normal_value: normal_value
+normal_entry:
   value: entry_value
-secretGuid:
+secret_guid:
   value: 12345678-abcd-efab-cdef-1234567890ab
-  isSecret: true
+  is_secret: true
   mask: guid
-secretInt:
+secret_int:
   value: 1234567890
-  isSecret: true
+  is_secret: true
   mask: headtail
-secretHeadTail:
+secret_head_tail:
   value: abcdefgh
-  isSecret: true
+  is_secret: true
   mask: headtail

--- a/lisa/tests/variable_secret.yml
+++ b/lisa/tests/variable_secret.yml
@@ -1,12 +1,12 @@
-normalValue: normal_value
-normalEntry:
+normal_value: normal_value
+normal_entry:
   value: entry_value
-secretGuid:
+secret_guid:
   value: 12345678-abcd-efab-cdef-1234567890ab
   mask: guid
-secretInt:
+secret_int:
   value: 1234567890
   mask: headtail
-secretHeadTail:
+secret_head_tail:
   value: abcdefgh
   mask: headtail

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -72,10 +72,10 @@ class Reboot(Tool):
             self._command = command_result.stdout
         self._log.debug(f"rebooting with boot time: {last_boot_time}")
         try:
-            # The reason for using function execute_async is,
-            # in some case, it doesn't return back after run reboot.
-            # e.g. SUSE sles-15-sp1-sapcal gen1 2020.10.23.
-            self.node.execute_async(f"sudo {self._command}")
+            # Reboot is not reliable, and sometime stucks,
+            # like SUSE sles-15-sp1-sapcal gen1 2020.10.23.
+            # In this case, use timeout to prevent hanging.
+            self.node.execute(f"sudo {self.command}", timeout=10)
         except Exception as identifier:
             # it doesn't matter to exceptions here. The system may reboot fast
             self._log.debug(f"ignorable exception on rebooting: {identifier}")

--- a/testsuites/runbooks/azure/p0.yml
+++ b/testsuites/runbooks/azure/p0.yml
@@ -4,18 +4,18 @@ extension:
     - "../../basic"
 variable:
   - file: secret.yml
-    isSecret: true
+    is_secret: true
 environment:
-  maxConcurrency: 1
-  warnAsError: false
+  max_concurrency: 1
+  warn_as_error: false
 platform:
   - type: azure
-    adminPrivateKeyFile: $(adminPrivateKeyFile)
+    admin_private_key_file: $(admin_private_key_file)
     azure:
-      servicePrincipalTenantId: $(servicePrincipalTenantId)
-      servicePrincipalClientId: $(servicePrincipalClientId)
-      servicePrincipalKey: $(servicePrincipalKey)
-      subscriptionId: $(subscriptionId)
+      service_principal_tenant_id: $(service_principal_tenant_id)
+      service_principal_client_id: $(service_principal_client_id)
+      service_principal_key: $(service_principal_key)
+      subscription_id: $(subscription_id)
 testcase:
   - criteria:
       priority: 0

--- a/testsuites/runbooks/azure/secret.yml
+++ b/testsuites/runbooks/azure/secret.yml
@@ -1,13 +1,13 @@
-servicePrincipalTenantId:
+service_principal_tenant_id:
   value: <real tenant id>
   mask: guid
-servicePrincipalClientId:
+service_principal_client_id:
   value: <real client id>
   mask: guid
-servicePrincipalKey:
+service_principal_key:
   value: <real key>
-subscriptionId:
+subscription_id:
   value: <real subscription id>
   mask: guid
-adminPrivateKeyFile:
+admin_private_key_file:
   value: <private key path>


### PR DESCRIPTION
The camelCase is recommended in yaml, but it's different with Python
style. The trouble is when searching in yaml, it's hard to find Python
schema, and versus. So, change to use snake_case, for easier searching.

There are some minor fixes also.