### PR TITLE
capture failure on gets env info hooks

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -332,12 +332,17 @@ class EnvironmentHookImpl:
 
         if environment.nodes:
             node = environment.default_node
-            if node.is_connected and node.is_posix:
-                uname = node.tools[Uname]
-                linux_information = uname.get_linux_information()
-                fields = ["hardware_platform", "kernel_version"]
-                information_dict = fields_to_dict(linux_information, fields=fields)
-                information.update(information_dict)
+            try:
+                if node.is_connected and node.is_posix:
+                    uname = node.tools[Uname]
+                    linux_information = uname.get_linux_information()
+                    fields = ["hardware_platform", "kernel_version"]
+                    information_dict = fields_to_dict(linux_information, fields=fields)
+                    information.update(information_dict)
+            except Exception as identifier:
+                environment._log.exception(
+                    "failed to get environment information", exc_info=identifier
+                )
 
         return information
 

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -83,10 +83,19 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
 
         assert environment.platform
         if environment.platform.type_name() != self.type_name():
+            # prevent multiple platform can be activated in future, it should call for
+            #  right platform only.
             return information
 
         information["platform"] = environment.platform.type_name()
-        information.update(self._get_environment_information(environment=environment))
+        try:
+            information.update(
+                self._get_environment_information(environment=environment)
+            )
+        except Exception as identifier:
+            self._log.exception(
+                "failed to get environment information on platform", exc_info=identifier
+            )
 
         return information
 


### PR DESCRIPTION
The get env info are called at end of run, and it's informative, and
shouldn't fail the run. I didn't find a general exception handling in
pluggy, so write for each implementation.