### PR TITLE
Add some fix to better support almalinux

### DIFF
--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -33,7 +33,7 @@ function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort 
 GetDistro
 
 case $DISTRO in
-    redhat_*|centos_*|almalinux*)
+    redhat_*|centos_*)
         # Check if vmbus string is recorded in dmesg
         hv_string=$(dmesg | grep "Vmbus version:")
         if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then

--- a/Testscripts/Linux/gpu-driver-install.sh
+++ b/Testscripts/Linux/gpu-driver-install.sh
@@ -28,7 +28,7 @@ grid_driver="https://go.microsoft.com/fwlink/?linkid=874272"
 
 #######################################################################
 function skip_test() {
-	if [[ $driver == "CUDA" ]] && ([[ $DISTRO == *"suse"* ]] || [[ $DISTRO == "redhat_8" ]] || [[ $DISTRO == *"debian"* ]]); then
+	if [[ $driver == "CUDA" ]] && ([[ $DISTRO == *"suse"* ]] || [[ $DISTRO == "redhat_8" ]] || [[ $DISTRO == *"debian"* ]] || [[ $DISTRO == "almalinux_8" ]]); then
 		LogMsg "$DISTRO not supported. Skip the test."
 		SetTestStateSkipped
 		exit 0

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -221,7 +221,7 @@ function Main {
         Write-Debug "Added GPU driver name to constants.sh file"
 
         # For CentOS and RedHat the requirement is to install LIS RPMs
-        if (@("REDHAT", "CENTOS", "ALMALINUX").contains($global:detectedDistro)) {
+        if (@("REDHAT", "CENTOS").contains($global:detectedDistro)) {
             # HPC images already have the LIS RPMs installed
             $sts = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $user -password $password `
                 -command "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v" -ignoreLinuxExitCode


### PR DESCRIPTION
1. No need to add almalinux in lis modules verified test cases
2. The PermitRootLogin is set "no" by default in AlmaLinux. It will be denied when using ssh key to connect to another dependency VM. Adding provision-VMsForLisa in SRIOV-RUN-COMMON-TEST.ps1 can solve this problem.
3. No need to install lis for almalinux when running gpu test cases, and skip gpu testing for almalinux_8.
