### PR TITLE
lsmod.py remove parameter

### DIFF
--- a/lisa/tools/lsmod.py
+++ b/lisa/tools/lsmod.py
@@ -36,7 +36,6 @@ class Lsmod(Tool):
         no_error_log: bool = True,
     ) -> bool:
         result = self.run(
-            mod_name,
             force_run=force_run,
             no_info_log=no_info_log,
             no_error_log=no_error_log,


### PR DESCRIPTION
lsmod tool was failing with exit code 1 because it was running `lsmod [mod_name]`. However, usage for lsmod is simply `lsmod`

This tool is utilized by the gpu feature, so we may want to ensure the gpu feature and gpu testsuit are functioning properly.