### PR TITLE
QEMU orchestrator: implement support for remote hosts

### DIFF
--- a/lisa/sut_orchestrator/qemu/context.py
+++ b/lisa/sut_orchestrator/qemu/context.py
@@ -18,6 +18,7 @@ class EnvironmentContext:
 @dataclass
 class NodeContext:
     vm_name: str = ""
+    vm_disks_dir: str = ""
     cloud_init_file_path: str = ""
     os_disk_source_file_path: Optional[str] = None
     os_disk_base_file_path: str = ""

--- a/lisa/sut_orchestrator/qemu/context.py
+++ b/lisa/sut_orchestrator/qemu/context.py
@@ -19,6 +19,7 @@ class EnvironmentContext:
 class NodeContext:
     vm_name: str = ""
     cloud_init_file_path: str = ""
+    os_disk_source_file_path: Optional[str] = None
     os_disk_base_file_path: str = ""
     os_disk_file_path: str = ""
     console_log_file_path: str = ""

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -731,7 +731,12 @@ class QemuPlatform(Platform):
         hypervisor = "qemu"
         host = self.qemu_platform_runbook.hosts[0]
 
-        host_addr = host.address if host.address else ""
-        transport = "+tcp" if host.address else ""
+        host_addr = ""
+        transport = ""
+        params = ""
+        if host.is_remote():
+            host_addr = host.address
+            transport = "+ssh"
+            params = f"?keyfile={host.private_key_file}"
 
-        self.libvirt_conn_str = f"{hypervisor}{transport}://{host_addr}/system"
+        self.libvirt_conn_str = f"{hypervisor}{transport}://{host_addr}/system{params}"

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -735,6 +735,7 @@ class QemuPlatform(Platform):
         transport = ""
         params = ""
         if host.is_remote():
+            assert host.address
             host_addr = host.address
             transport = "+ssh"
             params = f"?keyfile={host.private_key_file}"

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -415,8 +415,7 @@ class QemuPlatform(Platform):
                 log.warning(f"console log delete failed. {ex}")
 
             try:
-                vm_dir = os.path.dirname(node_context.os_disk_file_path)
-                self.host_node.shell.remove(Path(vm_dir), True)
+                self.host_node.shell.remove(Path(node_context.vm_disks_dir), True)
             except Exception as ex:
                 log.warning(f"Failed to delete VM files directory: {ex}")
 

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -73,8 +73,10 @@ class QemuPlatform(Platform):
         host = self.qemu_platform_runbook.host
         if host.is_remote():
             assert host.address
-            assert host.username
-            assert host.private_key_file
+            if not host.username:
+                raise LisaException("Username must be provided for remote host")
+            if not host.private_key_file:
+                raise LisaException("Private key file must be provided for remote host")
 
             self.host_node = RemoteNode(
                 runbook=schema.Node(name="qemu-host"),
@@ -82,6 +84,7 @@ class QemuPlatform(Platform):
                 logger_name="qemu-host",
                 parent_logger=log,
             )
