### PR TITLE
Filterout Kernel Makefile warnings while getting kernelversion from source 

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -118,7 +118,6 @@ class SourceInstaller(BaseInstaller):
 
         self._install_build(node=node, code_path=code_path)
 
-        #result = node.execute("make kernelrelease", cwd=code_path)
         result = node.execute("make kernelrelease 2>/dev/null", cwd=code_path, shell=True)
         kernel_version = result.stdout
         result.assert_exit_code(0, f"failed on get kernel version: {kernel_version}")

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -118,7 +118,8 @@ class SourceInstaller(BaseInstaller):
 
         self._install_build(node=node, code_path=code_path)
 
-        result = node.execute("make kernelrelease", cwd=code_path)
+        #result = node.execute("make kernelrelease", cwd=code_path)
+        result = node.execute("make kernelrelease 2>/dev/null", cwd=code_path, shell=True)
         kernel_version = result.stdout
         result.assert_exit_code(0, f"failed on get kernel version: {kernel_version}")
 


### PR DESCRIPTION
The patch fixed issues like below :
2021-09-29 10:41:04.423[18464][DEBUG] lisa.installer_node.cmd[1979] cmd: ['make', 'kernelrelease'], cwd: /mnt/code/linux, shell: False, sudo: False, posix: True, remote: True
2021-09-29 10:41:05.391[20924][DEBUG] lisa.installer_node.cmd[1979].stdout arch/x86/Makefile:148: CONFIG_X86_X32 enabled but no binutils support
2021-09-29 10:41:05.564[20924][DEBUG] lisa.installer_node.cmd[1979].stdout 5.13.0-rc7
2021-09-29 10:41:05.580[18464][DEBUG] lisa.installer_node.cmd[1979] execution time: 1.156 sec, exit code: 0

