### PR TITLE
Make LocalNode and RemoteNode extendable classes (yml-wise)

### DIFF
--- a/examples/testsuites/withscript.py
+++ b/examples/testsuites/withscript.py
@@ -8,6 +8,7 @@ from assertpy import assert_that
 
 from lisa import Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.executable import CustomScript, CustomScriptBuilder
+from lisa.node import is_remote
 from lisa.operating_system import Windows
 from lisa.testsuite import simple_requirement
 from lisa.util.perf_timer import create_timer
@@ -44,7 +45,7 @@ class WithScript(TestSuite):
         timer2 = create_timer()
         result2 = script.run(force_run=True)
         assert_that(result1.stdout).is_equal_to(result2.stdout)
-        if node.is_remote:
+        if is_remote(node):
             # the timer will be significant different on a remote node.
             assert_that(
                 timer1.elapsed(), "the second time should be faster, without uploading"

--- a/lisa/runners/legacy_runner.py
+++ b/lisa/runners/legacy_runner.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Pattern
 from retry import retry
 
 from lisa import schema
-from lisa.node import Node
+from lisa.node import LocalNode
 from lisa.runner import BaseRunner
 from lisa.testsuite import TestCaseMetadata, TestCaseRuntimeData, TestResult, TestStatus
 from lisa.tools import Git
@@ -71,11 +71,10 @@ class LegacyRunner(BaseRunner):
 
         super().__init__(*args, **kwargs)
         self.exit_code: int = 0
-        # leverage Node logic to run local processes.
-        self._local = Node.create(
+        # leverage LocalNode logic to run local processes.
+        self._local = LocalNode(
             index=-1,
-            node_type=constants.ENVIRONMENTS_NODES_LOCAL,
-            capability=schema.NodeSpace(),
+            runbook=schema.LocalNode(),
             logger_name="LISAv2",
         )
         self.canceled = False

--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -91,7 +91,8 @@ class LisaRunner(BaseRunner):
                 if picked_result is None:
                     self._log.debug(
                         f"env[{environment.name}] skipped "
-                        f"as not meet any case requirement"
+                        f"as LISA has not met any case requirement match"
+                        + " against test cases"
                     )
                     continue
 

--- a/lisa/tests/test_environment.py
+++ b/lisa/tests/test_environment.py
@@ -1,13 +1,109 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Any, List
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional, Type, cast
 from unittest import TestCase
 
-from lisa import schema, search_space
+from dataclasses_json import dataclass_json
+from marshmallow import validate
+
+from lisa import node, schema, search_space
 from lisa.environment import load_environments
 from lisa.testsuite import simple_requirement
 from lisa.util import constants
+
+CUSTOM_LOCAL = "custom_local"
+CUSTOM_REMOTE = "custom_remote"
+
+
+@dataclass_json()
+@dataclass
+class CustomLocalNodeSchema(schema.LocalNode):
+    type: str = field(
+        default=CUSTOM_LOCAL,
+        metadata=schema.metadata(
+            required=True,
+            validate=validate.OneOf([CUSTOM_LOCAL]),
+        ),
+    )
+
+    custom_local_field: Optional[str] = field(default=None)
+
+
+class CustomLocalNode(node.LocalNode):
+    def __init__(
+        self,
+        index: int,
+        runbook: CustomLocalNodeSchema,
+        logger_name: str,
+        base_log_path: Optional[Path] = None,
+        name: str = "",
+    ) -> None:
+        super().__init__(
+            index,
+            runbook,
+            logger_name=logger_name,
+            base_log_path=base_log_path,
+            name=name,
+        )
+        self.custom_local_field = runbook.custom_local_field
+        assert (
+            self.custom_local_field
+        ), f"custom_local_field field of {CUSTOM_LOCAL}-typed nodes cannot be empty"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return CUSTOM_LOCAL
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return CustomLocalNodeSchema
+
+
+@dataclass_json()
+@dataclass
+class CustomRemoteNodeSchema(schema.RemoteNode):
+    type: str = field(
+        default=CUSTOM_REMOTE,
+        metadata=schema.metadata(
+            required=True,
+            validate=validate.OneOf([CUSTOM_REMOTE]),
+        ),
+    )
+
+    custom_remote_field: Optional[str] = field(default=None)
+
+
+class CustomRemoteNode(node.RemoteNode):
+    def __init__(
+        self,
+        index: int,
+        runbook: CustomRemoteNodeSchema,
+        logger_name: str,
+        base_log_path: Optional[Path] = None,
+        name: str = "",
+    ) -> None:
+        super().__init__(
+            index,
+            runbook,
+            logger_name=logger_name,
+            base_log_path=base_log_path,
+            name=name,
+        )
+        self.custom_remote_field = runbook.custom_remote_field
+        assert (
+            self.custom_remote_field
+        ), f"custom_remote_field field of {CUSTOM_REMOTE}-typed nodes cannot be empty"
+
+    @classmethod
+    def type_name(cls) -> str:
+        return CUSTOM_REMOTE
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return CustomRemoteNodeSchema
 
 
 def generate_runbook(
@@ -15,6 +111,7 @@ def generate_runbook(
     local: bool = False,
     remote: bool = False,
     requirement: bool = False,
+    local_remote_node_extensions: bool = False,
 ) -> schema.EnvironmentRoot:
     environments: List[Any] = list()
     nodes: List[Any] = list()
@@ -47,11 +144,31 @@ def generate_runbook(
                 "nic_count": {"min": 1, "max": 1},
             }
         )
+    if local_remote_node_extensions:
+        nodes.extend(
+            [
+                {
+                    constants.TYPE: CUSTOM_LOCAL,
+                    constants.ENVIRONMENTS_NODES_CAPABILITY: {"core_count": {"min": 4}},
+                    "custom_local_field": CUSTOM_LOCAL,
+                },
+                {
+                    constants.TYPE: CUSTOM_REMOTE,
+                    constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS: "internal_address",
+                    constants.ENVIRONMENTS_NODES_REMOTE_PORT: 22,
+                    "public_address": "public_address",
+                    "public_port": 10022,
+                    constants.ENVIRONMENTS_NODES_REMOTE_USERNAME: "name_of_user",
+                    constants.ENVIRONMENTS_NODES_REMOTE_PASSWORD: "do_not_use_it",
+                    "custom_remote_field": CUSTOM_REMOTE,
+                },
+            ]
+        )
     if is_single_env:
         environments = [{"nodes": nodes}]
     else:
-        for node in nodes:
-            environments.append({"nodes": [node]})
+        for n in nodes:
+            environments.append({"nodes": [n]})
 
     data = {"max_concurrency": 2, constants.ENVIRONMENTS: environments}
     return schema.EnvironmentRoot.schema().load(data)  # type: ignore
@@ -70,9 +187,9 @@ class EnvironmentTestCase(TestCase):
         envs = load_environments(runbook)
         self.assertEqual(2, len(envs))
         for env in envs.values():
-            for node in env.nodes.list():
+            for n in env.nodes.list():
                 # mock initializing
-                node._is_initialized = True
+                n._is_initialized = True
             self.assertEqual(1, len(env.nodes))
 
     def test_create_from_runbook_merged(self) -> None:
@@ -80,9 +197,9 @@ class EnvironmentTestCase(TestCase):
         envs = load_environments(runbook)
         self.assertEqual(1, len(envs))
         for env in envs.values():
-            for node in env.nodes.list():
+            for n in env.nodes.list():
                 # mock initializing
-                node._is_initialized = True
+                n._is_initialized = True
             self.assertEqual(2, len(env.nodes))
 
     def test_create_from_runbook_cap(self) -> None:
@@ -91,11 +208,11 @@ class EnvironmentTestCase(TestCase):
         self.assertEqual(2, len(envs))
         env = envs.get("customized_0")
         assert env
-        for node in env.nodes.list():
+        for n in env.nodes.list():
             # mock initializing
-            node._is_initialized = True
-        self.assertEqual(search_space.IntRange(min=4), node.capability.core_count)
-        self.assertEqual(search_space.IntRange(min=1), node.capability.disk_count)
+            n._is_initialized = True
+        self.assertEqual(search_space.IntRange(min=4), n.capability.core_count)
+        self.assertEqual(search_space.IntRange(min=1), n.capability.disk_count)
         # check from env capability
         env_cap = env.capability
         self.assertEqual(1, len(env_cap.nodes))
@@ -129,6 +246,25 @@ class EnvironmentTestCase(TestCase):
         self.assertEqual(1, len(envs), "get or create again won't create new")
         assert env
         self.assertEqual(0, len(env.nodes))
-        self.assertIsNone(env.runbook.nodes)
+        self.assertSequenceEqual([], env.runbook.nodes)
         assert env.runbook.nodes_requirement
         self.assertEqual(2, len(env.runbook.nodes_requirement))
+
+    def test_create_from_custom_local_remote(self) -> None:
+        runbook = generate_runbook(
+            local_remote_node_extensions=True, is_single_env=True
+        )
+        envs = load_environments(runbook)
+        self.assertEqual(1, len(envs))
+        for env in envs.values():
+            done: int = 0
+            for n in env.nodes.list():
+                if n.type_name() == CUSTOM_LOCAL:
+                    l_n = cast(CustomLocalNode, n)
+                    self.assertEqual(l_n.custom_local_field, CUSTOM_LOCAL)
+                    done += 1
+                elif n.type_name() == CUSTOM_REMOTE:
+                    r_n = cast(CustomRemoteNode, n)
+                    self.assertEqual(r_n.custom_remote_field, CUSTOM_REMOTE)
+                    done += 1
+            self.assertEqual(2, done)

--- a/lisa/tests/test_platform.py
+++ b/lisa/tests/test_platform.py
@@ -150,7 +150,8 @@ class PlatformTestCase(TestCase):
         self.assertEqual(
             "no capability found for environment: "
             "Environment(name='customized_0', topology='subnet', "
-            "nodes_raw=None, nodes_requirement=None)",
+            "nodes_raw=[{'type': 'local', 'capability': {'core_count': {'min': 4}}}]"
+            ", nodes_requirement=None)",
             str(cm.exception),
         )
 

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -38,18 +38,22 @@ def wait_tcp_port_ready(
     timout_timer = create_timer()
     while timout_timer.elapsed(False) < timeout:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as tcp_socket:
-            result = tcp_socket.connect_ex((address, port))
-            if result == 0:
-                is_ready = True
-                break
-            else:
-                if times % 10 == 0 and log:
-                    log.debug(
-                        f"cannot connect to TCP port: {port}, error code: {result}, "
-                        f"tried times: {times}, elapsed: {timout_timer}. retrying..."
-                    )
-                sleep(1)
-                times += 1
+            try:
+                result = tcp_socket.connect_ex((address, port))
+                if result == 0:
+                    is_ready = True
+                    break
+                else:
+                    if times % 10 == 0 and log:
+                        log.debug(
+                            f"cannot connect to {address}:{port}, "
+                            f"error code: {result}, tried times: {times},"
+                            f" elapsed: {timout_timer}. retrying..."
+                        )
+                    sleep(1)
+                    times += 1
+            except Exception as e:
+                raise LisaException(f"failed to connect to {address}:{port}: {e}")
     return is_ready, result
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -304,7 +304,7 @@ dev = ["pytest", "ipython", "mypy (>=0.710)", "hypothesis", "portray", "flake8",
 
 [[package]]
 name = "decorator"
-version = "5.0.6"
+version = "5.0.7"
 description = "Decorators for Humans"
 category = "main"
 optional = false
@@ -312,7 +312,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "flake8"
-version = "3.9.0"
+version = "3.9.1"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
@@ -1267,7 +1267,6 @@ coverage = [
 ]
 cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1"},
-    {file = "cryptography-3.4.7-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250"},
     {file = "cryptography-3.4.7-cp36-abi3-manylinux2010_x86_64.whl", hash = "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2"},
     {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_aarch64.whl", hash = "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6"},
     {file = "cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl", hash = "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959"},
@@ -1284,12 +1283,12 @@ dataclasses-json = [
     {file = "dataclasses_json-0.5.2-py3-none-any.whl", hash = "sha256:b746c48d9d8e884e2a0ffa59c6220a1b21f94d4f9f12c839da0a8a0efd36dc19"},
 ]
 decorator = [
-    {file = "decorator-5.0.6-py3-none-any.whl", hash = "sha256:d9f2d2863183a3c0df05f4b786f2e6b8752c093b3547a558f287bf3022fd2bf4"},
-    {file = "decorator-5.0.6.tar.gz", hash = "sha256:f2e71efb39412bfd23d878e896a51b07744f2e2250b2e87d158e76828c5ae202"},
+    {file = "decorator-5.0.7-py3-none-any.whl", hash = "sha256:945d84890bb20cc4a2f4a31fc4311c0c473af65ea318617f13a7257c9a58bc98"},
+    {file = "decorator-5.0.7.tar.gz", hash = "sha256:6f201a6c4dac3d187352661f508b9364ec8091217442c9478f1f83c003a0f060"},
 ]
 flake8 = [
-    {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
-    {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
+    {file = "flake8-3.9.1-py2.py3-none-any.whl", hash = "sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a"},
+    {file = "flake8-3.9.1.tar.gz", hash = "sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378"},
 ]
 flake8-black = [
     {file = "flake8-black-0.2.1.tar.gz", hash = "sha256:f26651bc10db786c03f4093414f7c9ea982ed8a244cec323c984feeffdf4c118"},


### PR DESCRIPTION
Make LocalNode and RemoteNode extendable classes (yml-wise).

We do so by making use of BaseClassWithRunbookMixin, on the actual
instance classes, and ExtendableSchemaMixin, on the respective schema
classes. This makes it possible to have custom, type-defined sections
on general (SUT) nodes coming from the runbook, together with Platform
and Notifier.

This will come in handy for LISA users who have node logic/fields that
go beyond what is originally defined to work for (e.g.) Azure.

Example of power/usage:

By declaring this, on code:

```
@dataclass_json()
@dataclass
class MyNodeSchema(schema.RemoteNode):
    type: str = field(
        default=MYNAME,
        metadata=schema.metadata(
            required=True,
            validate=validate.OneOf([MYNAME]),
        ),
    )

    my_example_extra_field: Optional[str] = field(default=None)

class MyNode(node.RemoteNode):
    def __init__(
        self,
        index: int,
        runbook: MyNodeSchema,
        logger_name: str,
        base_log_path: Optional[Path] = None,
        name: str = "",
    ) -> None:
        super().__init__(index, runbook,
                         logger_name=logger_name,
                         base_log_path=base_log_path,
                         name=name)
        self.my_example_extra_field = runbook.my_example_extra_field
        assert self.my_example_extra_field, \
            f"my_example_extra_field field of {MYNAME}-typed " \
            "nodes cannot be empty "

    @classmethod
    def type_name(cls) -> str:
        return MYNAME

    @classmethod
    def type_schema(cls) -> Type[schema.TypedSchema]:
        return MyNodeSchema


```
one is now able to do this, yml-wise:

```
environment:
  warn_as_error: true
  environments:
    - nodes:
      - type: MYNAME
        public_address: ...
        public_port: ...
        username: ...
        password: ...
->      my_example_extra_field: ...

```
Of course, custom logic for only that type of node will be at your
fingertips, just by extending/overriding your node class. Of course
this is advanced usage and not meant for the average user.
