### PR TITLE
Adjust the params for latency and throughput tests

### DIFF
--- a/Testscripts/Linux/perf_lagscope.sh
+++ b/Testscripts/Linux/perf_lagscope.sh
@@ -104,8 +104,12 @@ else
 	cmd="lagscope"
 fi
 
-#Now, start lagscope on server and client VMs.
+# Enable busypoll
+core_mem_set_cmd="sysctl -w net.core.busy_poll=50; sysctl -w net.core.busy_read=50"
+ssh root@"${client}" "${core_mem_set_cmd}"
+ssh root@"${server}" "${core_mem_set_cmd}"
 
+#Now, start lagscope on server and client VMs.
 LogMsg "Now running Lagscope test"
 LogMsg "Starting server."
 ssh root@"${server}" "${cmd} -r${testServerIP}" &

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -464,6 +464,14 @@ Scenario 2 : You need to run all the performance tests quickly.
 		<ReplaceWith>(1 2 4 8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240 20480 40960 50000 55000)</ReplaceWith>
 	</Parameter>
 	<Parameter>
+		<ReplaceThis>NTTTCP_TCP_ONE_CONNECTION_BUFFER_SIZE</ReplaceThis>
+		<ReplaceWith>1048576</ReplaceWith>
+	</Parameter>
+	<Parameter>
+		<ReplaceThis>NTTTCP_TCP_MULTI_CONNECTIONS_BUFFER_SIZE</ReplaceThis>
+		<ReplaceWith>65536</ReplaceWith>
+	</Parameter>
+	<Parameter>
 		<ReplaceThis>NTTTCP_MULTICLIENTS_TCP_CONNECTIONS</ReplaceThis>
 		<ReplaceWith>(8 16 32 64 128 256 512 1024 2048 4096 6144 8192 10240 20480 40960 50000 55000)</ReplaceWith>
 	</Parameter>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -12,6 +12,8 @@
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_TCP_CONNECTIONS</param>
       <param>ntttcpVersion=master</param>
+      <param>oneConnectionBufferSize=NTTTCP_TCP_ONE_CONNECTION_BUFFER_SIZE</param>
+      <param>multiConnectionsBufferSize=NTTTCP_TCP_MULTI_CONNECTIONS_BUFFER_SIZE</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure,HyperV</Platform>
@@ -39,6 +41,8 @@
       <param>testType=tcp</param>
       <param>testConnections=NTTTCP_TCP_CONNECTIONS</param>
       <param>ntttcpVersion=master</param>
+      <param>oneConnectionBufferSize=NTTTCP_TCP_ONE_CONNECTION_BUFFER_SIZE</param>
+      <param>multiConnectionsBufferSize=NTTTCP_TCP_MULTI_CONNECTIONS_BUFFER_SIZE</param>
       <param>lagscopeVersion=LAGSCOPE_VERSION</param>
     </TestParameters>
     <Platform>Azure,HyperV</Platform>


### PR DESCRIPTION
Adjust our TCP throughput/latency parameters.
For latency, add two sysctl settings: 
    sysctl -w net.core.busy_poll=50; sysctl -w net.core.busy_read=50
For throughput, adjust buffer sizes: 
    1 connection:
    Send and receive buffer sizes are all 1M
    Other connections:
    Send and receive buffer sizes are all 64K.
