### PR TITLE
Add DPDK requirements

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -10,6 +10,7 @@ from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.features import Sriov
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Lspci, Mount
+from lisa.operating_system import Ubuntu, Redhat
 from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
 
 
@@ -19,15 +20,18 @@ from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
     description="""
     This test suite check DPDK functionality
     """,
+    requirement=simple_requirement(
+        supported_features=[Sriov],
+        min_core_count=8,
+        min_nic_count=2,
+        supported_os=[Ubuntu, Redhat],
+    ),
 )
 class Dpdk(TestSuite):
     @TestCaseMetadata(
         description="""
             This test case checks DPDK can be built and installed correctly.
         """,
-        requirement=simple_requirement(
-            supported_features=[Sriov],
-        ),
         priority=1,
     )
     def check_dpdk_build(self, node: Node, log: Logger) -> None:

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -24,7 +24,6 @@ from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
         supported_features=[Sriov],
         min_core_count=8,
         min_nic_count=2,
-        supported_os=[Ubuntu, Redhat],
     ),
 )
 class Dpdk(TestSuite):

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -70,7 +70,6 @@ class DpdkTestpmd(Tool):
         "kernel-modules-extra",
         "kernel-headers",
     ]
-    _rte_target = "x86_64-native-linuxapp-gcc"
     _dpdk_github = "https://github.com/DPDK/dpdk.git"
     _ninja_url = (
         "https://github.com/ninja-build/ninja/releases/"


### PR DESCRIPTION
I'd like to add a requirement so we don't run the dpdk tests on unsupported hosts. ~~In my testing with this runbook this code doesn't work as expected so I'm hoping to get some feedback.~~ EDIT: removing OS requirement allows core and nic count requirement to work, so I'll just remove since the unsupported OSs are skipped anyway.

```
name: dpdk
include:
  - path: ../../runbook/azure.yml
extension:
  - .
platform:
  - type: azure
    admin_private_key_file: $(admin_private_key_file)
    keep_environment: $(keep_environment)
    azure:
      subscription_id: $(subscription_id)
    requirement:
      core_count:
        min: 16
      nic_count: 2
      azure:
        vm_size: Standard_D15_v2
        marketplace: $(marketplace_image)
        location: westus2

testcase:
  - criteria:
      name: check_dpdk_build
```

Result:
`dpdk_build: SKIPPED  no available environment: ["os_type/capability cannot support some of requirements, requirement: 'allowed:True,items:[<class 'lisa.operating_system.Redhat'>,<class 'lisa.operating_system.Ubuntu'>]'capability: 'allowed:True,items:[<class 'lisa.util.BaseClassMixin'>,<class 'lisa.operating_system.Posix'>,<class 'lisa.operating_system.OperatingSystem'>,<class 'lisa.operating_system.Redhat'>,<class 'object'>,<class 'lisa.operating_system.Linux'>,<class 'lisa.operating_system.Fedora'>]', "]`




