### PR TITLE
Fix duplicate entries in the arm template.

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
@@ -917,7 +918,9 @@ class AzurePlatform(Platform):
                 )
                 arm_parameters.enable_sriov = False
 
-        template = self._load_template()
+        # the arm template may be updated by the hooks, so make a copy to avoid
+        # the original template is modified.
+        template = deepcopy(self._load_template())
         plugin_manager.hook.azure_update_arm_template(
             template=template, environment=environment
         )


### PR DESCRIPTION
The arm template is cached in memory to reduce disk io. The hooks on
template will modify it. The template should be copied before modified,
So it won't be modified multiple times.