### PR TITLE
Support variables in paths of runbook/extension, and variable itself.

### DIFF
--- a/lisa/parameter_parser/runbook.py
+++ b/lisa/parameter_parser/runbook.py
@@ -20,7 +20,9 @@ _schema: Optional[Schema] = None
 _get_init_logger = partial(get_logger, "init", "runbook")
 
 
-def _load_extend_paths(current_path: Path, data: Any) -> List[str]:
+def _load_extend_paths(
+    current_path: Path, data: Any, variables: Optional[Dict[str, VariableEntry]] = None
+) -> List[str]:
     result: List[str] = []
     if constants.EXTENSION in data:
         raw_extension = data[constants.EXTENSION]
@@ -30,6 +32,9 @@ def _load_extend_paths(current_path: Path, data: Any) -> List[str]:
                 data[constants.EXTENSION]
             )
             raw_extension = raw_extension.paths
+        # support variables in extension paths
+        if variables:
+            raw_extension = replace_variables(raw_extension, variables=variables)
         result = [
             str(current_path.joinpath(path).absolute().resolve())
             for path in raw_extension
@@ -213,7 +218,7 @@ def load_runbook(
 
     # load extended modules
     if constants.EXTENSION in data:
-        _import_extends(_load_extend_paths(constants.RUNBOOK_PATH, data))
+        _import_extends(_load_extend_paths(constants.RUNBOOK_PATH, data, variables))
 
     # replace variables:
     try:

--- a/lisa/tests/test_variable.py
+++ b/lisa/tests/test_variable.py
@@ -19,7 +19,7 @@ class VariableTestCase(TestCase):
         os.environ["LISA_normal_value"] = "value_from_env"
         os.environ["S_LISA_normal_entry"] = "s_value_from_env"
         variables = self._get_default_variables()
-        variables.update(variable.load_from_env())
+        variables.update(variable._load_from_env())
         data = self._replace_and_validate(variables, {"normal_entry": "******"})
         self.assertEqual("value_from_env", data["nested"]["normal_value"])
         self.assertEqual("s_value_from_env", data["normal_entry"])
@@ -28,7 +28,7 @@ class VariableTestCase(TestCase):
         pair1 = "normal_value:nv_from_pair"
         pair2 = "S:normal_entry:s_value_from_env"
         variables = self._get_default_variables()
-        variables.update(variable.load_from_pairs([pair1, pair2]))
+        variables.update(variable._load_from_pairs([pair1, pair2]))
         data = self._replace_and_validate(variables, {"normal_entry": "******"})
         self.assertEqual("nv_from_pair", data["nested"]["normal_value"])
         self.assertEqual("s_value_from_env", data["normal_entry"])
@@ -203,7 +203,7 @@ class VariableTestCase(TestCase):
     def test_invalid_file_extension(self) -> None:
         variables = self._get_default_variables()
         with self.assertRaises(LisaException) as cm:
-            variables.update(variable.load_from_file("file.xml"))
+            variables.update(variable._load_from_file("file.xml"))
         self.assertIsInstance(cm.exception, LisaException)
         self.assertIn("variable support only yaml and yml", str(cm.exception))
 
@@ -212,7 +212,7 @@ class VariableTestCase(TestCase):
     ) -> Any:
         constants.RUNBOOK_PATH = Path(__file__).parent
         variables = self._get_default_variables()
-        variables.update(variable.load_from_runbook(data))
+        variables.update(variable._load_from_runbook(data))
         data = self._replace_and_validate(variables, secret_variables)
         return data
 
@@ -221,7 +221,7 @@ class VariableTestCase(TestCase):
     ) -> Any:
         constants.RUNBOOK_PATH = Path(__file__).parent
         variables = self._get_default_variables()
-        variables.update(variable.load_from_file(file_name, is_secret=all_secret))
+        variables.update(variable._load_from_file(file_name, is_secret=all_secret))
         data = self._replace_and_validate(variables, secret_variables)
         self.assertEqual("normal_value", data["nested"]["normal_value"])
         self.assertEqual("entry_value", data["normal_entry"])

--- a/lisa/tests/test_variable.py
+++ b/lisa/tests/test_variable.py
@@ -86,6 +86,26 @@ class VariableTestCase(TestCase):
                 "secret_int": "1****0",
                 "secret_head_tail": "a****h",
             },
