### PR TITLE
Add quiet flag to tdnf.

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1288,7 +1288,7 @@ class CBLMariner(RPMDistro):
             self._dnf_tool_name = "dnf"
             return
 
-        self._dnf_tool_name = "tdnf"
+        self._dnf_tool_name = "tdnf -q"
 
     def _dnf_tool(self) -> str:
         return self._dnf_tool_name


### PR DESCRIPTION
tdnf can be quite noisy when installing a package. So, add quiet flag
so that it doesn't spam the debug logs.