### PR TITLE
Log cleanup

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -169,6 +169,7 @@ class Environment(ContextMixin, InitializableMixin):
         super().__init__()
 
         self.nodes: Nodes = Nodes()
+        self._local_node: Optional[Node] = None
         self.runbook = runbook
         self.name = runbook.name
         self.is_predefined: bool = is_predefined
@@ -322,6 +323,21 @@ class Environment(ContextMixin, InitializableMixin):
         self.nodes.append(node)
 
         return node
+
+    def local_node(self) -> Node:
+        if self._local_node:
+            return self._local_node
+
+        node_runbook = schema.LocalNode(capability=schema.Capability())
+        self._local_node = Node.create(
+            index=-1,
+            runbook=node_runbook,
+            logger_name="local",
+            base_log_path=self.log_path,
+            parent_logger=self.log,
+        )
+        self._local_node.name = "local"
+        return self._local_node
 
     def get_information(self) -> Dict[str, str]:
         final_information: Dict[str, str] = {}

--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -169,7 +169,6 @@ class Environment(ContextMixin, InitializableMixin):
         super().__init__()
 
         self.nodes: Nodes = Nodes()
-        self._local_node: Optional[Node] = None
         self.runbook = runbook
         self.name = runbook.name
         self.is_predefined: bool = is_predefined
@@ -323,21 +322,6 @@ class Environment(ContextMixin, InitializableMixin):
         self.nodes.append(node)
 
         return node
-
-    def local_node(self) -> Node:
-        if self._local_node:
-            return self._local_node
-
-        node_runbook = schema.LocalNode(capability=schema.Capability())
-        self._local_node = Node.create(
-            index=-1,
-            runbook=node_runbook,
-            logger_name="local",
-            base_log_path=self.log_path,
-            parent_logger=self.log,
-        )
-        self._local_node.name = "local"
-        return self._local_node
 
     def get_information(self) -> Dict[str, str]:
         final_information: Dict[str, str] = {}

--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -209,6 +209,7 @@ class Tool(InitializableMixin):
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[pathlib.PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
     ) -> Process:
@@ -233,6 +234,7 @@ class Tool(InitializableMixin):
                 sudo=sudo,
                 no_error_log=no_error_log,
                 no_info_log=no_info_log,
+                no_debug_log=no_debug_log,
                 cwd=cwd,
                 update_envs=update_envs,
             )
@@ -249,6 +251,7 @@ class Tool(InitializableMixin):
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[pathlib.PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
         timeout: int = 600,
@@ -265,6 +268,7 @@ class Tool(InitializableMixin):
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=cwd,
             update_envs=update_envs,
         )
@@ -338,6 +342,7 @@ class CustomScript(Tool):
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[pathlib.PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
     ) -> Process:
@@ -351,6 +356,7 @@ class CustomScript(Tool):
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=self._cwd,
             update_envs=update_envs,
         )
@@ -363,6 +369,7 @@ class CustomScript(Tool):
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[pathlib.PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
         timeout: int = 600,
@@ -376,6 +383,7 @@ class CustomScript(Tool):
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=cwd,
             update_envs=update_envs,
         )

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -118,13 +118,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
                     index = randint(0, 10000)
                 path_name = f"node-{index}"
             self._local_log_path = base_path / path_name
-            if self._local_log_path.exists():
-                raise LisaException(
-                    "Conflicting node log path detected, "
-                    "make sure LISA invocations have individual runtime paths."
-                    f"'{self._local_log_path}'"
-                )
-            self._local_log_path.mkdir(parents=True)
+            self._local_log_path.mkdir(parents=True, exist_ok=True)
 
         return self._local_log_path
 
@@ -530,6 +524,24 @@ class Nodes:
 
     def append(self, node: Node) -> None:
         self._list.append(node)
+
+
+def local_node_connect(
+    index: int = -1,
+    name: str = "local",
+    base_log_path: Optional[Path] = None,
+    parent_logger: Optional[Logger] = None,
+) -> Node:
+    node_runbook = schema.LocalNode(name=name, capability=schema.Capability())
+    node = Node.create(
+        index=index,
+        runbook=node_runbook,
+        logger_name=name,
+        base_log_path=base_log_path,
+        parent_logger=parent_logger,
+    )
+    node.initialize()
+    return node
 
 
 def quick_connect(

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -184,6 +184,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[PurePath] = None,
         timeout: int = 600,
         update_envs: Optional[Dict[str, str]] = None,
@@ -196,6 +197,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=cwd,
             update_envs=update_envs,
         )
@@ -212,6 +214,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = True,
+        no_debug_log: bool = False,
         cwd: Optional[PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
     ) -> Process:
@@ -228,6 +231,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=cwd,
             update_envs=update_envs,
         )
@@ -275,6 +279,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         sudo: bool = False,
         no_error_log: bool = False,
         no_info_log: bool = False,
+        no_debug_log: bool = False,
         cwd: Optional[PurePath] = None,
         update_envs: Optional[Dict[str, str]] = None,
     ) -> Process:
@@ -286,6 +291,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
             sudo=sudo,
             no_error_log=no_error_log,
             no_info_log=no_info_log,
+            no_debug_log=no_debug_log,
             cwd=cwd,
             update_envs=update_envs,
         )

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -5,7 +5,6 @@ import io
 import os
 import random
 import string
-import subprocess
 import time
 import xml.etree.ElementTree as ET  # noqa: N817
 from typing import Any, List, Optional, Tuple, Type
@@ -386,20 +385,10 @@ class QemuPlatform(Platform):
         node_context = get_node_context(node)
 
         # Create a new differencing image with the user provided image as the base.
-        subprocess.run(
-            [
-                "qemu-img",
-                "create",
-                "-F",
-                "qcow2",
-                "-f",
-                "qcow2",
-                "-b",
-                node_context.os_disk_base_file_path,
-                node_context.os_disk_file_path,
-            ],
-            check=True,
-            capture_output=True,
+        environment.local_node().execute(
+            f"qemu-img create -F qcow2 -f qcow2 -b"
+            f"{node_context.os_disk_base_file_path} {node_context.os_disk_file_path}",
+            expected_exit_code=0,
         )
 
     # Create the XML definition for the VM.

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -70,14 +70,19 @@ class Process:
         update_envs: Optional[Dict[str, str]] = None,
         no_error_log: bool = False,
         no_info_log: bool = False,
+        no_debug_log: bool = False,
     ) -> None:
         """
         command include all parameters also.
         """
         stdout_level = logging.INFO
         stderr_level = logging.ERROR
-        if no_info_log:
+
+        if no_debug_log:
+            stdout_level = logging.NOTSET
+        elif no_info_log:
             stdout_level = logging.DEBUG
+
         if no_error_log:
             stderr_level = stdout_level
 


### PR DESCRIPTION
1. Add a `local_node_connect` to make it easy to run commands
against the test runner machine

2. Add a `no_debug_log` option to the `Process.start` function and
all of its derivatives.  This will allow a caller to prevent output
from a process from being written to the DEBUG logs. This is useful
for commands with particularly spammy output. (For example,
`kubectl get -o yaml`.)