### PR TITLE
Poetry: update Windows install instructions, as noted in their github…

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -82,9 +82,9 @@ poetry install
 Enter the PowerShell command prompt and execute,
 
 ```powershell
-(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
-# the path can be added to system, so it applies to every terminal.
-$env:PATH += ";$env:USERPROFILE\.poetry\bin"
+(Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+# Add to PATH Poetry's binary location (either this or via Window's global env. vars. menu):
+$env:PATH += ";$env:APPDATA\Python\Scripts"
 poetry install
 ```
 


### PR DESCRIPTION
… repo

Check
https://github.com/python-poetry/poetry#windows-powershell-install-instructions
out. The old instructions failed big time for me on a second Windows
box I just tried to install it to. This new one works with the last
release just fine.