### PR TITLE
name change for test to fit convention

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -95,7 +95,7 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
         ),
     )
-    def verify_sriov_rescind_failover_send_only(
+    def verify_dpdk_sriov_rescind_failover_send_only(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
 


### PR DESCRIPTION
dpdk test name was missing 'dpdk' in name