### PR TITLE
add perf tests for huge vm

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -47,7 +47,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._validate_core_counts_are_equal(environment)
+
         self._run_dpdk_perf_test("failsafe", environment, log, variables)
 
     @TestCaseMetadata(
@@ -69,10 +69,8 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_count = self._validate_core_counts_are_equal(environment)
-
         self._run_dpdk_perf_test(
-            "failsafe", environment, log, variables, use_cores=core_count
+            "failsafe", environment, log, variables, use_max_cores=True
         )
 
     @TestCaseMetadata(
@@ -94,9 +92,8 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_count = self._validate_core_counts_are_equal(environment)
         self._run_dpdk_perf_test(
-            "failsafe", environment, log, variables, use_cores=core_count
+            "failsafe", environment, log, variables, use_max_cores=True
         )
 
     @TestCaseMetadata(
@@ -176,10 +173,8 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_count = self._validate_core_counts_are_equal(environment)
-
         self._run_dpdk_perf_test(
-            "netvsc", environment, log, variables, use_cores=core_count
+            "netvsc", environment, log, variables, use_max_cores=True
         )
 
     @TestCaseMetadata(
@@ -199,10 +194,8 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_count = self._validate_core_counts_are_equal(environment)
-
         self._run_dpdk_perf_test(
-            "netvsc", environment, log, variables, use_cores=core_count
+            "netvsc", environment, log, variables, use_max_cores=True
         )
 
     @TestCaseMetadata(
@@ -248,17 +241,23 @@ class DpdkPerformance(TestSuite):
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
-        use_cores: int = 0,
+        use_max_cores: bool = False,
         use_queues: bool = False,
     ) -> None:
         # run build + validation to populate results
+        max_core_count = self._validate_core_counts_are_equal(environment)
+        if use_max_cores:
+            core_count_argument = max_core_count
+        else:
+            core_count_argument = 0  # expected default, test will use 2 cores.
+
         if use_queues:
             send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
                 environment, log, variables, pmd
             )
         else:
             send_kit, receive_kit = verify_dpdk_send_receive(
-                environment, log, variables, pmd, use_cores
+                environment, log, variables, pmd, core_count_argument
             )
 
         # gather the performance data into message format

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -68,17 +68,10 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_counts = [
-            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
-        ]
-
-        assert_that(core_counts).described_as(
-            "Nodes contain different core counts, DPDK Suite expects sender "
-            "and receiver to have same core count."
-        ).contains_only(core_counts[0])
+        core_count = self._validate_core_counts_are_equal(environment)
 
         self._run_dpdk_perf_test(
-            "failsafe", environment, log, variables, use_cores=core_counts[0]
+            "failsafe", environment, log, variables, use_cores=core_count
         )
 
     @TestCaseMetadata(
@@ -100,17 +93,9 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_counts = [
-            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
-        ]
-
-        assert_that(core_counts).described_as(
-            "Nodes contain different core counts, DPDK Suite expects sender "
-            "and receiver to have same core count."
-        ).contains_only(core_counts[0])
-
+        core_count = self._validate_core_counts_are_equal(environment)
         self._run_dpdk_perf_test(
-            "failsafe", environment, log, variables, use_cores=core_counts[0]
+            "failsafe", environment, log, variables, use_cores=core_count
         )
 
     @TestCaseMetadata(
@@ -189,17 +174,10 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_counts = [
-            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
-        ]
-
-        assert_that(core_counts).described_as(
-            "Nodes contain different core counts, DPDK Suite expects sender "
-            "and receiver to have same core count."
-        ).contains_only(core_counts[0])
+        core_count = self._validate_core_counts_are_equal(environment)
 
         self._run_dpdk_perf_test(
-            "netvsc", environment, log, variables, use_cores=core_counts[0]
+            "netvsc", environment, log, variables, use_cores=core_count
         )
 
     @TestCaseMetadata(
@@ -219,17 +197,10 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        core_counts = [
-            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
-        ]
-
-        assert_that(core_counts).described_as(
-            "Nodes contain different core counts, DPDK Suite expects sender "
-            "and receiver to have same core count."
-        ).contains_only(core_counts[0])
+        core_count = self._validate_core_counts_are_equal(environment)
 
         self._run_dpdk_perf_test(
-            "netvsc", environment, log, variables, use_cores=core_counts[0]
+            "netvsc", environment, log, variables, use_cores=core_count
         )
 
     @TestCaseMetadata(
@@ -345,3 +316,14 @@ class DpdkPerformance(TestSuite):
         )
 
         return send_results, receive_results
+
+    def _validate_core_counts_are_equal(self, environment: Environment) -> int:
+        core_counts = [
+            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
+        ]
+
+        assert_that(core_counts).described_as(
+            "Nodes contain different core counts, DPDK Suite expects sender "
+            "and receiver to have same core count."
+        ).contains_only(core_counts[0])
+        return core_counts[0]

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -38,7 +38,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=4
         ),
     )
     def perf_dpdk_failsafe_pmd_dual_core(
@@ -55,10 +55,45 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2,
+            network_interface=Sriov(),
+            min_nic_count=2,
+            min_core_count=8,
         ),
     )
     def perf_dpdk_failsafe_pmd_multi_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        core_counts = [
+            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
+        ]
+
+        assert_that(core_counts).described_as(
+            "Nodes contain different core counts, DPDK Suite expects sender "
+            "and receiver to have same core count."
+        ).contains_only(core_counts[0])
+
+        self._run_dpdk_perf_test(
+            "failsafe", environment, log, variables, use_cores=core_counts[0]
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, maximal core count, default queue settings
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2,
+            network_interface=Sriov(),
+            min_nic_count=2,
+            min_core_count=48,
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_multi_core_huge_vm(
         self,
         environment: Environment,
         log: Logger,
@@ -85,10 +120,31 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=8
         ),
     )
     def perf_dpdk_failsafe_pmd_multi_queue(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test(
+            "failsafe", environment, log, variables, use_queues=True
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, maximum core count, maximum tx/rx queues
+        Run on a huge machine
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=48
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_multi_queue_huge_vm(
         self,
         environment: Environment,
         log: Logger,
@@ -106,7 +162,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=4
         ),
     )
     def perf_dpdk_netvsc_pmd_dual_core(
@@ -123,10 +179,40 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=8
         ),
     )
     def perf_dpdk_netvsc_pmd_multi_core(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        core_counts = [
+            n.tools[Lscpu].get_core_count() for n in environment.nodes.list()
+        ]
+
+        assert_that(core_counts).described_as(
+            "Nodes contain different core counts, DPDK Suite expects sender "
+            "and receiver to have same core count."
+        ).contains_only(core_counts[0])
+
+        self._run_dpdk_perf_test(
+            "netvsc", environment, log, variables, use_cores=core_counts[0]
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, maximum core count, default queues
+        Run on a big VM
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=48
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_multi_core_huge_vm(
         self,
         environment: Environment,
         log: Logger,
@@ -152,10 +238,29 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            min_count=2, network_interface=Sriov(), min_nic_count=2
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=8
         ),
     )
     def perf_dpdk_netvsc_pmd_multi_queue(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test("netvsc", environment, log, variables, use_queues=True)
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, maximum core count, maximum tx/rx queues,
+        Run on a huge machine
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2, network_interface=Sriov(), min_nic_count=2, min_core_count=48
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_multi_queue_huge_vm(
         self,
         environment: Environment,
         log: Logger,

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -47,6 +47,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
+        self._validate_core_counts_are_equal(environment)
         self._run_dpdk_perf_test("failsafe", environment, log, variables)
 
     @TestCaseMetadata(
@@ -156,6 +157,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
+        self._validate_core_counts_are_equal(environment)
         self._run_dpdk_perf_test("netvsc", environment, log, variables)
 
     @TestCaseMetadata(


### PR DESCRIPTION
Creates new test 'perf_dpdk_[pmd]_multicore_hugevm' that has a core count requirement of at least 48 cores.
Modifies the other previous tests to require 4 or 8 cores depending on their type. 
dual_core is supposed to be minimal core count so 4 is the absolute minimum. 
multicore and multiqueue require at least 8 (minimum recommended for dpdk)