### PR TITLE
Add error checking for missing interface info

### DIFF
--- a/Testscripts/Linux/dpdkPmdsBasicCheck.sh
+++ b/Testscripts/Linux/dpdkPmdsBasicCheck.sh
@@ -147,8 +147,16 @@ SetTestStateRunning
 mkdir -p $LOGDIR
 IFS=',' read -r -a pmd_array <<< "$pmds"
 exitcode=0
-eth1_vfname=$(ip addr|grep 'master eth1'|awk -F ': ' '{print $2}')
+eth1_vfinfo=$(ip addr show master eth1)
+checkCmdExitStatus "ip addr show master eth1"
+if [ $(echo "$eth1_vfinfo" | wc -c ) -ne 0 ];then
+	LogErr "Could not find vfinfo for eth1"
+	SetTestStateAborted
+fi
+LogMsg "eth1 vfinfo found: $eth1_vfinfo"
+eth1_vfname=$(echo "$eth1_vfinfo" | awk -F ': ' '{print $2}')
 bus_info=$(ethtool -i $eth1_vfname|grep bus-info|awk '{print $2}')
+checkCmdExitStatus "ethtool -i $eth1_vfname|grep bus-info|awk '{print $2}'"
 for pmd in ${pmd_array[@]};do
 	runTestPmd $pmd
 done


### PR DESCRIPTION
Code could previously fail silently if ipaddr+awk pipeline failed.
Add some error checking so allow for an ABORT if that situation arises.