### PR TITLE
clean up source code when rerun the existed environment

### DIFF
--- a/Testscripts/Linux/XDPDumpSetup.sh
+++ b/Testscripts/Linux/XDPDumpSetup.sh
@@ -77,6 +77,7 @@ function Install_XDPDump(){
 
     local install_ip="${1}"
     LogMsg "Cloning and building xdpdump"
+    ssh ${install_ip} "rm -rf bpf-samples"
     ssh ${install_ip} "git clone --recurse-submodules ${repo_url}"
     ssh ${install_ip} "cd bpf-samples/xdpdump && make"
     check_exit_status "xdpdump build on ${install_ip}" "exit"


### PR DESCRIPTION
Before fix, VERIFY-XDP-ACTION-DROP always fail when run after VERIFY-XDP-ACTION-ABORTED 

```
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 XDP                  VERIFY-XDP-ACTION-ABORTED                                                         PASS                 6.34 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202109080, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.8.0-1041-azure -> 5.8.0-1042-azure
    2 XDP                  VERIFY-XDP-ACTION-DROP                                                            FAIL                 4.52 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts latest, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.8.0-1041-azure -> 5.8.0-1042-azure
```

After fix, whenever compile the xdpdump, cleanup previous trace.
```
   ID TestArea             TestCaseName                                                                TestResult TestDuration(in minutes) 
-------------------------------------------------------------------------------------------------------------------------------------------
    1 XDP                  VERIFY-XDP-ACTION-ABORTED                                                         PASS                 5.98 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202109080, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.8.0-1041-azure -> 5.8.0-1042-azure
    2 XDP                  VERIFY-XDP-ACTION-DROP                                                            PASS                 3.81 
      ARMImageName: canonical 0001-com-ubuntu-server-focal 20_04-lts latest, Networking: SRIOV, OverrideVMSize: Standard_DS4_v2, TestLocation: westus2, Kernel Version: 5.8.0-1041-azure -> 5.8.0-1042-azure
```