### PR TITLE
Azure transformer: support deploy and delete transformers

### DIFF
--- a/docs/write_test/concepts.md
+++ b/docs/write_test/concepts.md
@@ -55,10 +55,10 @@ consistent manner.
 ### Tool and Script
 
 A **tool** includes runnable commands in a node, it needs to be installed and
-can be installed in many ways. 
+can be installed in many ways.
 
 A **script** is also considered a tool, except it can only be uploaded to a
-node. 
+node.
 
 In different Linux distributions, tools may have different installation methods,
 commands, or command-line parameters. LISA tools, however, provide a simple test
@@ -101,7 +101,8 @@ specification and all tests would run as you expect.
 
 ### Transformer
 
-A **transformer** generates variables from other variables, and multiple
+The **transformers** are used to prepare test environments and others before
+test runs. A transformer generates variables from other variables, and multiple
 transformers can run one by one to achieve complex transformation. For example,
 the first transformer can build Linux kernel and another one can save the VM to
 a VHD. The two transformers can be reused in other workflows.

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -181,7 +181,7 @@ def load_platform(platforms_runbook: List[schema.Platform]) -> Platform:
 
     factory = subclasses.Factory[Platform](Platform)
     default_platform: Platform = factory.create_by_runbook(runbook=platforms_runbook[0])
-    log.info(f"activated platform '{default_platform.type_name()}'")
+    log.debug(f"activated platform '{default_platform.type_name()}'")
 
     return default_platform
 

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -13,9 +13,11 @@ from lisa.environment import Environment, EnvironmentStatus
 from lisa.feature import Feature, Features
 from lisa.node import RemoteNode
 from lisa.notifier import MessageBase
