### PR TITLE
Add more buffer size for single TCP test

### DIFF
--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -437,11 +437,11 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SYNTHETIC-BUFFER-LENGTHS</ReplaceThis>
-		<ReplaceWith>(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)</ReplaceWith>
+		<ReplaceWith>(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576)</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SRIOV-BUFFER-LENGTHS</ReplaceThis>
-		<ReplaceWith>(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536)</ReplaceWith>
+		<ReplaceWith>(32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576)</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>PERF-STORAGE-1024K-IO-MODES</ReplaceThis>


### PR DESCRIPTION
For PERF-NETWORK-TCP-THROUGHPUT-MULTICONNECTION-NTTTCP tests, the buffer size is 1M when with one connection. In this single TCP test, we'd better add more buffer size, so that the max buffer size can achieve 1M. Then the two test cases will be more valuable when analyzing performance.