### PR TITLE
failsafe.sh script has moved from devnet

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -783,7 +783,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DPDK_FAILSAFE_SH_URL</ReplaceThis>
-		<ReplaceWith>https://gallery.technet.microsoft.com/Azure-DPDK-Failsafe-PMD-c34b1a4b/file/183012/1/failsafe.sh</ReplaceWith>
+		<ReplaceWith>https://web.archive.org/web/20200319030136/https://gallery.technet.microsoft.com/Azure-DPDK-Failsafe-PMD-c34b1a4b/file/183012/1/failsafe.sh</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NESTED_IMAGE_URL</ReplaceThis>


### PR DESCRIPTION
Grab it from the much more stable archive.org

This is a dumb fix but it's a legacy test, if we need this functionality in a new test we will version control the script.