### PR TITLE
Update for timesync_check_unbind_clocksource to count tsc/constant_tsc shown up times.

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -894,7 +894,7 @@ class AzurePlatform(Platform):
                 and features.Sriov.name() not in node.capability.features
             ):
                 self._log.debug(
-                    "use synthetic network since used size doesn't have"
+                    "use synthetic network since used size doesn't have "
                     "sriov capability"
                 )
                 arm_parameters.enable_sriov = False

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -131,9 +131,15 @@ class TimeSync(TestSuite):
         lscpu = node.tools[Lscpu]
         if "x86_64" == lscpu.get_architecture():
             cpu_info_result = cat.run("/proc/cpuinfo")
-            assert_that(cpu_info_result.stdout).described_as(
-                "Expected 'constant_tsc' shown up in cpu flags."
-            ).contains("constant_tsc")
+            if CpuType.Intel == lscpu.get_cpu_type():
+                expected_tsc_str = " constant_tsc "
+            elif CpuType.AMD == lscpu.get_cpu_type():
+                expected_tsc_str = " tsc "
+            shown_up_times = cpu_info_result.stdout.count(expected_tsc_str)
+            assert_that(shown_up_times).described_as(
+                f"Expected {expected_tsc_str} shown up times in cpu flags is"
+                " equal to cpu count."
+            ).is_equal_to(lscpu.get_core_count())
 
         # 3. Check clocksource name shown up in dmesg.
         dmesg = node.tools[Dmesg]


### PR DESCRIPTION
Need handle different logic when cpu type is different.