### PR TITLE
Fix result precedence issue with Get-FinalResultHeader

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -58,13 +58,36 @@ function ConvertFrom-SetupConfig([object]$SetupConfig, [switch]$WrappingLines) {
 }
 
 Function Get-FinalResultHeader($resultArr) {
+
+	# The following pattern-matching-switch iterates over the array of result
+	# strings and aggregates them into the final result.
+
+	# There is a precedence in how test results can change, illustrated here with
+	# a table of results compared to the other possible results with lower precedence
+	# NOTE: SKIP has the lowest precedence and FAIL has the highest.
+
+	# fail  > [ abort | skipped | pass ]
+	# abort > [ skip | pass ]
+	# pass  > [ skip ]
+	# skip  > []
+	Write-LogDbg "Processing result collection: $resultArr "
+	$result = $global:ResultSkipped
 	switch ($resultArr) {
 		{ ($_ -imatch "FAIL") } { $result = $global:ResultFail; break }
-		{ ($_ -imatch "Abort") } { $result = $global:ResultAborted; break }
-		{ ($_ -imatch "Skip") } { $result = $global:ResultSkipped; break }
-		{ ($_ -imatch "PASS") } { $result = $global:ResultPass; break }
+		{ ($_ -imatch "ABORT") } {
+			$result = $global:ResultAborted;
+			continue;
+		}
+		{ ($_ -imatch "SKIP") } { continue; }
+		{ ($_ -imatch "PASS") } {
+			if ($result -eq $global:ResultSkipped ) {
+				$result = $global:ResultPass;
+			}
+			continue;
+		}
 		default { $result = $global:ResultFail }
 	}
+	Write-LogDbg "Selected result: $result"
 	return $result
 }
 


### PR DESCRIPTION
While many tests use Get-FinalResultHeader on an array with a single item, Get-FinalResultHeader can operate on a collection of result strings. There are a few tests where a collection of sub-results are passed in and the current logic only selects the first result in the collection as the final result. Rather than rewrite those tests to force the user to filter their tests themselves, this fix introduces a precedence of results where any failure in the collection will result in the test being reported as failing, as well as handling the other possible results in a logical way. It preserves the behavior of the function when there is a single item.

See code comments for further details.