### PR TITLE
No need to add almalinux in lis modules verified test cases

### DIFF
--- a/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
+++ b/Testscripts/Linux/VERIFY-LIS-MODULES-VERSION.sh
@@ -33,7 +33,7 @@ function check_version_greater_equal() { test "$(echo "$@" | tr " " "\n" | sort 
 GetDistro
 
 case $DISTRO in
-    redhat_*|centos_*|almalinux*)
+    redhat_*|centos_*)
         # Check if vmbus string is recorded in dmesg
         hv_string=$(dmesg | grep "Vmbus version:")
         if [[ ( $hv_string == "" ) || ! ( $hv_string == *"hv_vmbus:"*"Vmbus version:"* ) ]]; then

--- a/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
+++ b/Testscripts/Windows/GPU-DRIVER-INSTALL.ps1
@@ -221,7 +221,7 @@ function Main {
         Write-Debug "Added GPU driver name to constants.sh file"
 
         # For CentOS and RedHat the requirement is to install LIS RPMs
-        if (@("REDHAT", "CENTOS", "ALMALINUX").contains($global:detectedDistro)) {
+        if (@("REDHAT", "CENTOS").contains($global:detectedDistro)) {
             # HPC images already have the LIS RPMs installed
             $sts = Run-LinuxCmd -ip $allVMData.PublicIP -port $allVMData.SSHPort -username $user -password $password `
                 -command "rpm -qa | grep kmod-microsoft-hyper-v && rpm -qa | grep microsoft-hyper-v" -ignoreLinuxExitCode


### PR DESCRIPTION
No need to verify lis modules for almalinux. 