### PR TITLE
Fixes for QEMU relating to logging directory change.

### DIFF
--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -75,6 +75,9 @@ class QemuPlatform(Platform):
         )
 
     def _prepare_environment(self, environment: Environment, log: Logger) -> bool:
+        # Ensure environment log directory is created before connecting to any nodes.
+        _ = environment.log_path
+
         if len(self.qemu_platform_runbook.hosts) > 1:
             log.warning(
                 "Multiple hosts are currently not supported. "
@@ -93,6 +96,7 @@ class QemuPlatform(Platform):
                 runbook=schema.Node(name="qemu-host"),
                 index=-1,
                 logger_name="qemu-host",
+                base_part_path=environment.environment_part_path,
                 parent_logger=log,
             )
 
@@ -102,7 +106,11 @@ class QemuPlatform(Platform):
                 private_key_file=host.private_key_file,
             )
         else:
-            self.host_node = local_node_connect(parent_logger=log)
+            self.host_node = local_node_connect(
+                name="qemu-host",
+                base_part_path=environment.environment_part_path,
+                parent_logger=log,
+            )
 
         self._init_libvirt_conn_string()
         self._configure_environment(environment, log)

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -568,7 +568,8 @@ class TestSuite:
             case_log = get_logger("case", case_name, parent=self.__log)
 
             case_log_path = self.__create_case_log_path(case_name)
-            case_working_path = self.__get_case_working_path(case_log_path)
+            case_part_path = self.__get_test_part_path(case_log_path)
+            case_working_path = self.__get_case_working_path(case_part_path)
             case_unique_name = case_log_path.name
             case_log_file = case_log_path / f"{case_log_path.name}.log"
             case_log_handler = create_file_handler(case_log_file, case_log)
@@ -579,6 +580,7 @@ class TestSuite:
             case_kwargs.update({"log": case_log})
             case_kwargs.update({"log_path": case_log_path})
             case_kwargs.update({"working_path": case_working_path})
+            case_kwargs.update({"part_path": case_part_path})
 
             case_log.info(
                 f"test case '{case_result.runtime_data.full_name}' is running"
@@ -648,7 +650,13 @@ class TestSuite:
             path.mkdir(parents=True)
         return path
 
-    def __get_case_working_path(self, log_path: Path) -> Path:
+    def __get_test_part_path(self, log_path: Path) -> Path:
+        if is_unittest():
+            return Path()
+
+        return Path(log_path.parts[-2]) / log_path.parts[-1]
+
+    def __get_case_working_path(self, test_part_path: Path) -> Path:
         if is_unittest():
             return Path()
 
@@ -656,9 +664,7 @@ class TestSuite:
         # associated. Unlike the log path, the working path won't be created, because
         # it's not used in most cases. So it doesn't need to be created too. The
         # test case should create it, when it's used.
-        working_path = (
-            constants.RUN_LOCAL_WORKING_PATH / log_path.parts[-2] / log_path.parts[-1]
-        )
+        working_path = constants.RUN_LOCAL_WORKING_PATH / test_part_path
         return working_path
 
     def __suite_method(


### PR DESCRIPTION
1. Ensure the environment's log directory is created before QEMU orchestrator
connects to any nodes.
    
2. Ensure QEMU host node logs sits under the envionment's log directory.
    
3. Ensure QEMU host node is always called "qemu-host" even if it is the
local machine.
    
4. Expose a test suite's `part_path` variable to test functions so that it
can be used when calling `local_node_connect()`.
