### PR TITLE
Fix TestRun final notification message

### DIFF
--- a/lisa/commands.py
+++ b/lisa/commands.py
@@ -45,9 +45,9 @@ def run(args: Namespace) -> int:
         run_error_message = str(identifier)
         raise identifier
     finally:
-        run_message = messages.TestRunMessage(
-            status=run_status, elapsed=run_timer.elapsed(), message=run_error_message
-        )
+        run_message.status = run_status
+        run_message.elapsed = run_timer.elapsed()
+        run_message.message = run_error_message
         notifier.notify(run_message)
         notifier.finalize()
         run_finalize()


### PR DESCRIPTION
The final TestRun notification (SUCCESS/FAILURE) does not have the correct TestRun field values. 

`2022-01-21 08:02:57.159[584][DEBUG] lisa.notifier[Console] received message [TestRun]: TestRunMessage(type='TestRun', elapsed=160.75330219999998, status=<TestRunStatus.SUCCESS: 3>, test_project='', test_pass='', tags=None, run_name='', message='')`

This is because a new obj of TestRunMessage is created before notifying. Changed it to use the same old object used for sending 'INITIALIZING' notification.