### PR TITLE
Bug fixes for some tier 1 tests for CBL-Mariner on QEMU.

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -948,23 +948,21 @@ class OpenBSD(BSD):
 
 
 @dataclass
-# yum repolist is of the form `<id> <name>`
+# dnf repolist is of the form `<id> <name>`
 # Example:
 # microsoft-azure-rhel8-eus  Microsoft Azure RPMs for RHEL8 Extended Update Support
-class FedoraRepositoryInfo(RepositoryInfo):
+class RPMRepositoryInfo(RepositoryInfo):
     # id for the repository, for example: microsoft-azure-rhel8-eus
     id: str
 
 
-class Fedora(Linux):
-    # Red Hat Enterprise Linux Server 7.8 (Maipo) => 7.8
-    _fedora_release_pattern_version = re.compile(r"^.*release\s+([0-9\.]+).*$")
-
+# Linux distros that use RPM.
+class RPMDistro(Linux):
     # microsoft-azure-rhel8-eus  Microsoft Azure RPMs for RHEL8 Extended Update Support
-    _fedora_repository_info_pattern = re.compile(r"(?P<id>\S+)\s+(?P<name>\S.*\S)\s*")
+    _rpm_repository_info_pattern = re.compile(r"(?P<id>\S+)\s+(?P<name>\S.*\S)\s*")
 
     # ex: dpdk-20.11-3.el8.x86_64
-    _fedora_version_splitter_regex = re.compile(
+    _rpm_version_splitter_regex = re.compile(
         r"(?P<package_name>[a-zA-Z0-9\-_]+)-"
         r"(?P<major>[0-9]+)\."
         r"(?P<minor>[0-9]+)"
@@ -972,13 +970,9 @@ class Fedora(Linux):
         r"(?P<build>-[a-zA-Z0-9-_\.]+)?"
     )
 
-    @classmethod
-    def name_pattern(cls) -> Pattern[str]:
-        return re.compile("^Fedora|fedora$")
-
     def get_repositories(self) -> List[RepositoryInfo]:
         repo_list_str = self._node.execute(
-            "yum repolist", sudo=True
+            f"{self._dnf_tool()} repolist", sudo=True
         ).stdout.splitlines()
 
         # skip to the first entry in the output
@@ -990,10 +984,10 @@ class Fedora(Linux):
 
         repositories: List[RepositoryInfo] = []
         for line in repo_list_str:
-            repo_info = self._fedora_repository_info_pattern.search(line)
+            repo_info = self._rpm_repository_info_pattern.search(line)
             if repo_info:
                 repositories.append(
-                    FedoraRepositoryInfo(
+                    RPMRepositoryInfo(
                         name=repo_info.group("name"), id=repo_info.group("id")
                     )
                 )
@@ -1008,7 +1002,7 @@ class Fedora(Linux):
             ),
         )
         # rpm package should be of format (package_name)-(version)
-        matches = self._fedora_version_splitter_regex.search(rpm_info.stdout)
+        matches = self._rpm_version_splitter_regex.search(rpm_info.stdout)
         if not matches:
             raise LisaException(
                 f"Could not parse package version {rpm_info} for {package_name}"
@@ -1020,7 +1014,7 @@ class Fedora(Linux):
         return self._cache_and_return_version_info(package_name, version_info)
 
     def _install_packages(self, packages: List[str], signed: bool = True) -> None:
-        command = f"dnf install -y {' '.join(packages)}"
+        command = f"{self._dnf_tool()} install -y {' '.join(packages)}"
         if not signed:
             command += " --nogpgcheck"
 
@@ -1030,7 +1024,7 @@ class Fedora(Linux):
         self._log.debug(f"{packages} is/are installed successfully.")
 
     def _package_exists(self, package: str) -> bool:
-        command = f"dnf list installed {package}"
+        command = f"{self._dnf_tool()} list installed {package}"
         result = self._node.execute(command, sudo=True)
         if result.exit_code == 0:
             for row in result.stdout.splitlines():
@@ -1038,6 +1032,18 @@ class Fedora(Linux):
                     return True
 
         return False
+
+    def _dnf_tool(self):
+        return "dnf"
+
+
+class Fedora(RPMDistro):
+    # Red Hat Enterprise Linux Server 7.8 (Maipo) => 7.8
+    _fedora_release_pattern_version = re.compile(r"^.*release\s+([0-9\.]+).*$")
+
+    @classmethod
+    def name_pattern(cls) -> Pattern[str]:
+        return re.compile("^Fedora|fedora$")
 
     def install_epel(self) -> None:
         # Extra Packages for Enterprise Linux (EPEL) is a special interest group
@@ -1218,6 +1224,9 @@ class Redhat(Fedora):
                 f"Failed to install {packages}. exit_code: {result.exit_code}"
             )
 
+    def _dnf_tool(self):
+        return "yum"
+
 
 class CentOs(Redhat):
     @classmethod
@@ -1238,6 +1247,12 @@ class Oracle(Redhat):
         # The name is "Oracle Linux Server", which doesn't support the default
         # full match.
         return re.compile("^Oracle")
+
+
+class CBLMariner(RPMDistro):
+    @classmethod
+    def name_pattern(cls) -> Pattern[str]:
+        return re.compile("^Common Base Linux Mariner|mariner$")
 
 
 @dataclass

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1033,7 +1033,7 @@ class RPMDistro(Linux):
 
         return False
 
-    def _dnf_tool(self):
+    def _dnf_tool(self) -> str:
         return "dnf"
 
 
@@ -1224,7 +1224,7 @@ class Redhat(Fedora):
                 f"Failed to install {packages}. exit_code: {result.exit_code}"
             )
 
