### PR TITLE
Isaiah/lisa2

### DIFF
--- a/Testscripts/Linux/nvme_basic_validation.sh
+++ b/Testscripts/Linux/nvme_basic_validation.sh
@@ -19,6 +19,16 @@
 }
 UtilsInit
 
+# Skip NVME-MAX-DISK-VALIDATION for centos_7.5 and below
+GetDistro
+mj=$(echo "$DISTRO_VERSION" | cut -d '.' -f 1)
+mn=$(echo "$DISTRO_VERSION" | cut -d '.' -f 2)
+if [[ $current_test_name == NVME-MAX-DISK-VALIDATION && $DISTRO == centos_7 && $mj -eq 7 && $mn -le 5 ]];then
+        LogMsg "WARNING: NVME-MAX-DISK-VALIDATION is not to be run on $DISTRO $mj.$mn."
+        SetTestStateSkipped
+        exit 0
+fi
+
 # Count the NVME disks
 disk_count=$(ls -l /dev | grep -w nvme[0-9]$ | awk '{print $10}' | wc -l)
 if [ "$disk_count" -eq "0" ]; then

--- a/Testscripts/Linux/run_dpdk_ring_latency.sh
+++ b/Testscripts/Linux/run_dpdk_ring_latency.sh
@@ -8,6 +8,7 @@ HOMEDIR=$(pwd)
 export RTE_SDK="${HOMEDIR}/dpdk"
 export RTE_TARGET="x86_64-native-linuxapp-gcc"
 export DPDK_RING_PING_PATH="${HOMEDIR}/dpdk-ring-ping"
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib64/pkgconfig/"
 
 # Source utils.sh
 . utils.sh || {

--- a/XML/TestCases/FunctionalTests-NVME.xml
+++ b/XML/TestCases/FunctionalTests-NVME.xml
@@ -26,6 +26,7 @@
     <files>.\Testscripts\Linux\utils.sh,.\Testscripts\Linux\nvme_basic_validation.sh</files>
     <testParameters>
       <param>nvme_version=NVME_VERSION</param>
+      <param>current_test_name=NVME-MAX-DISK-VALIDATION</param>
     </testParameters>
     <Timeout>1200</Timeout>
     <Platform>Azure</Platform>


### PR DESCRIPTION
[LISAv2] Skip NVME-MAX-DISK-VALIDATION test strictly for centos 7.5 and below

[DPDK] added /usr/local/lib64/pkgconfig/ to PKG_CONFIG_PATH
Problem: pkgconfig on RHEL 7 was not checking /usr/local/lib64/pkgconfig/ path
Fix: added /usr/local/lib64/pkgconfig/ to PKG_CONFIG_PATH