+from lisa.parameter_parser.runbook import RunbookBuilder
 from lisa.util import (
     InitializableMixin,
     LisaException,
+    constants,
     hookimpl,
     plugin_manager,
     subclasses,
@@ -182,3 +184,12 @@ def load_platform(platforms_runbook: List[schema.Platform]) -> Platform:
     log.info(f"activated platform '{default_platform.type_name()}'")
 
     return default_platform
+
+
+def load_platform_from_builder(runbook_builder: RunbookBuilder) -> Platform:
+    platform_runbook_data = runbook_builder.partial_resolve(constants.PLATFORM)
+    platform_runbook = schema.Platform.schema().load(  # type: ignore
+        platform_runbook_data, many=True
+    )
+    platform = load_platform(platform_runbook)
+    return platform

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -195,6 +195,8 @@ class Transformer(TypedSchema):
     depends_on: List[str] = field(default_factory=list)
     # rename some of variables for easier use.
     rename: Dict[str, str] = field(default_factory=dict)
+    # enable this transformer or not, only enabled transformers run actually.
+    enabled: bool = True
 
     delay_parsed: CatchAll = field(default_factory=dict)  # type: ignore
 

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -73,6 +73,9 @@ class VhdTransformerSchema(schema.Transformer):
     container_name: str = DEFAULT_VHD_CONTAINER_NAME
     file_name_part: str = ""
 
+    # restore environment or not
+    restore: bool = False
+
 
 class VhdTransformer(Transformer):
     """
@@ -106,7 +109,7 @@ class VhdTransformer(Transformer):
 
         vhd_location = self._export_vhd(platform, virtual_machine)
 
-        self._recover_vm(platform, virtual_machine, node)
+        self._restore_vm(platform, virtual_machine, node)
 
         return {self.__url_name: vhd_location}
 
@@ -209,7 +212,7 @@ class VhdTransformer(Transformer):
 
         return vhd_path
 
-    def _recover_vm(
+    def _restore_vm(
         self, platform: AzurePlatform, virtual_machine: Any, node: RemoteNode
     ) -> None:
         runbook: VhdTransformerSchema = self.runbook
@@ -224,8 +227,9 @@ class VhdTransformer(Transformer):
         )
         wait_operation(operation)
 
-        start_stop = node.features[StartStop]
-        start_stop.start()
+        if runbook.restore:
+            start_stop = node.features[StartStop]
+            start_stop.start()
 
     def _get_public_ip_address(
         self, platform: AzurePlatform, virtual_machine: Any

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -21,6 +21,7 @@ from lisa.util import LisaException, constants, get_date_str, get_datetime_path
 from lisa.util.perf_timer import create_timer
 
 from .common import (
+    AZURE_SHARED_RG_NAME,
     check_or_create_storage_account,
     get_compute_client,
     get_network_client,
@@ -176,7 +177,7 @@ class VhdTransformer(Transformer):
             credential=platform.credential,
             subscription_id=platform.subscription_id,
             account_name=runbook.storage_account_name,
-            resource_group_name=runbook.resource_group_name,
+            resource_group_name=AZURE_SHARED_RG_NAME,
             location=location,
             log=self._log,
         )

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -59,8 +59,7 @@ class VhdTransformerSchema(schema.Transformer):
     vm_name: str = "node-0"
 
     # values for SSH connection. public_address is optional, because it can be
-    # retrieved from vm_name. The private_key_file must be provided. Others can
-    # use default values.
+    # retrieved from vm_name. Others can be retrieved from platform.
     public_address: str = ""
     public_port: int = 22
     username: str = constants.DEFAULT_USER_NAME

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -65,7 +65,7 @@ class VhdTransformerSchema(schema.Transformer):
     public_port: int = 22
     username: str = constants.DEFAULT_USER_NAME
     password: str = ""
-    private_key_file: str = field(default="", metadata=schema.metadata(required=True))
+    private_key_file: str = ""
 
     # values for exported vhd. storage_account_name is optional, because it can
     # be the default storage of LISA.
@@ -121,6 +121,15 @@ class VhdTransformer(Transformer):
             runbook.public_address = self._get_public_ip_address(
                 platform, virtual_machine
             )
+
+        platform_runbook: schema.Platform = platform.runbook
+
+        if not runbook.username:
+            runbook.username = platform_runbook.admin_username
+        if not runbook.password:
+            runbook.password = platform_runbook.admin_password
+        if not runbook.private_key_file:
+            runbook.private_key_file = platform_runbook.admin_private_key_file
 
         node_runbook = schema.RemoteNode(
             name=runbook.vm_name,

--- a/lisa/tests/test_transformer.py
+++ b/lisa/tests/test_transformer.py
@@ -152,6 +152,24 @@ class TestTransformerCase(TestCase):
             result,
         )
 
+    def test_transformer_skip_disabled(self) -> None:
+        # the second transformer should be skipped, so the value is original.
+        transformers = self._generate_transformers_runbook(2)
+        transformers[0].rename = {"t0_v0": "v0"}
+        transformers[0].enabled = False
+        runbook_builder = self._generate_runbook_builder(transformers)
+
+        result = transformer._run_transformers(runbook_builder)
+        self._validate_variables(
+            {
+                "v0": "original",
+                "va": "original",
+                "t1_v0": "1_0 processed",
+                "t1_v1": "1_1 processed",
+            },
+            result,
+        )
+
     def _validate_variables(
         self, expected: Dict[str, str], actual: Dict[str, VariableEntry]
     ) -> None:

--- a/lisa/transformer.py
+++ b/lisa/transformer.py
@@ -135,9 +135,13 @@ def _run_transformers(
 
     transformers_runbook: List[schema.Transformer] = []
     for runbook_data in transfromers_data:
-        # get raw transformer runbook for replacing variables.
-        runbook = schema.Transformer.schema().load(runbook_data)  # type: ignore
-        transformers_runbook.append(runbook)
+        # get base transformer runbook for replacing variables.
+        runbook: schema.Transformer = schema.Transformer.schema().load(  # type: ignore
+            runbook_data
+        )
+
+        if runbook.enabled:
+            transformers_runbook.append(runbook)
 
     # resort the runbooks, and it's used in real run
     transformers_runbook = _sort(transformers_runbook)
@@ -149,7 +153,7 @@ def _run_transformers(
     factory = subclasses.Factory[Transformer](Transformer)
     for runbook in transformers_runbook:
         # serialize to data for replacing variables
-        runbook_data = runbook.to_dict()
+        runbook_data = runbook.to_dict()  # type: ignore
 
         # replace to validate all variables exist
         replace_variables(runbook_data, copied_variables)


### PR DESCRIPTION
With VHD transformers, the three transformers can deploy a VM and export to a VHD, then delete the VM. Other transformers can be applied to the deployed VM and then prepare a VHD. The VHD can be used on following all test cases. For example, install or build a kernel, change the LIS version and so on. 

Below is the example of runbook.

```yaml
transformer:
  - type: azure_deploy
    requirement:
      azure:
        marketplace: redhat rhel 7_9 7.9.2021051701
  - type: azure_vhd
    resource_group_name: $(azure_deploy_resource_group_name)
    rename:
      azure_vhd_url: vhd
  - type: azure_delete
    resource_group_name: $(azure_deploy_resource_group_name)
```