+
             self.host_node.set_connection_info(
                 address=host.address,
                 username=host.username,
@@ -408,7 +411,7 @@ class QemuPlatform(Platform):
                 vm_dir = os.path.dirname(node_context.os_disk_file_path)
                 self.host_node.shell.remove(Path(vm_dir), True)
             except Exception as ex:
-                log.warning(f"Working directory delete failed. {ex}")
+                log.warning(f"Failed to delete VM files directory: {ex}")
 
     # Delete a VM.
     def _stop_and_delete_vm(

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -14,15 +14,29 @@ class CloudInitSchema:
     # Additional values to apply to the cloud-init user-data file.
     extra_user_data: Optional[str] = None
 
+@dataclass_json()
+@dataclass
+class LibvirtHost:
+    address: str = ""
+    username: str = ""
+    private_key_file: str = ""
 
 # QEMU orchestrator's global configuration options.
 @dataclass_json()
 @dataclass
 class QemuPlatformSchema:
+    # An optional remote host for the VMs. All test VMs will be spawned on the
+    # specified host by connecting remotely to the libvirt instance running on it.
+    # If None, the local machine is used as host.
+    host: Optional[LibvirtHost] = None
+
     # The timeout length for how long to wait for the OS to boot and request an IP
     # address from the libvirt DHCP server.
     # Specified in seconds. Default: 30s.
     network_boot_timeout: Optional[float] = None
+
+    def is_host_remote(self) -> bool:
+        return self.host is not None
 
 
 # QEMU orchestrator's per-node configuration options.

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -17,9 +17,14 @@ class CloudInitSchema:
 @dataclass_json()
 @dataclass
 class LibvirtHost:
-    address: str = ""
-    username: str = ""
-    private_key_file: str = ""
+    address: Optional[str] = None
+    username: Optional[str] = None
+    private_key_file: Optional[str] = None
+
+    # The directory where lisa will store VM related files (such as disk images).
+    # This directory must already exist and the test user should have write permission
+    # to it.
+    lisa_working_dir: Optional[str] = "/var/tmp"
 
 # QEMU orchestrator's global configuration options.
 @dataclass_json()
@@ -28,7 +33,7 @@ class QemuPlatformSchema:
     # An optional remote host for the VMs. All test VMs will be spawned on the
     # specified host by connecting remotely to the libvirt instance running on it.
     # If None, the local machine is used as host.
-    host: Optional[LibvirtHost] = None
+    host: Optional[LibvirtHost] = LibvirtHost()
 
     # The timeout length for how long to wait for the OS to boot and request an IP
     # address from the libvirt DHCP server.
@@ -36,7 +41,7 @@ class QemuPlatformSchema:
     network_boot_timeout: Optional[float] = None
 
     def is_host_remote(self) -> bool:
-        return self.host is not None
+        return self.host.address is not None
 
 
 # QEMU orchestrator's per-node configuration options.

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -14,6 +14,7 @@ class CloudInitSchema:
     # Additional values to apply to the cloud-init user-data file.
     extra_user_data: Optional[str] = None
 
+
 @dataclass_json()
 @dataclass
 class LibvirtHost:
@@ -24,7 +25,11 @@ class LibvirtHost:
     # The directory where lisa will store VM related files (such as disk images).
     # This directory must already exist and the test user should have write permission
     # to it.
-    lisa_working_dir: Optional[str] = "/var/tmp"
+    lisa_working_dir: str = "/var/tmp"
+
+    def is_remote(self) -> bool:
+        return self.address is not None
+
 
 # QEMU orchestrator's global configuration options.
 @dataclass_json()
@@ -33,15 +38,12 @@ class QemuPlatformSchema:
     # An optional remote host for the VMs. All test VMs will be spawned on the
     # specified host by connecting remotely to the libvirt instance running on it.
     # If None, the local machine is used as host.
-    host: Optional[LibvirtHost] = LibvirtHost()
+    host: LibvirtHost = LibvirtHost()
 
     # The timeout length for how long to wait for the OS to boot and request an IP
     # address from the libvirt DHCP server.
     # Specified in seconds. Default: 30s.
     network_boot_timeout: Optional[float] = None
-
-    def is_host_remote(self) -> bool:
-        return self.host.address is not None
 
 
 # QEMU orchestrator's per-node configuration options.

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from dataclasses_json import dataclass_json
 
@@ -38,7 +38,7 @@ class QemuPlatformSchema:
     # An optional remote host for the VMs. All test VMs will be spawned on the
     # specified host by connecting remotely to the libvirt instance running on it.
     # If None, the local machine is used as host.
-    host: LibvirtHost = LibvirtHost()
+    hosts: List[LibvirtHost] = field(default_factory=lambda: [LibvirtHost()])
 
     # The timeout length for how long to wait for the OS to boot and request an IP
     # address from the libvirt DHCP server.

--- a/lisa/sut_orchestrator/qemu/schema.py
+++ b/lisa/sut_orchestrator/qemu/schema.py
@@ -37,7 +37,8 @@ class LibvirtHost:
 class QemuPlatformSchema:
     # An optional remote host for the VMs. All test VMs will be spawned on the
     # specified host by connecting remotely to the libvirt instance running on it.
-    # If None, the local machine is used as host.
+    #
+    # CAUTION: Even though this field is a List, only one host is supported currently.
     hosts: List[LibvirtHost] = field(default_factory=lambda: [LibvirtHost()])
 
     # The timeout length for how long to wait for the OS to boot and request an IP

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -18,7 +18,7 @@ from .ethtool import Ethtool
 from .fdisk import Fdisk
 from .find import Find
 from .fio import FIOMODES, Fio, FIOResult
-from .firewall import Firewall
+from .firewall import Firewall, Iptables
 from .gcc import Gcc
 from .git import Git
 from .hwclock import Hwclock
@@ -52,6 +52,7 @@ from .parted import Parted
 from .pgrep import Pgrep, ProcessInfo
 from .ping import Ping
 from .qemu import Qemu
+from .qemu_img import QemuImg
 from .reboot import Reboot
 from .sar import Sar
 from .service import Service
@@ -94,6 +95,7 @@ __all__ = [
     "Iperf3",
     "Hwclock",
     "InterruptInspector",
+    "Iptables",
     "KdumpBase",
     "Kill",
     "Lagscope",
@@ -125,6 +127,7 @@ __all__ = [
     "Ping",
     "ProcessInfo",
     "Qemu",
+    "QemuImg",
     "Reboot",
     "Sar",
     "Sed",

--- a/lisa/tools/firewall.py
+++ b/lisa/tools/firewall.py
@@ -60,6 +60,28 @@ class Iptables(Tool):
     def can_install(self) -> bool:
         return False
 
+    def start_forwarding(self, port: int, dst_ip: str, dst_port: str) -> None:
+        self.run(
+            f"-I FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
+            sudo=True
+        )
+
+        self.run(
+            f"-t nat -I PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
+            sudo=True
+        )
+
+    def stop_forwarding(self, port: int, dst_ip: str, dst_port: str) -> None:
+        self.run(
+            f"-D FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
+            sudo=True
+        )
+
+        self.run(
+            f"-t nat -D PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
+            sudo=True
+        )
+
     def stop(self) -> None:
         self.run("-P INPUT ACCEPT", shell=True, sudo=True)
         self.run("-P OUTPUT ACCEPT", shell=True, sudo=True)

--- a/lisa/tools/firewall.py
+++ b/lisa/tools/firewall.py
@@ -60,27 +60,31 @@ class Iptables(Tool):
     def can_install(self) -> bool:
         return False
 
-    def start_forwarding(self, port: int, dst_ip: str, dst_port: str) -> None:
-        self.run(
+    def start_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
+        result = self.run(
             f"-I FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
-            sudo=True
+            sudo=True,
         )
+        result.assert_exit_code()
 
-        self.run(
+        result = self.run(
             f"-t nat -I PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
-            sudo=True
+            sudo=True,
         )
+        result.assert_exit_code()
 
-    def stop_forwarding(self, port: int, dst_ip: str, dst_port: str) -> None:
-        self.run(
+    def stop_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
+        result = self.run(
             f"-D FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
-            sudo=True
+            sudo=True,
         )
+        result.assert_exit_code()
 
-        self.run(
+        result = self.run(
             f"-t nat -D PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
-            sudo=True
+            sudo=True,
         )
+        result.assert_exit_code()
 
     def stop(self) -> None:
         self.run("-P INPUT ACCEPT", shell=True, sudo=True)

--- a/lisa/tools/firewall.py
+++ b/lisa/tools/firewall.py
@@ -61,30 +61,30 @@ class Iptables(Tool):
         return False
 
     def start_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
-        result = self.run(
+        self.run(
             f"-I FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
             sudo=True,
+            expected_exit_code=0,
         )
-        result.assert_exit_code()
 
-        result = self.run(
+        self.run(
             f"-t nat -I PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
             sudo=True,
+            expected_exit_code=0,
         )
-        result.assert_exit_code()
 
     def stop_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
-        result = self.run(
+        self.run(
             f"-D FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
             sudo=True,
+            expected_exit_code=0,
         )
-        result.assert_exit_code()
 
-        result = self.run(
+        self.run(
             f"-t nat -D PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
             sudo=True,
+            expected_exit_code=0,
         )
-        result.assert_exit_code()
 
     def stop(self) -> None:
         self.run("-P INPUT ACCEPT", shell=True, sudo=True)

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -1,11 +1,14 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
 from lisa.executable import Tool
+
 
 class QemuImg(Tool):
     @property
     def command(self) -> str:
         return "qemu-img"
 
-    def createDiffQcow2(self, output_img_path, backing_img_path):
+    def create_diff_qcow2(self, output_img_path: str, backing_img_path: str) -> None:
         params = f"create -F qcow2 -f qcow2 -b {backing_img_path} {output_img_path}"
         self.run(params, True)
-

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -1,0 +1,11 @@
+from lisa.executable import Tool
+
+class QemuImg(Tool):
+    @property
+    def command(self) -> str:
+        return "qemu-img"
+
+    def createDiffQcow2(self, output_img_path, backing_img_path):
+        params = f"create -F qcow2 -f qcow2 -b {backing_img_path} {output_img_path}"
+        self.run(params, True)
+

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -13,6 +13,7 @@ class QemuImg(Tool):
         params = f"create -F qcow2 -f qcow2 -b {backing_img_path} {output_img_path}"
         self.run(
             params,
+            force_run=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="Failed to create differential disk.",
         )

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -11,4 +11,8 @@ class QemuImg(Tool):
 
     def create_diff_qcow2(self, output_img_path: str, backing_img_path: str) -> None:
         params = f"create -F qcow2 -f qcow2 -b {backing_img_path} {output_img_path}"
-        self.run(params, True)
+        self.run(
+            params,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="Failed to create differential disk.",
+        )

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -584,7 +584,10 @@ class LocalShell(InitializableMixin):
                        (will fail if that's the case and this flag is off)
         """
         assert isinstance(path, Path), f"actual: {type(path)}"
-        path.rmdir()
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
 
     def chmod(self, path: PurePath, mode: int) -> None:
         """Change the file mode bits of each given file according to mode (Posix targets only)

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -585,7 +585,10 @@ class LocalShell(InitializableMixin):
         """
         assert isinstance(path, Path), f"actual: {type(path)}"
         if path.is_dir():
-            shutil.rmtree(path)
+            if recursive:
+                shutil.rmtree(path)
+            else:
+                path.rmdir()
         else:
             path.unlink()
 


### PR DESCRIPTION
The current qemu orchestrator treats the local machine as the host for the VMs. Add support to allow specifying a remote
host in the runbook. The remote host should have libvirtd running and configured to allow remote connections. VMs under test are spawned on this remote host.

Example runbook for specifying a remote host
```YAML
name: qemu default
...<snip>...
platform:
  - type: qemu
    admin_private_key_file: $(admin_private_key_file)
    keep_environment: $(keep_environment)
    qemu:
      hosts:
        - address: "10.77.0.5"
          username: "anirudh"
          private_key_file: $(admin_private_key_file)
    requirement:
      qemu:
        qcow2: $(qcow2)
        cloud_init:
          extra_user_data: $(extra_user_data)
```

In case `host` is not specified in the runbook, the local machine is treated as `host` (existing behavior).