### PR TITLE
QEMU: Console log improvements.

### DIFF
--- a/lisa/sut_orchestrator/qemu/console_logger.py
+++ b/lisa/sut_orchestrator/qemu/console_logger.py
@@ -92,6 +92,7 @@ class QemuConsoleLogger:
 
                 if data == -2:
                     # No more data available at the moment.
+                    assert self._log_file
                     self._log_file.flush()
                     break
 

--- a/lisa/sut_orchestrator/qemu/console_logger.py
+++ b/lisa/sut_orchestrator/qemu/console_logger.py
@@ -92,6 +92,7 @@ class QemuConsoleLogger:
 
                 if data == -2:
                     # No more data available at the moment.
+                    self._log_file.flush()
                     break
 
                 if len(data) == 0:

--- a/lisa/sut_orchestrator/qemu/platform.py
+++ b/lisa/sut_orchestrator/qemu/platform.py
@@ -448,12 +448,6 @@ class QemuPlatform(Platform):
             assert node_context.console_logger
             node_context.console_logger.close()
 
-            # Delete console log file
-            try:
-                os.remove(node_context.console_log_file_path)
-            except Exception as ex:
-                log.warning(f"console log delete failed. {ex}")
-
         # Delete VM disks directory.
         try:
             self.host_node.shell.remove(Path(self.vm_disks_dir), True)


### PR DESCRIPTION
1. Keep the console log file after the test completes, as it could provide useful
debugging information.

2. Flush the console log after receiving a batch of data, to ensure that the logs
don't get stuck in Python's I/O buffering.