### PR TITLE
Ensure QEMU console log shuts down.

### DIFF
--- a/lisa/sut_orchestrator/qemu/console_logger.py
+++ b/lisa/sut_orchestrator/qemu/console_logger.py
@@ -83,7 +83,13 @@ class QemuConsoleLogger:
         if events & libvirt.VIR_STREAM_EVENT_READABLE:
             # Data is available to be read.
             while True:
-                data = stream.recv(libvirt.virStorageVol.streamBufSize)
+                try:
+                    data = stream.recv(libvirt.virStorageVol.streamBufSize)
+                except libvirt.libvirtError:
+                    # An error occured. So, close the stream.
+                    self._close_stream(True)
+                    break
+
                 if data == -2:
                     # No more data available at the moment.
                     break

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -429,15 +429,17 @@ class QemuPlatform(Platform):
     ) -> None:
         for node in environment.nodes.list():
             node_context = get_node_context(node)
-            log.debug(f"Delete VM: {node_context.vm_name}")
 
             # Shutdown and delete the VM.
+            log.debug(f"Delete VM: {node_context.vm_name}")
             self._stop_and_delete_vm(environment, log, qemu_conn, node)
 
+            log.debug(f"Close VM console log: {node_context.vm_name}")
             assert node_context.console_logger
             node_context.console_logger.close()
 
             # Delete console log file
+            log.debug(f"Delete VM files: {node_context.vm_name}")
             try:
                 os.remove(node_context.console_log_file_path)
             except Exception as ex:


### PR DESCRIPTION
In test automation, I am seeing a problem where LISA gets stuck during test shutdown.
This seems like it might be occuring during the QEMU VM teardown. However, there
isn't enough information in the logs to be able to pinpoint the exact cause. So, this
change adds extra debug logs.

In addition, I noticed there was a potential bug where the QEMU VM console log might
not close down correctly if the `recv` function hits an error. So, this change fixes
this problem.