### PR TITLE
Fix the exit code for parallel run, fix the db insertion for several perf cases, catch the exception of uploading perf results to db and log to TestSummary

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -233,7 +233,7 @@ function Start-LISAv2 {
 				}
 			}
 
-			if ($failedCount -eq 0 -and $errorCount -eq 0 and testCount -gt 0) {
+			if ($failedCount -eq 0 -and $errorCount -eq 0 -and testCount -gt 0) {
 				$ExitCode = 0
 			} else {
 				$ExitCode = 1

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -238,7 +238,7 @@ function Start-LISAv2 {
 				}
 			}
 
-			if ($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) {
+			if (($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) -or (-not $RunInParallel and $TestIdInParallel)) {
 				$ExitCode = 0
 			} else {
 				$ExitCode = 1

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -205,10 +205,7 @@ function Start-LISAv2 {
 			$zipFilePath = Join-Path (Get-Location).Path $zipFile
 			New-ZipFile -zipFileName $zipFilePath -sourceDir $LogDir
 
-			$reportFiles = @($TestReportXml)
-			if ($RunInParallel) {
-				$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${testId}*-junit.xml" }
-			}
+			$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${testId}*-junit.xml" }
 
 			$failedCount = 0
 			$errorCount = 0

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -233,7 +233,7 @@ function Start-LISAv2 {
 				}
 			}
 
-			if ($failedCount -eq 0 -and $errorCount -eq 0 -and testCount -gt 0) {
+			if ($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) {
 				$ExitCode = 0
 			} else {
 				$ExitCode = 1

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -214,10 +214,11 @@ function Start-LISAv2 {
 			$errorCount = 0
 			$testCount = 0
 			foreach ($reportFile in $reportFiles) {
-				Write-LogInfo "Analyzing test results from $reportFile ..."
-				if (Test-Path -Path $reportFile) {
+				$reportFilePath = $reportFile.FullName
+				Write-LogInfo "Analyzing test results from $reportFilePath ..."
+				if (Test-Path -Path $reportFilePath) {
 					try {
-						$results = [xml](Get-Content $reportFile -ErrorAction SilentlyContinue)
+						$results = [xml](Get-Content $reportFilePath -ErrorAction SilentlyContinue)
 					} catch {
 						throw "Could not parse test results from the test report."
 					}
@@ -227,7 +228,7 @@ function Start-LISAv2 {
 					$errorCount += [int] ($testSuiteresults.errors)
 					$testCount += [int] ($testSuiteresults.tests)
 				} else {
-					Write-LogErr "Summary file: $reportFile does not exist. Exiting with error code 1."
+					Write-LogErr "Summary file: $reportFilePath does not exist. Exiting with error code 1."
 					$ExitCode = 1
 					return
 				}

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -205,7 +205,7 @@ function Start-LISAv2 {
 			$zipFilePath = Join-Path (Get-Location).Path $zipFile
 			New-ZipFile -zipFileName $zipFilePath -sourceDir $LogDir
 
-			$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${testId}*-junit.xml" }
+			$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${TestId}([\-\d])+junit.xml" }
 
 			$failedCount = 0
 			$errorCount = 0

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -215,9 +215,9 @@ function Start-LISAv2 {
 			$testCount = 0
 			foreach ($reportFile in $reportFiles) {
 				Write-LogInfo "Analyzing test results from $reportFile ..."
-				if (Test-Path -Path $reportFiles) {
+				if (Test-Path -Path $reportFile) {
 					try {
-						$results = [xml](Get-Content $reportFiles -ErrorAction SilentlyContinue)
+						$results = [xml](Get-Content $reportFile -ErrorAction SilentlyContinue)
 					} catch {
 						throw "Could not parse test results from the test report."
 					}
@@ -227,7 +227,7 @@ function Start-LISAv2 {
 					$errorCount += [int] ($testSuiteresults.errors)
 					$testCount += [int] ($testSuiteresults.tests)
 				} else {
-					Write-LogErr "Summary file: $TestReportXml does not exist. Exiting with error code 1."
+					Write-LogErr "Summary file: $reportFile does not exist. Exiting with error code 1."
 					$ExitCode = 1
 					return
 				}

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -205,8 +205,15 @@ function Start-LISAv2 {
 			$zipFilePath = Join-Path (Get-Location).Path $zipFile
 			New-ZipFile -zipFileName $zipFilePath -sourceDir $LogDir
 
-			$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${TestId}([\-\d])+junit.xml" }
+			# for parallel run, only calculate the error counts in main process
+			if ($RunInParallel) {
+				$reportFiles = Get-ChildItem "$reportFolder" | Where-Object { $_.FullName -imatch "LISAv2_TestReport_${TestId}([\-\d])+junit.xml" }
+			# non-parallel run, and not the sub-process of parallel run
+			} elseif (-not $TestIdInParallel) {
+				$reportFiles = @(Get-Item -path $TestReportXml)
+			}
 
+			$ExitCode = 0
 			$failedCount = 0
 			$errorCount = 0
 			$testCount = 0

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -238,7 +238,7 @@ function Start-LISAv2 {
 				}
 			}
 
-			if (($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) -or (-not $RunInParallel and $TestIdInParallel)) {
+			if (($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) -or (-not $RunInParallel -and $TestIdInParallel)) {
 				$ExitCode = 0
 			} else {
 				$ExitCode = 1

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -543,8 +543,12 @@ Class TestController {
 			# Upload results to database
 			Write-LogInfo "==> Upload test results to database."
 			if ($currentTestResult.TestResultData) {
-				Upload-TestResultDataToDatabase -TestResultData $currentTestResult.TestResultData -DatabaseConfig $this.GlobalConfig.Global.$($this.TestPlatform).ResultsDatabase `
-					-DefaultResultTable $currentTestData.DefaultResultTable -TestPassID $this.TestPassID
+				try {
+					Upload-TestResultDataToDatabase -TestResultData $currentTestResult.TestResultData -DatabaseConfig $this.GlobalConfig.Global.$($this.TestPlatform).ResultsDatabase `
+						-DefaultResultTable $currentTestData.DefaultResultTable -TestPassID $this.TestPassID
+				} catch {
+					$currentTestResult.testSummary += New-ResultSummary -testResult "Exception happened when uploading test result data to database"
+				}
 			}
 
 			if ($CurrentTestData.SetupConfig.OSType -notcontains "Windows") {

--- a/Testscripts/Windows/PERF-NETWORK-TCP-NETPERF.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-NETPERF.ps1
@@ -185,12 +185,17 @@ collect_VM_properties
         #region Upload results to Netperf DB.
         try {
             Write-LogInfo "Uploading the test results.."
-            $dataSource = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.server
-            $user = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.user
-            $password = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.password
-            $database = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbname
-            $dataTableName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbtable
-            $TestExecutionTag = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.testTag
+            $dbConfig = $GlobalConfig.Global.$TestPlatform.ResultsDatabase
+            $dataSource = $dbConfig.server
+            $user = $dbConfig.user
+            $password = $dbConfig.password
+            $database = $dbConfig.dbname
+            if ($dbConfig.dbtable) {
+                $dataTableName = $dbConfig.dbtable
+            } elseif ($DefaultResultTable) {
+                $dataTableName = $currentTestData.DefaultResultTable
+            }
+            $TestExecutionTag = $dbConfig.testTag
             if (!$TestExecutionTag) {
                 $TestExecutionTag = $CurrentTestData.testName
             }

--- a/Testscripts/Windows/PERF-NETWORK-TCP-NETPERF.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-NETPERF.ps1
@@ -192,7 +192,7 @@ collect_VM_properties
             $database = $dbConfig.dbname
             if ($dbConfig.dbtable) {
                 $dataTableName = $dbConfig.dbtable
-            } elseif ($DefaultResultTable) {
+            } elseif ($currentTestData.DefaultResultTable) {
                 $dataTableName = $currentTestData.DefaultResultTable
             }
             $TestExecutionTag = $dbConfig.testTag

--- a/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
@@ -144,7 +144,7 @@ function Consume-Iperf3Results {
 
 function Main {
     param (
-        $TestParams, $AllVmData
+        $TestParams, $AllVmData, $CurrentTestData
     )
     $resultArr = @()
 
@@ -295,4 +295,4 @@ collect_VM_properties
     return $currentTestResult
 }
 
-Main -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n")) -AllVmData $AllVmData
+Main -TestParams (ConvertFrom-StringData $TestParams.Replace(";","`n")) -AllVmData $AllVmData -CurrentTestData $CurrentTestData

--- a/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
@@ -101,7 +101,7 @@ function Consume-Iperf3Results {
     $database = $dbConfig.dbname
     if ($dbConfig.dbtable) {
 		$dataTableName = $dbConfig.dbtable
-	} elseif ($DefaultResultTable) {
+	} elseif ($currentTestData.DefaultResultTable) {
 		$dataTableName = $currentTestData.DefaultResultTable
 	}
     $TestCaseName = $dbConfig.testTag

--- a/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
@@ -94,12 +94,17 @@ function Consume-Iperf3Results {
         $currentTestData
     )
 
-    $dataSource = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.server
-    $user = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.user
-    $password = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.password
-    $database = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbname
-    $dataTableName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbtable
-    $TestCaseName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.testTag
+    $dbConfig = $GlobalConfig.Global.$TestPlatform.ResultsDatabase
+    $dataSource = $dbConfig.server
+    $user = $dbConfig.user
+    $password = $dbConfig.password
+    $database = $dbConfig.dbname
+    if ($dbConfig.dbtable) {
+		$dataTableName = $dbConfig.dbtable
+	} elseif ($DefaultResultTable) {
+		$dataTableName = $currentTestData.DefaultResultTable
+	}
+    $TestCaseName = $dbConfig.testTag
     if (!$TestCaseName) {
         $TestCaseName = $CurrentTestData.testName
     }

--- a/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
@@ -109,7 +109,7 @@ function Consume-Iperf3Results {
 
     foreach ($perfResult in $Iperf3Results) {
         $resultMap = @{}
-        $resultMap["TestCaseName"] = $TestCaseName
+        $resultMap["TestCaseName"] = $currentTestData.testName
         $resultMap["DataPath"] = $DataPath
         $resultMap["TestDate"] = $TestDate
         $resultMap["HostBy"] = $CurrentTestData.SetupConfig.TestLocation

--- a/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT.ps1
@@ -139,7 +139,7 @@ function Main {
     $resultArr = @()
 
     try {
-	    $currentTestResult = Create-TestResultObject
+        $currentTestResult = Create-TestResultObject
         # Validate test setup
         $clientVMExists = $false
         $serverVMExists = $false

--- a/Testscripts/Windows/PERF-NETWORK-UDP-THROUGHPUT-MULTICONNECTION-IPERF3.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-UDP-THROUGHPUT-MULTICONNECTION-IPERF3.ps1
@@ -298,12 +298,17 @@ collect_VM_properties
         Write-LogInfo "Test Completed"
 
         Write-LogInfo "Uploading the test results to DB STARTED.."
-        $dataSource = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.server
-        $dbuser = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.user
-        $dbpassword = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.password
-        $database = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbname
-        $dataTableName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.dbtable
-        $TestCaseName = $GlobalConfig.Global.$TestPlatform.ResultsDatabase.testTag
+        $dbConfig = $GlobalConfig.Global.$TestPlatform.ResultsDatabase
+        $dataSource = $dbConfig.server
+        $dbuser = $dbConfig.user
+        $dbpassword = $dbConfig.password
+        $database = $dbConfig.dbname
+        if ($dbConfig.dbtable) {
+            $dataTableName = $dbConfig.dbtable
+        } elseif ($DefaultResultTable) {
+            $dataTableName = $currentTestData.DefaultResultTable
+        }
+        $TestCaseName = $dbConfig.testTag
         if (!$TestCaseName) {
             $TestCaseName = $CurrentTestData.testName
         }

--- a/Testscripts/Windows/PERF-NETWORK-UDP-THROUGHPUT-MULTICONNECTION-IPERF3.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-UDP-THROUGHPUT-MULTICONNECTION-IPERF3.ps1
@@ -305,7 +305,7 @@ collect_VM_properties
         $database = $dbConfig.dbname
         if ($dbConfig.dbtable) {
             $dataTableName = $dbConfig.dbtable
-        } elseif ($DefaultResultTable) {
+        } elseif ($currentTestData.DefaultResultTable) {
             $dataTableName = $currentTestData.DefaultResultTable
         }
         $TestCaseName = $dbConfig.testTag

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -657,7 +657,7 @@
       <OverrideVMSize>Standard_L64s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\TestScripts\Windows\SETUP-Config-VM.ps1,.\Testscripts\Windows\SETUP-Add-NVME-Disk.ps1</SetupScript>
     </SetupConfig>
-    <DefaultResultTable>Perf_Network_Storage</DefaultResultTable>
+    <DefaultResultTable>Perf_Storage</DefaultResultTable>
   </test>
   <test>
     <testName>PERF-GOLANG-BENCHMARK</testName>


### PR DESCRIPTION
1. Fix the exit code for parallel run, calculate the pass/fail/aborted/skipped count in the main process only.
2. Fix the database insertion for several perf cases, support using table name from DefaultResultTable tag.
3. Catch the exception of uploading perf results to database, and log to TestSummary