### PR TITLE
Add sriov feature.

### DIFF
--- a/lisa/feature.py
+++ b/lisa/feature.py
@@ -26,12 +26,11 @@ class Feature(InitializableMixin):
 
     @classmethod
     @abstractmethod
-    def enabled(cls) -> bool:
+    def can_disable(cls) -> bool:
         raise NotImplementedError()
 
-    @classmethod
     @abstractmethod
-    def can_disable(cls) -> bool:
+    def enabled(self) -> bool:
         raise NotImplementedError()
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:

--- a/lisa/features/__init__.py
+++ b/lisa/features/__init__.py
@@ -3,6 +3,7 @@
 
 from .gpu import Gpu
 from .serial_console import SerialConsole
+from .sriov import Sriov
 from .startstop import StartStop
 
-__all__ = ["Gpu", "SerialConsole", "StartStop"]
+__all__ = ["Gpu", "SerialConsole", "Sriov", "StartStop"]

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -33,6 +33,14 @@ class Gpu(Feature):
     def name(cls) -> str:
         return FEATURE_NAME_GPU
 
+    @classmethod
+    def enabled(cls) -> bool:
+        return True
+
+    @classmethod
+    def can_disable(cls) -> bool:
+        return True
+
     def _is_supported(self) -> bool:
         raise NotImplementedError()
 

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -34,10 +34,6 @@ class Gpu(Feature):
         return FEATURE_NAME_GPU
 
     @classmethod
-    def enabled(cls) -> bool:
-        return True
-
-    @classmethod
     def can_disable(cls) -> bool:
         return True
 
@@ -127,6 +123,9 @@ class Gpu(Feature):
         # TODO: more supportability can be defined here
         if not self._is_supported():
             raise SkippedException(f"GPU is not supported with distro {self._node.os}")
+
+    def enabled(self) -> bool:
+        return True
 
     def install_compute_sdk(
         self, driver: ComputeSDK = ComputeSDK.CUDA, version: str = ""

--- a/lisa/features/serial_console.py
+++ b/lisa/features/serial_console.py
@@ -37,11 +37,6 @@ class SerialConsole(Feature):
         return FEATURE_NAME_SERIAL_CONSOLE
 
     @classmethod
-    def enabled(cls) -> bool:
-        # most platform support shutdown
-        return True
-
-    @classmethod
     def can_disable(cls) -> bool:
         # no reason to disable it, it can not be used
         return False
@@ -54,6 +49,10 @@ class SerialConsole(Feature):
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         self._cached_console_log: Optional[bytes] = None
+
+    def enabled(self) -> bool:
+        # most platform support shutdown
+        return True
 
     def invalidate_cache(self) -> None:
         # sometime, if the serial log accessed too early, it may be empty.

--- a/lisa/features/sriov.py
+++ b/lisa/features/sriov.py
@@ -12,18 +12,17 @@ class Sriov(Feature):
         return FEATURE_NAME_SRIOV
 
     @classmethod
-    def enabled(cls) -> bool:
-        return True
-
-    @classmethod
     def can_disable(cls) -> bool:
         return True
 
     def _switch(self, enable: bool) -> None:
         raise NotImplementedError()
 
+    def disable(self) -> None:
+        self._switch(False)
+
     def enable(self) -> None:
         self._switch(True)
 
-    def disable(self) -> None:
-        self._switch(False)
+    def enabled(self) -> bool:
+        raise NotImplementedError()

--- a/lisa/features/sriov.py
+++ b/lisa/features/sriov.py
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from lisa.feature import Feature
+
+FEATURE_NAME_SRIOV = "Sriov"
+
+
+class Sriov(Feature):
+    @classmethod
+    def name(cls) -> str:
+        return FEATURE_NAME_SRIOV
+
+    @classmethod
+    def enabled(cls) -> bool:
+        return True
+
+    @classmethod
+    def can_disable(cls) -> bool:
+        return True
+
+    def _switch(self, enable: bool) -> None:
+        raise NotImplementedError()
+
+    def enable(self) -> None:
+        self._switch(True)
+
+    def disable(self) -> None:
+        self._switch(False)

--- a/lisa/features/startstop.py
+++ b/lisa/features/startstop.py
@@ -19,11 +19,6 @@ class StartStop(Feature):
         return FEATURE_NAME_STARTSTOP
 
     @classmethod
-    def enabled(cls) -> bool:
-        # most platform support shutdown
-        return True
-
-    @classmethod
     def can_disable(cls) -> bool:
         # no reason to disable it, it can not be used
         return False
@@ -36,6 +31,10 @@ class StartStop(Feature):
 
     def _restart(self, wait: bool = True) -> None:
         raise NotImplementedError()
+
+    def enabled(self) -> bool:
+        # most platform support shutdown
+        return True
 
     def stop(self, wait: bool = True) -> None:
         self._log.debug("stopping")

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -20,6 +20,12 @@
                 "description": "location"
             }
         },
+        "enable_sriov": {
+            "type": "bool",
+            "metadata": {
+                "description": "enable accelerated network"
+            }
+        },
         "nodes": {
             "type": "array",
             "metadata": {
@@ -140,6 +146,9 @@
                     },
                     "default_subnetId": {
                         "value": "[variables('default_subnetId')]"
+                    },
+                    "enable_sriov": {
+                        "value": "[parameters('enable_sriov')]"
                     }
                 },
                 "mode": "Incremental",
@@ -158,6 +167,9 @@
                         },
                         "default_subnetId": {
                             "type": "string"
+                        },
+                        "enable_sriov": {
+                            "type": "bool"
                         }
                     },
                     "resources": [
@@ -183,7 +195,8 @@
                                             "privateIPAllocationMethod": "Dynamic"
                                         }
                                     }
-                                ]
+                                ],
+                                "enableAcceleratedNetworking": "[parameters('enable_sriov')]"
                             }
                         }
                     ],


### PR DESCRIPTION
I submit an issue in azure python sdk github repo to ask how to judge image sriov capability, currently enable sriov when size supports, I tried an old image which doesn't support SRIOV, it can be provisioned successfully, just can't see VF in the guest.