### PR TITLE
Test Migration: lis_modules_check and verify_lis_modules_version

### DIFF
--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -1,0 +1,133 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from assertpy import assert_that
+from semver import VersionInfo
+
+from lisa import Logger, RemoteNode, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.operating_system import Redhat
+from lisa.sut_orchestrator.azure.tools import LisDriver
+from lisa.tools import Lsmod, Modinfo, Modprobe, Uname
+from lisa.util import SkippedException
+
+
+@TestSuiteMetadata(
+    area="core",
+    category="functional",
+    description="""
+    This test suite covers test cases previously handled by LISAv2:
+    LIS-MODULES-CHECK, VERIFY-LIS-MODULES-VERSION,
+    INITRD-MODULES-CHECK, RELOAD-MODULES-SMP
+
+    It is responsible for ensuring the Hyper V drivers are all present,
+    are included in initrd, and are all the same version.
+    """,
+)
+class HvModule(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        This test case will
+        1. Verify the list of given LIS kernel modules and verify if the version
+           matches with the Linux kernel release number. (Drivers loaded directly in
+           to the kernel are skipped)
+        """,
+        priority=1,
+    )
+    def verify_lis_modules_version(
+        self, case_name: str, log: Logger, node: RemoteNode
+    ) -> None:
+        if not isinstance(node.os, Redhat):
+            raise SkippedException(
+                f"{node.os.name} not supported. "
+                "This test case only supports Redhat distros."
+            )
+
+        lis_installed = node.os.package_exists("microsoft-hyper-v")
+
+        if not lis_installed:
+            raise SkippedException("This test case requires LIS to be installed")
+
+        modinfo = node.tools[Modinfo]
+        lis_driver = node.tools[LisDriver]
+        lis_version = lis_driver.get_version()
+
+        hv_modules = self._get_expected_modules(node)
+        for module in hv_modules:
+            module_version = VersionInfo.parse(modinfo.get_version(module))
+            assert_that(module_version).described_as(
+                f"Version of {module} does not match LIS version"
+            ).is_equal_to(lis_version)
+
+    @TestCaseMetadata(
+        description="""
+        This test case will
+        1. Verify the presence of all Hyper V drivers using lsmod
+           to look for the drivers not directly loaded into the kernel.
+        """,
+        priority=1,
+    )
+    def verify_hyperv_modules(
+        self, case_name: str, log: Logger, node: RemoteNode
+    ) -> None:
+        hv_modules = self._get_expected_modules(node)
+        distro_version = node.os.information.version
+
+        # Some versions of RHEL and CentOS have the LIS package installed
+        #   which includes extra drivers
+        if isinstance(node.os, Redhat):
+            modprobe = node.tools[Modprobe]
+            lis_installed = node.os.package_exists("microsoft-hyper-v")
+
+            if lis_installed:
+                hv_modules.append("pci_hyperv")
+                modprobe.run("pci_hyperv", sudo=True)
+
+            if (
+                distro_version >= "7.3.0" or distro_version < "7.5.0"
+            ) and lis_installed:
+                hv_modules.append("mlx4_en")
+                modprobe.run("mlx4_en", sudo=True)
+
+        # Counts the Hyper V drivers loaded as modules
+        missing_modules = []
+        lsmod = node.tools[Lsmod]
+        for module in hv_modules:
+            if lsmod.module_exists(module):
+                log.info(f"Module {module} present")
+            else:
+                log.error(f"Module {module} absent")
+                missing_modules.append(module)
+
+        assert_that(missing_modules).described_as(
+            "Not all Hyper V drivers are present."
+        ).is_length(0)
+
+    def _get_expected_modules(self, node: RemoteNode) -> list[str]:
+        """
+        Returns the hv_modules that are not directly loaded into the kernel and
+        therefore would be expected to show up in lsmod.
+        """
+        hv_modules_configuration = {
+            "hv_storvsc": "CONFIG_HYPERV_STORAGE",
+            "hv_netvsc": "CONFIG_HYPERV_NET",
+            "hv_vmbus": "CONFIG_HYPERV",
+            "hv_utils": "CONFIG_HYPERV_UTILS",
+            "hid_hyperv": "CONFIG_HID_HYPERV_MOUSE",
+            "hv_balloon": "CONFIG_HYPERV_BALLOON",
+            "hyperv_keyboard": "CONFIG_HYPERV_KEYBOARD",
+        }
+        uname = node.tools[Uname]
+        kernel_version = uname.get_linux_information().kernel_version_raw
+        config_path = f"/boot/config-{kernel_version}"
+
+        modules = []
+        for module in hv_modules_configuration:
+            if (
+                node.execute(
+                    f"grep ^{hv_modules_configuration[module]}=y {config_path}"
+                ).exit_code
+                != 0
+            ):
+                modules.append(module)
+
+        return modules


### PR DESCRIPTION
# verify_hyperv_modules
Checks whether the hv_modules are loaded directly into the kernel or loaded as modules.
Replaces LISAv2 test LIS-MODULES-CHECK

# verify_lis_modules_version
Only applied to CentOS and RHEL distros that have LIS installed. This test then ensured that all of the hv_modules are the same version as the LIS installation.
Replaces LISAv2 test VERIFY-LIS-MODULES-VERSION