### PR TITLE
Add more ioQdepth into storage test

### DIFF
--- a/Testscripts/Linux/perf_fio.sh
+++ b/Testscripts/Linux/perf_fio.sh
@@ -57,7 +57,7 @@ RunFIO()
 	if [ $type == "disk" ]; then
 		NUM_JOBS=(1 1 2 2 4 4)
 	else
-		NUM_JOBS=(1 1 2 2 4 4 8 8 8 8 8 8)
+		NUM_JOBS=(1 1 2 2 4 4 8 8 8 16 16 16)
 	fi
 
 	# Log Config

--- a/XML/TestCases/PerformanceTests.xml
+++ b/XML/TestCases/PerformanceTests.xml
@@ -316,7 +316,7 @@
     <TestParameters>
       <param>modes=PERF-STORAGE-4K-IO-MODES</param>
       <param>startQDepth=1</param>
-      <param>maxQDepth=256</param>
+      <param>maxQDepth=1024</param>
       <param>startIO=4</param>
       <param>ioruntime=FIO_RUNTIME_IN_SECONDS</param>
       <param>maxIO=4</param>
@@ -345,7 +345,7 @@
     <TestParameters>
       <param>modes=PERF-STORAGE-1024K-IO-MODES</param>
       <param>startQDepth=1</param>
-      <param>maxQDepth=256</param>
+      <param>maxQDepth=1024</param>
       <param>startIO=1024</param>
       <param>ioruntime=FIO_RUNTIME_IN_SECONDS</param>
       <param>maxIO=1024</param>


### PR DESCRIPTION
The IOPS haven't achieved the max IOPS when with the current max ioQdepth 256. We changed into 1024.
The test result is like this:
```
LISAv2 Test Results Summary]
Test Run On           : 07/17/2021 13:02:52
ARM Image Under Test  : RedHat : RHEL : 8_3 : Latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:1:36

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 STORAGE              PERF-STORAGE-4K-IO                                                                PASS                92.99 
      ARMImageName: RedHat RHEL 8_3 8.3.2021041912, StorageAccountType: Premium_LRS, TestLocation: westus2, Kernel Version: 4.18.0-240.22.1.el8_3.x86_64
      Mode=randread : block_size=4K q_depth=1 iops=466.537779
      Mode=randread : block_size=4K q_depth=2 iops=1017.158047
      Mode=randread : block_size=4K q_depth=4 iops=2144.305928
      Mode=randread : block_size=4K q_depth=8 iops=4131.038945
      Mode=randread : block_size=4K q_depth=16 iops=8467.066292
      Mode=randread : block_size=4K q_depth=32 iops=17733.175823
      Mode=randread : block_size=4K q_depth=64 iops=37823.296744
      Mode=randread : block_size=4K q_depth=128 iops=71424.148518
      Mode=randread : block_size=4K q_depth=256 iops=81288.915839
      Mode=randread : block_size=4K q_depth=512 iops=81129.290552
      Mode=randread : block_size=4K q_depth=1024 iops=80844.100053
      Mode=randwrite : block_size=4K q_depth=1 iops=491.662569
      Mode=randwrite : block_size=4K q_depth=2 iops=1074.016050
      Mode=randwrite : block_size=4K q_depth=4 iops=1962.417475
      Mode=randwrite : block_size=4K q_depth=8 iops=5079.431975
      Mode=randwrite : block_size=4K q_depth=16 iops=10749.553615
      Mode=randwrite : block_size=4K q_depth=32 iops=23297.344940
      Mode=randwrite : block_size=4K q_depth=64 iops=45311.455798
      Mode=randwrite : block_size=4K q_depth=128 iops=64941.596413
      Mode=randwrite : block_size=4K q_depth=256 iops=77241.838807
      Mode=randwrite : block_size=4K q_depth=512 iops=79859.086288
      Mode=randwrite : block_size=4K q_depth=1024 iops=79869.027698
      Mode=read : block_size=4K q_depth=1 iops=461.783970
      Mode=read : block_size=4K q_depth=2 iops=995.791702
      Mode=read : block_size=4K q_depth=4 iops=2068.966092
      Mode=read : block_size=4K q_depth=8 iops=4478.844014
      Mode=read : block_size=4K q_depth=16 iops=9372.085465
      Mode=read : block_size=4K q_depth=32 iops=16466.465283
      Mode=read : block_size=4K q_depth=64 iops=34606.634512
      Mode=read : block_size=4K q_depth=128 iops=66989.780636
      Mode=read : block_size=4K q_depth=256 iops=79742.286129
      Mode=read : block_size=4K q_depth=512 iops=81361.476595
      Mode=read : block_size=4K q_depth=1024 iops=81542.726192
      Mode=write : block_size=4K q_depth=1 iops=537.270523
      Mode=write : block_size=4K q_depth=2 iops=1255.895735
      Mode=write : block_size=4K q_depth=4 iops=2626.108837
      Mode=write : block_size=4K q_depth=8 iops=5835.619385
      Mode=write : block_size=4K q_depth=16 iops=11776.477531
      Mode=write : block_size=4K q_depth=32 iops=20370.010500
      Mode=write : block_size=4K q_depth=64 iops=40950.064299
      Mode=write : block_size=4K q_depth=128 iops=64626.706222
      Mode=write : block_size=4K q_depth=256 iops=75709.407053
      Mode=write : block_size=4K q_depth=512 iops=80452.035627
      Mode=write : block_size=4K q_depth=1024 iops=81454.752537
```