### PR TITLE
Fix hung issue on channel.recv_exit_status()

### DIFF
--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -153,8 +153,6 @@ def try_connect(connection_info: ConnectionInfo) -> Any:
     # flush commands and prevent more writes
     stdin.flush()
     stdin.channel.shutdown_write()
-    # give time for it to finish
-    _ = stdout.channel.recv_exit_status()
     paramiko_client.close()
 
     return stdout


### PR DESCRIPTION
Test hung on https://github.com/microsoft/lisa/blob/main/lisa/util/shell.py#L157 when use image spirentcommunications1594084187199 testcenter_virtual testcentervirtual 5.14.9956.
On these images, its shell is not a normal ssh shell.
![image](https://user-images.githubusercontent.com/10083705/116198708-e0823880-a768-11eb-8474-8d61e8f247ca.png)

![image](https://user-images.githubusercontent.com/10083705/116199100-54244580-a769-11eb-8ea9-f6f7d70bfd81.png)

I am not sure if it is the same issue, but when I invoke it after readline function, it works well. I remove it in try_connect, if you want to use it on windows, please use it outside of this function.
```
        stdout_content = stdout.readline()
        stdout.channel.recv_exit_status()
```