### PR TITLE
New Test: check_floppy_module

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -20,6 +20,7 @@ from .lsvmbus import Lsvmbus
 from .make import Make
 from .mkfs import Mkfsext, Mkfsxfs
 from .modinfo import Modinfo
+from .modprobe import Modprobe
 from .mount import Mount
 from .ntp import Ntp
 from .ntpstat import Ntpstat
@@ -51,6 +52,7 @@ __all__ = [
     "Mkfsext",
     "Mkfsxfs",
     "Modinfo",
+    "Modprobe",
     "Mount",
     "Ntp",
     "Ntpstat",

--- a/lisa/tools/modprobe.py
+++ b/lisa/tools/modprobe.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any
+
+from lisa.executable import Tool
+
+
+class Modprobe(Tool):
+    @property
+    def command(self) -> str:
+        return self._command
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self._command = "modprobe"
+
+    def is_module_loaded(
+        self,
+        mod_name: str,
+        force_run: bool = False,
+        no_info_log: bool = True,
+        no_error_log: bool = True,
+    ) -> bool:
+        result = self.run(
+            f"-nv {mod_name}",
+            force_run=force_run,
+            no_info_log=no_info_log,
+            no_error_log=no_error_log,
+        )
+        # Example possible outputs
+        # 1) insmod /lib/modules/.../floppy.ko.xz
+        #    Exists but is not loaded - return False
+        # 2) FATAL: Module floppy not found.
+        #    Module does not exist, therefore is not loaded - return False
+        # 3) (no output)
+        #    Module is loaded - return True
+        could_be_loaded = result.stdout and "insmod" in result.stdout
+        does_not_exist = (result.stderr and "not found" in result.stderr) or (
+            result.stdout and "not found" in result.stdout
+        )
+
+        return not (could_be_loaded or does_not_exist)

--- a/microsoft/testsuites/core/floppy.py
+++ b/microsoft/testsuites/core/floppy.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from assertpy import assert_that
+
+from lisa import RemoteNode, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.tools import Modprobe
+
+
+@TestSuiteMetadata(
+    area="core",
+    category="functional",
+    description="""
+    This test suite ensures the floppy driver is disabled.
+    The floppy driver is not needed on Azure and
+    is known to cause problems in some scenarios.
+    """,
+)
+class Floppy(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        The goal of this test is to ensure the floppy module is not enabled
+        for images used on the Azure platform.
+        This test case will
+        1. Dry-run modprobe to see if floppy module can be loaded
+        2. If "insmod" would be executed then the module is not already loaded
+        3. If module cannot be found then it is not loaded
+        If the module is loaded, running modprobe will have no output
+        """,
+        priority=1,
+    )
+    def check_floppy_module(self, node: RemoteNode) -> None:
+        modprobe = node.tools[Modprobe]
+
+        assert_that(modprobe.is_module_loaded("floppy")).described_as(
+            "The floppy module should not be loaded. "
+            "Try adding the module to the blacklist."
+        ).is_false()


### PR DESCRIPTION
Wrote check_floppy_module which uses modprobe to ensure that the floppy module is not loaded in the kernel.

Motivation:
* Ubuntu was having problems caused by the floppy driver being enabled (I do not know the details. More information about previous problems may be required). Since the module is not necessary on Azure, we want to ensure it is disabled on all other distros.
* On-demand loading of the module is outside the scope of this test

Considerations:
* Could check dmesg for 'I/O error dev fd0 sector 0'
* May want to add a check for module on blacklist.

Absolute path for modprobe must be used to bypass PATH issue #1511 on CentOS and Redhat