### PR TITLE
Fix failure in importing

### DIFF
--- a/lisa/util/module.py
+++ b/lisa/util/module.py
@@ -55,8 +55,8 @@ def import_module(
             module = importlib.util.module_from_spec(spec)
             assert spec
             assert spec.loader
-            spec.loader.exec_module(module)  # type: ignore
             sys.modules[full_module_name] = module
+            spec.loader.exec_module(module)  # type: ignore
 
 
 packages = ["lisa"]


### PR DESCRIPTION
The dataclasses uses the loading module underlying of exec_module. So it
needs to set the modules dict earlier.