### PR TITLE
Fix mypy paths in vscode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MYPYPATH=./typings

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,9 @@ Make sure below settings are in root level of `.vscode/settings.json`.
     "python.analysis.useLibraryCodeForTypes": false,
     "python.analysis.autoImportCompletions": false,
     "files.eol": "\n",
+    "terminal.integrated.env.windows": {
+        "mypypath": "${workspaceFolder}\\typings"
+    },
 }
 ```
 


### PR DESCRIPTION
.env is loaded by vs pylinting tools.
setting is loaded by integrated terminals.