### PR TITLE
Wait zypper run finish in check_package.

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -2160,7 +2160,7 @@ Function Invoke-ResourceGroupDeployment([string]$RGName, $TemplateFile, $UseExis
 	return @{ "Status" = $retValue ; "Error" = $errMsg }
 }
 
-Function Get-AllDeploymentData([string]$ResourceGroups, [string]$PatternOfResourceNamePrefix, [boolean]$UseExistingRG = $false, [int]$MaxRetryCount = 60) {
+Function Get-AllDeploymentData([string]$ResourceGroups, [string]$PatternOfResourceNamePrefix, [boolean]$UseExistingRG = $false, [int]$MaxRetryCount = 120) {
 	$allDeployedVMs = @()
 	function Create-QuickVMNode() {
 		$objNode = New-Object -TypeName PSObject

--- a/Testscripts/Linux/TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/TIMESYNC-NTP.sh
@@ -97,6 +97,11 @@ case $DISTRO in
         check_cmd_result $? "Successfully restarted ntpd daemon" "Unable to restart ntpd. Aborting"
     ;;
     suse*|sles*)
+        if [[ $DISTRO == "suse_15" ]]; then
+            LogMsg "$DISTRO does not support ntp. Test skipped."
+            SetTestStateSkipped
+            exit 0
+        fi
         #In SLES 12 service name is ntpd, in SLES 11 is ntp
         if  [[ $DISTRO == "suse_11" ]]; then
             srv="ntp"

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3546,6 +3546,7 @@ function check_package () {
 				;;
 
 			suse|opensuse|sles|sle_hpc)
+				CheckInstallLockSLES
 				zypper search "$package_name"
 				return $?
 				;;

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2868,6 +2868,7 @@ function install_netperf () {
 
 function install_net_tools () {
 	if [[ $DISTRO_NAME == "sles" ]] && [[ $DISTRO_VERSION =~ 15 ]] || [[ $DISTRO_NAME == "sle_hpc" ]]; then
+		add_sles_network_utilities_repo > /dev/null 2>&1
 		zypper_install "net-tools-deprecated" > /dev/null 2>&1
 	fi
 	if [[ "${DISTRO_NAME}" == "ubuntu" ]]; then


### PR DESCRIPTION
After fix - 
```
[LISAv2 Test Results Summary]
Test Run On           : 07/14/2021 03:29:50
ARM Image Under Test  : SUSE : sles-15-sp3-basic : gen2 : 2021.06.23
Total Test Cases      : 2 (2 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:10

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 NVME                 NVME-DISK-VALIDATION                                                              PASS                 1.49 
      ARMImageName: SUSE sles-15-sp3-basic gen2 2021.06.23, OverrideVMSize: Standard_L16s_v2, TestLocation: westus2, Kernel Version: 5.3.18-38.3-azure
      zypper_install nvme-cli: Success
      install_nvme: Success
      nvme0n1 detected!
      nvme1n1 detected!
      
    2 NVME                 NVME-MAX-DISK-VALIDATION                                                          PASS                 1.19 
      ARMImageName: SUSE sles-15-sp3-basic gen2 2021.06.23, OverrideVMSize: Standard_L80s_v2, TestLocation: westus2, Kernel Version: 5.3.18-38.3-azure
      zypper_install nvme-cli: Success
      install_nvme: Success
      nvme0n1 detected!
      nvme1n1 detected!
      nvme2n1 detected!
      nvme3n1 detected!
      nvme4n1 detected!
      nvme5n1 detected!
      nvme6n1 detected!
      nvme7n1 detected!
      nvme8n1 detected!
      nvme9n1 detected!
```