### PR TITLE
Use TIMESTAMP in log path structure

### DIFF
--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -469,7 +469,8 @@ Class TestController {
 		try {
 			# Prepare test case log folder
 			$currentTestName = $($CurrentTestData.testName)
-			$CurrentTestLogDir = "$global:LogDir\$currentTestName\$($VmData.RoleName)"
+			$uniqueId = New-TimeBasedUniqueId
+			$CurrentTestLogDir = "$global:LogDir\$currentTestName\$uniqueId"
 
 			New-Item -Type Directory -Path $CurrentTestLogDir -ErrorAction SilentlyContinue | Out-Null
 			Set-Variable -Name "LogDir" -Value $CurrentTestLogDir -Scope Global


### PR DESCRIPTION
Removed VMRoleName as, for Tests with multiple VMs can make the path long and used timestamp instead.

Ex: C:\Users\lizzha\lisa\TestResults\20210623235547-YN69\PERF-NETWORK-TCP-SINGLE-CONNECTION-THROUGHPUT-SYNTHETIC\LISAv2-penguinator-test-YN69-0623235803-role-1 LISAv2-penguinator-test-YN69-0623235803-role-0

This change will replace `LISAv2-penguinator-test-YN69-0623235803-role-1 LISAv2-penguinator-test-YN69-0623235803-role-0` with a timestamp.