### PR TITLE
Fix time out when check sourcestats in case timesync_chrony.

### DIFF
--- a/lisa/tools/chrony.py
+++ b/lisa/tools/chrony.py
@@ -67,7 +67,7 @@ class Chrony(Tool):
             echo.run("server 2.pool.ntp.org >> /etc/chrony.conf", shell=True, sudo=True)
             echo.run("server 3.pool.ntp.org >> /etc/chrony.conf", shell=True, sudo=True)
 
-    @retry(exceptions=LisaException, tries=20, delay=0.5)  # type: ignore
+    @retry(exceptions=LisaException, tries=40, delay=0.5)  # type: ignore
     def check_sources_and_stats(self) -> None:
         cmd_result = self.run("sources", force_run=True)
         if self.__service_not_ready in cmd_result.stdout:

--- a/lisa/tools/chrony.py
+++ b/lisa/tools/chrony.py
@@ -71,6 +71,9 @@ class Chrony(Tool):
     def check_sources_and_stats(self) -> None:
         cmd_result = self.run("sources", force_run=True)
         if self.__service_not_ready in cmd_result.stdout:
-            raise LisaException("Service chrony is not ready, retry.")
+            raise LisaException("chrony sources is not ready, retry.")
+        cmd_result.assert_exit_code()
         cmd_result = self.run("sourcestats", force_run=True)
+        if self.__service_not_ready in cmd_result.stdout:
+            raise LisaException("chrony sourcestats is not ready, retry.")
         cmd_result.assert_exit_code()

--- a/lisa/tools/chrony.py
+++ b/lisa/tools/chrony.py
@@ -48,7 +48,7 @@ class Chrony(Tool):
         service = self.node.tools[Service]
         service.restart_service(service_name)
 
-    @retry(exceptions=LisaException, tries=120, delay=0.5)  # type: ignore
+    @retry(exceptions=LisaException, tries=240, delay=0.5)  # type: ignore
     def check_tracking(self) -> None:
         cmd_result = self.run("tracking", force_run=True)
         cmd_result.assert_exit_code()


### PR DESCRIPTION
1. Till now there are 43 records for 'time out when check sourcestats in case timesync_chrony.'

```
failed. AssertionError: [ get unexpected exit code on cmd ['chronyc', 'sourcestats']] Expected <1> to be equal to <0>, but was not.
```

From the raw log, we can see the service is not ready, raise exception there, then it can use retry logic.
```
2021-08-30 12:12:05.920[14828][DEBUG] lisa.env[generated_0].node[0].cmd[5565] cmd: ['chronyc', 'sourcestats'], cwd: None, shell: False, sudo: False, posix: True, remote: True
2021-08-30 12:12:06.607[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout 210 Number of sources = 8
2021-08-30 12:12:06.607[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout Name/IP Address            NP  NR  Span  Frequency  Freq Skew  Offset  Std Dev
2021-08-30 12:12:06.607[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout ==============================================================================
2021-08-30 12:12:10.971[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout ns1.backplanedns.org        0   0     0     +0.000   2000.000     +0ns  4000ms
2021-08-30 12:12:10.986[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout dns1.campus-rv.net          4   3     7   +164.697   2127.154  +3121us   378us
2021-08-30 12:12:10.986[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout ntp1.flashdance.cx          4   4     7   -408.217   3533.311  -6376us   417us
2021-08-30 12:12:11.205[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout LAX.CALTICK.NET             4   4     7    -29.445    693.221  +1417us   121us
2021-08-30 12:12:11.205[7604][DEBUG] lisa.env[generated_0].node[0].cmd[5565].stdout 503 No such source
2021-08-30 12:12:11.221[14828][DEBUG] lisa.env[generated_0].node[0].cmd[5565] execution time: 5.300 sec, exit code: 1
```
2. There are 17 failures caused by 'retry time out when check sources'.
3. There are 14 failures caused by 'retry time out when check Leap status'