### PR TITLE
Node: fix is_connected is incorrect after reboot

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -41,7 +41,6 @@ class Node(ContextMixin, InitializableMixin):
         self.capability = capability
         self.name: str = ""
         self.index = index
-        self.is_connected: bool = False
 
         self.shell: Shell = LocalShell()
 
@@ -179,6 +178,10 @@ class Node(ContextMixin, InitializableMixin):
 
         return self._support_sudo
 
+    @property
+    def is_connected(self) -> bool:
+        return self.shell.is_connected
+
     def close(self) -> None:
         self.log.debug("closing node connection...")
         self.shell.close()
@@ -221,7 +224,6 @@ class Node(ContextMixin, InitializableMixin):
 
         self.shell.mkdir(self.working_path, parents=True, exist_ok=True)
         self.log.debug(f"working path is: '{self.working_path}'")
-        self.is_connected = True
 
     def _execute(
         self,

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -614,18 +614,21 @@ class AzurePlatform(Platform):
             node = None
         if node and node.is_connected and node.is_linux:
             node_runbook = node.capability.get_extended_runbook(AzureNodeSchema, AZURE)
-            if node.is_connected and node.is_linux:
-                dmesg = node.tools[Dmesg]
-                matched_host_version = find_patterns_in_lines(
-                    dmesg.get_output(), [HOST_VERSION_PATTERN]
-                )
-                information["host_version"] = (
-                    matched_host_version[0][0] if matched_host_version[0] else ""
-                )
 
+            node.log.debug("detecting host version...")
+            dmesg = node.tools[Dmesg]
+            matched_host_version = find_patterns_in_lines(
+                dmesg.get_output(), [HOST_VERSION_PATTERN]
+            )
+            information["host_version"] = (
+                matched_host_version[0][0] if matched_host_version[0] else ""
+            )
+
+            node.log.debug("detecting lis version...")
             modinfo = node.tools[Modinfo]
             information["lis_version"] = modinfo.get_version("hv_vmbus")
 
+            node.log.debug("detecting wala version...")
             waagent = node.tools[Waagent]
             information["wala_version"] = waagent.get_version()
 

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -167,6 +167,7 @@ class SshShell(InitializableMixin):
         self.is_remote = True
         self._connection_info = connection_info
         self._inner_shell: Optional[spur.SshShell] = None
+        self._is_connected: bool = False
 
         paramiko_logger = getLogger("paramiko")
         paramiko_logger.setLevel(logging.WARN)
@@ -224,6 +225,13 @@ class SshShell(InitializableMixin):
             # after closed, can be reconnect
             self._inner_shell = None
         self._is_initialized = False
+
+    @property
+    def is_connected(self) -> bool:
+        is_inner_shell_ready = False
+        if self._inner_shell:
+            is_inner_shell_ready = True
+        return is_inner_shell_ready
 
     def spawn(
         self,
@@ -370,7 +378,12 @@ class LocalShell(InitializableMixin):
             self.is_linux = True
 
     def close(self) -> None:
-        pass
+        ...
+
+    @property
+    def is_connected(self) -> bool:
+        # local shell is always available.
+        return True
 
     def spawn(
         self,


### PR DESCRIPTION
Previously, the is_connect is set by node level, but it may be
inconsistent with real state. In this change, it uses inner_shell to
detect if a node is connected.

Other minor refactoring on logging and remove useless logic.