### PR TITLE
Ignore warnings in "make kernelversion"

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -118,7 +118,7 @@ class SourceInstaller(BaseInstaller):
 
         self._install_build(node=node, code_path=code_path)
 
-        result = node.execute("make kernelrelease", cwd=code_path)
+        result = node.execute("make kernelrelease 2>/dev/null", cwd=code_path, shell=True)
         kernel_version = result.stdout
         result.assert_exit_code(0, f"failed on get kernel version: {kernel_version}")
 


### PR DESCRIPTION
The patch fixed issues like below :
...] lisa.installer_node.cmd[1979] cmd: ['make', 'kernelrelease'], cwd: /mnt/code/linux, shell: False, sudo: False, posix: True, remote: True
...] lisa.installer_node.cmd[1979].stdout arch/x86/Makefile:148: CONFIG_X86_X32 enabled but no binutils support
...] lisa.installer_node.cmd[1979].stdout 5.13.0-rc7
...] lisa.installer_node.cmd[1979] execution time: 1.156 sec, exit code: 0