### PR TITLE
Fix issue in getting storage accounts in a resource group, fix issues for creating storage accounts automatically

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2346,7 +2346,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 					$job = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $Name -AsJob
 				}
 				elseif ($ResourceGroupName) {
-					$job = Get-AzStorageAccount -AsJob
+					$job = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -AsJob
 				}
 				elseif ($Name) {
 					Throw "Get-LISAStorageAccount needs necessary parameter [-ResourceGroupName] when [-Name] is used"
@@ -2360,7 +2360,6 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 					if ($rgSAResources) {
 						$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
 					}
-					break
 				}
 				else {
 					Remove-Job $job -Force -ErrorAction SilentlyContinue
@@ -2370,16 +2369,13 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 			else {
 				if (!$ResourceGroupName -and !$Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount
-					break
 				}
 				elseif ($ResourceGroupName -and $Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $Name
-					break
 				}
 				elseif ($ResourceGroupName) {
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
 					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
-					break
 				}
 				elseif ($Name) {
 					Throw "Get-LISAStorageAccount needs necessary parameter [-ResourceGroupName] when [-Name] is used"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -421,11 +421,8 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 		}
 		&$UpdateSecretFileWithStorageAccounts -AzureSecretFile $XMLSecretFile -RSAMapping $regionStorageMapping
 	}
-	elseif ((2 * $allAvailableRegions.Count) -eq $lisaSANum) {
-		&$UpdateSecretFileWithStorageAccounts -AzureSecretFile $XMLSecretFile -RSAMapping $regionStorageMapping
-	}
 	else {
-		Throw "Existing count of StorageAccounts [$lisaSANum] is larger than `$allAvailableRegions.Count [$($allAvailableRegions.Count)] * 2"
+		&$UpdateSecretFileWithStorageAccounts -AzureSecretFile $XMLSecretFile -RSAMapping $regionStorageMapping
 	}
 }
 

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2388,7 +2388,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 		}
 	}
 	if ($retryCount -ge $maxRetryCount) {
-		Throw "Could not get AzStorageAccount info after 999 attempts"
+		Throw "Could not get AzStorageAccount info after $maxRetryCount attempts"
 	}
 	else {
 		Write-LogInfo "Get Storage Account information successfully"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2359,7 +2359,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 					$GetAzureRMStorageAccount = Receive-Job $job
 					Remove-Job $job -Force -ErrorAction SilentlyContinue
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
-					$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
+					$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
 					break
 				}
 				else {
@@ -2378,7 +2378,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 				}
 				elseif ($ResourceGroupName) {
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
-					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
+					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
 					break
 				}
 				elseif ($Name) {

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -397,7 +397,8 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 	}
 
 	if ((2 * $allAvailableRegions.Count) -gt $lisaSANum) {
-		foreach ($region in $allAvailableRegions) {
+		foreach ($availableRegion in $allAvailableRegions) {
+			$region = $availableRegion.Replace(" ","").ToLower()
 			if (!$regionStorageMapping.$region) {
 				$regionStorageMapping[$region] = @{}
 			}

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2330,7 +2330,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 		}
 	}
 	$retryCount = 0
-	$maxRetryCount = 99
+	$maxRetryCount = 10
 	$GetAzureRMStorageAccount = $null
 	$useAsJob = (Get-Command -Name Get-AzStorageAccount).Parameters.Keys -contains 'AsJob'
 	while (!$GetAzureRMStorageAccount -and ($retryCount -lt $maxRetryCount)) {
@@ -2368,16 +2368,13 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 			else {
 				if (!$ResourceGroupName -and !$Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount
-					break
 				}
 				elseif ($ResourceGroupName -and $Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $Name
-					break
 				}
 				elseif ($ResourceGroupName) {
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
 					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
-					break
 				}
 				elseif ($Name) {
 					Throw "Get-LISAStorageAccount needs necessary parameter [-ResourceGroupName] when [-Name] is used"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2357,7 +2357,9 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 					$GetAzureRMStorageAccount = Receive-Job $job
 					Remove-Job $job -Force -ErrorAction SilentlyContinue
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
-					$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
+					if ($rgSAResources) {
+						$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
+					}
 					break
 				}
 				else {
@@ -2368,13 +2370,16 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 			else {
 				if (!$ResourceGroupName -and !$Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount
+					break
 				}
 				elseif ($ResourceGroupName -and $Name) {
 					$GetAzureRMStorageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -Name $Name
+					break
 				}
 				elseif ($ResourceGroupName) {
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
 					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.StorageAccountName -contains $_.StorageAccountName}
+					break
 				}
 				elseif ($Name) {
 					Throw "Get-LISAStorageAccount needs necessary parameter [-ResourceGroupName] when [-Name] is used"

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -360,7 +360,7 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 				$null = $rasANode.AppendChild($regionNode)
 			}
 			$null = $AzureSecretXml.secrets.AppendChild($rasANode)
-			$AzureSecretXml.Save($AzureSecretFile)
+			$AzureSecretXml.Save((Get-Item $AzureSecretFile).FullName)
 		}
 	}
 	$allAvailableRegions = ((Get-AzResourceProvider -ProviderNamespace "Microsoft.Storage").ResourceTypes | `

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2326,7 +2326,10 @@ Function Create-RGDeploymentWithTempParameters([string]$RGName, $TemplateFile, $
 Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 	# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
 	if ($ResourceGroupName -and !$Name) {
-		$rgSAResources = Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Storage/storageAccounts"
+		$rgSAResources = Get-AzStorageAccount | where {$_.ResourceGroupName -eq $ResourceGroupName}
+		if (-not $rgSAResources) {
+			return $null
+		}
 	}
 	$retryCount = 0
 	$maxRetryCount = 99
@@ -2356,9 +2359,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 					$GetAzureRMStorageAccount = Receive-Job $job
 					Remove-Job $job -Force -ErrorAction SilentlyContinue
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
-					if ($rgSAResources) {
-						$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
-					}
+					$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
 					break
 				}
 				else {
@@ -2377,10 +2378,7 @@ Function Get-LISAStorageAccount ($ResourceGroupName, $Name) {
 				}
 				elseif ($ResourceGroupName) {
 					# Get-AzStorageAccounts may return incorrect result when only use -ResourceGroup as the parameter, so we choose workaround
-					$GetAzureRMStorageAccount = Get-AzStorageAccount
-					if ($rgSAResources) {
-						$GetAzureRMStorageAccount = $GetAzureRMStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
-					}
+					$GetAzureRMStorageAccount = Get-AzStorageAccount | Where-Object {$rgSAResources.Name -contains $_.StorageAccountName}
 					break
 				}
 				elseif ($Name) {


### PR DESCRIPTION
1. Fix issue in getting storage accounts in a resource group. 
    Before fix: if there's no storage account in the resource group, it returns all the storage accounts.
    After fix: if there's no storage account in the resource group, it returns $null
2. Fix issues for creating storage accounts automatically