### PR TITLE
Change the rule for selecting test cases to be the union of TestNames with the join of other group filter conditions

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -130,38 +130,42 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
             if (!$platformMatched) {
                 continue
             }
-            # if TestCategory not provided, or test case has Category completely matching one of expected TestCategory (case insensitive 'contains'), otherwise continue (skip this test case)
-            if (($TestCategory -ne "*") -and ($testCategoryArray -notcontains $test.Category)) {
-                continue
-            }
-            # if TestArea not provided, or test case has Area completely matching one of expected TestArea (case insensitive 'contains'), otherwise continue (skip this test case)
-            if (($TestArea -ne "*") -and ($testAreaArray -notcontains $test.Area)) {
-                continue
-            }
-            # if TestSetup not provided, or test case has SetupType value defined which could insensitively match one of expected Setup pattern, otherwise continue (skip this test case)
-            if (($TestSetup -ne "*") -and !$($testSetupTypeArray | Where-Object {$test.SetupConfig.SetupType -and ("$($test.SetupConfig.SetupType)" -imatch $_)})) {
-                continue
-            }
-            # if TestNames not provided, or test case has TestName completely matching one of expected TestNames (case insensitive 'contains'), otherwise continue (skip this test case)
-            if (($TestNames -ne "*") -and ($testNamesArray -notcontains $test.testName)) {
-                continue
-            }
 
