### PR TITLE
Enable multiple poll-mode-drivers for DPDK testing

### DIFF
--- a/lisa/tools/echo.py
+++ b/lisa/tools/echo.py
@@ -38,6 +38,8 @@ class Echo(Tool):
             shell=True,
             sudo=sudo,
             timeout=timeout,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=f"echo failed to write to {file}",
         ).stdout
         assert_that(result).does_not_contain("Permission denied")
 


### PR DESCRIPTION
DPDK testing in v2 checks multiple poll mode driver configurations, this PR adds the ability to run previous tests (verify build and verify send-receive) with the default failsafe PMD and by using the netvsc pmd directly.