### PR TITLE
Add test case verify_deployment_provision_synthetic_nic

### DIFF
--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -28,3 +28,4 @@ class NetworkInterface(Feature):
 
 
 Sriov = NetworkInterfaceOptionSettings(data_path=schema.NetworkDataPath.Sriov)
+Synthetic = NetworkInterfaceOptionSettings(data_path=schema.NetworkDataPath.Synthetic)

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -22,7 +22,7 @@ from lisa.features import (
     DiskStandardSSDLRS,
     SerialConsole,
 )
-from lisa.features.network_interface import Sriov
+from lisa.features.network_interface import Sriov, Synthetic
 from lisa.util.shell import wait_tcp_port_ready
 
 
@@ -61,6 +61,23 @@ class Provisioning(TestSuite):
         ),
     )
     def smoke_test(self, log: Logger, node: RemoteNode, log_path: Path) -> None:
+        self._smoke_test(log, node, log_path)
+
+    @TestCaseMetadata(
+        description="""
+        This case runs smoke test on a node provisioned with synthetic nic.
+        The test steps are same as `smoke_test`.
+        """,
+        priority=1,
+        requirement=simple_requirement(
+            environment_status=EnvironmentStatus.Deployed,
+            network_interface=Synthetic,
+            supported_features=[SerialConsole],
+        ),
+    )
+    def verify_deployment_provision_synthetic_nic(
+        self, log: Logger, node: RemoteNode, log_path: Path
+    ) -> None:
         self._smoke_test(log, node, log_path)
 
     @TestCaseMetadata(


### PR DESCRIPTION
By default smoke_test will use sriov if the size supports. Should we change smoke_test use Synthetic network? @squirrelsc @somil55 