### PR TITLE
Tar tool: enable strip-components and file content listing

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -95,7 +95,8 @@ class Kexec(Tool):
         wget = self.node.tools[Wget]
         kexec_tar = wget.get(self._kexec_repo, str(tool_path))
         tar = self.node.tools[Tar]
-        kexec_source = tar.extract(kexec_tar, str(tool_path))
+        tar.extract(kexec_tar, str(tool_path))
+        kexec_source = tar.get_root_folder(kexec_tar)
         code_path = tool_path.joinpath(kexec_source)
         self.node.tools[Gcc]
         make = self.node.tools[Make]

--- a/lisa/tools/tar.py
+++ b/lisa/tools/tar.py
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from typing import Callable, List
+
+from assertpy import assert_that
+
 from lisa.executable import Tool
 from lisa.util import LisaException
 
@@ -10,16 +14,86 @@ class Tar(Tool):
     def command(self) -> str:
         return "tar"
 
-    def extract(self, file: str, dest_dir: str) -> str:
+    def extract(
+        self,
+        file: str,
+        dest_dir: str,
+        strip_components: int = 0,
+    ) -> None:
         # create folder when it doesn't exist
+        assert_that(strip_components).described_as(
+            "--strip-components arg for tar must be int >= 0"
+        ).is_greater_than_or_equal_to(0)
         self.node.execute(f"mkdir -p {dest_dir}", shell=True)
-        result = self.run(
-            f"-xvf {file} -C {dest_dir}", shell=True, force_run=True, sudo=True
-        )
+        tar_cmd = f"-xvf {file} -C {dest_dir}"
+        if strip_components:
+            # optionally strip N top level components from a tar file
+            tar_cmd += f" --strip-components={strip_components}"
+        result = self.run(tar_cmd, shell=True, force_run=True, sudo=True)
         if result.exit_code != 0:
             raise LisaException(
                 f"Failed to extract file to {dest_dir}, {result.stderr}"
             )
-        # Get the folder name of the extracted file
-        source_name = result.stdout.split("/")[0]
-        return source_name
+
+    def list(
+        self, file: str, recursive: bool = True, folders_only: bool = False
+    ) -> List[str]:
+        # return a list of all the files and folders in a tar file
+        result = self.run(
+            f"-tf {file}",
+            shell=True,
+            force_run=True,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Could not list items in tar file {file}"
+            ),
+        )
+
+        # helper functions for processing stdout.splitlines()
+        # folders are listed with trailing slashes, so:
+        # ex: f1/f2/ f1/ f1/f2/f3/
+
+        def is_folder(tar_content: str) -> bool:
+            return tar_content.endswith("/")
+
+        def get_file_depth(tar_content: str) -> int:
+            slash_count = tar_content.count("/")
+            if is_folder(tar_content):  # contains >= 1 slash
+                return slash_count - 1
+            else:
+                return slash_count
+
+        def is_top_level(tar_content: str) -> bool:
+            return get_file_depth(tar_content) == 0
+
+        content = result.stdout.splitlines()
+        output: List[str] = []
+        filters: List[Callable[[str], bool]] = []
+
+        # assemble list of tests we need to apply
+        if not recursive:
+            filters.append(is_top_level)
+        if folders_only:
+            filters.append(is_folder)
+        # if we need to test anything, add inputs that pass all tests
+        if filters:
+            for item in content:
+                if all(map(lambda x: x(item), filters)):
+                    output.append(item)
+            return output
+        else:
+            return content
+
+    def get_root_folder(self, file: str) -> str:
+        # convenience method, get the top level output folder
+        # and remove the trailing slash
+        # NOTE: Will assert if there are multiple root folders.
+        folders = self.list(file, recursive=False, folders_only=True)
+        assert_that(folders).described_as(
+            (
+                "ERROR: get_root_folder was called but tar file "
+                "{file} has multiple top level output folders."
+            )
+        ).is_length(1)
+        return folders[0].replace("/", "")


### PR DESCRIPTION
- add 'list components' feature to check tar contents
- add methods to get output directories from a tar files
- add convenience method to get the single output dir name if
    there is a single one
- add support for 'strip components' flag which is useful for renaming
    an output dir if there is a single top-level-folder in the tar.
- fix use of Tar tool in kdump test to use the new version of the tool.