### PR TITLE
Add "placement" into diffDiskSettings in Azure template

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1492,6 +1492,7 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 						Add-Content -Value "$($indents[6])^diffDiskSettings^: " -Path $jsonFile
 						Add-Content -Value "$($indents[6]){" -Path $jsonFile
 						Add-Content -Value "$($indents[7])^option^: ^local^" -Path $jsonFile
+						Add-Content -Value "$($indents[7])^placement^: ^ResourceDisk^" -Path $jsonFile
 						Add-Content -Value "$($indents[6])}," -Path $jsonFile
 					}
 					else {
@@ -1552,6 +1553,7 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 						Add-Content -Value "$($indents[6])^diffDiskSettings^: " -Path $jsonFile
 						Add-Content -Value "$($indents[6]){" -Path $jsonFile
 						Add-Content -Value "$($indents[7])^option^: ^local^" -Path $jsonFile
+						Add-Content -Value "$($indents[7])^placement^: ^ResourceDisk^" -Path $jsonFile
 						Add-Content -Value "$($indents[6])}," -Path $jsonFile
 					}
 					else {


### PR DESCRIPTION
For ephemeral disk, if you want to opt for OS cache placement, the image OS disk's size should be less than or equal to the cache size of the VM size chosen. See [doc](https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#size-requirements).

When the image is Ubuntu20.04 gen2, and the VM size is D96ds_v5, from the Azure portal, it shows "The selected image is too large for the OS cache of the selected instance."  The OS cache placement option is not available.

![image](https://user-images.githubusercontent.com/56374758/156756372-fefb651c-eb94-40ed-93a1-2a56150c5b4c.png)

In lisav2, there is no "placement" specified in "diffDiskSettings". The VM is deployed as Temp disk placement.

But for SIG,  it has no information on the image size.  The error "An error occurred while loading image/size information. Ephemeral OS disk options are available, but they may fail to deploy" shows in the Azure portal. The OS cache placement is available. When using this template, the VM is deployed as cache disk type and the provision is failed with the errors "OS disk of Ephemeral VM with size greater than 3 GB is not allowed for VM size when the DiffDiskPlacement is **CacheDisk**".

![image](https://user-images.githubusercontent.com/56374758/156756860-c358a414-adfa-4a3f-be1c-63b02e717a66.png)

 ""placement": "ResourceDisk" " need to be added in "diffDiskSettings" object. Then the SIG image can be deployed successfully.