-    def _dnf_tool(self):
+    def _dnf_tool(self) -> str:
         return "yum"
 
 

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -80,6 +80,7 @@ class QemuPlatform(Platform):
         node_capabilities.disk = schema.DiskOptionSettings()
         node_capabilities.network_interface = schema.NetworkInterfaceOptionSettings()
         node_capabilities.network_interface.max_nic_count = 1
+        node_capabilities.network_interface.nic_count = 1
         node_capabilities.gpu_count = 0
         node_capabilities.features = search_space.SetSpace[schema.FeatureSettings](
             is_allow_set=True,

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -3,7 +3,7 @@
 
 from lisa.base_tools import Wget
 from lisa.executable import Tool
-from lisa.operating_system import CentOs, Debian, Redhat
+from lisa.operating_system import CBLMariner, CentOs, Debian, Redhat
 from lisa.tools.service import Service
 from lisa.util import LisaException
 
@@ -82,6 +82,8 @@ class Docker(Tool):
             self.node.os.install_packages(
                 ["docker", "docker-ce", "docker.socket", "docker.service"]
             )
+        elif isinstance(self.node.os, CBLMariner):
+            self.node.os.install_packages(["moby-engine", "moby-cli"])
         else:
             raise LisaException(f"{self.node.os.information.vendor} not supported")
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -14,10 +14,10 @@ from lisa.operating_system import (
     Debian,
     DebianRepositoryInfo,
     Fedora,
-    FedoraRepositoryInfo,
     Oracle,
     Posix,
     Redhat,
+    RPMRepositoryInfo,
     Suse,
     SuseRepositoryInfo,
     Ubuntu,
@@ -350,9 +350,9 @@ class AzureImageStandard(TestSuite):
     )
     def verify_repository_installed(self, node: Node) -> None:
         assert isinstance(node.os, Posix)
-        repositories = node.os.get_repositories()
 
         if isinstance(node.os, Debian):
+            repositories = node.os.get_repositories()
             debian_repositories = [
                 cast(DebianRepositoryInfo, repo) for repo in repositories
             ]
@@ -416,6 +416,7 @@ class AzureImageStandard(TestSuite):
                     "be in the `apt-get update` output",
                 ).is_true()
         elif isinstance(node.os, Suse):
+            repositories = node.os.get_repositories()
             suse_repositories = [
                 cast(SuseRepositoryInfo, repo) for repo in repositories
             ]
@@ -473,8 +474,9 @@ class AzureImageStandard(TestSuite):
                     "enabled/refreshed",
                 ).is_greater_than(2)
         elif isinstance(node.os, Oracle):
+            repositories = node.os.get_repositories()
             oracle_repositories = [
-                cast(FedoraRepositoryInfo, repo) for repo in repositories
+                cast(RPMRepositoryInfo, repo) for repo in repositories
             ]
 
             # verify that `base` repository is present
@@ -485,8 +487,9 @@ class AzureImageStandard(TestSuite):
                 is_latest_repository_present, "Latest repository should be present"
             ).is_true()
         elif isinstance(node.os, Fedora):
+            repositories = node.os.get_repositories()
             fedora_repositories = [
-                cast(FedoraRepositoryInfo, repo) for repo in repositories
+                cast(RPMRepositoryInfo, repo) for repo in repositories
             ]
 
             # verify that `base` repository is present

--- a/microsoft/testsuites/core/lsvmbus.py
+++ b/microsoft/testsuites/core/lsvmbus.py
@@ -2,7 +2,14 @@ import math
 
 from assertpy import assert_that
 
-from lisa import Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa import (
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.tools import VmGeneration
 from lisa.tools import Lscpu, Lsvmbus
 
@@ -63,6 +70,9 @@ class LsVmBus(TestSuite):
                 https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/drivers/scsi/storvsc_drv.c#n952 # noqa: E501
         """,
         priority=1,
+        requirement=simple_requirement(
+            supported_platform_type=[AZURE],
+        ),
     )
     def lsvmbus_count_devices_channels(self, node: Node) -> None:
         # 1. Check expected vmbus device names presented in the lsvmbus output.

--- a/microsoft/testsuites/core/vm_hot_resize.py
+++ b/microsoft/testsuites/core/vm_hot_resize.py
@@ -3,8 +3,14 @@
 
 from assertpy import assert_that
 
-from lisa import Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
-from lisa.features.resize import Resize
+from lisa import (
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.features import Resize
 from lisa.schema import NodeSpace
 from lisa.tools import Lscpu
 
@@ -27,6 +33,9 @@ class VmHotResize(TestSuite):
         2. Check the node's core count and memory size against their expected values
         """,
         priority=1,
+        requirement=simple_requirement(
+            supported_features=[Resize],
+        ),
     )
     def verify_vm_hot_resize(self, node: Node) -> None:
         resize = node.features[Resize]

--- a/microsoft/testsuites/docker/dockersuite.py
+++ b/microsoft/testsuites/docker/dockersuite.py
@@ -182,6 +182,7 @@ class DockerTestSuite(TestSuite):
 
         docker_run_output = node.execute(
             f"cat {docker_run_output_file}",
+            sudo=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="Docker run output file not found",
             cwd=node.working_path,


### PR DESCRIPTION
1. Add OS type for CBL-Mariner. While CBL-Mariner uses RPM
and so should share the package handling logic, it is not
a derivative of Fedora and has substantial differences.
Hence, the RPM handling logic was split off into a new
base class that both `Fedora` and `CBLMariner` classes
inherit from.

2. Fix a few tests that didn't declare their required
`supported_features`.

3. Restrict tests that rely on VMBus to the `AZURE` platform.
(When the Hyper-V support is added, it can be added as a
platform to these tests as well.)

4. Add support for CBL-Mariner to Docker tool.