### PR TITLE
swap to using dpdk-stable

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -75,7 +75,7 @@ class DpdkTestpmd(Tool):
         "kernel-headers",
     ]
     _rte_target = "x86_64-native-linuxapp-gcc"
-    _dpdk_github = "https://github.com/DPDK/dpdk.git"
+    _dpdk_github = "http://dpdk.org/git/dpdk-stable"
     _ninja_url = (
         "https://github.com/ninja-build/ninja/releases/"
         "download/v1.10.2/ninja-linux.zip"


### PR DESCRIPTION
DPDK test was previously using the dev version up on github, swap to using the 'stable' version from dpdk.org