### PR TITLE
Add test case KDUMP-CRASH-LARGE-VCPU

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -347,9 +347,6 @@ Config_"${OS_FAMILY}"
 # Remove old crashkernel params
 sed -i --follow-symlinks "s/crashkernel=\S*//g" $boot_filepath
 
-# Remove console params; It could interfere with the testing
-sed -i --follow-symlinks "s/console=\S*//g" $boot_filepath
-
 # Add the crashkernel param
 if [[ $DISTRO != "redhat_8" ]] && [[ $DISTRO != "centos_8" ]]; then
     sed -i --follow-symlinks "/vmlinuz-$(uname -r)/ s/$/ crashkernel=$crashkernel/" $boot_filepath

--- a/Testscripts/Windows/KDUMP-TestScript.ps1
+++ b/Testscripts/Windows/KDUMP-TestScript.ps1
@@ -41,6 +41,7 @@ function Main {
           "VM2NAME"       { $vm2Name = $fields[1].Trim() }
           "use_nfs"       { $useNFS = $fields[1].Trim() }
           "vmCpuNumber"   { $vCPU = $fields[1].Trim() }
+          "crashedVcpu"   { $crashedVcpu = $fields[1].Trim()}
           default         {}
         }
     }
@@ -147,6 +148,10 @@ function Main {
             Write-LogInfo "Kdump will be triggered on VCPU 3 of 4"
             Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
                 -command "taskset -c 2 echo c > /proc/sysrq-trigger" -RunInBackGround -runAsSudo | Out-Null
+        } elseif ($crashedVcpu) {
+            Write-LogInfo "Kdump will be triggered on $crashedVcpu"
+            Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
+                -command "taskset -c $crashedVcpu echo c > /proc/sysrq-trigger" -RunInBackGround -runAsSudo | Out-Null
         } else {
             # If directly use plink to trigger kdump, command fails to exit, so use start-process
             Write-LogInfo "Set /proc/sysrq-trigger"

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -805,4 +805,8 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceThis>NTTTCP_MONITOR_TOLERANCE</ReplaceThis>
 		<ReplaceWith>0.3</ReplaceWith>
 	</Parameter>
+	<Parameter>
+		<ReplaceThis>CRASHED_VCPU</ReplaceThis>
+		<ReplaceWith>32</ReplaceWith>
+	</Parameter>
 </ReplaceableTestParameters>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -741,6 +741,27 @@
     </SetupConfig>
   </test>
   <test>
+    <testName>KDUMP-CRASH-LARGE-VCPU</testName>
+    <testScript>KDUMP-TestScript.ps1</testScript>
+    <files>.\Testscripts\Linux\KDUMP-Execute.sh,.\Testscripts\Linux\KDUMP-Config.sh,.\Testscripts\Linux\KDUMP-Results.sh,.\Testscripts\Linux\utils.sh</files>
+    <TestParameters>
+      <param>crashedVcpu=CRASHED_VCPU</param>
+      <param>vmMemory=4GB</param>
+      <param>crashkernel=512M</param>
+      <param>kexecVersion=KEXEC_VERSION</param>
+    </TestParameters>
+    <Platform>Azure,HyperV</Platform>
+    <Category>Functional</Category>
+    <Area>KDUMP</Area>
+    <Tags>kdump</Tags>
+    <Priority>1</Priority>
+    <SetupConfig>
+      <SetupType>OneVM</SetupType>
+      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <SetupScript>.\TestScripts\Windows\SETUP-Config-VM.ps1</SetupScript>
+    </SetupConfig>
+  </test>
+  <test>
     <testName>SECUREBOOT-BASIC</testName>
     <testScript>SECUREBOOT.ps1</testScript>
     <Timeout>600</Timeout>


### PR DESCRIPTION
1. Trigger crash on vcpu 32 when total vcpu is 64.
2. Remove code for disable serial console log in kdump test case.