### PR TITLE
Add hyperv_generation variable into AzureNodeSchema

### DIFF
--- a/docs/run_test/platform.rst
+++ b/docs/run_test/platform.rst
@@ -28,6 +28,7 @@ To run using vhd, add the following to runbook :
          azure:
             ...
             vhd: "<VHD URL>"
+            hyperv_generation: <1 or 2>
 
 The `<VHD URL>` can either be a SAS url or a blob url. If it is
 a SAS url, the image is copied to the resource group :
@@ -36,6 +37,9 @@ a SAS url, the image is copied to the resource group :
 container : `lisa-sas-copied` in the subscription used to run LISA,
 which could potentially increase the runtime. The copied VHD has
 to be manually deleted by the user.
+
+If the selected VM Size's Hypervisor Generation is '2', hyperv_generation
+parameter is necessary, and should be specified as 2.
 
 Running using marketplace
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -243,7 +243,7 @@
                         "storageAccountType": "Standard_LRS"
                     }
                 },
-                "hyperVGeneration": "V1"
+                "hyperVGeneration": "[concat('V', parameters('nodes')[copyIndex('imageCopy')]['hyperv_generation'])]"
             }
         },
         {

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -94,6 +94,7 @@ class AzureNodeSchema:
         default=None, metadata=field_metadata(data_key="shared_gallery")
     )
     vhd: str = ""
+    hyperv_generation: int = 1
     nic_count: int = 1
     enable_sriov: bool = False
     data_disk_count: int = 0

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1017,6 +1017,11 @@ class AzurePlatform(Platform):
             raise LisaException("vm_size is not detected before deploy")
         if not azure_node_runbook.location:
             raise LisaException("location is not detected before deploy")
+        if azure_node_runbook.hyperv_generation not in [1, 2]:
+            raise LisaException(
+                "hyperv_generation need value 1 or 2, "
+                f"but {azure_node_runbook.hyperv_generation}",
+            )
         if azure_node_runbook.vhd:
             # vhd is higher priority
             azure_node_runbook.vhd = self._get_deployable_vhd_path(


### PR DESCRIPTION
When use vhd to create VM, we need hypverV generation parameter. Before fix, if the vhd is gen2 image, it will has error.