### PR TITLE
Add zypper lock check before installing fio

### DIFF
--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2377,6 +2377,7 @@ function install_fio () {
 
 		sles|sle_hpc)
 			if [[ $DISTRO_VERSION =~ 12|15* ]]; then
+				CheckInstallLockSLES
 				zypper refresh
 				add_sles_benchmark_repo
 				zypper --no-gpg-checks --non-interactive --gpg-auto-import-keys install wget mdadm blktrace libaio1 sysstat bc


### PR DESCRIPTION
Add zypper lock check before installing fio. When the VM start up, there are zypper process still running. It will be failed to run zypper install command.