### PR TITLE
Add P95 and P99 support for latency test case

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-TCP-LATENCY-LAGSCOPE.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-LATENCY-LAGSCOPE.ps1
@@ -89,9 +89,17 @@ collect_VM_properties
             $maximumLat = $matchLine.Split(",").Split("=").Trim().Replace("us","")[3]
             $averageLat = $matchLine.Split(",").Split("=").Trim().Replace("us","")[5]
 
+            $matchLine= (Select-String -Path "$LogDir\lagscope-n*-output.txt" -Pattern "95%\s+\d+").Line
+            $percentile95 = $matchLine.Split("%").Trim()[1]
+
+            $matchLine= (Select-String -Path "$LogDir\lagscope-n*-output.txt" -Pattern "99%\s+\d+").Line
+            $percentile99 = $matchLine.Split("%").Trim()[1]
+
             $currentTestResult.TestSummary += New-ResultSummary -testResult $minimumLat -metaData "Minimum Latency" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
             $currentTestResult.TestSummary += New-ResultSummary -testResult $maximumLat -metaData "Maximum Latency" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
             $currentTestResult.TestSummary += New-ResultSummary -testResult $averageLat -metaData "Average Latency" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+            $currentTestResult.TestSummary += New-ResultSummary -testResult $percentile95 -metaData "Percentile 95 Latency" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
+            $currentTestResult.TestSummary += New-ResultSummary -testResult $percentile99 -metaData "Percentile 99 Latency" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
         } catch {
             $currentTestResult.TestSummary += New-ResultSummary -testResult "Error in parsing logs." -metaData "LAGSCOPE" -checkValues "PASS,FAIL,ABORTED" -testName $currentTestData.testName
         }
@@ -158,9 +166,8 @@ collect_VM_properties
                     $resultMap["MaxLatency_us"] = [Decimal]$maximumLat
                     $resultMap["AverageLatency_us"] = [Decimal]$averageLat
                     $resultMap["MinLatency_us"] = [Decimal]$minimumLat
-                    #Percentile Values are not calculated yet. will be added in future
-                    $resultMap["Latency95Percentile_us"] = 0
-                    $resultMap["Latency99Percentile_us"] = 0
+                    $resultMap["Latency95Percentile_us"] = [Decimal]$percentile95
+                    $resultMap["Latency99Percentile_us"] = [Decimal]$percentile99
                     $resultMap["Interval_us"] = [int]$interval
                     $resultMap["Frequency"] = [int]$frequency
                     $currentTestResult.TestResultData += $resultMap

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -735,7 +735,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>LAGSCOPE_VERSION</ReplaceThis>
-		<ReplaceWith>v0.2.0</ReplaceWith>
+		<ReplaceWith>master</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DATA_DISK_SKU</ReplaceThis>


### PR DESCRIPTION
1. Some performance metrics need P95, P99 results. We added these two percentile.
2. Change the lagscope version to master.

Here is the test results:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/08/2021 04:28:34
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal : 20_04-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                 5.11 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202106230, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.8.0-1036-azure
      Minimum Latency : 27.000
      Maximum Latency : 8382.750
      Average Latency : 35.385
      Percentile 95 Latency : 51
      Percentile 99 Latency : 113
```
