### PR TITLE
Fix regression issue when only one test VM.

### DIFF
--- a/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
+++ b/Testscripts/Windows/SRIOV-RUN-COMMON-TEST.ps1
@@ -32,12 +32,6 @@ function Main {
                     $testVmExtraNICs = $testVmNICs | Where-Object {$_.Primary -eq $False}
                 }
             }
-            if ($null -eq $testVmData) {
-                throw "It's failed to get VM data. testVmData is null."
-            }
-            if ($null -eq $dependencyVmData) {
-                throw "It's failed to get VM data. dependencyVmData is null."
-            }
 
             $vmPort = $testVmData.SSHPort
             $publicIp = $testVmData.PublicIP


### PR DESCRIPTION
Fix regression issue of #1531 

One VM
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2021 14:37:25
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : 18.04.202109130
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:5

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                SRIOV-VERIFY-LSPCI                                                                PASS                 0.83 
      ARMImageName: canonical ubuntuserver 18.04-lts 18.04.202109130, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.4.0-1058-azure
```

Two VMs
```
[LISAv2 Test Results Summary]
Test Run On           : 09/18/2021 14:37:58
ARM Image Under Test  : canonical : ubuntuserver : 18.04-lts : latest
Total Test Cases      : 1 (1 Passed, 0 Failed, 0 Aborted, 0 Skipped)
Total Time (dd:hh:mm) : 0:0:8

   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 SRIOV                ETHTOOL-OFFLOADING-SETTING                                                        PASS                 5.09 
      ARMImageName: canonical ubuntuserver 18.04-lts 18.04.202108250, Networking: SRIOV, TestLocation: westus2, Kernel Version: 5.4.0-1056-azure
```