### PR TITLE
Skip replace boot kernel for focal gen2 + fde kernel.

### DIFF
--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -127,8 +127,13 @@ class KernelInstallerTransformer(Transformer):
         installed_kernel_version = installer.install()
         self._log.info(f"installed kernel version: {installed_kernel_version}")
 
-        posix = cast(Posix, node.os)
-        posix.replace_boot_kernel(installed_kernel_version)
+        # for ubuntu cvm kernel, there is no menuentry added into grub file
+        if (
+            hasattr(installer.runbook, "source")
+            and installer.runbook.source != "linux-image-azure-fde"
+        ):
+            posix = cast(Posix, node.os)
+            posix.replace_boot_kernel(installed_kernel_version)
 
         self._log.info("rebooting")
         node.reboot()


### PR DESCRIPTION
when install fde kernel (cvm), there is no menu entry generated into grub file. It will fail in step replace_boot_kernel.