### PR TITLE
QEMU: Bug fixes and improvements for storage directories.

### DIFF
--- a/lisa/sut_orchestrator/qemu/context.py
+++ b/lisa/sut_orchestrator/qemu/context.py
@@ -24,7 +24,6 @@ class EnvironmentContext:
 @dataclass
 class NodeContext:
     vm_name: str = ""
-    vm_disks_dir: str = ""
     cloud_init_file_path: str = ""
     os_disk_source_file_path: Optional[str] = None
     os_disk_base_file_path: str = ""


### PR DESCRIPTION
1. Since the VM disks directory is shared between all nodes, only try to delete it
once. This avoid unnecessary warnings in the logs.

2. Place the QEMU console log in the node's local log directory. Currently, it is
placed as a peer of the base QCOW2 image file.