### PR TITLE
DPDK: Ubuntu needs backports enabled for all releases

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -645,9 +645,7 @@ class Debian(Linux):
 
         return repositories
 
-    def add_repository(
-        self, url: str, codename: str, packages: str = "main", key_location: str = ""
-    ) -> None:
+    def add_repository(self, repo: str, key_location: str = "") -> None:
         if key_location:
             wget = self._node.tools[Wget]
             key_file_path = wget.get(
@@ -662,8 +660,9 @@ class Debian(Linux):
             )
         # This command will trigger apt update too, so it doesn't need to update
         # repos again.
+
         self._node.execute(
-            cmd=f'apt-add-repository "deb {url} {codename} {packages}"',
+            cmd=f'apt-add-repository "{repo}"',
             sudo=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="fail to add repository",

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -278,6 +278,8 @@ class DpdkTestpmd(Tool):
         cwd = node.working_path
 
         if isinstance(node.os, Ubuntu):
+            # DPDK requires backports channel for all releases
+            node.os.add_repository("ppa:canonical-server/server-backports")
             if "18.04" in node.os.information.release:
                 node.os.install_packages(list(self._ubuntu_packages_1804))
                 self.__execute_assert_zero("pip3 install --upgrade meson", cwd)
@@ -287,23 +289,6 @@ class DpdkTestpmd(Tool):
                 )
                 self.__execute_assert_zero("pip3 install --upgrade ninja", cwd)
             elif "20.04" in node.os.information.release:
-                # 20-04 requires backports to be added for dpdk related fixes
-                node.execute(
-                    "sudo add-apt-repository ppa:canonical-server/server-backports -y",
-                    sudo=True,
-                    expected_exit_code=0,
-                    expected_exit_code_failure_message=(
-                        "Could not add backports repo."
-                    ),
-                )
-                node.execute(
-                    "sudo apt-get update -y",
-                    sudo=True,
-                    expected_exit_code=0,
-                    expected_exit_code_failure_message=(
-                        "Error with apt-get update (post-backports repo add)"
-                    ),
-                )
                 node.os.install_packages(list(self._ubuntu_packages_2004))
 
         elif isinstance(node.os, Redhat):

--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -43,9 +43,11 @@ class XdpDump(Tool):
                 raise UnsupportedDistroException(self.node.os)
 
             self.node.os.add_repository(
-                url=f"http://apt.llvm.org/{self.node.os.information.codename}/",
-                codename=f"llvm-toolchain-{self.node.os.information.codename}-6.0",
-                packages="main",
+                repo=(
+                    f"deb http://apt.llvm.org/{self.node.os.information.codename}/ "
+                    f"llvm-toolchain-{self.node.os.information.codename}-6.0 "
+                    "main"
+                ),
                 key_location="https://apt.llvm.org/llvm-snapshot.gpg.key",
             )
 


### PR DESCRIPTION
Ubuntu previously used backports only for 20.04, 18.04 also requires them for dpdk packages.