### PR TITLE
Add serial console support to QEMU orchestrator.

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -774,9 +774,9 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
             search_space.check_countspace(self.memory_mb, capability.memory_mb),
             "memory_mb",
         )
-        if self.disk:
+        if self.disk and capability.disk:
             result.merge(self.disk.check(capability.disk))
-        if self.network_interface:
+        if self.network_interface and capability.network_interface:
             result.merge(self.network_interface.check(capability.network_interface))
         result.merge(
             search_space.check_countspace(self.gpu_count, capability.gpu_count),

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -774,9 +774,9 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
             search_space.check_countspace(self.memory_mb, capability.memory_mb),
             "memory_mb",
         )
-        if self.disk and capability.disk:
+        if self.disk:
             result.merge(self.disk.check(capability.disk))
-        if self.network_interface and capability.network_interface:
+        if self.network_interface:
             result.merge(self.network_interface.check(capability.network_interface))
         result.merge(
             search_space.check_countspace(self.gpu_count, capability.gpu_count),

--- a/lisa/sut_orchestrator/qemu/console_logger.py
+++ b/lisa/sut_orchestrator/qemu/console_logger.py
@@ -1,0 +1,130 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from threading import Event
+from typing import IO, Any, Optional, Union
+
+import libvirt  # type: ignore
+
+from . import libvirt_events_thread
+
+
+# Reads serial console log from libvirt VM and writes it to a file.
+class QemuConsoleLogger:
+    def __init__(self) -> None:
+        self._stream_completed = Event()
+        self._console_stream: Optional[libvirt.virStream] = None
+        self._console_stream_callback_started = False
+        self._console_stream_callback_added = False
+        self._log_file: Optional[IO[Any]] = None
+
+    # Attach logger to a libvirt VM.
+    def attach(
+        self,
+        qemu_conn: libvirt.virConnect,
+        domain: libvirt.virDomain,
+        log_file_path: str,
+    ) -> None:
+        # Open the log file.
+        self._log_file = open(log_file_path, "ab")
+
+        # Open the libvirt console stream.
+        console_stream = qemu_conn.newStream(libvirt.VIR_STREAM_NONBLOCK)
+        domain.openConsole(
+            None,
+            console_stream,
+            libvirt.VIR_DOMAIN_CONSOLE_FORCE | libvirt.VIR_DOMAIN_CONSOLE_SAFE,
+        )
+        self._console_stream = console_stream
+
+        libvirt_events_thread.run_callback(self._register_console_callbacks)
+        self._console_stream_callback_started = True
+
+    # Close the logger.
+    def close(self) -> None:
+        # Check if attach() run successfully.
+        if self._console_stream_callback_started:
+            # Close the stream on libvirt callbacks thread.
+            libvirt_events_thread.run_callback(self._close_stream, True)
+            self._stream_completed.wait()
+
+        else:
+            if self._console_stream:
+                self._console_stream.abort()
+
+            if self._log_file:
+                self._log_file.close()
+
+    # Wait until the stream closes.
+    # Typically used when gracefully shutting down a VM.
+    def wait_for_close(self) -> None:
+        if self._console_stream_callback_started:
+            self._stream_completed.wait()
+
+    # Register the console stream events.
+    # Threading: Must only be called on libvirt events thread.
+    def _register_console_callbacks(self) -> None:
+        # Attach callback for stream events.
+        assert self._console_stream
+        self._console_stream.eventAddCallback(
+            libvirt.VIR_STREAM_EVENT_READABLE
+            | libvirt.VIR_STREAM_EVENT_ERROR
+            | libvirt.VIR_STREAM_EVENT_HANGUP,
+            self._stream_event,
+            None,
+        )
+        self._console_stream_callback_added = True
+
+    # Handles events for the console stream.
+    # Threading: Must only be called on libvirt events thread.
+    def _stream_event(
+        self, stream: libvirt.virStream, events: Union[int, bytes], context: Any
+    ) -> None:
+        if events & libvirt.VIR_STREAM_EVENT_READABLE:
+            # Data is available to be read.
+            while True:
+                data = stream.recv(libvirt.virStorageVol.streamBufSize)
+                if data == -2:
+                    # No more data available at the moment.
+                    break
+
+                if len(data) == 0:
+                    # EOF reached.
+                    self._close_stream(False)
+                    break
+
+                assert self._log_file
+                self._log_file.write(data)
+
+        if (
+            events & libvirt.VIR_STREAM_EVENT_ERROR
+            or events & libvirt.VIR_STREAM_EVENT_HANGUP
+        ):
+            # Stream is shutting down. So, close it.
+            self._close_stream(True)
+
+    # Close the stream resource.
+    # Threading: Must only be called on libvirt events thread.
+    def _close_stream(self, abort: bool) -> None:
+        if self._stream_completed.is_set():
+            # Already closed. Nothing to do.
+            return
+
+        try:
+            # Close the log file
+            assert self._log_file
+            self._log_file.close()
+
+            # Close the stream
+            assert self._console_stream
+            if self._console_stream_callback_added:
+                self._console_stream.eventRemoveCallback()
+
+            if abort:
+                self._console_stream.abort()
+            else:
+                self._console_stream.finish()
+
+        finally:
+            # Signal that the stream has closed.
+            self._stream_completed.set()

--- a/lisa/sut_orchestrator/qemu/context.py
+++ b/lisa/sut_orchestrator/qemu/context.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional
 from lisa.environment import Environment
 from lisa.node import Node
 
+from .console_logger import QemuConsoleLogger
+
 
 @dataclass
 class EnvironmentContext:
@@ -16,7 +18,9 @@ class NodeContext:
     cloud_init_file_path: str = ""
     os_disk_base_file_path: str = ""
     os_disk_file_path: str = ""
+    console_log_file_path: str = ""
     extra_cloud_init_user_data: Optional[Dict[str, Any]] = None
+    console_logger: Optional[QemuConsoleLogger] = None
 
 
 def get_environment_context(environment: Environment) -> EnvironmentContext:

--- a/lisa/sut_orchestrator/qemu/libvirt_events_thread.py
+++ b/lisa/sut_orchestrator/qemu/libvirt_events_thread.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+# To use libvirt callbacks, one has to setup a single process-wide event loop for
+# libvirt. This module provisions the event loop in a python thread dedicated to
+# handling libvirt events.
+
+import asyncio
+from threading import Event, Lock, Thread
+from typing import Any, Callable, Optional
+
+import libvirtaio  # type: ignore
+
+_callbacks_thread_lock = Lock()
+_callbacks_thread: Optional[Thread] = None
+_callbacks_thread_running = Event()
+_callbacks_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+# Entry-point for the libvirt events thread.
+def _libvirt_events_thread() -> None:
+    global _callbacks_loop
+
+    # Provision this thread as an asyncio thread.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    _callbacks_loop = loop
+
+    # Initialize this thread as the libvirt events thread.
+    libvirtaio.virEventRegisterAsyncIOImpl()
+
+    # Signal that thread is initialized.
+    _callbacks_thread_running.set()
+
+    # Run the asyncio loop.
+    loop.run_forever()
+
+
+def init() -> None:
+    global _callbacks_thread
+
+    # Check if the events thread is already running.
+    if _callbacks_thread_running.is_set():
+        return
+
+    _callbacks_thread_lock.acquire()
+    try:
+        # Check if the events thread already exists.
+        if not _callbacks_thread:
+            # Start the thread.
+            thread = Thread(target=_libvirt_events_thread)
+            thread.daemon = True
+            thread.start()
+
+            _callbacks_thread = thread
+    finally:
+        _callbacks_thread_lock.release()
+
+    # Wait for the events thread to initialize.
+    _callbacks_thread_running.wait()
+
+
+# Run a callback on the libvirt events thread.
+def run_callback(callback: Callable[..., Any], *args: Any) -> asyncio.Handle:
+    assert _callbacks_thread_running.is_set()
+
+    assert _callbacks_loop
+    return _callbacks_loop.call_soon_threadsafe(callback, *args)

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -8,7 +8,7 @@ import string
 import subprocess
 import time
 import xml.etree.ElementTree as ET  # noqa: N817
-from typing import List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type
 
 import libvirt  # type: ignore
 import pycdlib  # type: ignore
@@ -46,6 +46,9 @@ class QemuPlatform(Platform):
     def supported_features(cls) -> List[Type[Feature]]:
         return QemuPlatform._supported_features
 
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        libvirt_events_thread.init()
+
     def _prepare_environment(self, environment: Environment, log: Logger) -> bool:
         return True
 
@@ -57,8 +60,6 @@ class QemuPlatform(Platform):
             self._delete_nodes(environment, log, qemu_conn)
 
     def _deploy_nodes(self, environment: Environment, log: Logger) -> None:
-        libvirt_events_thread.init()
-
         self._configure_nodes(environment, log)
 
         with libvirt.open("qemu:///system") as qemu_conn:

--- a/lisa/sut_orchestrator/qemu/serial_console.py
+++ b/lisa/sut_orchestrator/qemu/serial_console.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from lisa import features
+
+from .context import get_node_context
+
+
+# Implements the SerialConsole feature.
+class SerialConsole(features.SerialConsole):
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        super()._initialize(*args, **kwargs)
+
+    def _get_console_log(self, saved_path: Optional[Path]) -> bytes:
+        node_context = get_node_context(self._node)
+
+        # Open the log file.
+        # This file is simultaneously being written to by QemuConsoleLogger.
+        with open(
+            node_context.console_log_file_path, mode="r", encoding="utf-8"
+        ) as file:
+            log = file.read()
+
+        # Remove ANSI control codes.
+        log = re.sub("\x1b\\[[0-9;]*[mGKF]", "", log)
+
+        log_bytes = log.encode("utf-8")
+        return log_bytes


### PR DESCRIPTION
1. Add support for libvirt event callbacks. Libvirt requires
setting up a single process-wide event loop for handling the
events. This change provisions a separate Python thread for
this purpose.

2. Create a reader for the libvirt console stream that writes
the console output to file. (Ideally we would use the inbuilt
libvirt support for writing the console to file. But SELinux
doesn't like this for whatever reason.) This mimics the Azure
API that provides the serial console output as a log that can
be downloaded.

3. Implement the orchestrator serial console feature. This
just reads and dumps the console log file.

4. Fix a minor bug in NodeSpace schema class, that causes
a crash for some runbook configurations.