### PR TITLE
QEMU orchestrator: Respect the `keep_environment` flag.

### DIFF
--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -103,7 +103,10 @@ class QemuPlatform(Platform):
                 self._fill_nodes_metadata(environment, log, qemu_conn)
 
             except Exception as ex:
-                self._delete_nodes(environment, log, qemu_conn)
+                assert environment.platform
+                if not environment.platform.runbook.keep_environment:
+                    self._delete_nodes(environment, log, qemu_conn)
+
                 raise ex
 
     # Pre-determine all the nodes' properties, including the name of all the resouces

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -104,7 +104,7 @@ class QemuPlatform(Platform):
 
             except Exception as ex:
                 assert environment.platform
-                if not environment.platform.runbook.keep_environment:
+                if environment.platform.runbook.keep_environment == constants.ENVIRONMENT_KEEP_NO:
                     self._delete_nodes(environment, log, qemu_conn)
 
                 raise ex

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -104,7 +104,10 @@ class QemuPlatform(Platform):
 
             except Exception as ex:
                 assert environment.platform
-                if environment.platform.runbook.keep_environment == constants.ENVIRONMENT_KEEP_NO:
+                if (
+                    environment.platform.runbook.keep_environment
+                    == constants.ENVIRONMENT_KEEP_NO
+                ):
                     self._delete_nodes(environment, log, qemu_conn)
 
                 raise ex


### PR DESCRIPTION
If the `keep_environment` flag has been set, then don't
delete the VMs if the VM deployment fails.