### PR TITLE
SGX - update clang-7 to clang-8

### DIFF
--- a/Testscripts/Linux/validate-intel-sgx-driver.sh
+++ b/Testscripts/Linux/validate-intel-sgx-driver.sh
@@ -62,7 +62,7 @@ function install_prereq_1604() {
     sudo apt-get update
 
     echo "----- Install Open Enclave packages and dependencies -----"
-    install_package "clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave"
+    install_package "clang-8 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf9v5 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave"
 }
 
 . /etc/lsb-release


### PR DESCRIPTION
Before fix, sample build fail on ubuntu 16.04

After fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 03/08/2021 23:45:44
ARM Image Under Test  : Canonical : UbuntuServer : 18_04-lts-gen2 : latest
ARM Image Under Test  : Canonical : UbuntuServer : 16_04-lts-gen2 : latest
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:16

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 3.88 
      ARMImageName: Canonical UbuntuServer 16_04-lts-gen2 16.04.202102260, OverrideVMSize: Standard_DC2s_v2, TestLocation: uksouth, VMGeneration: 2, Kernel Version: 4.15.0-1108-azure
    2 SGX                  VALIDATE-INTEL-SGX-DRIVER-FOR-DC-VM                                               PASS                 5.29 
      ARMImageName: Canonical UbuntuServer 18_04-lts-gen2 18.04.202101290, OverrideVMSize: Standard_DC2s_v2, TestLocation: uksouth, VMGeneration: 2, Kernel Version: 5.4.0-1039-azure
```