### PR TITLE
add a first time init for lscpu

### DIFF
--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -97,7 +97,10 @@ class Lscpu(Tool):
         return architecture
 
     def get_core_count(self, force_run: bool = False) -> int:
-        result = self.run(force_run=force_run)
+        if not self._core_count:
+            result = self.run(force_run=True)
+        else:
+            result = self.run(force_run=force_run)
         matched = self.__vcpu.findall(result.stdout)
         assert_that(
             len(matched),


### PR DESCRIPTION
Add a first-time init if there isn't any core count info yet.