### PR TITLE
Bugfixes: Ubuntu 20.04 missing pkg-config, NIC logic fix

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -27,7 +27,6 @@ class NicInfo:
         lower: str = "",
         pci_slot: str = "",
     ) -> None:
-        self.has_lower = lower != "" or pci_slot == ""
         self.upper = upper
         self.lower = lower
         self.pci_slot = pci_slot
@@ -114,16 +113,16 @@ class Nics(InitializableMixin):
         return len(self._nics) == 0
 
     def get_unpaired_devices(self) -> List[str]:
-        return [x.upper for x in self._nics.values() if not x.has_lower]
+        return [x.upper for x in self._nics.values() if not x.lower]
 
     def get_upper_nics(self) -> List[str]:
-        return [self._nics[x].upper for x in self._nics.keys()]
+        return [x.upper for x in self._nics.values() if x.lower]
 
     def get_lower_nics(self) -> List[str]:
-        return [self._nics[x].lower for x in self._nics.keys()]
+        return [x.lower for x in self._nics.values() if x.lower]
 
     def get_device_slots(self) -> List[str]:
-        return [self._nics[x].pci_slot for x in self._nics.keys()]
+        return [x.pci_slot for x in self._nics.values() if x.pci_slot]
 
     def get_nic(self, nic_name: str) -> NicInfo:
         return self._nics[nic_name]

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -126,7 +126,7 @@ class Dpdk(TestSuite):
         echo = node.tools[Echo]
         rping_build_env_vars = [
             "export RTE_TARGET=build",
-            f"export RTE_SDK={testpmd.dpdk_cwd.as_posix()}",
+            f"export RTE_SDK={testpmd.dpdk_path.as_posix()}",
         ]
         echo.write_to_file(
             ";".join(rping_build_env_vars), node.get_pure_path("~/.bashrc"), append=True
@@ -372,8 +372,8 @@ def initialize_node_resources(node: Node, log: Logger, pmd: str) -> DpdkTestReso
     node_nic_info = Nics(node)
     node_nic_info.initialize()
     assert_that(len(node_nic_info)).described_as(
-        "Test needs at least 2 NICs on the test node."
-    ).is_greater_than_or_equal_to(2)
+        "Test needs at least 1 NIC on the test node."
+    ).is_greater_than_or_equal_to(1)
 
     # bind test nic to desired pmd
     _, nic_to_bind = node_nic_info.get_test_nic()


### PR DESCRIPTION
Fixing a few bugs:
- Ubuntu 20.04 needs pkg-config installed, add the package to the list of 20.04 packages.
- Fixing a bug where synthetic interfaces could end up in the `get_upper_nics` list.
- Get rid of 'has_lower' logic error (we can just check 'lower' since "" will resolve to false)
