### PR TITLE
Updating the Windows-Installation and Troubleshooting documentation

### DIFF
--- a/docs/installation_windows.rst
+++ b/docs/installation_windows.rst
@@ -76,7 +76,7 @@ Enter the ``PowerShell`` command prompt and then execute below commands:
 
 .. code:: powershell
 
-   (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python -
+   (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py -UseBasicParsing).Content | python -
 
    # Add poetry.exe's path to your `PATH` environment variable.
    $env:PATH += ";$env:APPDATA\Python\Scripts"

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -50,6 +50,14 @@ Poetry provides different packages according to the folder, and depends
 on the ``pyproject.toml`` file in the current folder. Make sure to run
 ``poetry`` in the root folder of LISA.
 
+Error: (For Windows installation) Cannot open Scripts folder
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Shell interface tries to locate the Scripts folder inside python.exe.
+Error line: Cannot open <Your local AppData dir>\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe\\Scripts'
+Reason: This could happen when you install the Python version via Microsoft store.
+Fix: uninstall the Microsoft Store version and install the standalone version from https://www.python.org/downloads/windows/
+
 Error: Poetry "The virtual environment seems to be broken"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -51,12 +51,17 @@ on the ``pyproject.toml`` file in the current folder. Make sure to run
 ``poetry`` in the root folder of LISA.
 
 Error: (For Windows installation) Cannot open Scripts folder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Shell interface tries to locate the Scripts folder inside python.exe.
-Error line: Cannot open <Your local AppData dir>\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe\\Scripts'
-Reason: This could happen when you install the Python version via Microsoft store.
-Fix: uninstall the Microsoft Store version and install the standalone version from https://www.python.org/downloads/windows/
+
+Error line: Cannot open <Your local AppData dir>\\Microsoft\\WindowsApps\
+\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\python.exe\\Scripts'
+
+Reason: This could happen when you install the Python version via Microsoft
+store.
+Fix: uninstall the Microsoft Store version and install the standalone
+version from https://www.python.org/downloads/windows/
 
 Error: Poetry "The virtual environment seems to be broken"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
List of changes:
1.  Updating the Poetry installation link in installation_windows.rst
2. Adding a scenario to troubleshooting guide: Error: (For Windows installation) Cannot open Scripts folder