### PR TITLE
Lsmod was always returning False

### DIFF
--- a/lisa/tools/lsmod.py
+++ b/lisa/tools/lsmod.py
@@ -46,7 +46,7 @@ class Lsmod(Tool):
             )
 
         module_info = find_patterns_in_lines(result.stdout, [self.__output_pattern])
-        if any(mod_name in info for info in module_info):
+        if any(mod_name in info for sublist in module_info for info in sublist):
             return True
 
         return False


### PR DESCRIPTION
lsmod.py : line 49

48 module_info = find_patterns_in_lines(result.stdout, [self.__output_pattern])
49 if any(mod_name in info for info in module_info):
50         return True
module_info is of the form [[(str,str,str)]] so line 49 is checking for str in [(str)] comparing string to tuple never matches so Lsmod always returns False.

Adding an extra loop solves the issue but may not be the best solution.