### PR TITLE
[DPDK] Better handling of unimplemented and unsupported OS's

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -550,14 +550,14 @@ class DpdkTestpmd(Tool):
                     f"Ubuntu {str(node.os.information.release)} is EOL and "
                     "if not supported by dpdk tests",
                 )
-            elif "16.04" in node.os.information.release:
+            elif node.os.information.release < "18.04.0":
                 raise UnsupportedDistroException(
                     node.os,
                     "16.04 install is not supported yet."
                     "The installation must be adjusted to only install dpdk 18.11."
                     "Current install from source only supports >19.11",
                 )
-            elif "18.04" in node.os.information.release:
+            elif node.os.information.release < "20.04.0":
                 node.os.install_packages(list(self._ubuntu_packages_1804))
                 # ubuntu 18 has some issue with the packaged versions of meson
                 # and ninja. To guarantee latest, install and update with pip3
@@ -599,7 +599,7 @@ class DpdkTestpmd(Tool):
                         "pip3 upgrade for ninja failed"
                     ),
                 )
-            elif "20.04" in node.os.information.release:
+            else:
                 node.os.install_packages(list(self._ubuntu_packages_2004))
 
         elif isinstance(node.os, Redhat):

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -546,7 +546,6 @@ class DpdkTestpmd(Tool):
             node.os.add_repository("ppa:canonical-server/server-backports")
             if node.os.information.release < "16.04.0":
                 raise SkippedException(
-                    node.os,
                     f"Ubuntu {str(node.os.information.release)} is EOL and "
                     "if not supported by dpdk tests",
                 )
@@ -606,7 +605,7 @@ class DpdkTestpmd(Tool):
             if node.os.information.version.major < 7:
                 # SKIP for old unsupported versions.
                 raise SkippedException(
-                    node.os, "DPDK for Redhat < 7 is not supported by this test"
+                    "DPDK for Redhat < 7 is not supported by this test"
                 )
             elif node.os.information.version.major == 7:
                 # Add packages for rhel7


### PR DESCRIPTION
Adds some changes to:
- Make sure all Fedora based versions are run (Fedora,RHEL,Centos,CentosStream etc)
- Skip EOL versions of CentOs, RHEL, and Ubuntu.
- Throw more verbose error for Ubuntu 16.04 and other unimplemented OS flavors.