### PR TITLE
Fix verify_deployment_provision_ephemeral_managed_disk

### DIFF
--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -112,6 +112,7 @@ class Provisioning(TestSuite):
         priority=1,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
+            min_core_count=8,
             disk=DiskEphemeral(),
             supported_features=[SerialConsole],
         ),


### PR DESCRIPTION
Current case failed for below error, I try 4 cores, the same failure.

```
Provisioning.verify_deployment_provision_ephemeral_managed_disk: FAILED   deployment failed. LisaException: NotSupported: OS disk of Ephemeral VM with size greater than 14 GB is not allowed for VM size Standard_DS2_v2 when the DiffDiskPlacement is ResourceDisk. Please refer to https://aka.ms/Ephemeral for more details.
```