### PR TITLE
Add enhancement for get_host_version

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -3111,12 +3111,12 @@ Function Upload-AzureBootAndDeploymentDataToDB ($DeploymentTime, $AllVMData, $Cu
 				#endregion
 
 				#region Host Version checking
-				$foundLineNumber = (Select-String -Path $dmesgFile -Pattern "Hyper-V Host Build").LineNumber
+				$foundLineNumber = (Select-String -Path $dmesgFile -Pattern "Hyper-V Host Build|Hyper-V: Host Build").LineNumber
 				$actualLineNumber = $foundLineNumber - 1
 				$finalLine = (Get-Content -Path $dmesgFile)[$actualLineNumber]
 				$finalLine = $finalLine.Replace('; Vmbus version:4.0', '')
 				$finalLine = $finalLine.Replace('; Vmbus version:3.0', '')
-				$HostVersion = ($finalLine.Split(":")[$finalLine.Split(":").Count - 1 ]).Trim().TrimEnd(";")
+				$HostVersion = ($finalLine.Split(" :")[$finalLine.Split(" :").Count - 1 ]).Trim().TrimEnd(";")
 				#endregion
 			}
 			else {

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -953,7 +953,7 @@ Class TestController {
 				if ($LISMatch) {
 					$LISVersion = $LISMatch.Split(":").Trim()[1]
 				}
-				$HostBuildMatches = Select-string -Path "$global:LogDir\$($vmData.RoleName)-dmesg.txt" -Pattern "Hyper-V\s*Host.*Build:\s*([^a-zA-Z:;\s]+)"
+				$HostBuildMatches = Select-string -Path "$global:LogDir\$($vmData.RoleName)-dmesg.txt" -Pattern "Hyper-V.*Host.*Build[:| ]([^a-zA-Z:;\s]+)"
 				if ($HostBuildMatches) {
 					$HostVersion = $HostBuildMatches.Matches.Groups[1].Value
 				}

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -1961,7 +1961,7 @@ function get_lis_version() {
 
 # Get the version of host
 function get_host_version() {
-	dmesg | grep "Host Build" | sed "s/.*Host Build://"| awk '{print  $1}'| sed "s/;//"
+	dmesg | grep "Host Build" | sed "s/.*Host Build[^0-9]//"| awk '{print  $1}'| sed "s/;//"
 }
 
 # Validate the exit status of previous execution


### PR DESCRIPTION
The dmesg of current VM sizes is like this:
[    0.000000] Hyper-V Host Build:18362-10.0-3-0.3256

But the dmesg of some new VM sizes is like this:
[    0.000000] Hyper-V: Host Build 10.0.20279.1008-1-0

Add fix for get_host_version.