### PR TITLE
Add support for testing image in shared gallery

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -278,7 +278,7 @@
                     "linuxConfiguration": "[if(empty(parameters('admin_key_data')), json('null'), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')))]"
                 },
                 "storageProfile": {
-                    "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')]))]",
+                    "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')])))]",
                     "osDisk": {
                         "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-osDisk')]",
                         "managedDisk": {
@@ -325,6 +325,20 @@
                     "output": {
                         "type": "object",
                         "value": "[parameters('node')['marketplace']]"
+                    }
+                },
+                "getOsDiskSharedGallery": {
+                    "parameters": [
+                        {
+                            "name": "node",
+                            "type": "object"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": {
+                            "id": "[resourceId(parameters('node')['subscription_id'], 'None', 'Microsoft.Compute/galleries/images/versions', parameters('node')['image_gallery'], parameters('node')['image_definition'], parameters('node')['image_version'])]"
+                        }
                     }
                 },
                 "getOsDiskVhd": {

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -839,6 +839,9 @@ class AzurePlatform(Platform):
             azure_node_runbook = node_space.get_extended_runbook(
                 AzureNodeSchema, type_name=AZURE
             )
+            # Subscription Id is used by Shared Gallery images located
+            # in subscription different from where LISA is run
+            azure_node_runbook.subscription_id = self.subscription_id
 
             # init node
             node = environment.nodes.from_requirement(
@@ -859,7 +862,13 @@ class AzurePlatform(Platform):
             if azure_node_runbook.vhd:
                 # vhd is higher priority
                 azure_node_runbook.marketplace = None
-            elif not azure_node_runbook.marketplace:
+                azure_node_runbook.shared_gallery = None
+            elif azure_node_runbook.shared_gallery:
+                azure_node_runbook.marketplace = None
+            elif azure_node_runbook.marketplace:
+                # marketplace value is already set in runbook
+                pass
+            else:
                 # set to default marketplace, if nothing specified
                 azure_node_runbook.marketplace = AzureVmMarketplaceSchema()
 


### PR DESCRIPTION
Runbook example : 

- If the shared image gallery is in the same subscription where LISA is run : 

```
azure:
        shared_gallery: "<image_gallery>/<image_definition>/<image_version>"
```

- If the shared image gallery is in a different subscription : 


```
azure:
        shared_gallery: "<subscription_id>/<image_gallery>/<image_definition>/<image_version>"
```