### PR TITLE
Add some fix for better supporting rocky linux

### DIFF
--- a/Testscripts/Linux/NET-Test-Legacy.sh
+++ b/Testscripts/Linux/NET-Test-Legacy.sh
@@ -290,7 +290,7 @@ while [ $__synth_iterator -lt ${#SYNTH_NET_INTERFACES[@]} ]; do
         LogMsg "Trying to ping $REMOTE_SERVER from synthetic interface ${SYNTH_NET_INTERFACES[$__synth_iterator]}"
         # In some cases eth1 and eth2 would fail to ping6, restarting the network solves the issue
         if [ "$pingVersion" == "ping6" ] && [ ${#SYNTH_NET_INTERFACES[@]} -ge 1 ]; then
-            if [[ "$DISTRO" == "redhat"* || "$DISTRO" == "centos"* || "$DISTRO" == "almalinux"* ]] "$DISTRO" == "rockylinux"* ]]; then
+            if [[ "$DISTRO" == "redhat"* || "$DISTRO" == "centos"* || "$DISTRO" == "almalinux"* || "$DISTRO" == "rockylinux"* ]]; then
                 service network restart
                 if [ $? -ne 0 ]; then
                     LogMsg "Unable to restart network service."

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -2114,6 +2114,8 @@ function detect_linux_distribution() {
 		linux_distribution='debian'
 	elif echo "$linux_distribution" | grep -qi "mariner"; then
 		linux_distribution='mariner'
+	elif echo "$linux_distribution" | grep -qi "Rocky"; then
+		linux_distribution='rockylinux'
 	fi
 	echo "$(echo "$linux_distribution" | awk '{print tolower($0)}')"
 }


### PR DESCRIPTION
Before fix, DOCKER-BASIC-JAVA-APP test case is failed.
After fix:
```
[LISAv2 Test Results Summary]
Test Run On           : 07/23/2021 10:27:59
VHD Under Test        : https://lisawestus2.blob.core.windows.net/vhds/almalinux-8.4-x86_64.azure.vhd
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:6

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 CONTAINER            DOCKER-BASIC-JAVA-APP                                                             PASS                 3.51 
      OsVHD: http://lisawestus2.blob.core.windows.net/vhds/almalinux-8.4-x86_64.azure.vhd, TestLocation: westus2, VMGeneration: 1, Kernel Version: 4.18.0-305.7.1.el8_4.x86_64
      yum_install yum-utils: Success
```