### PR TITLE
Add almalinux support for KDUMP auto size config

### DIFF
--- a/Testscripts/Linux/KDUMP-Config.sh
+++ b/Testscripts/Linux/KDUMP-Config.sh
@@ -395,7 +395,7 @@ Install_Kexec
 # Configure kdump - this has distro specific behaviour
 #
 config_path=$(get_bootconfig_path)
-if [[ $DISTRO != "redhat_8" ]];then
+if [[ $DISTRO != "redhat_8" ]] && [[ $DISTRO != "almalinux_8" ]];then
     if ! grep CONFIG_KEXEC_AUTO_RESERVE=y "$config_path" && [[ "$crashkernel" == "auto" ]];then
         LogErr "crashkernel=auto doesn't work for this distro. Please use this pattern: crashkernel=X@Y."
         SetTestStateSkipped


### PR DESCRIPTION
```
[LISAv2 Test Results Summary]
Test Run On           : 07/19/2021 07:34:47
VHD Under Test        : https://lisawestus2.blob.core.windows.net/vhds/almalinux-8.4-x86_64.azure.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:9

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-AUTO-SIZE                                                             PASS                 3.74 
      OsVHD: http://lisasouthcentralus.blob.core.windows.net/vhds/almalinux-8.4-x86_64.azure.vhd, TestLocation: southcentralus, VMGeneration: 1, Kernel Version: 4.18.0-305.7.1.el8_4.x86_64
```