### PR TITLE
NICs: use ordered dict for node.nics, add clearer 'get' functions for…

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -120,7 +120,7 @@ class Dpdk(TestSuite):
 
         try:
             # run OVS tests, providing OVS with the NIC info needed for DPDK init
-            ovs.setup_ovs(node.nics.get_nic_by_index().pci_slot)
+            ovs.setup_ovs(node.nics.get_secondary_sriov_nic().pci_slot)
 
             # validate if OVS was able to initialize DPDK
             node.execute(
@@ -199,7 +199,7 @@ class Dpdk(TestSuite):
         server_proc = node.execute_async(
             (
                 f"{server_app_path} -l 1-2 -n 4 "
-                f"-b {node.nics.get_nic_by_index(0).pci_slot} -- -p 3 -n 1"
+                f"-b {node.nics.get_primary_sriov_nic().pci_slot} -- -p 3 -n 1"
             ),
             sudo=True,
             shell=True,
@@ -214,7 +214,7 @@ class Dpdk(TestSuite):
         client_result = node.execute(
             (
                 f"timeout -s INT 2 {client_app_path} --proc-type=secondary -l 3 -n 4"
-                f" -b {node.nics.get_nic_by_index(0).pci_slot} -- -n 0"
+                f" -b {node.nics.get_primary_sriov_nic().pci_slot} -- -n 0"
             ),
             sudo=True,
             shell=True,
@@ -284,7 +284,7 @@ class Dpdk(TestSuite):
 
         test_kit = initialize_node_resources(node, log, variables, "failsafe")
         testpmd = test_kit.testpmd
-        test_nic = node.nics.get_nic_by_index()
+        test_nic = node.nics.get_secondary_sriov_nic()
         testpmd_cmd = testpmd.generate_testpmd_command(
             test_nic, 0, "txonly", "failsafe"
         )
@@ -343,7 +343,7 @@ class Dpdk(TestSuite):
         vpp.install()
 
         net = node.nics
-        nic = net.get_nic_by_index()
+        nic = net.get_secondary_sriov_nic()
 
         # set devices to down and restart vpp service
         ip = node.tools[Ip]
@@ -521,7 +521,7 @@ class Dpdk(TestSuite):
     ) -> None:
         lsmod = node.tools[Lsmod]
         modprobe = node.tools[Modprobe]
-        nic = node.nics.get_nic_by_index()
+        nic = node.nics.get_secondary_sriov_nic()
         if nic.bound_driver == "hv_netvsc":
             enable_uio_hv_generic_for_nic(node, nic)
         bind_nic_to_dpdk_pmd(node.nics, nic, "netvsc")

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -32,7 +32,7 @@ class DpdkTestResources:
         self.nic_controller = _node.features[NetworkInterface]
         self.dmesg = _node.tools[Dmesg]
         self._last_dmesg = ""
-        test_nic = self.node.nics.get_nic_by_index()
+        test_nic = self.node.nics.get_secondary_sriov_nic()
         # generate hotplug pattern for this specific nic
         self.vf_hotplug_regex = re.compile(
             f"{test_nic.upper}: Data path switched to VF: {test_nic.lower}"
@@ -104,7 +104,9 @@ def generate_send_receive_run_info(
     rxq: int = 1,
 ) -> Dict[DpdkTestResources, str]:
 
-    snd_nic, rcv_nic = [x.node.nics.get_nic_by_index() for x in [sender, receiver]]
+    snd_nic, rcv_nic = [
+        x.node.nics.get_secondary_sriov_nic() for x in [sender, receiver]
+    ]
 
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
@@ -213,7 +215,7 @@ def initialize_node_resources(
         "Test needs at least 1 NIC on the test node."
     ).is_greater_than_or_equal_to(1)
 
-    nic_to_bind = node.nics.get_nic_by_index()
+    nic_to_bind = node.nics.get_secondary_sriov_nic()
 
     # netvsc pmd requires uio_hv_generic to be loaded before use
     if pmd == "netvsc":
@@ -322,7 +324,7 @@ def verify_dpdk_build(
     testpmd = test_kit.testpmd
 
     # grab a nic and run testpmd
-    test_nic = node.nics.get_nic_by_index()
+    test_nic = node.nics.get_secondary_sriov_nic()
 
     testpmd_cmd = testpmd.generate_testpmd_command(
         test_nic,


### PR DESCRIPTION
Use ordered dict for node.nics since get_nic_by_index is not guaranteed to return nics in any specific order.
Additionally add functions for DPDK tests to explicitly get the default SRIOV nic and secondary SRIOV nics. 
These functions have checks to make sure we are returning NICs with SRIOV.