### PR TITLE
Remove 'consoleFull' suffix in BuildURL

### DIFF
--- a/Libraries/Database.psm1
+++ b/Libraries/Database.psm1
@@ -42,10 +42,7 @@ Function Get-SQLQueryOfTelemetryData ($TestPlatform, $TestLocation, $TestCategor
 		$UploadedURL = .\Utilities\UploadFilesToStorageAccount.ps1 -filePaths $uploadFileName `
 			-destinationStorageAccount $testLogStorageAccount -destinationContainer "lisav2logs" `
 			-destinationFolder "$testLogFolder" -destinationStorageKey $testLogStorageAccountKey
-		if ($BuildURL) {
-			$BuildURL = "$BuildURL`consoleFull"
-		}
-		else {
+		if (!$BuildURL) {
 			$BuildURL = ""
 		}
 		$SQLQuery = "INSERT INTO $TableName (DateTimeUTC,TestPlatform,TestLocation,TestCategory,TestArea,TestName,TestResult,ExecutionTag,GuestDistro,KernelVersion,HardwarePlatform,LISVersion,HostVersion,VMSize,VMGeneration,ARMImage,OsVHD,LogFile,BuildURL,TestPassID,FailureReason,TestResultDetails) VALUES "


### PR DESCRIPTION
Current BuildURL is appended with 'consoleFull' which works well for Jenkins but leads to invalid URL in case of ADO / Other pipelines. Hence, removed it.