### PR TITLE
Update stress-ng

### DIFF
--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2098,7 +2098,7 @@ Function Publish-App([string]$appName, [string]$customIP, [string]$appGitURL, [s
         -command "cd $appName; git checkout tags/$appGitTag > /dev/null 2>&1"
     }
     if ($appName -eq "stress-ng") {
-        $appInstall = "cd $appName; echo '${password}' | sudo -S make install"
+        $appInstall = "cd $appName; echo '${password}' | sudo -S make"
         $retVal = Run-LinuxCmd -username $user -password $password -ip $customIP -port $VMSSHPort `
              -command $appInstall
     }

--- a/Testscripts/Linux/Linux-Kernel-Self-Tests.sh
+++ b/Testscripts/Linux/Linux-Kernel-Self-Tests.sh
@@ -81,14 +81,18 @@ function install_dependencies() {
             deb_packages=(make git gcc flex bison clang llvm fuse gcc-multilib libfuse2 \
                         libc6-i386 libc6-dev-i386 libelf-dev libcap-ng-dev libfuse-dev \
                         libpopt-dev libnuma-dev libmount-dev libcap-dev build-essential \
-                        pkg-config bc rsync)
+                        pkg-config bc rsync libaio-dev libapparmor-dev libattr1-dev libbsd-dev \
+                        libgcrypt11-dev libipsec-mb-dev libjudy-dev libkeyutils-dev \
+                        libsctp-dev libatomic1 zlib1g-dev libkmod-dev)
             LogMsg "Dependency package names： ${deb_packages[@]}"
             install_package "${deb_packages[@]}" >> $BUILDING_LOG 2>&1
             ;;
         centos_7 | centos_8 | redhat_7 | redhat_8)
             rpm_packages=(make git gcc flex bison clang llvm fuse libcap-ng-devel popt-devel \
                         libcap-devel glibc-devel.*i686 fuse-devel elfutils-devel \
-                        numactl-devel glibc-devel)
+                        numactl-devel libaio-devel libattr-devel libbsd-devel \
+                        libgcrypt-devel Judy-devel keyutils-libs-devel \
+                        lksctp-tools-devel libatomic zlib-devel kmod-devel)
             if [[ $DISTRO != centos_8 ]]; then
                 rpm_packages+=(libmount-devel glibc-static)
             fi
@@ -99,7 +103,9 @@ function install_dependencies() {
         suse*)
             suse_packages=(make git gcc flex bison fuse libcap-ng-devel fuse-devel popt-devel \
                          numactl libnuma-devel libmount-devel libcap-devel libcap-progs \
-                         glibc-devel libelf-devel glibc-static)
+                         glibc-devel libelf-devel glibc-static keyutils-devel libaio-devel \
+                         libapparmor-devel libattr-devel libbsd-devel libseccomp-devel \
+                         lksctp-tools-devel libatomic1 zlib-devel libkmod-devel)
             LogMsg "Dependency package names： ${suse_packages[@]}"
             install_package "${suse_packages[@]}" >> $BUILDING_LOG 2>&1
             ;;

--- a/XML/Other/ReplaceableTestParameters.xml
+++ b/XML/Other/ReplaceableTestParameters.xml
@@ -409,7 +409,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>APP_GIT_TAG</ReplaceThis>
-		<ReplaceWith>V0.07.16</ReplaceWith>
+		<ReplaceWith>V0.13.07</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>DYNAMIC_MEMORY_STRESSAPP</ReplaceThis>
@@ -429,7 +429,7 @@ Scenario 2 : You need to run all the performance tests quickly.
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>STRESS-NG_TAG</ReplaceThis>
-		<ReplaceWith>V0.07.16</ReplaceWith>
+		<ReplaceWith>V0.13.07</ReplaceWith>
 	</Parameter>
 	<Parameter>
 		<ReplaceThis>HYPERV_PERF_NIC_NAME</ReplaceThis>


### PR DESCRIPTION
[Stress-ng](https://github.com/ColinIanKing/stress-ng) V0.07.16 no longer works with newer version of gcc 11.2.0
