### PR TITLE
Test in Parallel: change parallel model to dynamic

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -3,16 +3,15 @@
 This document describes the existing developer tooling we have in place (and what to
 expect of it), as well as our design and development philosophy.
 
-- [Development Guideline](#development-guideline)
-  - [Understand LISA](#understand-lisa)
-  - [Environment Setup](#environment-setup)
-    - [Visual Studio Code](#visual-studio-code)
-    - [Emacs](#emacs)
-    - [Other setups](#other-setups)
-  - [Code guideline](#code-guideline)
-    - [Naming Conventions](#naming-conventions)
-    - [Code checks](#code-checks)
-  - [Extended reading](#extended-reading)
+- [Understand LISA](#understand-lisa)
+- [Environment Setup](#environment-setup)
+  - [Visual Studio Code](#visual-studio-code)
+  - [Emacs](#emacs)
+  - [Other setups](#other-setups)
+- [Code guideline](#code-guideline)
+  - [Naming Conventions](#naming-conventions)
+  - [Code checks](#code-checks)
+- [Extended reading](#extended-reading)
 
 ## Understand LISA
 
@@ -38,6 +37,7 @@ environment.
 
     ```json
     {
+        "markdown.extension.toc.levels": "2..6",
         "python.analysis.typeCheckingMode": "strict",
         "python.formatting.provider": "black",
         "python.linting.enabled": true,

--- a/docs/run.md
+++ b/docs/run.md
@@ -8,18 +8,20 @@
 
 ## Quick start
 
-`lisa.sh` (for Linux) and `lisa.cmd` (for Windows) are provided to wrap `Poetry` 
+`lisa.sh` (for Linux) and `lisa.cmd` (for Windows) are provided to wrap `Poetry`
 for you to run LISA test.
 
-In Linux, you could create an alias for this simple script. For example, add below 
-line to add to `.bashrc`:
-```
+In Linux, you could create an alias for this simple script. For example, add
+below line to add to `.bashrc`:
+
+```bash
 alias lisa="./lisa.sh"
 ```
 
-If no argument specified, LISA will run some sample test cases with the default 
-runbook (`examples/runbook/hello_world.yml`) on your local computer. You can use this way 
-to verify your local LISA environment setup. This test will not modify your computer.
+If no argument specified, LISA will run some sample test cases with the default
+runbook (`examples/runbook/hello_world.yml`) on your local computer. You can use
+this way to verify your local LISA environment setup. This test will not modify
+your computer.
 
 ```bash
 lisa
@@ -27,19 +29,20 @@ lisa
 
 If you see any error from this run, please check [FAQ and troubleshooting](troubleshooting.md).
 
-
 ### Run in Azure
 
-Please follow below steps to configure your local computer to run LISA test against Linux VM on Azure.
+Please follow below steps to configure your local computer to run LISA test
+against Linux VM on Azure.
 
 1. Sign in to Azure
 
-    Make sure [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or 
-    [Azure PowerShell](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) has been 
-    installed on your local computer. Then, please login to your Azure subscription to authenticate 
-    your current session. LISA also supports other Azure authentications, refer to 
-    [runbook reference](runbook.md).
-    
+    Make sure [Azure
+    CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or [Azure
+    PowerShell](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps)
+    has been installed on your local computer. Then, please login to your Azure
+    subscription to authenticate your current session. LISA also supports other
+    Azure authentications, refer to [runbook reference](runbook.md).
+
     Here, let's choose `Azure CLI` for the setup. You should see a page pop up and all your Azure subscriptions.
 
     ```bash
@@ -48,8 +51,8 @@ Please follow below steps to configure your local computer to run LISA test agai
 
 2. Get the subscription id
 
-    LISA needs to know the Azure subscription ID for your testing. Run below command to retrieve 
-    subscription information.
+    LISA needs to know the Azure subscription ID for your testing. Run below
+    command to retrieve subscription information.
 
     ```bash
     az account show --subscription "<your subscription Name>"
@@ -74,23 +77,23 @@ Please follow below steps to configure your local computer to run LISA test agai
     }
     ```
 
-3. Prepare ssh key pair
+3. Prepare SSH key pair
 
-    LISA connects to the Azure test VM by SSH with key authentication; please have your key pair 
-    (public key and private key) ready before running the test. If you don't have a key pair, 
-    run below command to create a new one.
+    LISA connects to the Azure test VM by SSH with key authentication; please
+    have your key pair (public key and private key) ready before running the
+    test. If you don't have a key pair, run below command to create a new one.
 
     ```bash
     ssh-keygen
     ```
-    
-    :warning:	Don't use passphrase to protect your key. LISA doesn't support that.
 
+    :warning:   Don't use passphrase to protect your key. LISA doesn't support
+    that.
 
 4. Run LISA
 
-    Use above `<subscription id>` and `<private key file>` to run LISA. It might take 
-    several minutes to complete.
+    Use above `<subscription id>` and `<private key file>` to run LISA. It might
+    take several minutes to complete.
 
     ```bash
     lisa -r ./microsoft/runbook/azure.yml -v subscription_id:<subscription id> -v "admin_private_key_file:<private key file>"
@@ -98,17 +101,18 @@ Please follow below steps to configure your local computer to run LISA test agai
 
 5. Verify test result
 
-    After test completed, you can refer the LISA console log, or the html report file for the 
-    test results. See an example html report as below:
+    After test completed, you can refer the LISA console log, or the html report
+    file for the test results. See an example html report as below:
 
     ![image](img/smoke_test_result.png)
 
-    Please learn more from [runbook reference](runbook.md) for how to specify more parameters 
-    to customize your test.
+    Please learn more from [runbook reference](runbook.md) for how to specify
+    more parameters to customize your test.
 
 ### Run in Ready computers
 
-If you have prepared a Linux computer for testing, please run LISA with `ready` runbook:
+If you have prepared a Linux computer for testing, please run LISA with `ready`
+runbook:
 
 1. Get the IP address of your computer for testing.
 
@@ -120,15 +124,17 @@ If you have prepared a Linux computer for testing, please run LISA with `ready` 
     lisa -r ./microsoft/runbook/ready.yml -v public_address:<public address> -v "user_name:<user name>" -v "admin_private_key_file:<private key file>"
     ```
 
-`ready` runbook also supports tests which require multiple computers (for example, networking 
-testing); and, it supports password authentication too. Learn more from [runbook reference](runbook.md).
+`ready` runbook also supports tests which require multiple computers (for
+example, networking testing); and, it supports password authentication too.
+Learn more from [runbook reference](runbook.md).
 
 ## Run Microsoft tests
 
-LISA comes with a set of test suites to verify Linux distro/kernel quality on Microsoft's platforms 
-(including Azure, and HyperV). The test cases in those test suites are organized with multiple test 
-`Tiers` (`T0`, `T1`, `T2`, `T3`, `T4`). Please refer [Microsoft tests](microsoft_tests.md) to 
-know more about the test tier definition.
+LISA comes with a set of test suites to verify Linux distro/kernel quality on
+Microsoft's platforms (including Azure, and HyperV). The test cases in those
+test suites are organized with multiple test `Tiers` (`T0`, `T1`, `T2`, `T3`,
+`T4`). Please refer [Microsoft tests](microsoft_tests.md) to know more about the
+test tier definition.
 
 You can specify the test cases by the test tier, with `-v tier:<tier id>`:
 
@@ -136,15 +142,16 @@ You can specify the test cases by the test tier, with `-v tier:<tier id>`:
 lisa -r ./microsoft/runbook/azure.yml -v subscription_id:<subscription id> -v "admin_private_key_file:<private key file>" -v tier:<tier id>
 ```
 
-:construction:	Currently we are migrating previous LISAv2 test cases to this LISA (v3) framework. 
-Before we complete the test case migration, only T0 test cases can be launched on LISA (v3). Other test
-cases can be executed in LISA (v3) with "Compatibility mode", which will invoke a shim layer to call 
-LISAv2; so you need to run LISA on a Windows computer with providing the secret file. Learn more from 
-[how to run legacy test cases](run_legacy.md).
+:construction:  Currently we are migrating previous LISAv2 test cases to this
+LISA (v3) framework. Before we complete the test case migration, only T0 test
+cases can be launched on LISA (v3). Other test cases can be executed in LISA
+(v3) with "Compatibility mode", which will invoke a shim layer to call LISAv2;
+so you need to run LISA on a Windows computer with providing the secret file.
+Learn more from [how to run legacy test cases](run_legacy.md).
 
-
-For a comprehensive introduction to LISA supported test parameters and runbook schema, please read 
-[command-line arguments](command_line.md) and [runbook reference](runbook.md).
+For a comprehensive introduction to LISA supported test parameters and runbook
+schema, please read [command-line arguments](command_line.md) and [runbook
+reference](runbook.md).
 
 ## Run legacy LISAv2 test cases
 

--- a/examples/runbook/hello_world.yml
+++ b/examples/runbook/hello_world.yml
@@ -1,7 +1,6 @@
 extension:
   - "../testsuites"
 environment:
-  allow_create: false
   environments:
     - nodes:
         - type: local

--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -146,6 +146,9 @@ class Environment(ContextMixin, InitializableMixin):
         # original runbook or generated from test case which this environment supports
         self.runbook: schema.Environment
         self.warn_as_error = warn_as_error
+        # indicate is this environment is deploying, preparing, testing or not.
+        self.is_in_use: bool = False
+
         self._default_node: Optional[Node] = None
         self._log = get_logger("env", self.name)
         # Not to set the log path until its first used. Because the path
@@ -165,6 +168,15 @@ class Environment(ContextMixin, InitializableMixin):
     @status.setter
     def status(self, value: EnvironmentStatus) -> None:
         self._status = value
+
+    @property
+    def is_alive(self) -> bool:
+        return self._status in [
+            EnvironmentStatus.New,
+            EnvironmentStatus.Prepared,
+            EnvironmentStatus.Deployed,
+            EnvironmentStatus.Connected,
+        ]
 
     @classmethod
     def create(

--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -100,6 +100,9 @@ class RootRunner(Action):
         except Exception as identifer:
             cancel()
             raise identifer
+        finally:
+            for runner in self._runners:
+                runner.close()
 
         self._output_results(self._results)
 

--- a/lisa/runners/legacy_runner.py
+++ b/lisa/runners/legacy_runner.py
@@ -205,7 +205,7 @@ class ResultStateManager:
         # copy a list to find changed cases
         new_running_cases = running_cases[:]
         not_matched_results = [
-            x for x in self._results if x.status != TestStatus.NOTRUN
+            x for x in self._results if x.status != TestStatus.QUEUED
         ]
         # remove existing running case, left new running cases
         for running_case in running_cases:
@@ -220,16 +220,16 @@ class ResultStateManager:
         )
 
         # set new running case information
-        notrun_results = [x for x in self._results if x.status == TestStatus.NOTRUN]
+        queued_results = [x for x in self._results if x.status == TestStatus.QUEUED]
         for running_case in new_running_cases:
             name = running_case["name"]
-            for result in notrun_results:
+            for result in queued_results:
                 if result.name == name:
                     # initialize new running case
                     running_case["status"] = str(TestStatus.RUNNING.name)
                     self._set_result(result, information=running_case)
                     # every not run just match one
-                    notrun_results.remove(result)
+                    queued_results.remove(result)
                     break
 
     def _set_completed_results(self, completed_cases: List[Dict[str, str]]) -> None:
@@ -238,7 +238,7 @@ class ResultStateManager:
         not_matched_results = [
             x
             for x in self._results
-            if x.status not in [TestStatus.NOTRUN, TestStatus.RUNNING]
+            if x.status not in [TestStatus.QUEUED, TestStatus.RUNNING]
         ]
         # remove existing completed case
         for completed_case in completed_cases:

--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -210,7 +210,7 @@ class LisaRunner(BaseRunner):
                         "features into this environment.",
                     )
                     matched_result = next(
-                        (result for result in test_results if result.is_notrun),
+                        (result for result in test_results if result.is_queued),
                         None,
                     )
                 if not matched_result:
@@ -326,7 +326,7 @@ class LisaRunner(BaseRunner):
         results = [
             x
             for x in source_results
-            if x.is_notrun
+            if x.is_queued
             and (
                 use_new_environment is None
                 or x.runtime_data.use_new_environment == use_new_environment
@@ -358,7 +358,7 @@ class LisaRunner(BaseRunner):
                 if not check_result.result:
                     test_result.set_status(TestStatus.SKIPPED, check_result.reasons)
 
-            if test_result.is_notrun:
+            if test_result.is_queued:
                 assert test_req.environment
                 # if case need a new env to run, force to create one.
                 # if not, get or create one.

--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -63,12 +63,13 @@ class LisaRunner(BaseRunner):
         platform_message = PlatformMessage(name=platform.type_name())
         notifier.notify(platform_message)
 
-        # get environment requirements
-        self._merge_test_requirements(
-            test_results=test_results,
-            existing_environments=candidate_environments,
-            platform_type=platform.type_name(),
-        )
+        if not candidate_environments:
+            # if no runbook environment defined, generate from requirements
+            self._merge_test_requirements(
+                test_results=test_results,
+                existing_environments=candidate_environments,
+                platform_type=platform.type_name(),
+            )
 
         # there may not need to handle requirements, if all environment are predefined
 

--- a/lisa/runners/tests/test_legacy_runner.py
+++ b/lisa/runners/tests/test_legacy_runner.py
@@ -32,10 +32,10 @@ class ResultStateManagerTestCase(TestCase):
             0,
             0,
             [
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -45,9 +45,9 @@ class ResultStateManagerTestCase(TestCase):
             0,
             [
                 TestStatus.RUNNING,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -57,9 +57,9 @@ class ResultStateManagerTestCase(TestCase):
             1,
             [
                 TestStatus.PASSED,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -70,8 +70,8 @@ class ResultStateManagerTestCase(TestCase):
             [
                 TestStatus.PASSED,
                 TestStatus.RUNNING,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -82,8 +82,8 @@ class ResultStateManagerTestCase(TestCase):
             [
                 TestStatus.PASSED,
                 TestStatus.PASSED,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -95,7 +95,7 @@ class ResultStateManagerTestCase(TestCase):
                 TestStatus.PASSED,
                 TestStatus.PASSED,
                 TestStatus.RUNNING,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
             ],
         )
         self._set_check_state(
@@ -131,7 +131,7 @@ class ResultStateManagerTestCase(TestCase):
         completed_count: int,
         expected_statuses: List[TestStatus],
     ) -> None:
-        all = self._create_information(all_count, TestStatus.NOTRUN)
+        all = self._create_information(all_count, TestStatus.QUEUED)
         running = self._create_information(running_count, TestStatus.RUNNING)
         completed = self._create_information(completed_count, TestStatus.PASSED)
         state.set_states(all, running, completed)
@@ -144,7 +144,7 @@ class ResultStateManagerTestCase(TestCase):
         for i in range(count):
             result = {"name": f"name{i}"}
             results.append(result)
-            if status == TestStatus.NOTRUN:
+            if status == TestStatus.QUEUED:
                 continue
             result["image"] = f"image{i}"
             result["location"] = f"location{i}"

--- a/lisa/runners/tests/test_lisa_runner.py
+++ b/lisa/runners/tests/test_lisa_runner.py
@@ -72,7 +72,7 @@ class RunnerTestCase(TestCase):
         )
         self.verify_test_results(
             expected_envs=["", "", ""],
-            expected_status=[TestStatus.NOTRUN, TestStatus.NOTRUN, TestStatus.NOTRUN],
+            expected_status=[TestStatus.QUEUED, TestStatus.QUEUED, TestStatus.QUEUED],
             expected_message=["", "", ""],
             test_results=test_results,
         )
@@ -101,7 +101,7 @@ class RunnerTestCase(TestCase):
             list(envs),
         )
         self.assertListEqual(
-            [TestStatus.NOTRUN, TestStatus.NOTRUN, TestStatus.NOTRUN],
+            [TestStatus.QUEUED, TestStatus.QUEUED, TestStatus.QUEUED],
             [x.status for x in test_results],
         )
 
@@ -132,7 +132,7 @@ class RunnerTestCase(TestCase):
         )
         self.verify_test_results(
             expected_envs=["", "", ""],
-            expected_status=[TestStatus.NOTRUN, TestStatus.NOTRUN, TestStatus.NOTRUN],
+            expected_status=[TestStatus.QUEUED, TestStatus.QUEUED, TestStatus.QUEUED],
             expected_message=["", "", ""],
             test_results=test_results,
         )
@@ -162,9 +162,9 @@ class RunnerTestCase(TestCase):
         self.verify_test_results(
             expected_envs=["", "", ""],
             expected_status=[
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
-                TestStatus.NOTRUN,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
+                TestStatus.QUEUED,
             ],
             expected_message=["", "", ""],
             test_results=test_results,

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -819,6 +819,7 @@ class Runbook:
     test_project: str = ""
     test_pass: str = ""
     tags: Optional[List[str]] = None
+    concurrency: int = 1
     parent: Optional[List[Parent]] = field(default=None)
     extension: Optional[List[Union[str, Extension]]] = field(default=None)
     variable: Optional[List[Variable]] = field(default=None)

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -674,6 +674,9 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
     # yes/always/True: means to keep the environment regardless case fail or pass
     keep_environment: Optional[Union[str, bool]] = False
 
+    # platform can specify a default environment requirement
+    requirement: Optional[Capability] = None
+
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.admin_username, PATTERN_HEADTAIL)
         add_secret(self.admin_password)

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -723,7 +723,7 @@ class Criteria:
     )
 
 
-@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass_json(undefined=Undefined.INCLUDE)
 @dataclass
 class BaseTestCaseFilter(TypedSchema, BaseClassMixin):
     """
@@ -735,6 +735,8 @@ class BaseTestCaseFilter(TypedSchema, BaseClassMixin):
     )
     # if it's false, current filter is ineffective.
     enable: bool = field(default=True)
+
+    mismatched: CatchAll = field(default_factory=dict)  # type: ignore
 
 
 @dataclass_json()

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -654,7 +654,6 @@ class EnvironmentRoot:
         default=1,
         metadata=metadata(validate=validate.Range(min=1)),
     )
-    allow_create: bool = True
     warn_as_error: bool = field(default=False)
     environments: List[Environment] = field(default_factory=list)
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -19,6 +19,7 @@ from lisa.environment import Environment
 from lisa.node import Node
 from lisa.util import LisaException
 from lisa.util.logger import Logger
+from lisa.util.parallel import check_cancelled
 
 if TYPE_CHECKING:
     from .platform_ import AzurePlatform
@@ -190,7 +191,7 @@ def get_environment_context(environment: Environment) -> EnvironmentContext:
 
 
 def wait_operation(operation: Any) -> Any:
-    # to support timeout in future
+    check_cancelled()
     return operation.wait()
 
 

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -340,12 +340,6 @@ class AzurePlatform(Platform):
                     for azure_cap in location_info.capabilities:
                         if azure_cap.vm_size == node_runbook.vm_size:
                             predefined_cost += azure_cap.estimated_cost
-                            # set a min value for nic_count
-                            # work around for an azure python sdk bug
-                            # nic_count is 0 when get capability for some sizes
-                            # e.g. Standard_D8a_v3
-                            if azure_cap.capability.nic_count == 0:
-                                azure_cap.capability.nic_count = 1
 
                             min_cap: schema.NodeSpace = req.generate_min_capability(
                                 azure_cap.capability
@@ -393,7 +387,7 @@ class AzurePlatform(Platform):
                     for azure_cap in location_caps:
                         if found_capabilities[req_index]:
                             # found, so skipped
-                            continue
+                            break
 
                         check_result = req.check(azure_cap.capability)
                         if check_result.result:
@@ -1183,6 +1177,11 @@ class AzurePlatform(Platform):
                 node_space.gpu_count = int(sku_capability.value)
                 # update features list if gpu feature is supported
                 node_space.features.update(features.Gpu.name())
+
+        # set a min value for nic_count work around for an azure python sdk bug
+        # nic_count is 0 when get capability for some sizes e.g. Standard_D8a_v3
+        if node_space.nic_count == 0:
+            node_space.nic_count = 1
 
         # all nodes support following features
         node_space.features.update(

--- a/lisa/tests/test_environment.py
+++ b/lisa/tests/test_environment.py
@@ -176,7 +176,6 @@ class EnvironmentTestCase(TestCase):
         self.assertEqual(0, len(envs))
         self.assertEqual(False, envs.warn_as_error)
         self.assertEqual(1, envs.max_concurrency)
-        self.assertEqual(True, envs.allow_create)
 
     def test_create_from_runbook_split(self) -> None:
         runbook = generate_runbook(local=True, remote=True)

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -93,6 +93,10 @@ class TestResult:
         return self.status == TestStatus.NOTRUN
 
     @property
+    def can_run(self) -> bool:
+        return self.status in [TestStatus.NOTRUN, TestStatus.ASSIGNED]
+
+    @property
     def is_completed(self) -> bool:
         return self.status in [
             TestStatus.FAILED,

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -42,7 +42,23 @@ if TYPE_CHECKING:
 
 
 TestStatus = Enum(
-    "TestStatus", ["NOTRUN", "RUNNING", "FAILED", "PASSED", "SKIPPED", "ATTEMPTED"]
+    "TestStatus",
+    [
+        # A test result is created, but not assigned to any running queue.
+        "NOTRUN",
+        # A test result is assigned to an environment, may be run later or not
+        # able to run. It may be returned to NOTRUN status, if the environment
+        # doesn't fit this case.
+        "ASSIGNED",
+        # A test result is running
+        "RUNNING",
+        "FAILED",
+        "PASSED",
+        # A test result is skipped, won't be run anymore.
+        "SKIPPED",
+        # A test result is failed with known issue.
+        "ATTEMPTED",
+    ],
 )
 
 _all_suites: Dict[str, TestSuiteMetadata] = dict()
@@ -75,6 +91,15 @@ class TestResult:
     @property
     def is_notrun(self) -> bool:
         return self.status == TestStatus.NOTRUN
+
+    @property
+    def is_completed(self) -> bool:
+        return self.status in [
+            TestStatus.FAILED,
+            TestStatus.PASSED,
+            TestStatus.SKIPPED,
+            TestStatus.ATTEMPTED,
+        ]
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         self._send_result_message()

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -28,7 +28,7 @@ class SkippedException(Exception):
     ...
 
 
-class NotRunException(Exception):
+class QueuedException(Exception):
     """
     If current environment doesn't meet requirement of a test case, it can be set to
     not run and try next environment.

--- a/lisa/util/parallel.py
+++ b/lisa/util/parallel.py
@@ -1,10 +1,58 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import concurrent.futures
-import time
-from typing import Any, Callable, List, Optional
 
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from typing import Any, Callable, Generic, List, Optional, TypeVar
+
+from . import LisaException
 from .logger import Logger
+
+T_RESULT = TypeVar("T_RESULT")
+
+
+class TaskManager(Generic[T_RESULT]):
+    def __init__(self, max_workers: int, callback: Callable[[T_RESULT], None]) -> None:
+        self._pool = ThreadPoolExecutor(max_workers=max_workers)
+        self._max_workers = max_workers
+        self._futures: List[Future[T_RESULT]] = list()
+        self._callback = callback
+        self._cancelled = False
+
+    def __enter__(self) -> Any:
+        return self._pool.__enter__()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Optional[bool]:
+        return self._pool.__exit__(exc_type, exc_val, exc_tb)
+
+    def submit_task(self, task: Callable[[], T_RESULT]) -> None:
+        future: Future[T_RESULT] = self._pool.submit(task)
+        self._futures.append(future)
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def check_cancelled(self) -> None:
+        if self._cancelled:
+            raise LisaException("Tasks are cancelled")
+
+    def has_idle_worker(self) -> bool:
+        return len(self._futures) < self._max_workers
+
+    def wait_worker(self) -> bool:
+        """
+        Return:
+            True, if there is running worker.
+        """
+
+        done_futures, _ = wait(self._futures[:], return_when=FIRST_COMPLETED)
+        for future in done_futures:
+            # join exceptions of subthreads to main thread
+            result = future.result()
+            # removed finished threads
+            self._futures.remove(future)
+            # exception will throw at this point
+            self._callback(result)
+        return len(self._futures) > 0
 
 
 def _cancel_threads(
@@ -43,7 +91,7 @@ def run_in_threads(
     results: List[Any] = []
     if max_workers <= 0:
         max_workers = len(methods)
-    with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
+    with ThreadPoolExecutor(max_workers) as pool:
         futures = [pool.submit(method) for method in methods]
         if completed_callback:
             for future in futures:
@@ -78,3 +126,22 @@ def run_in_threads(
             # exception will throw at this point
             results.append(future.result())
     return results
+
+
+_default_task_manager: Optional[TaskManager[Any]] = None
+
+
+def set_global_task_manager(task_manager: TaskManager[Any]) -> None:
+    global _default_task_manager
+    assert not _default_task_manager, "the default task manager can be set only once"
+    _default_task_manager = task_manager
+
+
+def cancel() -> None:
+    if _default_task_manager:
+        _default_task_manager.cancel()
+
+
+def check_cancelled() -> None:
+    if _default_task_manager:
+        _default_task_manager.check_cancelled()

--- a/lisa/util/parallel.py
+++ b/lisa/util/parallel.py
@@ -5,7 +5,6 @@ from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Generic, List, Optional, TypeVar
 
 from . import LisaException
-from .logger import Logger
 
 T_RESULT = TypeVar("T_RESULT")
 
@@ -53,79 +52,6 @@ class TaskManager(Generic[T_RESULT]):
             # exception will throw at this point
             self._callback(result)
         return len(self._futures) > 0
-
-
-def _cancel_threads(
-    futures: List[Any],
-    completed_callback: Optional[Callable[[Any], None]] = None,
-) -> List[Any]:
-    success_futures: List[Any] = []
-    for future in futures:
-        if future.done() and future.exception():
-            # throw exception, if it's not here.
-            future.result()
-        elif not future.done():
-            # cancel running threads. It may need cancellation callback
-            result = future.cancel()
-            if not result and completed_callback:
-                # make sure it's status changed to canceled
-                completed_callback(False)
-            # join exception back to main thread
-            future.result()
-        else:
-            success_futures.append(future)
-    # return empty list to prevent cancel again.
-    return success_futures
-
-
-def run_in_threads(
-    methods: List[Any],
-    max_workers: int = 0,
-    completed_callback: Optional[Callable[[Any], None]] = None,
-    log: Optional[Logger] = None,
-) -> List[Any]:
-    """
-    start methods in a thread pool
-    """
-
-    results: List[Any] = []
-    if max_workers <= 0:
-        max_workers = len(methods)
-    with ThreadPoolExecutor(max_workers) as pool:
-        futures = [pool.submit(method) for method in methods]
-        if completed_callback:
-            for future in futures:
-                future.add_done_callback(completed_callback)
-        try:
-            while any(not x.done() for x in futures):
-                # if there is any change, skip sleep to get faster
-                changed = False
-                for future in futures:
-                    # join exceptions of subthreads to main thread
-                    if future.done():
-                        changed = True
-                        # removed finished threads
-                        futures.remove(future)
-                        # exception will throw at this point
-                        results.append(future.result())
-                        break
-                if not changed:
-                    time.sleep(0.1)
-
-        except KeyboardInterrupt:
-            if log:
-                log.info("received CTRL+C, stopping threads...")
-            # support to interrupt runs on local debugging.
-            futures = _cancel_threads(futures, completed_callback=completed_callback)
-            pool.shutdown(True)
-        finally:
-            if log:
-                log.debug("finalizing threads...")
-            futures = _cancel_threads(futures, completed_callback=completed_callback)
-        for future in futures:
-            # exception will throw at this point
-            results.append(future.result())
-    return results
 
 
 _default_task_manager: Optional[TaskManager[Any]] = None

--- a/lisa/util/subclasses.py
+++ b/lisa/util/subclasses.py
@@ -73,6 +73,9 @@ class Factory(InitializableMixin, Generic[T_BASECLASS], SubClassTypeDict):
                 f"cannot find subclass '{type_name}' of {self._base_type.__name__}"
             )
         instance = sub_type.schema().load(raw_runbook)  # type: ignore
+        if hasattr(instance, "mismatched"):
+            if instance.mismatched:
+                raise LisaException(f"found unknown fields: {instance.mismatched}")
         return cast(T_BASECLASS, instance)
 
     def create_by_type_name(self, type_name: str, **kwargs: Any) -> T_BASECLASS:

--- a/microsoft/runbook/azure.yml
+++ b/microsoft/runbook/azure.yml
@@ -16,16 +16,6 @@ variable:
     value: false
 notifier:
   - type: html
-environment:
-  warn_as_error: false
-  environments:
-    - nodes:
-        - type: requirement
-          core_count:
-            min: 2
-          azure:
-            marketplace: $(marketplace_image)
-            location: $(location)
 platform:
   - type: azure
     admin_private_key_file: $(admin_private_key_file)
@@ -35,3 +25,9 @@ platform:
       deploy: $(deploy)
       subscription_id: $(subscription_id)
       wait_delete: $(wait_delete)
+    requirement:
+      core_count:
+        min: 2
+      azure:
+        marketplace: $(marketplace_image)
+        location: $(location)

--- a/microsoft/runbook/azure.yml
+++ b/microsoft/runbook/azure.yml
@@ -18,7 +18,6 @@ notifier:
   - type: html
 environment:
   warn_as_error: false
-  allow_create: false
   environments:
     - nodes:
         - type: requirement

--- a/microsoft/runbook/ready.yml
+++ b/microsoft/runbook/ready.yml
@@ -9,7 +9,6 @@ variable:
 notifier:
   - type: html
 environment:
-  allow_create: false
   environments:
     - nodes:
         - type: remote


### PR DESCRIPTION
Before this change, the LISA use a static parallel model, and the LISA runner doesn't support test in parallel. With this change, LISA runner supports parallel now. The concurrency number can be set in runbook, and LISA will start the same number of threads to run tests.