### PR TITLE
Add variable 'marketplace_image' definition in azure.yaml.

### DIFF
--- a/microsoft/runbook/azure.yml
+++ b/microsoft/runbook/azure.yml
@@ -6,6 +6,8 @@ variable:
     value: westus2
   - name: reserve_environment
     value: "no"
+  - name: marketplace_image
+    value: ""
 notifier:
   - type: html
 environment:


### PR DESCRIPTION
Fix #1284 

After fix -
```
.\lisa.cmd -r ./microsoft/runbook/azure.yml -v subscription_id:*** -v "admin_private_key_file:***"

2021-04-22 15:17:32.691 INFO LISA.[azure]deploy[customized_0] vm setting: AzureNodeSchema(name='node-0', vm_size='Standard_DS2_v2', location='westus2', marketplace_raw={'publisher': 'Canonical', 'offer': 'UbuntuSer
TS', 'version': '18.04.202104150'}, vhd='', nic_count=1, purchase_plan=None)

15:20:14.988 INFO LISA.[azure]del[customized_0] deleting resource group: lisa_azure_default_20210422_151724_293_e0, wait: False
15:20:17.007 INFO LISA.RootRunner ________________________________________
15:20:17.007 INFO LISA.RootRunner                            Provisioning.smoke_test: PASSED
15:20:17.012 INFO LISA.RootRunner test result summary
15:20:17.013 INFO LISA.RootRunner   TOTAL      : 1
15:20:17.014 INFO LISA.RootRunner     NOTRUN   : 0
15:20:17.015 INFO LISA.RootRunner     RUNNING  : 0
15:20:17.016 INFO LISA.RootRunner     FAILED   : 0
15:20:17.016 INFO LISA.RootRunner     PASSED   : 1
15:20:17.018 INFO LISA.RootRunner     SKIPPED  : 0
```

Before fix -
```
lisa.util.LisaException: cannot find variable 'marketplace_image', make sure its value filled in runbook, command line or environment variables.
```
