### PR TITLE
QEMU: Add network boot timeout config value.

### DIFF
--- a/lisa/sut_orchestrator/qemu/context.py
+++ b/lisa/sut_orchestrator/qemu/context.py
@@ -11,6 +11,9 @@ from .console_logger import QemuConsoleLogger
 class EnvironmentContext:
     ssh_public_key: str = ""
 
+    # Timeout for the OS to boot and acquire an IP address, in seconds.
+    network_boot_timeout: float = 30.0
+
 
 @dataclass
 class NodeContext:

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -19,7 +19,10 @@ class CloudInitSchema:
 @dataclass_json()
 @dataclass
 class QemuPlatformSchema:
-    pass
+    # The timeout length for how long to wait for the OS to boot and request an IP
+    # address from the libvirt DHCP server.
+    # Specified in seconds. Default: 30s.
+    network_boot_timeout: Optional[float] = None
 
 
 # QEMU orchestrator's per-node configuration options.


### PR DESCRIPTION
On some systems and/or some guest OS images, the OS may take
longer to boot to the point where it requests an IP address
from the libvirt DHCP server. Therefore, provide an option
to extend this timeout length.