### PR TITLE
DPDK Perf tests

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -1,0 +1,242 @@
+from typing import Any, Dict, Tuple
+
+from assertpy import assert_that
+
+from lisa import (
+    Logger,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    notifier,
+    simple_requirement,
+)
+from lisa.environment import Environment
+from lisa.features import Sriov
+from lisa.messages import NetworkPPSPerformanceMessage, create_message
+from lisa.tools import Lscpu
+from lisa.util import constants
+from microsoft.testsuites.dpdk.dpdkutil import (
+    DpdkTestResources,
+    verify_dpdk_send_receive,
+    verify_dpdk_send_receive_multi_txrx_queue,
+)
+
+
+@TestSuiteMetadata(
+    area="dpdk",
+    category="performance",
+    description="""
+    This test suite is to validate DPDK performance
+    """,
+)
+class DpdkPerformance(TestSuite):
+    TIMEOUT = 12000
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, minimal core count
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_dual_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+        self._run_dpdk_perf_test("failsafe", environment, log, variables)
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, maximal core count, default queue settings
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_multi_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        core_counts = [
+            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
+        ]
+
+        assert_that(core_counts).described_as(
+            "Nodes contain different core counts, DPDK Suite expects sender "
+            "and receiver to have same core count."
+        ).contains_only(core_counts[0])
+
+        self._run_dpdk_perf_test(
+            "failsafe", environment, log, variables, use_cores=core_counts[0]
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, maximum core count, maximum tx/rx queues
+
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_multi_queue(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test(
+            "failsafe", environment, log, variables, use_queues=True
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, minimal core count, default queues
+
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_dual_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+        self._run_dpdk_perf_test("netvsc", environment, log, variables)
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, maximum core count, default queues
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_multi_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        core_counts = [
+            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
+        ]
+
+        assert_that(core_counts).described_as(
+            "Nodes contain different core counts, DPDK Suite expects sender "
+            "and receiver to have same core count."
+        ).contains_only(core_counts[0])
+
+        self._run_dpdk_perf_test(
+            "netvsc", environment, log, variables, use_cores=core_counts[0]
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, maximum core count, maximum tx/rx queues
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_multi_queue(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test("netvsc", environment, log, variables, use_queues=True)
+
+    def _run_dpdk_perf_test(
+        self,
+        pmd: str,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        use_cores: int = 0,
+        use_queues: bool = False,
+    ) -> None:
+        # run build + validation to populate results
+        if use_queues:
+            send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
+                environment, log, variables, pmd
+            )
+        else:
+            send_kit, receive_kit = verify_dpdk_send_receive(
+                environment, log, variables, pmd, use_cores
+            )
+
+        # gather the performance data into message format
+        result_messages = self._create_pps_performance_results(
+            send_kit, receive_kit, environment, f"perf_dpdk_{pmd}"
+        )
+
+        # pass result messages to notifier
+        for message in result_messages:
+            notifier.notify(message)
+
+    def _create_pps_performance_results(
+        self,
+        send_kit: DpdkTestResources,
+        receive_kit: DpdkTestResources,
+        environment: Environment,
+        test_case_name: str,
+    ) -> Tuple[NetworkPPSPerformanceMessage, NetworkPPSPerformanceMessage]:
+        sender_fields: Dict[str, Any] = {}
+        receiver_fields: Dict[str, Any] = {}
+
+        # shared results fields
+        for result_fields in [sender_fields, receiver_fields]:
+            result_fields["tool"] = constants.NETWORK_PERFORMANCE_TOOL_DPDK_TESTPMD
+            result_fields["test_type"] = "performance"
+
+        # send side fields
+        sender = send_kit.testpmd
+        sender_fields["role"] = "sender"
+        sender_fields["tx_pps_maximum"] = sender.get_max_tx_pps()
+        sender_fields["tx_pps_average"] = sender.get_mean_tx_pps()
+        sender_fields["tx_pps_minimum"] = sender.get_min_tx_pps()
+
+        # receive side fields
+        receiver = receive_kit.testpmd
+        receiver_fields["role"] = "receiver/forwarder"
+        receiver_fields["rx_pps_maximum"] = receiver.get_max_rx_pps()
+        receiver_fields["rx_pps_average"] = receiver.get_mean_rx_pps()
+        receiver_fields["rx_pps_minimum"] = receiver.get_min_rx_pps()
+        receiver_fields["fwd_pps_maximum"] = receiver.get_max_tx_pps()
+        receiver_fields["fwd_pps_average"] = receiver.get_mean_tx_pps()
+        receiver_fields["fwd_pps_minimum"] = receiver.get_min_tx_pps()
+
+        send_results = create_message(
+            NetworkPPSPerformanceMessage,
+            send_kit.node,
+            environment,
+            test_case_name,
+            sender_fields,
+        )
+        receive_results = create_message(
+            NetworkPPSPerformanceMessage,
+            receive_kit.node,
+            environment,
+            test_case_name,
+            receiver_fields,
+        )
+
+        return send_results, receive_results

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -100,8 +100,9 @@ def generate_send_receive_run_info(
     pmd: str,
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
-    txq: int = 1,
-    rxq: int = 1,
+    txq: int = 0,
+    rxq: int = 0,
+    core_count: int = 0,
 ) -> Dict[DpdkTestResources, str]:
 
     snd_nic, rcv_nic = [x.node.nics.get_nic_by_index() for x in [sender, receiver]]
@@ -114,6 +115,7 @@ def generate_send_receive_run_info(
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         txq=txq,
         rxq=rxq,
+        use_core_count=core_count,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
@@ -122,6 +124,7 @@ def generate_send_receive_run_info(
         pmd,
         txq=txq,
         rxq=rxq,
+        use_core_count=core_count,
     )
 
     kit_cmd_pairs = {
@@ -346,6 +349,7 @@ def verify_dpdk_send_receive(
     log: Logger,
     variables: Dict[str, Any],
     pmd: str,
+    core_count: int = 0,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
 
     # helpful to have the public ips labeled for debugging
@@ -361,7 +365,9 @@ def verify_dpdk_send_receive(
 
     test_kits = init_nodes_concurrent(environment, log, variables, pmd)
     sender, receiver = test_kits
-    kit_cmd_pairs = generate_send_receive_run_info(pmd, sender, receiver)
+    kit_cmd_pairs = generate_send_receive_run_info(
+        pmd, sender, receiver, core_count=core_count
+    )
 
     results = run_testpmd_concurrent(kit_cmd_pairs, 15, log)
 


### PR DESCRIPTION
Add DPDK Perf tests

- Add DpdkPerf module with tests for dual-core, multicore, and multiqueue for both netvsc and failsafe pmd
- Fix multiqueue/multicore functions and logic to allow multicore without multiqueue. 
- Multiqueue automatically uses max cores available or enough for each queue and port, add override to use less (or more) if needed.