### PR TITLE
Rectify branch to clone in legacy_runner

### DIFF
--- a/lisa/runners/legacy_runner.py
+++ b/lisa/runners/legacy_runner.py
@@ -99,7 +99,7 @@ class LegacyRunner(BaseRunner):
             git.clone(
                 config.repo,
                 cwd=self._working_folder,
-                ref=config.branch,
+                ref=f"origin/{config.branch}",
                 dir_name=self._get_dir_name(self.id, index),
             )
 


### PR DESCRIPTION
Legacy runner fails to checkout the given V2 branch because of https://github.com/microsoft/lisa/blob/main/lisa/runners/legacy_runner.py#L102 . 

Used `origin/branch_name` instead of `branch_name`