+            {},
+        )
+        self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
+        self.assertEqual(1234567890, data["list"][1]["dictInList"])
+        self.assertEqual("abcdefgh", data["headtail"])
+        self.assertEqual("normal_value", data["nested"]["normal_value"])
+        self.assertEqual("entry_value", data["normal_entry"])
+
+    def test_in_runbook_path_with_variable(self) -> None:
+        runbook_data: Dict[str, Any] = {
+            "variable": [{"file": "variable_$(var_in_cmd).yml"}]
+        }
+        data = self._test_runbook_file_entry(
+            runbook_data,
+            {
+                "secret_guid": "12345678-****-****-****-********90ab",
+                "secret_int": "1****0",
+                "secret_head_tail": "a****h",
+            },
+            {"var_in_cmd": variable.VariableEntry("normal", False)},
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
         self.assertEqual(1234567890, data["list"][1]["dictInList"])
@@ -131,6 +151,7 @@ class VariableTestCase(TestCase):
                 "secret_int": "1****0",
                 "secret_head_tail": "a****h",
             },
+            {},
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ab", data["list"][0])
         self.assertEqual(1234567890, data["list"][1]["dictInList"])
@@ -177,6 +198,7 @@ class VariableTestCase(TestCase):
                 "secret_int": "1****1",
                 "secret_head_tail": "a****i",
             },
+            {},
         )
         self.assertEqual("12345678-abcd-efab-cdef-1234567890ac", data["list"][0])
         self.assertEqual(1234567891, data["list"][1]["dictInList"])
@@ -208,11 +230,14 @@ class VariableTestCase(TestCase):
         self.assertIn("variable support only yaml and yml", str(cm.exception))
 
     def _test_runbook_file_entry(
-        self, data: Any, secret_variables: Dict[str, str]
+        self,
+        data: Any,
+        secret_variables: Dict[str, str],
+        current_variables: Dict[str, variable.VariableEntry],
     ) -> Any:
         constants.RUNBOOK_PATH = Path(__file__).parent
         variables = self._get_default_variables()
-        variables.update(variable._load_from_runbook(data))
+        variables.update(variable._load_from_runbook(data, current_variables))
         data = self._replace_and_validate(variables, secret_variables)
         return data
 

--- a/microsoft/runbook/azure.yml
+++ b/microsoft/runbook/azure.yml
@@ -1,6 +1,6 @@
 name: azure default
 parent:
-  - path: ./tiers/t0.yml
+  - path: ./tiers/tier.yml
 variable:
   - name: reserve_environment
     value: "no"

--- a/microsoft/runbook/local.yml
+++ b/microsoft/runbook/local.yml
@@ -1,0 +1,11 @@
+name: local default
+parent:
+  - path: ./tiers/tier.yml
+notifier:
+  - type: html
+environment:
+  environments:
+    - nodes:
+        - type: local
+platform:
+  - type: ready

--- a/microsoft/runbook/ready.yml
+++ b/microsoft/runbook/ready.yml
@@ -1,6 +1,6 @@
 name: ready default
 parent:
-  - path: ./tiers/t0.yml
+  - path: ./tiers/tier.yml
 variable:
   - name: user_name
     value: "lisatest"
@@ -12,7 +12,6 @@ environment:
   environments:
     - nodes:
         - type: remote
-          isDefault: true
           public_address: $(public_address)
           public_port: $(public_port)
           username: $(user_name)

--- a/microsoft/runbook/tiers/t0.yml
+++ b/microsoft/runbook/tiers/t0.yml
@@ -1,5 +1,3 @@
-parent:
-  - path: base.yml
 testcase:
   - criteria:
       priority: 0

--- a/microsoft/runbook/tiers/t1.yml
+++ b/microsoft/runbook/tiers/t1.yml
@@ -1,5 +1,3 @@
-parent:
-  - path: base.yml
 variable:
   - name: v2_rg
     value: v2-t1

--- a/microsoft/runbook/tiers/tier.yml
+++ b/microsoft/runbook/tiers/tier.yml
@@ -1,7 +1,10 @@
+parent:
+  - path: ./t$(tier).yml
 extension:
-  paths:
-    - ../../../testsuites/basic
+  - ../../testsuites/basic
 variable:
+  - name: tier
+    value: 0
   - name: location
     value: westus2
   - name: v2_rg_cleanup


### PR DESCRIPTION
When runbook is loading parents, the variable is effective also. So,
variables can be used to select different parent.
The variable in extension is also identified in previous requirements.
So, support variables in extension paths too.

A small refactoring to variable.py, it gives simpler and clear APIs.