### PR TITLE
Handle error in delete environment task

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -390,7 +390,12 @@ class LisaRunner(BaseRunner):
         ) or (
             environment.status == EnvironmentStatus.Prepared and environment.is_in_use
         ):
-            self.platform.delete_environment(environment)
+            try:
+                self.platform.delete_environment(environment)
+            except Exception as identifier:
+                self._log.debug(
+                    f"error on deleting environment '{environment.name}': {identifier}"
+                )
         else:
             environment.status = EnvironmentStatus.Deleted
 


### PR DESCRIPTION
Error : 

```
Traceback (most recent call last):
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\main.py", line 91, in <module>
    exit_code = main()
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\main.py", line 80, in main
    exit_code = args.func(args)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\commands.py", line 46, in run
    raise identifier
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\commands.py", line 42, in run
    asyncio.run(runner.start())
  File "c:\python38\lib\asyncio\runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "c:\python38\lib\asyncio\base_events.py", line 616, in run_until_complete
    return future.result()
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runner.py", line 161, in start
    raise identifer
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runner.py", line 158, in start
    self._start_loop()
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runner.py", line 274, in _start_loop
    while task_manager.wait_worker() or remaining_runners:
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\util\parallel.py", line 49, in wait_worker
    result = future.result()
  File "c:\python38\lib\concurrent\futures\_base.py", line 432, in result
    return self.__get_result()
  File "c:\python38\lib\concurrent\futures\_base.py", line 388, in __get_result
    raise self._exception
  File "c:\python38\lib\concurrent\futures\thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runners\lisa_runner.py", line 443, in _run_task
    task_method(environment=environment, test_results=test_results, **kwargs)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runners\lisa_runner.py", line 306, in _deploy_environment_task
    self._delete_environment_task(environment=environment, test_results=[])
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\runners\lisa_runner.py", line 396, in _delete_environment_task
    self.platform.delete_environment(environment)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\platform_.py", line 176, in delete_environment
    self._delete_environment(environment, log)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 531, in _delete_environment
    self._delete_boot_diagnostic_container(resource_group_name, log)
  File "C:\Users\divyan\code\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 556, in _delete_boot_diagnostic_container
    for vm in vms:
  File "C:\Users\divyan\code\lsg-lisa\.venv\lib\site-packages\azure\core\paging.py", line 129, in __next__
    return next(self._page_iterator)
  File "C:\Users\divyan\code\lsg-lisa\.venv\lib\site-packages\azure\core\paging.py", line 76, in __next__
    self._response = self._get_next(self.continuation_token)
  File "C:\Users\divyan\code\lsg-lisa\.venv\lib\site-packages\azure\mgmt\compute\v2021_03_01\operations\_virtual_machines_operations.py", line 1088, in get_next
    map_error(status_code=response.status_code, response=response, error_map=error_map)
  File "C:\Users\divyan\code\lsg-lisa\.venv\lib\site-packages\azure\core\exceptions.py", line 105, in map_error
    raise error
azure.core.exceptions.ResourceNotFoundError: (ResourceGroupNotFound) Resource group 'lisa_Azure_fleet_smoke_20210920_210252_925_e23' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'lisa_Azure_fleet_smoke_20210920_210252_925_e23' could not be found.
```