### PR TITLE
get_public_key_data() is not working expectedly.

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -77,7 +77,8 @@ def get_public_key_data(private_key_file_path: str) -> str:
     if not private_key_path.exists():
         raise LisaException(f"private key file not exist {private_key_file_path}")
 
-    public_key_path = private_key_path.parent / f"{private_key_path.name}.pub"
+    public_key_file = Path(private_key_path).stem
+    public_key_path = private_key_path.parent / f"{public_key_file}.pub"
     try:
         with open(public_key_path, "r") as fp:
             public_key_data = fp.read()


### PR DESCRIPTION
This method doesn't strip the extension from the private key path which
is why resulting in wrong public key path