### PR TITLE
Add NotRun, Skipped exceptions for test case

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -14,7 +14,9 @@ from lisa.feature import Feature
 from lisa.operating_system import OperatingSystem
 from lisa.util import (
     LisaException,
+    NotRunException,
     PassedException,
+    SkippedException,
     constants,
     get_datetime_path,
     set_filtered_fields,
@@ -32,10 +34,6 @@ TestStatus = Enum(
 
 _all_suites: Dict[str, TestSuiteMetadata] = dict()
 _all_cases: Dict[str, TestCaseMetadata] = dict()
-
-
-class SkipTestCaseException(LisaException):
-    pass
 
 
 @dataclass
@@ -398,6 +396,16 @@ class TestSuite:
                         logger=self.log,
                     )
                     case_result.set_status(TestStatus.PASSED, "")
+                except SkippedException as identifier:
+                    self.log.info(f"case skipped: {identifier}")
+                    self.log.debug("case skipped", exc_info=identifier)
+                    # case is skipped dynamically
+                    case_result.set_status(TestStatus.SKIPPED, f"{identifier}")
+                except NotRunException as identifier:
+                    self.log.info(f"case keep NOTRUN: {identifier}")
+                    self.log.debug("case NOTRUN", exc_info=identifier)
+                    # case is not run dynamically.
+                    case_result.set_status(TestStatus.NOTRUN, f"{identifier}")
                 except PassedException as identifier:
                     self.log.info(f"case parial passed: {identifier}")
                     self.log.debug("case parial passed", exc_info=identifier)

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -8,7 +8,24 @@ T = TypeVar("T")
 
 
 class LisaException(Exception):
-    pass
+    ...
+
+
+class SkippedException(Exception):
+    """
+    A test case can be skipped based on runtime information.
+    """
+
+    ...
+
+
+class NotRunException(Exception):
+    """
+    If current environment doesn't meet requirement of a test case, it can be set to
+    not run and try next environment.
+    """
+
+    ...
 
 
 class PassedException(Exception):
@@ -18,7 +35,7 @@ class PassedException(Exception):
     Exception to bring an error message, and make test pass also.
     """
 
-    pass
+    ...
 
 
 class ContextMixin:


### PR DESCRIPTION
The two exceptions make test case can skipped or marked to not run
dynamically, if environment doesn't meet requirement.
For example, the kernel version doesn't meet test criteria, but it can
be detected on runtime only.