### PR TITLE
Delete resourcegroup from SharedImageGallery to keep consistent with lisav3

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -27,9 +27,9 @@ function Start-LISAv2 {
 		[string] $ARMImageName = "",
 		# Required for Azure if -ARMImageName and -OsVHD is not provided
 		# If the shared image gallery is in the same subscription that is used to run LISA, this parameter can be:
-		#     <resource_group>/<image_gallery>/<image_definition>/<image_version>
+		#     <image_gallery>/<image_definition>/<image_version>
 		# otherwise, this parameter should be:
-		#     <subscription_id>/<resource_group>/<image_gallery>/<image_definition>/<image_version>
+		#     <subscription_id>/<image_gallery>/<image_definition>/<image_version>
 		[string] $SharedImageGallery = "",
 		[string] $StorageAccount="",
 

--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1461,12 +1461,10 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 				Add-Content -Value "$($indents[5]){" -Path $jsonFile
 
 				$sharedImageInfo = $SharedImageName.Split('/')
-				if ($sharedImageInfo.Count -eq 5) {
-					$imageResource = "$($sharedImageInfo[1])/providers/Microsoft.Compute/galleries/$($sharedImageInfo[2])/images/$($sharedImageInfo[3])/versions/$($sharedImageInfo[4])"
-					Add-Content -Value "$($indents[6])^Id^: ^/subscriptions/$($sharedImageInfo[0])/resourceGroups/$imageResource^," -Path $jsonFile
+				if ($sharedImageInfo.Count -eq 4) {
+					Add-Content -Value "$($indents[6])^Id^: ^[resourceId('$($sharedImageInfo[0])', 'None', 'Microsoft.Compute/galleries/images/versions', '$($sharedImageInfo[1])', '$($sharedImageInfo[2])', '$($sharedImageInfo[3])')]^," -Path $jsonFile
 				} else {
-					$imageResource = "$($sharedImageInfo[0])/providers/Microsoft.Compute/galleries/$($sharedImageInfo[1])/images/$($sharedImageInfo[2])/versions/$($sharedImageInfo[3])"
-					Add-Content -Value "$($indents[6])^Id^: ^[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/$imageResource')]^," -Path $jsonFile
+					Add-Content -Value "$($indents[6])^Id^: ^[resourceId(subscription().subscriptionId, 'None', 'Microsoft.Compute/galleries/images/versions', '$($sharedImageInfo[0])', '$($sharedImageInfo[1])', '$($sharedImageInfo[2])')]^," -Path $jsonFile
 				}
 				Add-Content -Value "$($indents[5])}," -Path $jsonFile
 			}

--- a/TestControllers/AzureController.psm1
+++ b/TestControllers/AzureController.psm1
@@ -93,15 +93,15 @@ Class AzureController : TestController {
 			# $this.GlobalConfig has been set by base ([TestController]$this).ParseAndValidateParameters() at the beginning of this overwritten function
 			if (!$this.GlobalConfig.Global.Azure.DefaultARMImageName) {
 				$parameterErrors += "-OsVHD <'VHD_Name.vhd'>, or -ARMImageName '<Publisher> <Offer> <Sku> <Version>,<Publisher> <Offer> <Sku> <Version>,...', " + `
-							"or -SharedImageGallery '<subscription_id>/<resource_group>/<image_gallery>/<image_definition>/<image_version>', <DefaultARMImageName> from .\XML\GlobalConfigurations.xml if required."
+							"or -SharedImageGallery '<subscription_id>/<image_gallery>/<image_definition>/<image_version>', <DefaultARMImageName> from .\XML\GlobalConfigurations.xml if required."
 			}
 		}
 		elseif ($this.SharedImageGallery) {
 			$parameterCount = $this.SharedImageGallery.Split("/").Trim().Count
 			if ($parameterCount -lt 3 -or $parameterCount -gt 4) {
 				$parameterErrors += "Invalid value for the provided SharedImageGallery parameter: <'$($this.SharedImageGallery)'>." + `
-						"The SharedImageGallery should be in the format: '<subscription_id>/<resource_group>/<image_gallery>/<image_definition>/<image_version>' " + `
-						"Or '<resource_group>/<image_gallery>/<image_definition>/<image_version>' if the shared image gallery is in the same subscription that is used to run LISA."
+						"The SharedImageGallery should be in the format: '<subscription_id>/<image_gallery>/<image_definition>/<image_version>' " + `
+						"Or '<image_gallery>/<image_definition>/<image_version>' if the shared image gallery is in the same subscription that is used to run LISA."
 			}
 		}
 		elseif ($this.ARMImageName) {


### PR DESCRIPTION
Delete resource group from SharedImageGallery parameter to keep it consistent with lisav3 and Penguinator.