### PR TITLE
Chang the test duration and the VM size for performance test

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-THROUGHPUT-MULTICONNECTION-NTTTCP.ps1
@@ -61,7 +61,7 @@ function Main {
         #endregion
 
         Write-LogInfo "Getting Systemd Version."
-        $getSystemdVersion = "systemctl --version | head -n1 | awk '{ print `$NF }'"
+        $getSystemdVersion = "systemctl --version | head -n1 | awk '{ print `$2 }'"
         $systemdVersion = (Run-LinuxCmd -ip $clientVMData.PublicIP -port $clientVMData.SSHPort `
             -username $user -password $password -command $getSystemdVersion ).Trim()
         Write-LogInfo "Systemd Version is $systemdVersion. Set Systemd user config file..."

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -83,7 +83,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>NTTTCP_RUNTIME_IN_SECONDS</ReplaceThis>
-		<ReplaceWith>300</ReplaceWith>
+		<ReplaceWith>120</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>IPERF3_RUNTIME_IN_SECONDS</ReplaceThis>
@@ -91,7 +91,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_RUNTIME_IN_SECONDS</ReplaceThis>
-		<ReplaceWith>300</ReplaceWith>
+		<ReplaceWith>120</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>FIO_STRESS_RUNTIME</ReplaceThis>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -333,7 +333,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
-      <SetupType>OneVM12Disk</SetupType>
+      <SetupType>OneVM16Disk</SetupType>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Storage</DefaultResultTable>
@@ -359,7 +359,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
-      <SetupType>OneVM12Disk</SetupType>
+      <SetupType>OneVM16Disk</SetupType>
     </SetupConfig>
     <DefaultResultTable>Perf_Storage</DefaultResultTable>
   </test>

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -24,6 +24,7 @@
     <SetupConfig>
       <Networking>Synthetic</Networking>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_TCP</DefaultResultTable>
@@ -53,6 +54,7 @@
     <SetupConfig>
       <Networking>SRIOV</Networking>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_TCP</DefaultResultTable>
@@ -81,6 +83,7 @@
     <SetupConfig>
       <Networking>Synthetic</Networking>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_UDP</DefaultResultTable>
@@ -109,6 +112,7 @@
     <SetupConfig>
       <Networking>SRIOV</Networking>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_UDP</DefaultResultTable>
@@ -221,6 +225,7 @@
     <Priority>1</Priority>
     <SetupConfig>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_Latency</DefaultResultTable>
@@ -244,6 +249,7 @@
     <SetupConfig>
       <Networking>SRIOV</Networking>
       <SetupType>TwoVM2Host</SetupType>
+      <OverrideVMSize>Standard_F72s_v2</OverrideVMSize>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\SETUP-PERF-Add-NIC.ps1</SetupScript>
     </SetupConfig>
     <DefaultResultTable>Perf_Network_Latency</DefaultResultTable>

--- a/XML/TestCases/StressTests.xml
+++ b/XML/TestCases/StressTests.xml
@@ -249,7 +249,7 @@
     <Priority>3</Priority>
     <SetupConfig>
       <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
-      <SetupType>OneVM12Disk</SetupType>
+      <SetupType>OneVM16Disk</SetupType>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</SetupScript>
     </SetupConfig>
   </test>
@@ -284,7 +284,7 @@
     <SetupConfig>
       <DiskType>Managed</DiskType>
       <StorageAccountType>PERF_STORAGE_ACCOUNT_TYPE</StorageAccountType>
-      <SetupType>OneVM12Disk</SetupType>
+      <SetupType>OneVM16Disk</SetupType>
       <SetupScript>.\Testscripts\Windows\SETUP-Check-PowerPlan.ps1,.\Testscripts\Windows\AddHardDisk.ps1</SetupScript>
     </SetupConfig>
   </test>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -318,7 +318,7 @@
         <ResourceGroup>
             <VirtualMachine>
                 <state></state>
-                <InstanceSize>Standard_DS14_v2</InstanceSize>
+                <InstanceSize>Standard_F72s_v2</InstanceSize>
                 <EndPoints>
                     <Name>SSH</Name>
                     <Protocol>tcp</Protocol>

--- a/XML/VMConfigurations/OneVM.xml
+++ b/XML/VMConfigurations/OneVM.xml
@@ -313,7 +313,7 @@
             </VirtualMachine>
         </ResourceGroup>
     </OneVM6DiskNested>
-    <OneVM12Disk>
+    <OneVM16Disk>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>
             <VirtualMachine>
@@ -385,9 +385,29 @@
                     <DiskSizeInGB>1023</DiskSizeInGB>
                     <HostCaching>None</HostCaching>
                 </DataDisk>
+                <DataDisk>
+                    <LUN>12</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
+                <DataDisk>
+                    <LUN>13</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
+                <DataDisk>
+                    <LUN>14</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
+                <DataDisk>
+                    <LUN>15</LUN>
+                    <DiskSizeInGB>1023</DiskSizeInGB>
+                    <HostCaching>None</HostCaching>
+                </DataDisk>
             </VirtualMachine>
         </ResourceGroup>
-    </OneVM12Disk>
+    </OneVM16Disk>
     <OneVM12DiskNested>
         <isDeployed>NO</isDeployed>
         <ResourceGroup>


### PR DESCRIPTION
1. Change network and storage performance testing VM size to F72s_v2;
2. Change the network and storage performance testing time to 120s;
3.  Fix to get the right version of systemd for Ubuntu 20.04;
4. Change OneVM12Disk to OneVM16Disk.

