### PR TITLE
meson-0.57.0 needs python 3.6.

### DIFF
--- a/Testscripts/Linux/dpdkUtils.sh
+++ b/Testscripts/Linux/dpdkUtils.sh
@@ -229,6 +229,9 @@ function Install_Dpdk () {
 			then
 				LogMsg "Adding dpdk repo to ${DISTRO_NAME} ${DISTRO_VERSION} for DPDK test..."
 				ssh "${1}" ". utils.sh && CheckInstallLockUbuntu && add-apt-repository ppa:canonical-server/dpdk-azure -y"
+				ssh "${1}" ". utils.sh && CheckInstallLockUbuntu && add-apt-repository -y ppa:deadsnakes/ppa -y"
+				ssh "${1}" "apt update -y && apt-get install -y python3.6"
+				ssh "${1}" "rm -rf /usr/bin/python3 && ln -s /usr/bin/python3.6 /usr/bin/python3"
 			else
 				packages+=(rdma-core)
 			fi


### PR DESCRIPTION
Build dpdk on ubuntu 16.04 hit below issue, it needs install python3.6
```
Collecting meson
  Downloading https://files.pythonhosted.org/packages/07/9e/fcdaaaf4f27394e9ee1be666b68ccd01d26fb741ffcef35e5bc7a905c7dc/meson-0.57.0.tar.gz (1.8MB)
    Complete output from command python setup.py egg_info:
    ERROR: Tried to install Meson with an unsupported Python version:
    3.5.2 (default, Oct  7 2020, 17:19:02)
    [GCC 5.4.0 20160609]
    Meson requires Python 3.6.0 or greater

```