### PR TITLE
Update test case names for same test of multiple iterations, do not pass Auto_Complete StorageAccout to subprocesses of parallel run

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -206,7 +206,7 @@ Function Select-TestCases($TestXMLs, $TestCategory, $TestArea, $TestNames, $Test
 }
 
 Function Add-SetupConfig {
-    param ([System.Collections.ArrayList]$AllTests, [string]$ConfigName, [string]$ConfigValue, [string]$DefaultConfigValue, [string]$SplitBy = ',', [bool]$Force = $false)
+    param ([System.Collections.ArrayList]$AllTests, [string]$ConfigName, [string]$ConfigValue, [string]$DefaultConfigValue, [string]$SplitBy = ',', [bool]$Force = $false, [switch]$UpdateName)
 
     $AddSplittedConfigValue = {
         param ([System.Collections.ArrayList]$TestCollections, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
@@ -274,6 +274,9 @@ Function Add-SetupConfig {
                     # If not pre-defined in TestXml, or -ForceCustom used, duplicate
                     if (!$singleTest.SetupConfig.$ConfigName -or $Force) {
                         $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
+                        if ($UpdateName) {
+                            $clonedTest.testName = $clonedTest.testName + "-" + $singleConfigValue.Replace(" ","")
+                        }
                         $null = $clonedTests.Add($clonedTest)
                     }
                     elseif ($singleConfigValue) {
@@ -288,6 +291,9 @@ Function Add-SetupConfig {
                         else {
                             $clonedTest = ([System.Xml.XmlElement]$singleTest).CloneNode($true)
                             $clonedTest.SetupConfig.$ConfigName = [string]$singleConfigValue
+                            if ($UpdateName) {
+                                $clonedTest.testName = $clonedTest.testName + "-" + $singleConfigValue.Replace(" ","")
+                            }
                             $null = $clonedTests.Add($clonedTest)
                         }
                     }

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -387,4 +387,11 @@ Class AzureController : TestController {
 			Measure-SubscriptionCapabilities
 		}
 	}
+
+	[void] RunTestCasesInParallel([int] $CountInParallel, [int] $ParallelTimeoutHours) {
+		if ($this.StorageAccount -imatch "^Auto_Complete_RG=.+") {
+			$this.ParamsInParallel.Remove("StorageAccount")
+		}
+		([TestController]$this).RunTestCasesInParallel($CountInParallel, $ParallelTimeoutHours)
+	}
 }

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -319,7 +319,7 @@ Class AzureController : TestController {
 			Add-SetupConfig -AllTests $AllTests -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -Force $this.ForceCustom
 			if ($this.TestIterations -gt 1) {
 				$testIterationsParamValue = @(1..$this.TestIterations) -join ','
-				Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
+				Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom -UpdateName
 			}
 			Add-SetupConfig -AllTests $AllTests -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
 			Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom

--- a/TestControllers/HyperVController.psm1
+++ b/TestControllers/HyperVController.psm1
@@ -150,7 +150,7 @@ Class HyperVController : TestController
 		Add-SetupConfig -AllTests $AllTests -ConfigName "TestLocation" -ConfigValue $this.CustomParams["TestLocation"] -SplitBy ';' -Force $this.ForceCustom
 		if ($this.TestIterations -gt 1) {
 			$testIterationsParamValue = @(1..$this.TestIterations) -join ','
-			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom -UpdateName
 		}
 		Add-SetupConfig -AllTests $AllTests -ConfigName "OverrideVMSize" -ConfigValue $this.CustomParams["OverrideVMSize"] -Force $this.ForceCustom
 		Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -248,7 +248,7 @@ Class TestController {
 		Add-SetupConfig -AllTests $AllTests -ConfigName "OsVHD" -ConfigValue $this.CustomParams["OsVHD"] -Force $this.ForceCustom
 		if ($this.TestIterations -gt 1) {
 			$testIterationsParamValue = @(1..$this.TestIterations) -join ','
-			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom
+			Add-SetupConfig -AllTests $AllTests -ConfigName "TestIteration" -ConfigValue $testIterationsParamValue -Force $this.ForceCustom -UpdateName
 		}
 
 		foreach ($test in $AllTests) {


### PR DESCRIPTION
1. Distinguish the test case names for the same test of multiple iterations
2. Do not set Auto_Complete StorageAccout for subprocesses of parallel run