### PR TITLE
Fix the issue that OsVHD SAS URL is escaped multiple times. Skip the location with "(" in name

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -143,7 +143,7 @@ Function Assert-ResourceLimitationForDeployment($RGXMLData, [ref]$TargetLocation
 		if ($CurrentTestData.SetupConfig.OsVHD -and $VMGeneration -and !$AllTestVMSizes.$testVMSize.Generations.Contains($VMGeneration)) {
 			$TargetLocation.Value = 'NOT_ENABLED'
 			$overFlowErrors += 1
-			Write-LogErr "Requested VM size: '$testVMSize' with VM generation: '$VMGeneration' is supported, this should be an Azure limitation temporarily, please try other VM Sizes that support HyperVGeneration '$VMGeneration'."
+			Write-LogErr "Requested VM size: '$testVMSize' with VM generation: '$VMGeneration' is NOT supported, this should be an Azure limitation temporarily, please try other VM Sizes that support HyperVGeneration '$VMGeneration'."
 		}
 		elseif (!$AllTestVMSizes.$testVMSize.AvailableLocations) {
 			$TargetLocation.Value = 'NOT_ENABLED'

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -383,15 +383,19 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 	$lisaSAPrefix = 'lisa'
 	$existingLISAStorageAccounts | ForEach-Object {
 		if ($_.StorageAccountName -imatch "^$lisaSAPrefix.+") {
-			$lisaSANum++;
-			if (!$regionStorageMapping[$_.Location]) {
-				$regionStorageMapping[$_.Location] = @{}
-			}
-			if ($_.Sku.Name -imatch "Standard_LRS") {
-				$regionStorageMapping[$_.Location]["StandardStorage"] = $_
-			}
-			elseif ($_.Sku.Name -imatch "Premium_LRS") {
-				$regionStorageMapping[$_.Location]["PremiumStorage"] = $_
+			$location = $_.Location
+			# Skip the location contains '(' in name
+			if (-not $location.contains("(")) {
+				$lisaSANum++;
+				if (!$regionStorageMapping[$location]) {
+					$regionStorageMapping[$location] = @{}
+				}
+				if ($_.Sku.Name -imatch "Standard_LRS") {
+					$regionStorageMapping[$location]["StandardStorage"] = $_
+				}
+				elseif ($_.Sku.Name -imatch "Premium_LRS") {
+					$regionStorageMapping[$location]["PremiumStorage"] = $_
+				}
 			}
 		}
 	}

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -364,7 +364,7 @@ Function PrepareAutoCompleteStorageAccounts ($storageAccountsRGName, $XMLSecretF
 		}
 	}
 	$allAvailableRegions = ((Get-AzResourceProvider -ProviderNamespace "Microsoft.Storage").ResourceTypes | `
-			Where-Object ResourceTypeName -eq "storageaccounts").Locations
+			Where-Object ResourceTypeName -eq "storageaccounts").Locations | where {-not $_.Contains("(")}
 	# Create ResourceGroup for StorageAccounts to run LISAv2
 	$getRGResult = Get-AzResourceGroup -Name $storageAccountsRGName -ErrorAction SilentlyContinue
 	if (!$getRGResult.ResourceGroupName ) {

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -210,21 +210,22 @@ Function Add-SetupConfig {
 
     $AddSplittedConfigValue = {
         param ([System.Collections.ArrayList]$TestCollections, [string]$ConfigName, [string]$ConfigValue, [bool]$Force = $false)
+        $newConfigValue = $ConfigValue
         foreach ($test in $TestCollections) {
             if (!$test.SetupConfig.$ConfigName) {
                 # if the $ConfigValue contains certain characters as below, use [System.Security.SecurityElement]::Escape() to avoid exception
                 if ($ConfigValue -imatch "&|<|>|'|""") {
-                    $ConfigValue = [System.Security.SecurityElement]::Escape($ConfigValue)
+                    $newConfigValue = [System.Security.SecurityElement]::Escape($ConfigValue)
                 }
                 if ($null -eq $test.SetupConfig.$ConfigName) {
-                    $test.SetupConfig.InnerXml += "<$ConfigName>$ConfigValue</$ConfigName>"
+                    $test.SetupConfig.InnerXml += "<$ConfigName>$newConfigValue</$ConfigName>"
                 }
                 else {
-                    $test.SetupConfig.$ConfigName = $ConfigValue
+                    $test.SetupConfig.$ConfigName = $newConfigValue
                 }
             }
             elseif ($Force) {
-                $test.SetupConfig.$ConfigName = $ConfigValue
+                $test.SetupConfig.$ConfigName = $newConfigValue
             }
         }
     }


### PR DESCRIPTION
1. Fix the issue that OsVHD SAS URL is escaped multiple times. 
2. Skip the location with "(" in name