### PR TITLE
Add support for platform specific modules.

### DIFF
--- a/lisa/main.py
+++ b/lisa/main.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple
 
 from retry import retry
 
+import lisa.mixin_modules  # noqa: F401
 from lisa.parameter_parser.argparser import parse_args
 from lisa.util import constants, get_datetime_path
 from lisa.util.logger import (

--- a/lisa/mixin_modules.py
+++ b/lisa/mixin_modules.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+# The file imports all the mix-in types that can be initialized
+# using reflection.
+
+import lisa.combinators.batch_combinator  # noqa: F401
+import lisa.combinators.csv_combinator  # noqa: F401
+import lisa.combinators.grid_combinator  # noqa: F401
+import lisa.notifiers.console  # noqa: F401
+import lisa.notifiers.env_stats  # noqa: F401
+import lisa.notifiers.html  # noqa: F401
+import lisa.notifiers.text_result  # noqa: F401
+import lisa.runners.legacy_runner  # noqa: F401
+import lisa.runners.lisa_runner  # noqa: F401
+import lisa.sut_orchestrator.azure.hooks  # noqa: F401
+import lisa.sut_orchestrator.azure.transformers  # noqa: F401
+import lisa.sut_orchestrator.ready  # noqa: F401
+import lisa.transformers.kernel_source_installer  # noqa: F401
+import lisa.transformers.script_transformer  # noqa: F401
+import lisa.transformers.to_list  # noqa: F401

--- a/lisa/parameter_parser/runbook.py
+++ b/lisa/parameter_parser/runbook.py
@@ -61,10 +61,6 @@ class RunbookBuilder:
         """
         builder = RunbookBuilder(path=path, cmd_args=cmd_args)
 
-        # load lisa itself modules, it's for subclasses, and other dynamic loading.
-        base_module_path = Path(__file__).parent.parent
-        import_package(base_module_path, enable_log=False)
-
         # merge all parameters
         builder._log.info(f"loading runbook: {builder._path}")
         data = builder._load_data(

--- a/lisa/parameter_parser/runbook.py
+++ b/lisa/parameter_parser/runbook.py
@@ -160,7 +160,7 @@ class RunbookBuilder:
             for index, extension in enumerate(extensions):
                 if not extension.name:
                     extension.name = f"lisa_ext_{index}"
-                import_package(Path(extension.path), package_name=extension.name)
+                import_package(Path(extension.path), extension.name)
 
             del self._raw_data[constants.EXTENSION]
 


### PR DESCRIPTION
1. Manually import all the mix-in modules, instead of
dynamically importing everything. This will allow for
platform `if` statements over the `import` statements
of platform specific modules.

2. Allow extensions to specify a single python file
instead of only supporting importing an entire
directory. An extension can use this to import a
file that handles any custom import rules they have,
such as using platform `if` statements.

3. Improve sub-class not found exception message.