### PR TITLE
Enable tar.gz source for dpdk

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -27,6 +27,7 @@ from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
 
 VDEV_TYPE = "net_vdev_netvsc"
 MAX_RING_PING_LIMIT_NS = 200000
+DPDK_STABLE_GIT = "http://dpdk.org/git/dpdk-stable"
 
 
 @TestSuiteMetadata(
@@ -134,7 +135,7 @@ class Dpdk(TestSuite):
         echo = node.tools[Echo]
         rping_build_env_vars = [
             "export RTE_TARGET=build",
-            f"export RTE_SDK={testpmd.dpdk_path.as_posix()}",
+            f"export RTE_SDK={str(testpmd.dpdk_path)}",
         ]
         echo.write_to_file(
             ";".join(rping_build_env_vars), node.get_pure_path("~/.bashrc"), append=True
@@ -361,7 +362,12 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
 def initialize_node_resources(
     node: Node, log: Logger, variables: Dict[str, Any], pmd: str
 ) -> DpdkTestResources:
+    dpdk_source = variables.get("dpdk_source", DPDK_STABLE_GIT)
     dpdk_branch = variables.get("dpdk_branch", "")
+    log.info(
+        "Dpdk initialize_node_resources running"
+        f"found dpdk_source '{dpdk_source}' and dpdk_branch '{dpdk_branch}'"
+    )
 
     network_interface_feature = node.features[NetworkInterface]
     sriov_is_enabled = network_interface_feature.is_enabled_sriov()
@@ -378,6 +384,7 @@ def initialize_node_resources(
 
     # initialize testpmd tool (installs dpdk)
     testpmd = DpdkTestpmd(node)
+    testpmd.set_dpdk_source(dpdk_source)
     testpmd.set_dpdk_branch(dpdk_branch)
     testpmd.install()
 


### PR DESCRIPTION
Enable tar.gz source archives for dpdk testing. This required a few changes:
- Add a variable for dpdk_source, this can be a git link or a link to a targz archive.
- get and expand the archive, rename it from it's expanded name which has the version number to just dpdk to match the git checkout name
- Enable a default path when neither is selected where the regular dpdk-stable git is used and main is checked out.
The if conditions in 'install' were getting too nested, so some minor cleanup is in this commit too:
- Remove the return type from install_dependencies since it is unused.