### PR TITLE
Use `admin_private_key_file` variable in ready.yml

### DIFF
--- a/microsoft/runbook/ready.yml
+++ b/microsoft/runbook/ready.yml
@@ -16,6 +16,6 @@ environment:
           public_address: $(public_address)
           public_port: $(public_port)
           username: $(user_name)
-          private_key_file: $(private_key_file)
+          private_key_file: $(admin_private_key_file)
 platform:
   - type: ready


### PR DESCRIPTION
* Added missing `marketplace_image` parameter in `Run in Azure` section
* Updated `private_key_file` variable to `admin_private_key_file` at [ready.yml](https://github.com/microsoft/lisa/blob/main/microsoft/runbook/ready.yml#L19) to maintain consistency in command parameters.