### PR TITLE
Ignore shared cache azure credentials

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -811,7 +811,9 @@ class AzurePlatform(Platform):
                 ] = azure_runbook.service_principal_client_id
             if azure_runbook.service_principal_key:
                 os.environ["AZURE_CLIENT_SECRET"] = azure_runbook.service_principal_key
-            credential = DefaultAzureCredential()
+            credential = DefaultAzureCredential(
+                exclude_shared_token_cache_credential=True
+            )
 
             with SubscriptionClient(credential) as self._sub_client:
                 # suppress warning message by search for different credential types


### PR DESCRIPTION
Adding this line to avoid this issue I've been hitting on the lisa servers:

`2022-01-05 01:07:51.859[35552][ERROR] lisa. DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials:
        EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
        ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no managed identity endpoint
found.
        SharedTokenCacheCredential: Azure Active Directory error '(invalid_grant) AADSTS700082: The refresh token has
expired due to inactivity. The token was issued on 2021-09-28T21:28:21.6690275Z and was inactive for 90.00:00:00.
Trace ID: 147c3384-cb98-401c-ab38-a9a0ce987302
Correlation ID: d6f8e18b-6ec2-4b0f-af0c-dc83ef893a52
Timestamp: 2022-01-05 01:07:51Z'
Traceback (most recent call last):
  File "C:\Users\mamcgove\lisa\lisa\main.py", line 102, in <module>
    exit_code = main()
  File "C:\Users\mamcgove\lisa\lisa\main.py", line 88, in main
    exit_code = args.func(args)
  File "C:\Users\mamcgove\lisa\lisa\commands.py", line 46, in run
    raise identifier
  File "C:\Users\mamcgove\lisa\lisa\commands.py", line 42, in run
    asyncio.run(runner.start())
  File "C:\Program Files\Python39\lib\asyncio\runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "C:\Program Files\Python39\lib\asyncio\base_events.py", line 642, in run_until_complete
    return future.result()
  File "C:\Users\mamcgove\lisa\lisa\runner.py", line 195, in start
    raise identifer
  File "C:\Users\mamcgove\lisa\lisa\runner.py", line 192, in start
    self._start_loop()
  File "C:\Users\mamcgove\lisa\lisa\runner.py", line 358, in _start_loop
    runner = next(runner_iterator)
  File "C:\Users\mamcgove\lisa\lisa\runner.py", line 246, in _fetch_runners
    for runner in self._generate_runners(
  File "C:\Users\mamcgove\lisa\lisa\runner.py", line 285, in _generate_runners
    runner.initialize()
  File "C:\Users\mamcgove\lisa\lisa\util\__init__.py", line 218, in initialize
    raise identifier
  File "C:\Users\mamcgove\lisa\lisa\util\__init__.py", line 215, in initialize
    self._initialize(*args, **kwargs)
  File "C:\Users\mamcgove\lisa\lisa\runners\lisa_runner.py", line 49, in _initialize
    self.platform.initialize()
  File "C:\Users\mamcgove\lisa\lisa\util\__init__.py", line 218, in initialize
    raise identifier
  File "C:\Users\mamcgove\lisa\lisa\util\__init__.py", line 215, in initialize
    self._initialize(*args, **kwargs)
  File "C:\Users\mamcgove\lisa\lisa\sut_orchestrator\azure\platform_.py", line 778, in _initialize
    self._initialize_credential()
  File "C:\Users\mamcgove\lisa\lisa\sut_orchestrator\azure\platform_.py", line 821, in _initialize_credential
    subscription = self._sub_client.subscriptions.get(
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\mgmt\resource\subscriptions\v2019_11_01\operations\_subscriptions_operations.py", line 160, in get
    pipeline_response = self._client._pipeline.run(request, stream=False, **kwargs)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\_base.py", line 211, in run
    return first_node.send(pipeline_request)  # type: ignore
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\_base.py", line 71, in send
    response = self.next.send(request)
  [Previous line repeated 2 more times]
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\mgmt\core\policies\_base.py", line 47, in send
    response = self.next.send(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\policies\_redirect.py", line 158, in send
    response = self.next.send(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\policies\_retry.py", line 445, in send
    response = self.next.send(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\policies\_authentication.py", line 117, in send
    self.on_request(request)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\core\pipeline\policies\_authentication.py", line 94, in on_request
    self._token = self._credential.get_token(*self._scopes)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\identity\_credentials\default.py", line 150, in get_token
    return super(DefaultAzureCredential, self).get_token(*scopes, **kwargs)
  File "C:\Users\mamcgove\AppData\Local\pypoetry\Cache\virtualenvs\lisa-DBTAmbFY-py3.9\lib\site-packages\azure\identity\_credentials\chained.py", line 90, in get_token
    raise ClientAuthenticationError(message=message)
azure.core.exceptions.ClientAuthenticationError: DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials:
        EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
        ManagedIdentityCredential: ManagedIdentityCredential authentication unavailable, no managed identity endpoint
found.
        SharedTokenCacheCredential: Azure Active Directory error '(invalid_grant) AADSTS700082: The refresh token has
expired due to inactivity. The token was issued on 2021-09-28T21:28:21.6690275Z and was inactive for 90.00:00:00.
Trace ID: 147c3384-cb98-401c-ab38-a9a0ce987302
Correlation ID: d6f8e18b-6ec2-4b0f-af0c-dc83ef893a52`
