### PR TITLE
Add RHEL missing package fail, add warning for nonfatal error code

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -74,6 +74,18 @@ class UnsupportedOperationException(LisaException):
     ...
 
 
+class MissingPackagesException(LisaException):
+    """
+    Use to signal that packages were not found during installation.
+    """
+
+    def __init__(self, packages: List[str]) -> None:
+        self.packages = packages
+
+    def __str__(self) -> str:
+        return f"Package manager could not install packages: {' '.join(self.packages)}"
+
+
 class UnsupportedDistroException(LisaException):
     """
     This exception is used to indicate that a test case does not support the testing


### PR DESCRIPTION
yum error code 1 means DNF handled an error with installation. Not checking for missing packages could result in the package installation failing silently, since missing packages halt the installation.
This adds a check for missing packages and fails if they are present. Other handled errors result in a warning.