### PR TITLE
Organize logs into test run instance folders

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -469,7 +469,7 @@ Class TestController {
 		try {
 			# Prepare test case log folder
 			$currentTestName = $($CurrentTestData.testName)
-			$CurrentTestLogDir = "$global:LogDir\$currentTestName"
+			$CurrentTestLogDir = "$global:LogDir\$currentTestName\$($VmData.RoleName)"
 
 			New-Item -Type Directory -Path $CurrentTestLogDir -ErrorAction SilentlyContinue | Out-Null
 			Set-Variable -Name "LogDir" -Value $CurrentTestLogDir -Scope Global


### PR DESCRIPTION
When multiple instances of same test cases are run, some of the log files(files that do not prefix the vm role name) are overwritten and only the final instance files are available. To avoid this, we can restructure the logs into its separate vm role folders.