### PR TITLE
modify shell.chown to accept string username or group id

### DIFF
--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -452,7 +452,7 @@ class SshShell(InitializableMixin):
         destination_str = self._purepath_to_str(destination)
         self._inner_shell.symlink(source_str, destination_str)
 
-    def chown(self, path: PurePath, uid: int, gid: int) -> None:
+    def chown(self, path: PurePath, uid: Union[int, str], gid: Union[int, str]) -> None:
         """Change the user and/or group ownership of each given file (Posix targets only)
         Inputs:
             path: target path. (Absolute. Use a PurePosixPath, if the
@@ -649,7 +649,7 @@ class LocalShell(InitializableMixin):
         assert isinstance(destination, Path), f"actual: {type(destination)}"
         source.symlink_to(destination)
 
-    def chown(self, path: PurePath, uid: int, gid: int) -> None:
+    def chown(self, path: PurePath, uid: Union[int, str], gid: Union[int, str]) -> None:
         """Change the user and/or group ownership of each given file (Posix targets only)
         Inputs:
             path: target path. (Absolute)


### PR DESCRIPTION
The chown function we call to allows for a string username or groupid, however we had type-checked it to only allow integers. This PR modifies our type-checking definitions to allow for either a string or an int.