### PR TITLE
Run-LinuxCmd: Don't throw away the last line of command output

### DIFF
--- a/Libraries/TestHelpers.psm1
+++ b/Libraries/TestHelpers.psm1
@@ -562,7 +562,7 @@ Function Run-LinuxCmd([string] $username, [string] $password, [string] $ip, [str
 			$jobOut = Receive-Job $runLinuxCmdJob 2> $LogDir\$randomFileName
 			if ($jobOut) {
 				$jobOut = $jobOut.Replace("[sudo] password for $username`: ", "").Replace("Password: ", "")
-				$RunLinuxCmdOutput = ($jobOut | Select-Object -SkipLast 1) -Join [Environment]::NewLine
+				$RunLinuxCmdOutput = $jobOut -Replace 'AZURE-LINUX-EXIT-CODE-[0-9]+$',''
 			}
 			$LinuxExitCode = (Select-String -Pattern "AZURE-LINUX-EXIT-CODE-[0-9]*" -InputObject $jobOut).Matches.Value
 


### PR DESCRIPTION
Fix a bug that caused the last line of command output to be lost if it
didn't contain a newline at the end of the line.

If the $command passed to Run-LinuxCmd() was "printf 1", which doesn't
print a trailing newline, then $RunLinuxCmdOutput would be an empty
string after the attempt to split up the script's output from the
AZURE-LINUX-EXIT-CODE-* string. $jobOut would be
"1AZURE-LINUX-EXIT-CODE-0" and, therefore, $RunLinuxCmdOutput would be
"".

Fix this by only removing the AZURE-LINUX-EXIT-CODE-* portion of the
$jobOut string.

Signed-off-by: Tyler Hicks <tyhicks@linux.microsoft.com>