### PR TITLE
allow for shell variables in rhel package installs

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -915,7 +915,7 @@ class Redhat(Fedora):
         if not signed:
             command += " --nogpgcheck"
 
-        install_result = self._node.execute(command, sudo=True)
+        install_result = self._node.execute(command, shell=True, sudo=True)
         self.__verify_package_result(install_result, packages)
 
     def _package_exists(self, package: str, signed: bool = True) -> bool:


### PR DESCRIPTION
Enable use of shell variables for packages in RHEL, useful for kernel-devel-$(uname -r)