### PR TITLE
Add some enhancement into LISAv2

### DIFF
--- a/Testscripts/Linux/KDUMP-Execute.sh
+++ b/Testscripts/Linux/KDUMP-Execute.sh
@@ -149,13 +149,23 @@ Exec_mariner()
 
 Configure_NMI()
 {
-    sysctl -w kernel.unknown_nmi_panic=1
-    if [ $? -ne 0 ]; then
-        LogErr "Failed to enable kernel to call panic when it receives a NMI."
-        SetTestStateAborted
-        exit 0
+    # /proc/sys/kernel/unknown_nmi_panic:
+    # The value in this file affects behavior of handling NMI. When the value is
+    # non-zero, unknown NMI is trapped and then panic occurs. If need to dump the
+    # crash, the value should be set 1.
+    # Some architectures don't provide architected NMIs,such as ARM64. So this file
+    # doesn't exist.
+    if [ -e "/proc/sys/kernel/unknown_nmi_panic" ] ; then
+        sysctl -w kernel.unknown_nmi_panic=1
+        if [ $? -ne 0 ]; then
+            LogErr "Failed to enable kernel to call panic when it receives a NMI."
+            SetTestStateAborted
+            exit 0
+        else
+            UpdateSummary "Success: enabling kernel to call panic when it receives a NMI."
+        fi
     else
-        UpdateSummary "Success: enabling kernel to call panic when it receives a NMI."
+        UpdateSummary "The kernel may not support to NMI. Ignore it and keep running."
     fi
 }
 

--- a/Testscripts/Linux/docker_compose_wordpress_mysql_app.sh
+++ b/Testscripts/Linux/docker_compose_wordpress_mysql_app.sh
@@ -84,6 +84,13 @@ function EvaluateTestResult() {
 }
 UtilsInit
 
+# https://github.com/docker/compose/releases only contain releases for amd64/x86_64
+# When https://github.com/docker/compose/issues/6831 is merged, we should add support
+# for other architecture
+if [[ $(uname -m) != "x86_64" ]];then
+    HandleSkip "The Docker Compose only support amd64/x86_64 architecture now" 0
+fi
+
 GetDistro
 update_repos
 

--- a/Testscripts/Windows/KDUMP-TestScript.ps1
+++ b/Testscripts/Windows/KDUMP-TestScript.ps1
@@ -119,7 +119,12 @@ function Main {
     Run-LinuxCmd -username $VMUserName -password $VMPassword -ip $Ipv4 -port $VMPort `
         -command "sync; reboot" -runAsSudo -RunInBackGround | Out-Null
     Write-LogInfo "Rebooting VM $VMName after kdump configuration..."
-    Start-Sleep -Seconds 10 # Wait for kvp & ssh services stop
+
+    # We need extend the sleep time.
+    # If sleeping a shorter time after reboot, the network may haven't stopped even if the VM is rebooting.
+    # Then Wait-ForVMToStartSSH will return ture. We will get a pseudomorph that the VM has startup after reboot.
+    # But actually not. Then KDUMP-Execute may failed for network error.
+    Start-Sleep -Seconds 20 # Wait for kvp & ssh services stop
 
     # Wait for VM boot up and update ip address
     Wait-ForVMToStartSSH -Ipv4addr $Ipv4 -StepTimeout 360 | Out-Null


### PR DESCRIPTION
There is no other architecture's package of Docker Compose. So skip the docker compose test case if not x86_64.

Here is the kdump test results:
```
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 KDUMP                KDUMP-CRASH-16-CORES                                                              PASS                 11.4 
    2 KDUMP                KDUMP-CRASH-AUTO-SIZE                                                          SKIPPED                  4.5 
    3 KDUMP                KDUMP-CRASH-DIFFERENT-VCPU                                                        PASS                 11.2 
```