### PR TITLE
Install libarchive to fix the cmake error when build lagscope

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2568,7 +2568,7 @@ function install_lagscope () {
 	case "$DISTRO_NAME" in
 		oracle|rhel|centos|almalinux)
 			install_epel
-			yum -y --nogpgcheck install libaio sysstat git bc make gcc wget cmake
+			yum -y --nogpgcheck install libaio sysstat git bc make gcc wget cmake libarchive
 			build_lagscope "${1}"
 			iptables -F
 			systemctl stop firewalld.service || service firewalld stop


### PR DESCRIPTION
When use cmake to build lagscope, Redhat/Centos/Oracle have this error:
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

We need to install "libarchive" if we want to use cmake. After fixing, this test case can be passed when running in Redhat/Centos/Oracle.

```
    1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                 5.11 
      ARMImageName: RedHat RHEL 8_3 8.3.2021041912, Networking: SRIOV, OverrideVMSize: Standard_F72s_v2, TestLocation: westus2, Kernel Version: 4.18.0-240.22.1.el8_3.x86_64

 1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                 3.94 
      ARMImageName: Oracle Oracle-Linux ol82 8.2.3, Networking: SRIOV, OverrideVMSize: Standard_F72s_v2, TestLocation: westus2, Kernel Version: 5.4.17-2036.101.2.el8uek.x86_64

 1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                 4.22 
      ARMImageName: OpenLogic CentOS 8_3 8.3.2021020400, Networking: SRIOV, OverrideVMSize: Standard_F72s_v2, TestLocation: westus2, Kernel Version: 4.18.0-240.10.1.el8_3.x86_64

1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                 5.51 
      ARMImageName: RedHat RHEL 7.8 7.8.2021051701, Networking: SRIOV, OverrideVMSize: Standard_F72s_v2, TestLocation: westus2, Kernel Version: 3.10.0-1127.el7.x86_64

 1 NETWORK              PERF-NETWORK-TCP-LATENCY-SRIOV                                                    PASS                  4.1 
      Networking: SRIOV, OsVHD: http://lisawestus2.blob.core.windows.net/vhds/almalinux-8.4-x86_64.azure.vhd, OverrideVMSize: Standard_F72s_v2, TestLocation: westus2, VMGeneration: 1, Kernel Version: 4.18.0-305.3.1.el8_4.x86_64
```