### PR TITLE
Fix test cases issues.

### DIFF
--- a/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
+++ b/Testscripts/Linux/nested_kvm_ntttcp_private_bridge.sh
@@ -193,6 +193,7 @@ Bring_Up_Nic_With_Private_Ip() {
 		else
 			sleep 30
 			Log_Msg "Try to bring up the nested VM NIC with private IP, left retry times: $retry_times" $log_file
+			Remote_Exec_Wrapper "root" $host_fwd_port "dhclient $NIC_NAME"
 			Remote_Exec_Wrapper "root" $host_fwd_port "ip addr add $ip_addr/24 dev $NIC_NAME && ip link set $NIC_NAME up"
 			Remote_Exec_Wrapper "root" $host_fwd_port "ip addr show dev $NIC_NAME | grep -i $ip_addr/24"
 			exit_status=$?

--- a/Testscripts/Linux/nested_vm_utils.sh
+++ b/Testscripts/Linux/nested_vm_utils.sh
@@ -95,6 +95,13 @@ Install_KVM_Dependencies()
         make install
         cd ..
     fi
+    # ifconfig command is needed
+    install_net_tools
+    # dnsmasq is needed
+    check_package "dnsmasq"
+    if [ $? -eq 0 ]; then
+        install_package dnsmasq
+    fi
 }
 
 Download_Image_Files()

--- a/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
@@ -142,9 +142,10 @@ collect_VM_properties
 
         #region MONITOR TEST
         while ((Get-Job -Id $testJob).State -eq "Running") {
-            $currentStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username "root" -password $password -command "tail -2 ntttcpConsoleLogs.txt | head -1"
-            Write-LogInfo "Current Test Status : $currentStatus"
-            Wait-Time -seconds 20
+            $currentStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username "root" -password $password -command "tail -2 ntttcpConsoleLogs.txt | head -1" -ignoreLinuxExitCode:$true -maxRetryCount 60
+            Write-LogInfo "Current Test Status : $currentStatus."
+            Write-LogInfo "Sleep for 1 min."
+            Wait-Time -seconds 60
         }
         $finalStatus = Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort -username "root" -password $password -command "cat /root/state.txt"
         Copy-RemoteFiles -downloadFrom $clientVMData.PublicIP -port $clientVMData.SSHPort -username "root" -password $password -download -downloadTo $LogDir -files "/root/ntttcpConsoleLogs.txt"

