### PR TITLE
Run with sudo for commands in /usr/sbin

### DIFF
--- a/lisa/tools/lsmod.py
+++ b/lisa/tools/lsmod.py
@@ -36,6 +36,7 @@ class Lsmod(Tool):
         no_error_log: bool = True,
     ) -> bool:
         result = self.run(
+            sudo=True,
             force_run=force_run,
             no_info_log=no_info_log,
             no_error_log=no_error_log,

--- a/lisa/tools/modinfo.py
+++ b/lisa/tools/modinfo.py
@@ -30,20 +30,13 @@ class Modinfo(Tool):
     ) -> str:
         result = self.run(
             mod_name,
+            sudo=True,
             force_run=force_run,
             no_info_log=no_info_log,
             no_error_log=no_error_log,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=f"Modinfo failed for module {mod_name}",
         )
-        if result.exit_code != 0:
-            # CentOS may not include the path when started,
-            # specify path and try again.
-            self._command = "/usr/sbin/modinfo"
-            result = self.run(
-                mod_name,
-                force_run=force_run,
-                no_info_log=no_info_log,
-                no_error_log=no_error_log,
-            )
         return result.stdout
 
     def get_version(


### PR DESCRIPTION
closes #1511 
Commands in /usr/sbin are not included in the PATH for some versions of CentOS and RHEL (other distros may be impacted) Using sudo generally fixes the issue because /usr/sbin is included in the sudo PATH.