### PR TITLE
Add the notion of a non-SUT node

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -182,17 +182,9 @@ class Environment(ContextMixin, InitializableMixin):
 
         if runbook.nodes:
             for node_runbook in runbook.nodes:
-                if isinstance(node_runbook, schema.LocalNode):
-                    environment.nodes.from_local(
-                        node_runbook, base_log_path=environment.log_path
-                    )
-                else:
-                    assert isinstance(
-                        node_runbook, schema.RemoteNode
-                    ), f"actual: {type(node_runbook)}"
-                    environment.nodes.from_remote(
-                        node_runbook, base_log_path=environment.log_path
-                    )
+                environment.nodes.from_either(
+                    node_runbook, base_log_path=environment.log_path
+                )
 
                 has_default_node = environment.__validate_single_default(
                     has_default_node, node_runbook.is_default

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -344,6 +344,20 @@ class Nodes:
         for node in self._list:
             node.close()
 
+    def from_either(
+        self,
+        node_runbook: Union[schema.LocalNode, schema.RemoteNode],
+        logger_name: str = "node",
+        base_log_path: Optional[Path] = None,
+    ) -> Optional[Node]:
+        if isinstance(node_runbook, schema.LocalNode):
+            return self.from_local(node_runbook, logger_name, base_log_path)
+        else:
+            assert isinstance(
+                node_runbook, schema.RemoteNode
+            ), f"actual: {type(node_runbook)}"
+            return self.from_remote(node_runbook, logger_name, base_log_path)
+
     def from_local(
         self,
         node_runbook: schema.LocalNode,

--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -91,7 +91,8 @@ class LisaRunner(BaseRunner):
                 if picked_result is None:
                     self._log.debug(
                         f"env[{environment.name}] skipped "
-                        f"as not meet any case requirement"
+                        f"as LISA has not met any case requirement match"
+                        + " against test cases"
                     )
                     continue
 

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -575,7 +575,20 @@ class Capability(NodeSpace):
 
 @dataclass_json()
 @dataclass
-class LocalNode(TypedSchema):
+class Node(TypedSchema):
+    name: str = ""
+    is_default: bool = field(default=False)
+    capability: Capability = field(default_factory=Capability)
+    # All nodes considered Systems Under Test, unless otherwise
+    # explicitly stated. One might have such scenarios
+    # (e.g. dependency on one TFTP server, for a given
+    # platform/enviroment)
+    sut: bool = field(default=True)
+
+
+@dataclass_json()
+@dataclass
+class LocalNode(Node):
     type: str = field(
         default=constants.ENVIRONMENTS_NODES_LOCAL,
         metadata=metadata(
@@ -583,14 +596,11 @@ class LocalNode(TypedSchema):
             validate=validate.OneOf([constants.ENVIRONMENTS_NODES_LOCAL]),
         ),
     )
-    name: str = ""
-    is_default: bool = field(default=False)
-    capability: Capability = field(default_factory=Capability)
 
 
 @dataclass_json()
 @dataclass
-class RemoteNode(TypedSchema):
+class RemoteNode(Node):
     type: str = field(
         default=constants.ENVIRONMENTS_NODES_REMOTE,
         metadata=metadata(
@@ -598,8 +608,6 @@ class RemoteNode(TypedSchema):
             validate=validate.OneOf([constants.ENVIRONMENTS_NODES_REMOTE]),
         ),
     )
-    name: str = ""
-    is_default: bool = field(default=False)
     address: str = ""
     port: int = field(
         default=22, metadata=metadata(validate=validate.Range(min=1, max=65535))
@@ -612,7 +620,6 @@ class RemoteNode(TypedSchema):
     username: str = field(default="", metadata=metadata(required=True))
     password: str = ""
     private_key_file: str = ""
-    capability: Capability = field(default_factory=Capability)
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.address)

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -85,6 +85,9 @@ class ConnectionInfo:
         if not self.username:
             raise LisaException("username must be set")
 
+    def __str__(self) -> str:
+        return f"{self.username}@{self.address}:{self.port}"
+
 
 class WindowsShellType(object):
     """


### PR DESCRIPTION
We might encounter environments/platforms in which helper nodes are
needed. For example, think of a test suite in which interaction with a
TFTP server is part of the game. It does not mean that that server is
one of the SUT ones. We want to be able to leverage the tooling around
nodes, nevertheless, for that one too, but skipping all the test flow
for it.

No support for that flag on "requirement" nodes. If that is shown to
make sense in the future, we can add that.