### PR TITLE
-y is indeed needed

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -684,7 +684,7 @@ class Debian(Linux):
         # repos again.
 
         self._node.execute(
-            cmd=f'apt-add-repository "{repo}"',
+            cmd=f'apt-add-repository -y "{repo}"',
             sudo=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="fail to add repository",


### PR DESCRIPTION
add apt repo needs -y for some repos that ask a question and want confirmation.