### PR TITLE
Update VM api version and add "placement" into diffDiskSettings

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -276,7 +276,7 @@
             }
         },
         {
-            "apiVersion": "2019-07-01",
+            "apiVersion": "2020-12-01",
             "type": "Microsoft.Compute/virtualMachines",
             "copy": {
                 "name": "vmCopy",
@@ -306,7 +306,7 @@
                     "imageReference": "[if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')])))]",
                     "osDisk": {
                         "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-osDisk')]",
-                        "diffDiskSettings": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'Ephemeral'), json('{\"option\": \"Local\"}'), json('null'))]",
+                        "diffDiskSettings": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'Ephemeral'), json('{\"option\": \"local\", \"placement\": \"ResourceDisk\"}'), json('null'))]",
                         "managedDisk": "[if(not(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'Ephemeral')), json(concat('{\"storageAccountType\": \"',parameters('nodes')[copyIndex('vmCopy')]['disk_type'],'\"}')), json('null'))]",
                         "caching": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'Ephemeral'), 'ReadOnly', 'ReadWrite')]",
                         "createOption": "FromImage"


### PR DESCRIPTION
For ephemeral disk, if you want to opt for OS cache placement, the image OS disk's size should be less than or equal to the cache size of the VM size chosen. See [doc](https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#size-requirements).

When the image is Ubuntu20.04 gen2, and the VM size is D96ds_v5, from the Azure portal, it shows "The selected image is too large for the OS cache of the selected instance."  The OS cache placement option is not available.

![image](https://user-images.githubusercontent.com/56374758/156756372-fefb651c-eb94-40ed-93a1-2a56150c5b4c.png)

In lisav2, there is no "placement" specified in "diffDiskSettings". The VM is deployed as Temp disk placement.

But for SIG,  it has no information on the image size.  The error "An error occurred while loading image/size information. Ephemeral OS disk options are available, but they may fail to deploy" shows in the Azure portal. The OS cache placement is available. When using this template, the VM is deployed as cache disk type and the provision is failed with the errors "OS disk of Ephemeral VM with size greater than 3 GB is not allowed for VM size when the DiffDiskPlacement is **CacheDisk**".

![image](https://user-images.githubusercontent.com/56374758/156756860-c358a414-adfa-4a3f-be1c-63b02e717a66.png)

When we add ""placement": "ResourceDisk" " in "diffDiskSettings" object, it has error "Could not find member 'placement' on object of type 'DiffDiskSettings'". After updating the API version to "2020-12-01". The SIG image can be deployed with the ephemeral disk.