### PR TITLE
Set timeout for parallel run processes

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -80,7 +80,8 @@ function Start-LISAv2 {
 		[switch] $RunInParallel,
 		[int]    $TotalCountInParallel,
 		[object] $ParamsInParallel,
-		[string] $TestIdInParallel
+		[string] $TestIdInParallel,
+		[int]    $ParallelTimeoutHours
 	)
 
 	PROCESS {

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -125,7 +125,8 @@ Param(
 	[switch] $ReuseVMOnFailure,
 	[switch] $RunInParallel,
 	[int]    $TotalCountInParallel,
-	[string] $TestIdInParallel
+	[string] $TestIdInParallel,
+	[int]    $ParallelTimeoutHours
 )
 
 Set-Location $PSScriptRoot

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -684,7 +684,7 @@ Class TestController {
 				$jobId = $parallelJobIds[$i]
 				$parallelJob = Get-Job -Id $jobId
 				Write-LogWarn "Stopping job $($parallelJob.Name)"
-				Stop-Job $parallelJob -Force
+				Stop-Job $parallelJob
 				Remove-Job $parallelJob -Force
 			}
 		}

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -682,7 +682,7 @@ Class TestController {
 		}
 		if ($parallelJobIds.Count -gt 0) {
 			Write-LogErr "Test execution time exceeds $ParallelTimeoutHours hours, stopping the running jobs..."
-			for ($i = 0; $i -lt $parallelJobIds.Count; ) {
+			for ($i = 0; $i -lt $parallelJobIds.Count; $i++) {
 				$jobId = $parallelJobIds[$i]
 				$parallelJob = Get-Job -Id $jobId -ErrorAction SilentlyContinue
 				if ($parallelJob) {

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -78,6 +78,7 @@ Class TestController {
 	[int] $TotalCountInParallel
 	[object] $ParamsInParallel
 	[string] $TestIdInParallel
+	[int] $ParallelTimeoutHours
 
 	[void] SyncEquivalentCustomParameters([string] $Key, [string] $Value) {
 		if ($Value) {
@@ -135,6 +136,7 @@ Class TestController {
 			$processorCount = (Get-WmiObject -class Win32_ComputerSystem).numberoflogicalprocessors
 			$this.TotalCountInParallel = [math]::Ceiling($processorCount / 2)
 		}
+		$this.ParallelTimeoutHours = $ParamTable["ParallelTimeoutHours"]
 		$this.ParamsInParallel = $ParamTable["ParamsInParallel"]
 		$this.TestIdInParallel = $ParamTable["TestIdInParallel"]
 		$GlobalConfigurationFile = "$PSScriptRoot\..\XML\GlobalConfigurations.xml"
@@ -592,7 +594,7 @@ Class TestController {
 		return $currentTestResult
 	}
 
-	[void] RunTestCasesInParallel([int] $CountInParallel) {
+	[void] RunTestCasesInParallel([int] $CountInParallel, [int] $ParallelTimeoutHours) {
 		$this.ParamsInParallel.Remove("RunInParallel")
 		$this.ParamsInParallel.Remove("TotalCountInParallel")
 		$parallelJobIds = [System.Collections.ArrayList]@()
@@ -857,7 +859,7 @@ Class TestController {
 			$this.RunTestCasesInSequence($TestIterations)
 		}
 		else {
-			$this.RunTestCasesInParallel($this.TotalCountInParallel)
+			$this.RunTestCasesInParallel($this.TotalCountInParallel, $this.ParallelTimeoutHours)
 		}
 
 		$this.JunitReport.CompleteLogTestSuite("LISAv2Test-$($this.TestPlatform)")

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -679,7 +679,7 @@ Class TestController {
 			}
 		}
 		if ($parallelJobIds.Count -gt 0) {
-			Write-LogErr "Test execution time exceeds the timeout value, stopping the running jobs..."
+			Write-LogErr "Test execution time exceeds $ParallelTimeoutHours hours, stopping the running jobs..."
 			for ($i = 0; $i -lt $parallelJobIds.Count; ) {
 				$jobId = $parallelJobIds[$i]
 				$parallelJob = Get-Job -Id $jobId


### PR DESCRIPTION
Sometimes the parallel process may hang, set a timeout value for them, default to be 2 days.