--- a/Testscripts/Windows/RELOAD-MODULES.ps1
+++ b/Testscripts/Windows/RELOAD-MODULES.ps1
@@ -30,40 +30,33 @@ function Check-Result {
         Start-Sleep -Seconds 20
         Write-LogInfo "Test is running. Attempt number ${attempts} to reach VM"
         $attempts++
-        $isVmAlive = Is-VmAlive -AllVMDataObject $AllVMData -MaxRetryCount 5
-        if ($isVmAlive -eq "True") {
-            $TestConnection = Run-LinuxCmd -ip $VmIp -port $VMPort -username $User -password $Password -command "echo Connected"
-            if ($TestConnection -eq "Connected") {
-                $state = Run-LinuxCmd -ip $VmIp -port $VMPort -username $User -password $Password -command "cat state.txt" -ignoreLinuxExitCode
-                if (-not $state) {
-                    if ($TestPlatform -eq "HyperV" -and (Get-VMIntegrationService $VMName -ComputerName $HvServer | `
-                        Where-Object {$_.name -eq "Heartbeat"}).PrimaryStatusDescription `
-                        -match "No Contact|Lost Communication") {
+        try {
+            $state = Run-LinuxCmd -ip $VmIp -port $VMPort -username $User -password $Password -command "cat state.txt" -ignoreLinuxExitCode
+            if (-not $state) {
+                if ($TestPlatform -eq "HyperV" -and (Get-VMIntegrationService $VMName -ComputerName $HvServer | `
+                    Where-Object {$_.name -eq "Heartbeat"}).PrimaryStatusDescription `
+                    -match "No Contact|Lost Communication") {
 
-                        Stop-VM -Name $VMName -ComputerName $HvServer -Force -TurnOff
-                        Write-LogErr "Lost Communication or No Contact to VM!"
-                        break
-                    } else {
-                        Write-LogInfo "Current VM is inaccessible, please wait for a while."
-                    }
+                    Stop-VM -Name $VMName -ComputerName $HvServer -Force -TurnOff
+                    Write-LogErr "Lost Communication or No Contact to VM!"
+                    break
                 } else {
-                    if ($state -eq $testRunning){
-                        Write-LogInfo "Test is still running!"
-                    } elseif (($state -eq $testCompleted) -or ($state -eq $testSkipped)) {
-                        Write-LogInfo "state file contains ${state}"
-                        $retVal = $True
-                        break
-                    } elseif (($state -eq $testAborted) -or ($state -eq $testFailed)) {
-                        Write-LogErr "state file contains ${state}"
-                        break
-                    }
+                    Write-LogInfo "Current VM is inaccessible, please wait for a while."
                 }
             } else {
-                Write-LogInfo "Current VM is inaccessible, please wait for a while."
-                continue
+                if ($state -eq $testRunning){
+                    Write-LogInfo "Test is still running!"
+                } elseif (($state -eq $testCompleted) -or ($state -eq $testSkipped)) {
+                    Write-LogInfo "state file contains ${state}"
+                    $retVal = $True
+                    break
+                } elseif (($state -eq $testAborted) -or ($state -eq $testFailed)) {
+                    Write-LogErr "state file contains ${state}"
+                    break
+                }
             }
-        } else {
-            Write-LogInfo "Current VM is inaccessible, please wait for a while."
+        } catch {
+            Write-LogDbg "Current VM is inaccessible, please wait for a while."
         }
     }
     if ($sw.elapsed -ge $timeout) {


### PR DESCRIPTION
PERF-NETWORK-TCP-THROUGHPUT-MULTICONNECTION-NTTTCP-Synthetic
Sometimes SSH is too busy to response, fix it adding retry times when execute remote command.

RELOAD-MODULES-SMP
Sometimes test case abort when upload file into test machine, add try catch here.

NESTED-KVM-NTTTCP-PRIVATE-BRIDGE
In high distro, there is no ifconfig and dnsmasq by default, fix it by install them.

```
[LISAv2 Test Results Summary]
Test Run On           : 04/11/2021 13:57:30
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:2:7

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-THROUGHPUT-MULTICONNECTION-NTTTCP-Synthetic                      PASS               119.17 
      ARMImageName: canonical 0001-com-ubuntu-server-focal-daily 20_04-daily-lts 20.04.202104090, Networking: Synthetic, TestLocation: westus2, Kernel Version: 5.4.0-1043-azure -> 5.8.0-1027-azure
      Connections=1 : throughput=2.44Gbps cyclesPerByte_sender=1.30 cyclesPerByte_receiver=1.33 Avg_TCP_lat=587.854 pktsPerInterrupt=1.60 conCreatedTime=1232 retransSegs=669
      Connections=2 : throughput=4.32Gbps cyclesPerByte_sender=.67 cyclesPerByte_receiver=0.96 Avg_TCP_lat=3678.490 pktsPerInterrupt=2.32 conCreatedTime=1268 retransSegs=2664
      Connections=4 : throughput=5.95Gbps cyclesPerByte_sender=.84 cyclesPerByte_receiver=1.20 Avg_TCP_lat=531.864 pktsPerInterrupt=1.70 conCreatedTime=1355 retransSegs=31155
      Connections=8 : throughput=12.51Gbps cyclesPerByte_sender=.62 cyclesPerByte_receiver=1.01 Avg_TCP_lat=11041.869 pktsPerInterrupt=1.90 conCreatedTime=1448 retransSegs=3953
      Connections=16 : throughput=14.49Gbps cyclesPerByte_sender=.96 cyclesPerByte_receiver=1.27 Avg_TCP_lat=482.191 pktsPerInterrupt=1.78 conCreatedTime=1665 retransSegs=13193
      Connections=32 : throughput=20.01Gbps cyclesPerByte_sender=.91 cyclesPerByte_receiver=1.81 Avg_TCP_lat=9590.938 pktsPerInterrupt=1.79 conCreatedTime=3242 retransSegs=28962
      Connections=64 : throughput=20.56Gbps cyclesPerByte_sender=1.06 cyclesPerByte_receiver=2.81 Avg_TCP_lat=11689.750 pktsPerInterrupt=2.03 conCreatedTime=22784 retransSegs=298047
      Connections=128 : throughput=20.54Gbps cyclesPerByte_sender=1.24 cyclesPerByte_receiver=3.71 Avg_TCP_lat=13942.634 pktsPerInterrupt=2.70 conCreatedTime=46610 retransSegs=1424068
      Connections=256 : throughput=19.53Gbps cyclesPerByte_sender=1.75 cyclesPerByte_receiver=4.95 Avg_TCP_lat=14614.547 pktsPerInterrupt=4.37 conCreatedTime=54647 retransSegs=3146299
      Connections=512 : throughput=16.38Gbps cyclesPerByte_sender=4.27 cyclesPerByte_receiver=9.05 Avg_TCP_lat=12505.392 pktsPerInterrupt=9.04 conCreatedTime=110589 retransSegs=10027152
      Connections=1024 : throughput=11.94Gbps cyclesPerByte_sender=5.88 cyclesPerByte_receiver=16.50 Avg_TCP_lat=17227.960 pktsPerInterrupt=11.70 conCreatedTime=130593 retransSegs=4044564
      Connections=2048 : throughput=7.72Gbps cyclesPerByte_sender=10.04 cyclesPerByte_receiver=26.83 Avg_TCP_lat=13643.054 pktsPerInterrupt=14.73 conCreatedTime=202253 retransSegs=2407213
      Connections=4096 : throughput=7.29Gbps cyclesPerByte_sender=12.56 cyclesPerByte_receiver=30.36 Avg_TCP_lat=35523.966 pktsPerInterrupt=16.56 conCreatedTime=347757 retransSegs=5706437
      Connections=6144 : throughput=6.95Gbps cyclesPerByte_sender=14.76 cyclesPerByte_receiver=32.25 Avg_TCP_lat=39035.188 pktsPerInterrupt=16.87 conCreatedTime=362402 retransSegs=8481956
      Connections=8192 : throughput=6.92Gbps cyclesPerByte_sender=15.75 cyclesPerByte_receiver=32.60 Avg_TCP_lat=76598.090 pktsPerInterrupt=15.54 conCreatedTime=437610 retransSegs=7737819
      Connections=10240 : throughput=6.74Gbps cyclesPerByte_sender=12.88 cyclesPerByte_receiver=31.16 Avg_TCP_lat=149718.969 pktsPerInterrupt=10.26 conCreatedTime=500664 retransSegs=1052907
      Connections=20480 : throughput=6.54Gbps cyclesPerByte_sender=15.36 cyclesPerByte_receiver=33.11 Avg_TCP_lat=137677.031 pktsPerInterrupt=10.35 conCreatedTime=840696 retransSegs=1993294
      Connections=40960 : throughput=5.84Gbps cyclesPerByte_sender=24.13 cyclesPerByte_receiver=41.52 Avg_TCP_lat=42256.362 pktsPerInterrupt=20.38 conCreatedTime=3336869 retransSegs=21449821
      Connections=50000 : throughput=5.87Gbps cyclesPerByte_sender=24.09 cyclesPerByte_receiver=41.28 Avg_TCP_lat=25388.989 pktsPerInterrupt=20.55 conCreatedTime=6389623 retransSegs=20541259
      Connections=55000 : throughput=5.88Gbps cyclesPerByte_sender=24.18 cyclesPerByte_receiver=42.12 Avg_TCP_lat=17870.528 pktsPerInterrupt=20.28 conCreatedTime=8387738 retransSegs=20325375

[LISAv2 Test Results Summary]
Test Run On           : 04/12/2021 02:28:22
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:11

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CORE                 RELOAD-MODULES-SMP                                                                PASS                 7.79 
      ARMImageName: canonical 0001-com-ubuntu-server-focal-daily 20_04-daily-lts 20.04.202104090, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.4.0-1043-azure -> 5.8.0-1027-azure

[LISAv2 Test Results Summary]
Test Run On           : 04/12/2021 04:38:56
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal-daily : 20_04-daily-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:52

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NESTED               NESTED-KVM-NTTTCP-PRIVATE-BRIDGE                                                  PASS                41.82 
      ARMImageName: canonical 0001-com-ubuntu-server-focal-daily 20_04-daily-lts 20.04.202104090, OverrideVMSize: Standard_E16s_v3, TestLocation: westus2, Kernel Version: 5.4.0-1043-azure -> 5.8.0-1027-azure
```