### PR TITLE
Adjust VM sizes to support both gen1 and gen2 VMs, fix some issues in VM resize test and GPU test

### DIFF
--- a/Testscripts/Linux/gpu-tensorflow.sh
+++ b/Testscripts/Linux/gpu-tensorflow.sh
@@ -40,10 +40,10 @@ InstallCUDAToolKit() {
 
     ubuntu*)
         GetOSVersion
-        CUDA_REPO_PKG="cuda-repo-ubuntu$os_RELEASE//./_$CUDADriverVersion_amd64.deb"
+        CUDA_REPO_PKG="cuda-repo-ubuntu${os_RELEASE//./}_${CUDADriverVersion}_amd64.deb"
         LogMsg "Using $CUDA_REPO_PKG"
 
-        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/"$CUDA_REPO_PKG" -O /tmp/"$CUDA_REPO_PKG"
+        wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/"$CUDA_REPO_PKG" -O /tmp/"$CUDA_REPO_PKG"
         if [ $? -ne 0 ]; then
             LogErr "Failed to download $CUDA_REPO_PKG"
             SetTestStateAborted
@@ -52,7 +52,7 @@ InstallCUDAToolKit() {
             LogMsg "Successfully downloaded $CUDA_REPO_PKG"
         fi
 
-        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"$os_RELEASE//./"/x86_64/7fa2af80.pub
+        apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu"${os_RELEASE//./}"/x86_64/7fa2af80.pub
         dpkg -i /tmp/"$CUDA_REPO_PKG"
         dpkg_configure
         apt update

--- a/Testscripts/Windows/VM-HOT-RESIZE.ps1
+++ b/Testscripts/Windows/VM-HOT-RESIZE.ps1
@@ -86,6 +86,15 @@ function Main {
             $actualMemorySizeInKB = Run-LinuxCmd -username $user -password $password -ip $AllVMData.PublicIP -port $AllVMData.SSHPort   `
                                  -command "grep -i memtotal /proc/meminfo | awk '{ print `$`2 }'"
             $actualMemorySizeInMB = [math]::Truncate($actualMemorySizeInKB/1024)
+
+            # PowerShell api returns wrong CPU cores for constrained vCPU sizes
+            # https://docs.microsoft.com/en-us/azure/virtual-machines/constrained-vcpu
+            if ($expectedCPUCount -ne $actualCPUCount -and $vmSize.Contains("-")) {
+                if ($vmSize.split("-")[1] -imatch "(^[\d]+)") {
+                    $expectedCPUCount = $Matches[1]
+                }
+            }
+
             Write-LogInfo "Expected CPU Count: $expectedCPUCount"
             Write-LogInfo "Actual CPU Count: $actualCPUCount"
             Write-LogInfo "Expected Memory Size in MB: $expectedMemorySizeInMB"

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -44,7 +44,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NC24</OverrideVMSize>
+      <OverrideVMSize>Standard_NC24s_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/FunctionalTests-GPU.xml
+++ b/XML/TestCases/FunctionalTests-GPU.xml
@@ -27,7 +27,7 @@
     <Priority>0</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NV6</OverrideVMSize>
+      <OverrideVMSize>Standard_NV12s_v3</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>
@@ -58,7 +58,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NV24</OverrideVMSize>
+      <OverrideVMSize>Standard_NV48s_v3</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/FunctionalTests-Network.xml
+++ b/XML/TestCases/FunctionalTests-Network.xml
@@ -773,7 +773,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM8NIC</SetupType>
-      <OverrideVMSize>Standard_B16ms</OverrideVMSize>
+      <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-NET-Add-Max-NIC.ps1</SetupScript>
     </SetupConfig>
   </test>
@@ -792,7 +792,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_B16ms</OverrideVMSize>
+      <OverrideVMSize>Standard_DS4_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -787,7 +787,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <SetupScript>.\TestScripts\Windows\SETUP-Config-VM.ps1</SetupScript>
     </SetupConfig>
   </test>
@@ -872,6 +872,7 @@
     <Priority>2</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
+	    <OverrideVMSize>Standard_DS1_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/FunctionalTests.xml
+++ b/XML/TestCases/FunctionalTests.xml
@@ -575,7 +575,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_B4ms</OverrideVMSize>
+      <OverrideVMSize>Standard_D4s_v3</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>
@@ -872,7 +872,6 @@
     <Priority>2</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_A4</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -756,7 +756,7 @@
     <Priority>2</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D3_v2</OverrideVMSize>
+      <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>
@@ -773,7 +773,7 @@
     <Priority>2</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D3_v2</OverrideVMSize>
+      <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>
@@ -790,7 +790,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_D3_v2</OverrideVMSize>
+      <OverrideVMSize>Standard_DS3_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -722,7 +722,7 @@
     <Priority>2</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NV6</OverrideVMSize>
+      <OverrideVMSize>Standard_NV12s_v3</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>
@@ -935,7 +935,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <setupType>TwoVM2NIC</setupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>
@@ -953,7 +953,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <setupType>TwoVM2NIC</setupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>
@@ -975,7 +975,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <setupType>TwoVM2NIC</setupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>
@@ -993,7 +993,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <setupType>TwoVM2NIC</setupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
    </test>
@@ -1012,7 +1012,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>ThreeVM2NIC</SetupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>
@@ -1031,7 +1031,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>ThreeVM2NIC</SetupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>
@@ -1049,7 +1049,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>ThreeVM2NIC</SetupType>
-      <OverrideVMSize>Standard_D64_v3</OverrideVMSize>
+      <OverrideVMSize>Standard_D64s_v3</OverrideVMSize>
       <Networking>SRIOV</Networking>
     </SetupConfig>
   </test>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -86,7 +86,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NV24</OverrideVMSize>
+      <OverrideVMSize>Standard_NV48s_v3</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -68,7 +68,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <SetupType>OneVM</SetupType>
-      <OverrideVMSize>Standard_NC24</OverrideVMSize>
+      <OverrideVMSize>Standard_NC24s_v2</OverrideVMSize>
     </SetupConfig>
   </test>
   <test>


### PR DESCRIPTION
1. Adjust VM sizes to support both gen1 and gen2 VMs
2. Fix the issue in VM resize test due to Powershell api returns wrong CPU number for constrained vCPU sizes
3. Fix issue in gpu-tensorflow.sh for Ubuntu distro
4. Tested for most size changes, except cases change from D to Ds of same CPU core.