### PR TITLE
find_partition_with_freespace: refactor function to hoist to node level

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -427,6 +427,9 @@ class RemoteNode(Node):
         return self.get_pure_path(result.stdout)
 
     def find_partition_with_freespace(self, size_in_gb: int) -> str:
+        if self.os.is_windows:
+            raise NotImplementedError()
+
         df = self.tools[Df]
         home_partition = df.get_partition_by_mountpoint("/home")
         if home_partition and df.check_partition_size(home_partition, size_in_gb):

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -12,7 +12,7 @@ from lisa.executable import Tools
 from lisa.feature import Features
 from lisa.nic import Nics
 from lisa.operating_system import OperatingSystem
-from lisa.tools import Echo, Reboot
+from lisa.tools import Df, Echo, Reboot
 from lisa.util import (
     ContextMixin,
     InitializableMixin,
@@ -425,6 +425,20 @@ class RemoteNode(Node):
         result = echo.run(working_path, shell=True)
 
         return self.get_pure_path(result.stdout)
+
+    def find_partition_with_freespace(self, size_in_gb: int) -> str:
+        df = self.tools[Df]
+        home_partition = df.get_partition_by_mountpoint("/home")
+        if home_partition and df.check_partition_size(home_partition, size_in_gb):
+            return home_partition.mountpoint
+
+        mnt_partition = df.get_partition_by_mountpoint("/mnt")
+        if mnt_partition and df.check_partition_size(mnt_partition, size_in_gb):
+            return mnt_partition.mountpoint
+
+        raise LisaException(
+            f"No partition with Required disk space of {size_in_gb}GB found"
+        )
 
 
 class LocalNode(Node):

--- a/lisa/tools/df.py
+++ b/lisa/tools/df.py
@@ -58,13 +58,13 @@ class Df(Tool):
     def check_partition_size(
         self,
         partition: PartitionInfo,
-        size: int,
+        size_in_gb: int,
     ) -> bool:
         # check if the partition has enough space to download nested image file
         unused_partition_size_in_gb = (
             partition.total_blocks - partition.used_blocks
         ) / (1024 * 1024)
-        if unused_partition_size_in_gb > size:
+        if unused_partition_size_in_gb > size_in_gb:
             return True
 
         return False

--- a/lisa/tools/df.py
+++ b/lisa/tools/df.py
@@ -54,3 +54,17 @@ class Df(Tool):
             if partition.mountpoint == mountpoint:
                 return partition
         return None
+
+    def check_partition_size(
+        self,
+        partition: PartitionInfo,
+        size: int,
+    ) -> bool:
+        # check if the partition has enough space to download nested image file
+        unused_partition_size_in_gb = (
+            partition.total_blocks - partition.used_blocks
+        ) / (1024 * 1024)
+        if unused_partition_size_in_gb > size:
+            return True
+
+        return False


### PR DESCRIPTION
@somil55 added a function find_partition_with_freespace to the nested virt test suite and it looks super useful. Let's hoist it!

This PR:

- Moves the check-for-freespace function to node level. 
- Renames and moves a dependency for that function. The renamed function `check_partition_size` becomes a public function of the Df tool, since it depends on that tool to perform it's check.

The end result is that the caller can use `node.find_partition_with_freespace(size_in_gb)`