### PR TITLE
Fix error on incorrect path of env log

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import sys
 from collections import UserDict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -30,6 +29,7 @@ from lisa.util import (
     get_datetime_path,
     hookimpl,
     hookspec,
+    is_unittest,
     plugin_manager,
 )
 from lisa.util.logger import create_file_handler, get_logger, remove_handler
@@ -244,7 +244,7 @@ class Environment(ContextMixin, InitializableMixin):
     @property
     def log_path(self) -> Path:
         # avoid to create path for UT. There may be path conflict in UT.
-        if "unittest" in sys.modules:
+        if is_unittest():
             return Path()
 
         if not self._log_path:

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
@@ -38,6 +37,7 @@ from lisa.util import (
     fields_to_dict,
     get_datetime_path,
     hookspec,
+    is_unittest,
     plugin_manager,
     set_filtered_fields,
 )
@@ -635,7 +635,7 @@ class TestSuite:
                 break
             sleep(0.1)
         # avoid to create folder for UT
-        if "unittest" not in sys.modules:
+        if not is_unittest():
             path.mkdir(parents=True)
         return path
 

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -451,3 +452,7 @@ def field_metadata(
         decoder=decoder,
         mm_field=field_function(*args, **kwargs),
     )
+
+
+def is_unittest() -> bool:
+    return "unittest" in sys.argv[0]

--- a/lisa/util/logger.py
+++ b/lisa/util/logger.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, TextIO, Union, cast
 
 from lisa.secret import mask
-from lisa.util import LisaException, filter_ansi_escape
+from lisa.util import LisaException, filter_ansi_escape, is_unittest
 
 # to prevent circular import, hard code it here.
 ENV_KEY_RUN_LOCAL_PATH = "LISA_RUN_LOCAL_PATH"
@@ -154,7 +154,7 @@ def add_handler(
     logger: Optional[logging.Logger] = None,
     formatter: Optional[logging.Formatter] = None,
 ) -> None:
-    if "unittest" in sys.modules:
+    if is_unittest():
         return None
 
     if logger is None:
@@ -170,7 +170,7 @@ def add_handler(
 def remove_handler(
     log_handler: logging.Handler, logger: Optional[logging.Logger] = None
 ) -> None:
-    if "unittest" in sys.modules:
+    if is_unittest():
         return None
 
     if logger is None:
@@ -184,7 +184,7 @@ def create_file_handler(
     formatter: Optional[logging.Formatter] = None,
 ) -> logging.FileHandler:
     # skip to create log file in UT
-    if "unittest" in sys.modules:
+    if is_unittest():
         return None  # type: ignore
 
     file_handler = logging.FileHandler(path, "w", "utf-8")


### PR DESCRIPTION
The root cause is the approach of detecting unittest doesn't work in
lab. So, change it to check command line, it looks more reliable.