### PR TITLE
Fix smoke test time out against teradata images.

### DIFF
--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -100,7 +100,7 @@ class Reboot(Tool):
             # Reboot is not reliable, and sometime stuck,
             # like SUSE sles-15-sp1-sapcal gen1 2020.10.23.
             # In this case, use timeout to prevent hanging.
-            self.run(force_run=True, sudo=True, timeout=10)
+            self.run("-f", force_run=True, sudo=True, timeout=10)
         except Exception as identifier:
             # it doesn't matter to exceptions here. The system may reboot fast
             self._log.debug(f"ignorable exception on rebooting: {identifier}")


### PR DESCRIPTION
Fix the issue "failed. TimeoutError: time out in 3600 seconds."