### PR TITLE
Add support for almalinux in lisav3

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -551,7 +551,7 @@ class Redhat(Fedora):
 
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
-        return re.compile("^rhel|Red|Scientific|acronis|Actifio$")
+        return re.compile("^rhel|Red|AlmaLinux|Scientific|acronis|Actifio$")
 
     def _initialize_package_installation(self) -> None:
         # older images cost much longer time when update packages
@@ -606,7 +606,7 @@ class Redhat(Fedora):
             cmd="cat /etc/redhat-release", no_error_log=True
         )
         if cmd_result.exit_code == 0 and cmd_result.stdout != "":
-            for vendor in ["Red Hat", "CentOS", "XenServer"]:
+            for vendor in ["Red Hat", "CentOS", "XenServer", "AlmaLinux"]:
                 if vendor not in cmd_result.stdout:
                     continue
                 os_version.vendor = vendor

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -535,19 +535,15 @@ class Fedora(Linux):
             no_error_log=True,
         )
         if cmd_result.exit_code == 0 and cmd_result.stdout != "":
-            for vendor in ["Fedora", "CentOS", "Red Hat", "XenServer"]:
-                if vendor not in cmd_result.stdout:
-                    continue
-                os_version.vendor = vendor
-                os_version.release = get_matched_str(
-                    cmd_result.stdout, self._fedora_release_pattern_version
-                )
-                os_version.codename = get_matched_str(
-                    cmd_result.stdout, self.__distro_codename_pattern
-                )
-                break
-            if os_version.vendor == "":
+            if "Fedora" not in cmd_result.stdout:
                 raise LisaException("OS version information not found")
+            os_version.vendor = "Fedora"
+            os_version.release = get_matched_str(
+                cmd_result.stdout, self._fedora_release_pattern_version
+            )
+            os_version.codename = get_matched_str(
+                cmd_result.stdout, self.__distro_codename_pattern
+            )
         else:
             raise LisaException(
                 "Error in running command 'cat /etc/fedora-release'"


### PR DESCRIPTION
1. Add support for AlmaLinux in LISAv3;
2. Add ID_LIKE support, put the ID_LIKE match in the end.
3. If the vendor is CentOs, RedHat, XenServer, the _get_os_version method is overridden in Redhat already, it just need to check whether it's Fedora in _get_os_version of Fedora class. We removed duplicate code.