### PR TITLE
Service tool exit code handling changes

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -601,10 +601,20 @@ class DpdkTestpmd(Tool):
             node.os.install_packages(list(self._redhat_packages))
 
             # ensure RDMA service is started if present.
+
             service_name = "rdma"
             service = node.tools[Service]
             if service.check_service_exists(service_name):
-                service.restart_service(service_name)
+                if not service.check_service_status(service_name):
+                    service.enable_service(service_name)
+
+                # some versions of RHEL and CentOS have service.rdma
+                # that will refuse manual start/stop and will return
+                # NOPERMISSION. This is not fatal and can be continued.
+                # If the service is present it should start when needed.
+                service.restart_service(
+                    service_name, ignore_exit_code=service.SYSTEMD_EXIT_NOPERMISSION
+                )
 
             node.execute(
                 "pip3 install --upgrade meson",


### PR DESCRIPTION
CentOS and RHEL have some verisons which set service.rdma to refuse manual start/stop commands. This PR:
- Adds an optional exit code ignore in addition to 0 for success.
- Adds a constant to service for a systemd exit code that the setup for testpmd will encounter nonfatally on some platforms.