### PR TITLE
Revert "Ignore shared cache azure credentials"

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -812,9 +812,7 @@ class AzurePlatform(Platform):
                 ] = azure_runbook.service_principal_client_id
             if azure_runbook.service_principal_key:
                 os.environ["AZURE_CLIENT_SECRET"] = azure_runbook.service_principal_key
-            credential = DefaultAzureCredential(
-                exclude_shared_token_cache_credential=True
-            )
+            credential = DefaultAzureCredential()
 
             with SubscriptionClient(credential) as self._sub_client:
                 # suppress warning message by search for different credential types


### PR DESCRIPTION
Reverts microsoft/lisa#1680
When provision time is more than 5 mins, encounter the exception below.

```
2022-01-05 03:43:45.563[4884][ERROR] lisa.runner[0] case failed 
Traceback (most recent call last): 
File "D:\a\_work\1\s\lisa\lisa\runners\lisa_runner.py", line 282, in _deploy_environment_task 
self.platform.deploy_environment(environment) 
File "D:\a\_work\1\s\lisa\lisa\platform_.py", line 162, in deploy_environment 
self._deploy_environment(environment, log) 
File "D:\a\_work\1\s\lisa\lisa\sut_orchestrator\azure\platform_.py", line 519, in _deploy_environment 
raise identifier 
File "D:\a\_work\1\s\lisa\lisa\sut_orchestrator\azure\platform_.py", line 513, in _deploy_environment 
self._deploy(location, deployment_parameters, log) 
File "D:\a\_work\1\s\lisa\lisa\sut_orchestrator\azure\platform_.py", line 1196, in _deploy 
result = wait_operation(deployment_operation) 
File "D:\a\_work\1\s\lisa\lisa\sut_orchestrator\azure\common.py", line 337, in wait_operation 
raise Exception("Timeout on operation") 
Exception: Timeout on operation 
```