### PR TITLE
util: fix path generator to take low order part of microseconds

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -254,7 +254,7 @@ def get_datetime_path(current: Optional[datetime] = None) -> str:
     if current is None:
         current = datetime.now()
     date = get_date_str(current)
-    time = current.utcnow().strftime("%H%M%S-%f")[:-3]
+    time = current.utcnow().strftime("%H%M%S-%f")[-3:]
     return f"{date}-{time}"
 
 


### PR DESCRIPTION
'%f', on strftime(), reads as "Microsecond as a decimal number,
zero-padded to 6 digits". If we ever want to be minimally safer
against collisions on consecutive runs, let's stick to the low order
part of that, not the higher, which has a high chance of clashing,
under the same second. Still not clash proof, but much better.