### PR TITLE
Add support of shared image gallery for lisav2

### DIFF
--- a/Documents/How-to-use.md
+++ b/Documents/How-to-use.md
@@ -56,6 +56,7 @@ If you add a custom test menu, you will need to re-build the Jenkins menu, and t
 
             ii. For Azure
                 $ARMImageName: The ARM image name
+                $SharedImageGallery: The shared image gallery path
 
             iii. For HyperV
                 $HyperVInstanceSize: The VM size of VM on HyperV

--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -25,6 +25,12 @@ function Start-LISAv2 {
 		# [Required] for Azure.
 		[string] $TestLocation="",
 		[string] $ARMImageName = "",
+		# Required for Azure if -ARMImageName and -OsVHD is not provided
+		# If the shared image gallery is in the same subscription that is used to run LISA, this parameter can be:
+		#     <image_gallery>/<image_definition>/<image_version>
+		# otherwise, this parameter should be:
+		#     <subscription_id>/<image_gallery>/<image_definition>/<image_version>
+		[string] $SharedImageGallery = "",
 		[string] $StorageAccount="",
 
 		# [Required] for Two Hosts HyperV
@@ -32,7 +38,7 @@ function Start-LISAv2 {
 
 		# [Required] Common for HyperV and Azure.
 		[string] $RGIdentifier = "",
-		[string] $OsVHD = "",   #... [Azure: Required only if -ARMImageName is not provided.]
+		[string] $OsVHD = "",   #... [Azure: Required if -ARMImageName and -SharedImageGallery are not provided.]
 								#... [HyperV: Mandatory]
 								#... [WSL: Mandatory, which can be the URL of the distro, or the path to the distro file on the local host]
 								#... [Ready: Not needed, and will be ignored if provided]
@@ -202,7 +208,7 @@ function Start-LISAv2 {
 			Write-LogInfo "Test $global:testId finished"
 
 			# Output text summary
-			$plainTextSummary = $testController.TestSummary.GetPlainTextSummary($OsVHD, $testController.ARMImageName, $OverrideVMSize)
+			$plainTextSummary = $testController.TestSummary.GetPlainTextSummary($OsVHD, $testController.ARMImageName, $testController.SharedImageGallery, $OverrideVMSize)
 			Write-LogInfo $plainTextSummary
 
 			# Zip the test log folder

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -286,7 +286,7 @@ Class TestSummary
 		$this.TestPriority = $TestPriority
 	}
 
-	[string] GetPlainTextSummary ($OSVHD, $ARMImageName, $OverrideVMSize)
+	[string] GetPlainTextSummary ($OSVHD, $ARMImageName, $SharedImageGallery, $OverrideVMSize)
 	{
 		$testDuration= [Datetime]::Now.ToUniversalTime() - $this.TestStartTime
 		$durationStr=$testDuration.Days.ToString() + ":" +  $testDuration.hours.ToString() + ":" + $testDuration.minutes.ToString()
@@ -302,6 +302,10 @@ Class TestSummary
 				$imageInfo = $_.Split(' ')
 				$str += "`r`nARM Image Under Test  : " + "$($imageInfo[0]) : $($imageInfo[1]) : $($imageInfo[2]) : $($imageInfo[3])"
 			}
+		}
+		# This is 'SharedImageGallery' from Controller
+		if ($SharedImageGallery) {
+			$str += "`r`nShared Image Under Test  : " + "$SharedImageGallery"
 		}
 		if ($OverrideVMSize) {
 			$overrideVMSizeArr = @($OverrideVMSize.Trim(", ").Split(',').Trim())

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Please follow the steps mentioned at [here](https://docs.microsoft.com/en-us/azu
                 <!--This 'ARMStorageAccount' is mandatory if '-StorageAccount' is not specified when Run-LISAv2.ps1, otherwise, it's optional-->
                 <ARMStorageAccount>ExistingStorage_Standard</ARMStorageAccount>
             </Subscription>
-            <!--This 'DefaultARMImageName' is the default value for '-ARMImageName' from Azure Gallery, when '-OsVHD' and '-ARMImageName' both are not specified form Run-LISAv2 test parameters-->
+            <!--This 'DefaultARMImageName' is the default value for '-ARMImageName' from Azure Gallery, when '-OsVHD', '-SharedImageGallery' and '-ARMImageName' are not specified form Run-LISAv2 test parameters-->
             <DefaultARMImageName>Canonical UbuntuServer 18.04-LTS Latest</DefaultARMImageName>
         </Azure>
         <HyperV>
@@ -197,7 +197,7 @@ Please follow the steps mentioned at [here](https://docs.microsoft.com/en-us/azu
 3. There are two ways to run LISAv2 tests:
   * Note when testing with 'Azure' platform:
 
-    * `-ARMImageName` is optional when testing with Azure Gallery Images (`-OsVHD` is used for testing with custom image). If both `-ARMImageName` and `-OsVHD` are not provided from Run-LISAv2.ps1 parameters, LISAv2 will try to use `<DefaultARMImageName>` from .\XML\GlobalConfigurations.xml as value of `-ARMImageName`. In this case, if `<DefaultARMImageName>` is not defined from `.\XML\GlobalConfigurations.xml`, exeption will be thrown.
+    * `-ARMImageName` is optional when testing with Azure Gallery Images (`-OsVHD` is used for testing with custom image). If `-ARMImageName`, `-SharedImageGallery` and `-OsVHD` are not provided from Run-LISAv2.ps1 parameters, LISAv2 will try to use `<DefaultARMImageName>` from .\XML\GlobalConfigurations.xml as value of `-ARMImageName`. In this case, if `<DefaultARMImageName>` is not defined from `.\XML\GlobalConfigurations.xml`, exeption will be thrown.
 
     * `-TestLocation` is optional. If `-TestLocation` is not provided from Run-LISAv2.ps1 parameters, LISAv2 will use the pre-defined `<TestLocation>` from test definition xml for each test case. If test case does not have any specific `<TestLocation>`, LISAv2 will choose an Azure Region automatically per test case Vm Size and Vm Family from current subscription context. The auto-selected TestLocation (Azure Region) is likely to have the most available vCPUs Compute resources for the target Vm Size and Vm Family of current test case. The available vCPU resources of all enabled Azure Regions is calculated and ordered by LISAv2 dynamically based on the current Compute vCPUs resource usage of current subscription when necessary. Run-LISAv2 without `-TestLocation` can be used when Compute resources for testing VM Sizes are not coming from single Azure Region, but distributed from different Azure Regions, in that case, running selected test cases all in once of LISAv2 execution is possible. If the target VM Size is not enabled from any region of current subscription, LISAv2 will report exception. If LISAv2 could not deploy a target Vm Size due to vCPUs Compute resource is not enough temporarily, LISAv2 will wait for at most 1 hour for any released Compute resources, and then continue the testing when resources getting available, or abort the current test case when waiting timeout.
 

--- a/Run-LisaV2.ps1
+++ b/Run-LisaV2.ps1
@@ -56,6 +56,12 @@ Param(
 	# [Required] for Azure.
 	[string] $TestLocation="",
 	[string] $ARMImageName = "",
+	# Required for Azure if -ARMImageName and -OsVHD are not provided
+	# If the shared image is in the same subscription that is used to run LISA, this parameter can be:
+	#     <image_gallery>/<image_definition>/<image_version>
+	# otherwise, this parameter should be:
+	#     <subscription_id>/<image_gallery>/<image_definition>/<image_version>
+	[string] $SharedImageGallery = "",
 	[string] $StorageAccount="",
 
 	# [Required] for Two Hosts HyperV
@@ -63,7 +69,7 @@ Param(
 
 	# [Required] Common for HyperV and Azure.
 	[string] $RGIdentifier = "",
-	[string] $OsVHD = "",   #... [Azure: Required only if -ARMImageName is not provided.]
+	[string] $OsVHD = "",   #... [Azure: Required only if -ARMImageName and -SharedImageGallery are not provided.]
 							#... [HyperV: Mandatory]
 							#... [WSL: Mandatory, which can be the URL of the distro, or the path to the distro file on the local host]
 							#... [Ready: Not needed, and will be ignored if provided]

--- a/TestControllers/TestController.psm1
+++ b/TestControllers/TestController.psm1
@@ -1014,11 +1014,16 @@ Class TestController {
 						Default { if ($this.TestCasePassStatus -notcontains $CurrentTestResult.TestResult) { $failureReason = "Pending Triage" }; break }
 					}
 				}
+				if ($CurrentTestData.SetupConfig.SharedImageGallery) {
+					$image = $CurrentTestData.SetupConfig.SharedImageGallery
+				} else {
+					$image = $CurrentTestData.SetupConfig.ARMImageName
+				}
 				$SQLQuery = Get-SQLQueryOfTelemetryData -TestPlatform $global:TestPlatform -TestLocation $CurrentTestData.SetupConfig.TestLocation -TestCategory $CurrentTestData.Category `
 					-TestArea $CurrentTestData.Area -TestName $CurrentTestData.TestName -CurrentTestResult $CurrentTestResult `
 					-ExecutionTag ($global:GlobalConfig).Global.($global:TestPlatform).ResultsDatabase.testTag -GuestDistro $GuestDistro -KernelVersion $global:FinalKernelVersion `
 					-HardwarePlatform $HardwarePlatform -LISVersion $LISVersion -HostVersion $HostVersion -VMSize $VMSize -VMGeneration $VMGen -Networking $Networking `
-					-ARMImageName $CurrentTestData.SetupConfig.ARMImageName -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL -TableName $dataTableName -TestPassID $this.TestPassID -FailureReason $failureReason
+					-ARMImageName $image -OsVHD $global:BaseOsVHD -BuildURL $env:BUILD_URL -TableName $dataTableName -TestPassID $this.TestPassID -FailureReason $failureReason
 
 				Upload-TestResultToDatabase -SQLQuery $SQLQuery
 

--- a/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
+++ b/Testscripts/Windows/CAPTURE-VHD-BEFORE-TEST.ps1
@@ -40,9 +40,12 @@ function Main {
             $Append += "-$env:BUILD_NUMBER"
         }
         #Copy the OS VHD with different name.
-        if ($CurrentTestData.SetupConfig.ARMImageName) {
+        if ($CurrentTestData.SetupConfig.ARMImageName -and !$CurrentTestData.SetupConfig.SharedImageGallery) {
             $ARMImage = $CurrentTestData.SetupConfig.ARMImageName.Split(" ")
             $newVHDName = "EOSG-AUTOBUILT-$($ARMImage[0])-$($ARMImage[1])-$($ARMImage[2])-$($ARMImage[3])-$Append"
+        } elseif ($CurrentTestData.SetupConfig.SharedImageGallery) {
+            $sharedImage = $CurrentTestData.SetupConfig.SharedImageGallery.Replace('/','-')
+            $newVHDName = "EOSG-AUTOBUILT-$sharedImage-$Append"
         }
         if ($global:BaseOsVHD) {
             $OSVhd = $global:BaseOsVHD.Split('/')[-1]

--- a/Testscripts/Windows/NESTED-KVM-NETPERF-PPS.ps1
+++ b/Testscripts/Windows/NESTED-KVM-NETPERF-PPS.ps1
@@ -56,7 +56,11 @@ function Send-ResultToDatabase ($GlobalConfig, $logDir, $ParseResultArray, $curr
 			$flag=0
 		}
 
-		$imageName = $CurrentTestData.SetupConfig.ARMImageName
+		if ($CurrentTestData.SetupConfig.SharedImageGallery) {
+			$imageName = $CurrentTestData.SetupConfig.SharedImageGallery
+		} else {
+			$imageName = $CurrentTestData.SetupConfig.ARMImageName
+		}
 
 		foreach ( $param in $currentTestData.TestParameters.param) {
 			if ($param -match "NestedCpuNum") {

--- a/Testscripts/Windows/NESTED-KVM-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
+++ b/Testscripts/Windows/NESTED-KVM-NTTTCP-DIFFERENT-L1-PUBLIC-BRIDGE.ps1
@@ -54,7 +54,11 @@ function Send-ResultToDatabase ($GlobalConfig, $logDir, $currentTestData) {
 			$flag=0
 		}
 
-		$imageName = $CurrentTestData.SetupConfig.ARMImageName
+		if ($CurrentTestData.SetupConfig.SharedImageGallery) {
+			$imageName = $CurrentTestData.SetupConfig.SharedImageGallery
+		} else {
+			$imageName = $CurrentTestData.SetupConfig.ARMImageName
+		}
 
 		foreach ( $param in $currentTestData.TestParameters.param)
 		{

--- a/Testscripts/Windows/NESTED-KVM-NTTTCP-PRIVATE-BRIDGE.ps1
+++ b/Testscripts/Windows/NESTED-KVM-NTTTCP-PRIVATE-BRIDGE.ps1
@@ -50,7 +50,11 @@ function Send-ResultToDatabase ($GlobalConfig, $logDir) {
         $l1GuestOSType    = "Linux"
         $l1GuestSize = $AllVMData.InstanceSize
         $l1GuestKernelVersion    = Get-Content "$logDir\VM_properties.csv" | Select-String "Kernel version"| ForEach-Object{$_ -replace ",Kernel version,",""}
-        $imageName = $CurrentTestData.SetupConfig.ARMImageName
+        if ($CurrentTestData.SetupConfig.SharedImageGallery) {
+            $imageName = $CurrentTestData.SetupConfig.SharedImageGallery
+        } else {
+            $imageName = $CurrentTestData.SetupConfig.ARMImageName
+        }
 
         # Get L2 guest info
         $l2GuestDistro    = Get-Content "$logDir\nested_properties.csv" | Select-String "OS type"| ForEach-Object{$_ -replace ",OS type,",""}

--- a/XML/TestParameters.xml
+++ b/XML/TestParameters.xml
@@ -43,6 +43,7 @@
 	<TestLocation></TestLocation>
 	<RGIdentifier></RGIdentifier>
 	<ARMImageName></ARMImageName>
+	<SharedImageGallery></SharedImageGallery>
 	<StorageAccount></StorageAccount>
 
 	<!-- [Required] for Two Hosts HyperV -->


### PR DESCRIPTION
If the shared image is in the same subscription that is used to run LISA, this parameter can be:
<image_gallery>/<image_definition>/<image_version>
otherwise, this parameter should be:
<subscription_id>/<image_gallery>/<image_definition>/<image_version>

For example:
-SharedImageGallery "SharedImageGalleryTest/Ubuntu1804/20211018.0.64"

SharedImageGallery can't coexist with ARMImageName or OsVhd.