### PR TITLE
🚧 RFC only, not to merge 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install Python dependencies
         run: make setup
 
+      - name: Enable OpenSSH server for Windows
+        if: runner.os == 'Windows'
+        run: |
+          Add-WindowsCapability -Online -Name OpenSSH.Server
+
       - name: Run hello-world
         run: make run
 

--- a/lisa/tests/test_environment.py
+++ b/lisa/tests/test_environment.py
@@ -108,6 +108,10 @@ def generate_runbook(
     remote: bool = False,
     requirement: bool = False,
     local_remote_node_extensions: bool = False,
+    public_addr: str = "public_address",
+    public_port: int = 10022,
+    user_name: str = "name_of_user",
+    priv_key_path: str = "",
 ) -> schema.EnvironmentRoot:
     environments: List[Any] = list()
     nodes: List[Any] = list()
@@ -124,12 +128,17 @@ def generate_runbook(
                 constants.TYPE: constants.ENVIRONMENTS_NODES_REMOTE,
                 constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS: "internal_address",
                 constants.ENVIRONMENTS_NODES_REMOTE_PORT: 22,
-                "public_address": "public_address",
-                "public_port": 10022,
-                constants.ENVIRONMENTS_NODES_REMOTE_USERNAME: "name_of_user",
+                "public_address": public_addr,
+                "public_port": public_port,
+                constants.ENVIRONMENTS_NODES_REMOTE_USERNAME: user_name,
                 constants.ENVIRONMENTS_NODES_REMOTE_PASSWORD: "do_not_use_it",
             }
         )
+        if priv_key_path:
+            del nodes[-1][constants.ENVIRONMENTS_NODES_REMOTE_PASSWORD]
+            nodes[-1][
+                constants.ENVIRONMENTS_NODES_REMOTE_PRIVATE_KEY_FILE
+            ] = priv_key_path
     if requirement:
         nodes.append(
             {


### PR DESCRIPTION
While I've just begun to investigate some weird Linux boxes, that hang
on shell.py's "try_connnect"--they absolutely should not, but them
we're talking about ancient, weird systems, like 3.x kernel--we must
guarantee that that function serves its purpose, which is *to detect
Windows boxes*.

When I arrived on LISA, that functionality was broken and I made it work (just to find
that these weird cases now appear, but anyhow). One internal platform
of ours totally depends on talking to Windows boxes via SSH and, well,
the nodes need to be recognized as such for things to work.

I'd like, in parallel with any fix that will come with this
investigation, to have a unit test for such functionality. My initial
thoughts were to take advantage of the Windows instance on our CI, the
OpenSSH server feature/capability of Windows 10, and have a remote
note pointing to self (localhost) in a test, then to assert that it
was marked non-POSIX.

I'd reach that by enabling the feature, editing configs to allow for
key logins, enabling/starting the service, generating keys and using
those as credentials to the node, along with user, of course. The
test, finally, would only run on Windows (preferably detecting the
ones with the service running).

Problem is that OpenSSH's situation on Windows is a clusterf*^Wvery
poorly handled, and key logins generally only work with luck.

Anyone with a better idea on how to test that or with better abilities
with Windows + OpenSSH to help me with this?

Thanks!