### PR TITLE
QEMU: Fix for deadlock on VM delete.

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -153,32 +153,20 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         xml = ET.tostring(domain, "unicode")
         return xml
 
-    def _stop_and_delete_vm(
-        self,
-        environment: Environment,
-        log: Logger,
-        lv_conn: libvirt.virConnect,
-        node: Node,
-    ) -> None:
-        super()._stop_and_delete_vm_flags(
-            environment,
-            log,
-            lv_conn,
-            node,
-            0,  # ch driver currently doesn't support any flags
-        )
+    def _get_domain_undefine_flags(self) -> int:
+        return 0
 
     def _create_domain_and_attach_logger(
         self,
         libvirt_conn: libvirt.virConnect,
-        domain: libvirt.virDomain,
         node_context: NodeContext,
     ) -> None:
-        domain.createWithFlags(0)
+        assert node_context.domain
+        node_context.domain.createWithFlags(0)
 
         assert node_context.console_logger
         node_context.console_logger.attach(
-            libvirt_conn, domain, node_context.console_log_file_path
+            libvirt_conn, node_context.domain, node_context.console_log_file_path
         )
 
     # Create the OS disk.

--- a/lisa/sut_orchestrator/libvirt/console_logger.py
+++ b/lisa/sut_orchestrator/libvirt/console_logger.py
@@ -41,11 +41,14 @@ class QemuConsoleLogger:
         self._console_stream_callback_started = True
 
     # Close the logger.
-    def close(self) -> None:
+    def close(self, abort: bool = True) -> None:
         # Check if attach() run successfully.
         if self._console_stream_callback_started:
-            # Close the stream on libvirt callbacks thread.
-            libvirt_events_thread.run_callback(self._close_stream, True)
+            if abort:
+                # Close the stream on libvirt callbacks thread.
+                libvirt_events_thread.run_callback(self._close_stream, True)
+
+            # Wait for stream to close.
             self._stream_completed.wait()
 
         else:

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+import libvirt  # type: ignore
+
 from lisa.environment import Environment
 from lisa.node import Node
 
@@ -34,10 +36,12 @@ class NodeContext:
     os_disk_file_path: str = ""
     console_log_file_path: str = ""
     extra_cloud_init_user_data: List[Dict[str, Any]] = field(default_factory=list)
-    console_logger: Optional[QemuConsoleLogger] = None
     use_bios_firmware: bool = False
     data_disks: List[DataDiskContext] = field(default_factory=list)
     next_disk_index: int = 0
+
+    console_logger: Optional[QemuConsoleLogger] = None
+    domain: Optional[libvirt.virDomain] = None
 
 
 def get_environment_context(environment: Environment) -> EnvironmentContext:


### PR DESCRIPTION
It seems that libvirt can sometimes deadlock if two threads
simultaneously try to close the console log stream and delete
(undefine) the VM. I am not sure if this is intended behavior or not.

This change changes the node shutdown flow, so that the console log is
fully closed before attempting to undefine the VM. Hopefully this will
prevent the deadlock.

The watchdog timer has been kept in case there are other ways this
deadlock can occur.