-            # if TestTag not provided, or test case has Tags not defined (backward compatible), or test case has defined Tags scope and this Tags scope has value completely matching one of expected TestTag (case insensitive 'contains'), otherwise continue (skip this test case)
-            if (($TestTag -ne "*")) {
-                if (!$test.Tags) {
-                    Write-LogWarn "Test Tags of $($test.TestName) is not defined; include this test case by default."
-                }
-                elseif (!$($testTagArray | Where-Object {$test.Tags.Trim(', ').Split(',').Trim() -contains $_})) {
+            # If TestName is provided and contains the current case name, then pick the case, unless it's in excluded tests. Otherwise, check other filter conditions.
+            if (($testNamesArray -notcontains $test.testName)) {
+                # if TestCategory not provided, or test case has Category completely matching one of expected TestCategory (case insensitive 'contains'), otherwise continue (skip this test case)
+                if (($TestCategory -ne "*") -and ($testCategoryArray -notcontains $test.Category)) {
                     continue
                 }
-            }
-            # if TestPriority not provided, or test case has Priority defined which equals to one of expected TestPriority, otherwise continue (skip this test case)
-            if (($TestPriority -ne "*") -and !$($testPriorityArray | Where-Object {$test.Priority -and ($test.Priority -eq $_)})) {
-                if (!$test.Priority) {
-                    Write-LogWarn "Priority of $($test.TestName) is not defined."
+                # if TestArea not provided, or test case has Area completely matching one of expected TestArea (case insensitive 'contains'), otherwise continue (skip this test case)
+                if (($TestArea -ne "*") -and ($testAreaArray -notcontains $test.Area)) {
+                    continue
                 }
-                continue
+                # if TestSetup not provided, or test case has SetupType value defined which could insensitively match one of expected Setup pattern, otherwise continue (skip this test case)
+                if (($TestSetup -ne "*") -and !$($testSetupTypeArray | Where-Object {$test.SetupConfig.SetupType -and ("$($test.SetupConfig.SetupType)" -imatch $_)})) {
+                    continue
+                }
+                # if TestNames not provided, or test case has TestName completely matching one of expected TestNames (case insensitive 'contains'), otherwise continue (skip this test case)
+                if (($TestNames -ne "*") -and ($testNamesArray -notcontains $test.testName)) {
+                    continue
+                }
+
+                # if TestTag not provided, or test case has Tags not defined (backward compatible), or test case has defined Tags scope and this Tags scope has value completely matching one of expected TestTag (case insensitive 'contains'), otherwise continue (skip this test case)
+                if (($TestTag -ne "*")) {
+                    if (!$test.Tags) {
+                        Write-LogWarn "Test Tags of $($test.TestName) is not defined; include this test case by default."
+                    }
+                    elseif (!$($testTagArray | Where-Object {$test.Tags.Trim(', ').Split(',').Trim() -contains $_})) {
+                        continue
+                    }
+                }
+                # if TestPriority not provided, or test case has Priority defined which equals to one of expected TestPriority, otherwise continue (skip this test case)
+                if (($TestPriority -ne "*") -and !$($testPriorityArray | Where-Object {$test.Priority -and ($test.Priority -eq $_)})) {
+                    if (!$test.Priority) {
+                        Write-LogWarn "Priority of $($test.TestName) is not defined."
+                    }
+                    continue
+                }
             }
 
             if ($ExcludeTests) {

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -132,7 +132,8 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
             }
 
             # If TestName is provided and contains the current case name, then pick the case, unless it's in excluded tests. Otherwise, check other filter conditions.
-            if (($testNamesArray -notcontains $test.testName)) {
+            if (($testNamesArray -notcontains $test.testName) -and
+                ($TestCategory -ne "*" -or $TestArea -ne "*" -or $TestTag -ne "*" -or $TestSetup -ne "*" -or $TestPriority -ne "*")) {
                 # if TestCategory not provided, or test case has Category completely matching one of expected TestCategory (case insensitive 'contains'), otherwise continue (skip this test case)
                 if (($TestCategory -ne "*") -and ($testCategoryArray -notcontains $test.Category)) {
                     continue

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -145,10 +145,6 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
                 if (($TestSetup -ne "*") -and !$($testSetupTypeArray | Where-Object {$test.SetupConfig.SetupType -and ("$($test.SetupConfig.SetupType)" -imatch $_)})) {
                     continue
                 }
-                # if TestNames not provided, or test case has TestName completely matching one of expected TestNames (case insensitive 'contains'), otherwise continue (skip this test case)
-                if (($TestNames -ne "*") -and ($testNamesArray -notcontains $test.testName)) {
-                    continue
-                }
 
                 # if TestTag not provided, or test case has Tags not defined (backward compatible), or test case has defined Tags scope and this Tags scope has value completely matching one of expected TestTag (case insensitive 'contains'), otherwise continue (skip this test case)
                 if (($TestTag -ne "*")) {

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -132,8 +132,7 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
             }
 
             # If TestName is provided and contains the current case name, then pick the case, unless it's in excluded tests. Otherwise, check other filter conditions.
-            if (($testNamesArray -notcontains $test.testName) -and
-                ($TestCategory -ne "*" -or $TestArea -ne "*" -or $TestTag -ne "*" -or $TestSetup -ne "*" -or $TestPriority -ne "*")) {
+            if ($testNamesArray -notcontains $test.testName) {
                 # if TestCategory not provided, or test case has Category completely matching one of expected TestCategory (case insensitive 'contains'), otherwise continue (skip this test case)
                 if (($TestCategory -ne "*") -and ($testCategoryArray -notcontains $test.Category)) {
                     continue
@@ -161,6 +160,11 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
                     if (!$test.Priority) {
                         Write-LogWarn "Priority of $($test.TestName) is not defined."
                     }
+                    continue
+                }
+
+                # If none of the group filter condition is specified, skip this test case
+                if ($TestCategory -eq "*" -and $TestArea -eq "*" -and $TestTag -eq "*" -and $TestSetup -eq "*" -and $TestPriority -eq "*") {
                     continue
                 }
             }


### PR DESCRIPTION
Specifying the following parameters:
-TestNames "VERIFY-DEPLOYMENT-PROVISION"
-TestCategory "Performance"
-TestPriority 1

Before the change, it collects 0 test cases.
After the change, it collects the "VERIFY-DEPLOYMENT-PROVISION" case + all the P1 Performance test cases