### PR TITLE
Add interval 0 into the sql database

### DIFF
--- a/Testscripts/Windows/PERF-NETWORK-TCP-LATENCY-LAGSCOPE.ps1
+++ b/Testscripts/Windows/PERF-NETWORK-TCP-LATENCY-LAGSCOPE.ps1
@@ -146,7 +146,7 @@ collect_VM_properties
                 }
                 $interval = ($line.Trim() -replace '\s+',' ').Split(" ")[0]
                 $frequency = ($line.Trim() -replace '\s+',' ').Split(" ")[1]
-                if (($interval -match "^\d+$") -and ($frequency -match "^\d+$") -and ($interval -ne "0")) {
+                if (($interval -match "^\d+$") -and ($frequency -match "^\d+$")) {
                     $resultMap = @{}
                     if ($properties) {
                         $resultMap["GuestDistro"] = $properties.GuestDistro


### PR DESCRIPTION
Add interval(usec)"0" in the output of the lagscope into the SQL database.
The output of lagscope is like:

lagscope 1.0.1
---------------------------------------------------------
09:58:22 INFO: New connection: local:25001 [socket:3] --> 10.0.0.5:6001
09:58:45 INFO: TEST COMPLETED.
09:58:45 INFO: Ping statistics for 10.0.0.5:
09:58:45 INFO:    Number of successful Pings: 1000000
09:58:45 INFO:    Minimum = 20.000us, Maximum = 54.250us, Average = 21.436us
09:58:45 INFO: Dumping all latencies into csv file: Latency-20220323-0958.csv

Percentile       Latency(us)
     50%         21
     75%         21
     90%         22
     95%         22
     99%         23
   99.9%         27
  99.99%         38
 99.999%         50

Interval(usec)   Frequency
      0          999459
     30          511
     45          30
     60          0
     75          0
     90          0
    105          0
    120          0
    135          0
    150          0
    165          0
    180          0
    195          0
    210          0
    225          0
    240          0
    255          0
    270          0
    285          0
    300          0
    315          0
    330          0
    345          0
    360          0
    375          0
    390          0
    405          0
    420          0
    435          0
    450          0
    465          0
    480          0
