### PR TITLE
Skip test case when ethtool -N return 'operation not supported'

### DIFF
--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -781,7 +781,7 @@ class Ethtool(Tool):
         result = self.run(
             f"-n {interface} rx-flow-hash {protocol}", force_run=force_run
         )
-        if (result.exit_code != 0) and ("Operation not supported" in result.stdout):
+        if "Operation not supported" in result.stdout:
             raise UnsupportedOperationException(
                 f"ethtool -n {interface} operation not supported."
             )
@@ -813,7 +813,7 @@ class Ethtool(Tool):
             sudo=True,
             force_run=True,
         )
-        if (result.exit_code != 0) and ("Operation not supported" in result.stdout):
+        if "Operation not supported" in result.stdout:
             raise UnsupportedOperationException(
                 f"ethtool -N {interface} rx-flow-hash {protocol} {param}"
                 " operation not supported."

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -401,9 +401,12 @@ class NetworkSettings(TestSuite):
                 original_hlevel = device_hlevel_info.protocol_hash_map[protocol]
                 expected_hlevel = not original_hlevel
 
-                new_settings = ethtool.change_device_rx_hash_level(
-                    interface, protocol, expected_hlevel
-                )
+                try:
+                    new_settings = ethtool.change_device_rx_hash_level(
+                        interface, protocol, expected_hlevel
+                    )
+                except UnsupportedOperationException as identifier:
+                    raise SkippedException(identifier)
                 assert_that(
                     new_settings.protocol_hash_map[protocol],
                     f"Changing RX hash level for {protocol} didn't succeed",


### PR DESCRIPTION
For old image 'OpenLogic CentOS 7.5 7.5.201808150', when run ethtool -N, it will return 0 though the output is 'Operation not supported'