### PR TITLE
Migrated Test: verify_initrd_modules

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -611,7 +611,7 @@ class LisaRunner(BaseRunner):
 
             # check if there is platform requirement on test case
             if test_req.platform_type and len(test_req.platform_type) > 0:
-                check_result = test_req.platform_type.check(platform_type_set)
+                check_result = platform_type_set.check(test_req.platform_type)
                 if not check_result.result:
                     test_result.set_status(TestStatus.SKIPPED, check_result.reasons)
 

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -15,6 +15,7 @@ from .git import Git
 from .hwclock import Hwclock
 from .kdump import KdumpBase
 from .lscpu import Lscpu
+from .lsinitrd import Lsinitrd
 from .lsmod import Lsmod
 from .lspci import Lspci
 from .lsvmbus import Lsvmbus
@@ -50,6 +51,7 @@ __all__ = [
     "Hwclock",
     "KdumpBase",
     "Lscpu",
+    "Lsinitrd",
     "Lsmod",
     "Lspci",
     "Lsvmbus",

--- a/lisa/tools/find.py
+++ b/lisa/tools/find.py
@@ -23,6 +23,7 @@ class Find(Tool):
         name_pattern: str = "",
         path_pattern: str = "",
         ignore_case: bool = False,
+        sudo: bool = False,
     ) -> List[str]:
         if not self.node.shell.exists(start_path):
             raise LisaException(f"Path {start_path} does not exist.")
@@ -42,7 +43,7 @@ class Find(Tool):
         # for possibility of newline character in the file/folder name.
         cmd += " -print0"
 
-        result = self.run(cmd)
+        result = self.run(cmd, sudo=sudo)
         if result.exit_code != 0:
             raise LisaException(
                 f"{cmd} command got non-zero exit code: {result.exit_code}"

--- a/lisa/tools/lsinitrd.py
+++ b/lisa/tools/lsinitrd.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+from typing import cast
+
+from lisa.executable import Tool
+from lisa.operating_system import Posix
+from lisa.util import LisaException, find_patterns_in_lines, get_matched_str
+
+
+class Lsinitrd(Tool):
+    _non_comment_pattern = re.compile(r"^\s*[^#\s].*$", re.MULTILINE)
+    _modules_dep_file_pattern = re.compile(
+        r".*\s(?P<PATH>[^\s]*\/modules\.dep)\s*$", re.MULTILINE
+    )
+
+    @property
+    def command(self) -> str:
+        return "lsinitrd"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def _install(self) -> bool:
+        posix_os: Posix = cast(Posix, self.node.os)
+        posix_os.install_packages("dracut-core")
+        return self._check_exists()
+
+    def has_module(self, module_file_name: str, initrd_file_path: str = "") -> bool:
+        """
+        1) Finds path of modules.dep in initrd
+        2) Searches modules.dep for the module file name
+        """
+        result = self.run(
+            initrd_file_path,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=f"`lsinitrd {initrd_file_path}` failed.",
+        )
+
+        modules_dep_path = get_matched_str(
+            result.stdout, self._modules_dep_file_pattern
+        )
+
+        if not modules_dep_path:
+            raise LisaException(
+                f"[lsinitrd] modules.dep could not be found. "
+                f"Make sure the file is present in initrd image {initrd_file_path}."
+            )
+
+        result = self.run(
+            f"-f {modules_dep_path} {initrd_file_path}",
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=f"`lsinitrd -f /{modules_dep_path} "
+            f"{initrd_file_path}` failed.",
+        )
+        modules_required = find_patterns_in_lines(
+            result.stdout, [self._non_comment_pattern]
+        )
+
+        return any(
+            module_file_name in requirement for requirement in modules_required[0]
+        )


### PR DESCRIPTION
This test case covers the functionality tested by LISAv2 test INITRD-MODULES-CHECK.

This test case ensures all of the necessary modules are present in initrd.