### PR TITLE
Fix test issues.

### DIFF
--- a/Testscripts/Linux/SetupRDMA.sh
+++ b/Testscripts/Linux/SetupRDMA.sh
@@ -231,6 +231,7 @@ function Main() {
 		ubuntu*)
 			LogMsg "Disable rename ib0 on Ubuntu by adding net.ifnames=0 biosdevname=0 into kernel parameter."
 			sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 biosdevname=0"/' /etc/default/grub
+			sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 biosdevname=0"/' /etc/default/grub.d/50-cloudimg-settings.cfg
 			update-grub
 			LogMsg "Starting RDMA setup for Ubuntu"
 			hpcx_ver="ubuntu"$VERSION_ID
@@ -444,8 +445,8 @@ function Main() {
 		export PATH=$PATH:"${mpirun_path%/*}"
 		LogMsg "$?: Set $mpirun_path to PATH, $PATH"
 		# add sourcing file in each session
-		echo "source ${mpirun_path%/*}/setvars.sh" >> $HOMEDIR/.bashrc
-
+		setvars=$(find / -name setvars.sh)
+		echo "source ${setvars} > /dev/null 2>&1 " >> $HOMEDIR/.bashrc
 		LogMsg "$?: Completed Intel MPI installation"
 
 	elif [ $mpi_type == "open" ]; then

--- a/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
+++ b/Testscripts/Windows/FILE-SYSTEM-VERIFICATION-TESTS.ps1
@@ -60,7 +60,21 @@ function New-FileShare {
     }
     $sharePassword = (Get-AzStorageAccountKey -ResourceGroupName $AllVmData.ResourceGroupName `
         -Name $storageAccountName).Value[0]
-    $shareHost = (Get-AzStorageShare -Context $storageAccount.Context).Uri.Host[0]
+    $share = Get-AzStorageShare -Context $storageAccount.Context
+    if ($null -eq $share) {
+        Write-LogErr "Failed to get the share."
+        Remove-StorageAccount $storageAccountName
+        return 1
+    }
+    if ($null -ne $share[0].Uri) {
+        $shareHost = $share[0].Uri.Host
+    } elseif ($null -ne $share[0].ShareClient.Uri) {
+        $shareHost = $share[0].ShareClient.Uri.Host
+    } else {
+        Write-LogErr "Failed to get the share host."
+        Remove-StorageAccount $storageAccountName
+        return 1
+    }
     $url_main = $shareHost + "/" + $fileShareName
     $url_scratch = $shareHost + "/" + $scratchName
     Add-Content -Value "TEST_DEV=//$url_main" -Path $xfstestsConfig

--- a/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
+++ b/Testscripts/Windows/VERIFY-INFINIBAND-MultiVM.ps1
@@ -144,7 +144,7 @@ function Main {
 				$password "echo $($VmData.RoleName) > /etc/hostname" | Out-Null
 			if ($VmData.RoleName -imatch "Client" -or $VmData.RoleName -imatch "dependency"){
 				Run-LinuxCmd -ip $ServerVMData.PublicIP -port $ServerVMData.SSHPort -username $superUser -password $password `
-					"echo '$($VmData.RoleName) $($VmData.InternalIP)' >> /etc/hosts" | Out-Null
+					"echo '$($VmData.InternalIP) $($VmData.RoleName)' >> /etc/hosts" | Out-Null
 			}
 		}
 		#endregion


### PR DESCRIPTION
INFINIBAND-OPEN-MPI-2VM  on Ubuntu 20.04
```
[LISAv2 Test Results Summary]
Test Run On           : 07/19/2021 03:52:08
ARM Image Under Test  : canonical : 0001-com-ubuntu-server-focal : 20_04-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:24

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 INFINIBAND           INFINIBAND-OPEN-MPI-2VM                                                           PASS                19.68 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202106230, OverrideVMSize: Standard_HC44rs, TestLocation: westus2, Kernel Version: 5.8.0-1036-azure -> 5.4.0-1054-azure
      InfiniBand-Verification-1-FirstBoot : eth0 IP : PASS
      InfiniBand-Verification-1-FirstBoot : IBV_PINGPONG : PASS
      InfiniBand-Verification-1-FirstBoot : IMB PingPong Intranode : PASS
      InfiniBand-Verification-1-FirstBoot : IMB-MPI1 : PASS
      InfiniBand-Verification-1-FirstBoot : IMB-P2P : PASS
      InfiniBand-Verification-1-FirstBoot : IMB-NBC : PASS
      InfiniBand-Verification-2-Reboot : eth0 IP : PASS
      InfiniBand-Verification-2-Reboot : IBV_PINGPONG : PASS
      InfiniBand-Verification-2-Reboot : IMB PingPong Intranode : PASS
      InfiniBand-Verification-2-Reboot : IMB-MPI1 : PASS
      InfiniBand-Verification-2-Reboot : IMB-P2P : PASS
```