### PR TITLE
set a default value for max_nic_count

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1444,6 +1444,10 @@ class AzurePlatform(Platform):
             elif name == "EphemeralOSDiskSupported":
                 if eval(sku_capability.value) is True:
                     node_space.disk.disk_type.add(schema.DiskType.Ephemeral)
+        # for some new sizes, there is no MaxNetworkInterfaces capability
+        # and we have to set a default value for max_nic_count
+        if not node_space.network_interface.max_nic_count:
+            node_space.network_interface.max_nic_count = 8
 
         # some vm size do not have resource disk present
         # https://docs.microsoft.com/en-us/azure/virtual-machines/azure-vms-no-temp-disk


### PR DESCRIPTION
for some new sizes, there is no MaxNetworkInterfaces capability, it caused case skip.
![image](https://user-images.githubusercontent.com/10083705/139019737-18077182-fc56-41b0-9001-e5664ca223c8.png)
