### PR TITLE
Chown Tool: remove broken shell.chown and replace with node.tools[Chown]

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -5,6 +5,7 @@
 from lisa.base_tools import Cat, Sed, Uname, Wget
 
 from .blkid import Blkid
+from .chown import Chown
 from .chrony import Chrony
 from .date import Date
 from .df import Df
@@ -70,6 +71,7 @@ from .xfstests import Xfstests
 __all__ = [
     "Blkid",
     "Cat",
+    "Chown",
     "Chrony",
     "Date",
     "Df",

--- a/lisa/tools/chown.py
+++ b/lisa/tools/chown.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import PurePath
+from typing import List
+
+from assertpy import assert_that
+
+from lisa.executable import Tool
+
+
+class Chown(Tool):
+    @property
+    def command(self) -> str:
+        return "chown"
+
+    def _check_exists(self) -> bool:
+        return self.node.is_posix
+
+    def change_owner(
+        self, file: PurePath, user: str = "", group: str = "", recurse: bool = False
+    ) -> None:
+        # from manpage:
+        # chown [OPTION]... [OWNER][:[GROUP]] FILE...
+        arguments: List[str] = []
+
+        # option for recursive chown for a folder
+        if recurse:
+            arguments.append("-R")
+
+        # add [OWNER][:[GROUP]]
+        if group:
+            group = f":{group}"
+        new_owner = f"{user}{group}"
+        if new_owner:
+            arguments.append(new_owner)
+
+        # add FILE
+        assert_that(str(file)).described_as(
+            "chown: filepath was empty and file is a required argument"
+        ).is_true()
+        arguments.append(f"{str(file)}")
+
+        # execute chown
+        self.run(
+            parameters=" ".join(arguments),
+            shell=True,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Chown failed to change owner for {file}"
+            ),
+        )

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -452,20 +452,6 @@ class SshShell(InitializableMixin):
         destination_str = self._purepath_to_str(destination)
         self._inner_shell.symlink(source_str, destination_str)
 
-    def chown(self, path: PurePath, uid: int, gid: int) -> None:
-        """Change the user and/or group ownership of each given file (Posix targets only)
-        Inputs:
-            path: target path. (Absolute. Use a PurePosixPath, if the
-                               target node is a Posix one, because LISA
-                               might be ran from Windows)
-            uid: numeric user ID
-            gid: numeric group ID
-        """
-        self.initialize()
-        assert self._inner_shell
-        path_str = self._purepath_to_str(path)
-        self._inner_shell.chown(path_str, uid, gid)
-
     def copy(self, local_path: PurePath, node_path: PurePath) -> None:
         """Upload local file to target node
         Inputs:
@@ -648,16 +634,6 @@ class LocalShell(InitializableMixin):
         assert isinstance(source, Path), f"actual: {type(source)}"
         assert isinstance(destination, Path), f"actual: {type(destination)}"
         source.symlink_to(destination)
-
-    def chown(self, path: PurePath, uid: int, gid: int) -> None:
-        """Change the user and/or group ownership of each given file (Posix targets only)
-        Inputs:
-            path: target path. (Absolute)
-            uid: numeric user ID
-            gid: numeric group ID
-        """
-        assert isinstance(path, Path), f"actual: {type(path)}"
-        shutil.chown(path, cast(str, uid), cast(str, gid))
 
     def copy(self, local_path: PurePath, node_path: PurePath) -> None:
         """Upload local file to target node


### PR DESCRIPTION
shell.chown is broken, replace it with a tool for posix systems.