### PR TITLE
Support redhat_9 distro in TIME-CLOCKSOURCE

### DIFF
--- a/Testscripts/Linux/TIME-CLOCKSOURCE.sh
+++ b/Testscripts/Linux/TIME-CLOCKSOURCE.sh
@@ -134,7 +134,7 @@ case $DISTRO in
 		LogMsg "WARNING: $DISTRO does not support unbinding the current clocksource, only check sourcing"
 		CheckSource
 		;;
-	redhat_8 | centos_8 | fedora* | clear-linux-os | ubuntu* | suse* | coreos*)
+	redhat_9 | redhat_8 | centos_8 | fedora* | clear-linux-os | ubuntu* | suse* | coreos*)
 		CheckSource
 		UnbindCurrentSource
 		;;

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -288,6 +288,9 @@ function GetDistro() {
 		*Red*8.*)
 			DISTRO=redhat_8
 			;;
+		*Red*9.*)
+			DISTRO=redhat_9
+			;;
 		*Red*)
 			DISTRO=redhat_x
 			;;


### PR DESCRIPTION
Now RHEL-9 is in testing. So add RHEL-9 distro support, and enable RHEL-9 support for TIME-CLOCKSOURCE case.

```
# bash TIME-CLOCKSOURCE.sh
OS family: Rhel
Sun Feb 07 16:58:24 2021 : Testscript running on redhat_9
Sun Feb 07 16:58:24 2021 : Successfully initialized testscript!
Sun Feb 07 16:58:24 2021 : Running CheckSource
Sun Feb 07 16:58:24 2021 : Temporary clocksource: hyperv_clocksource_tsc_page
Sun Feb 07 16:58:24 2021 : Found currect_clocksource hyperv_clocksource_tsc_page in /sys/devices/system/clocksource/clocksource0/current_clocksource
Sun Feb 07 16:58:24 2021 : Test successful. Proper file was found. Clocksource file content is hyperv_clocksource_tsc_page
Sun Feb 07 16:58:24 2021 : Test successful. /proc/cpuinfo contains flag tsc
grep: /var/log/journal/ab259847658446af95d3c96e7d9d9903/system.journal: binary file matches
grep: /var/log/journal/ab259847658446af95d3c96e7d9d9903/system@c77edc68eb654ccfa92ed35d48c15ea7-0000000000000c61-0005ba786c0bc075.journal: binary file matches
grep: /var/log/journal/ab259847658446af95d3c96e7d9d9903/system@c77edc68eb654ccfa92ed35d48c15ea7-0000000000000001-0005ba6424ab628d.journal: binary file matches
Sun Feb 07 16:58:25 2021 : dmesg log search result: /var/log/messages:512:Feb  7 12:09:50 localhost kernel: clocksource: Switched to clocksource hyperv_clocksource_tsc_page
Sun Feb 07 16:58:25 2021 : Test successful. dmesg contains log - /var/log/messages:512:Feb  7 12:09:50 localhost kernel: clocksource: Switched to clocksource hyperv_clocksource_tsc_page
Sun Feb 07 16:58:25 2021 : Running UnbindCurrentSource
Sun Feb 07 16:58:25 2021 : Assign hyperv_clocksource_tsc_page to /sys/devices/system/clocksource/clocksource0/unbind_clocksource
Sun Feb 07 16:58:25 2021 : Found _clocksource: acpi_pm
Sun Feb 07 16:58:25 2021 : Sleep 10 seconds for message show up in log file for the 1 time(s).
grep: /var/log/journal/ab259847658446af95d3c96e7d9d9903/system.journal: binary file matches
Sun Feb 07 16:58:36 2021 : Test successful. After unbind, current clocksource is acpi_pm
Sun Feb 07 16:58:36 2021 : Test completed successfully.
```

Signed-off-by: Yuxin Sun <yuxisun@redhat.com>