### PR TITLE
Add JUnit notifier.

### DIFF
--- a/lisa/commands.py
+++ b/lisa/commands.py
@@ -27,6 +27,7 @@ def run(args: Namespace) -> int:
         notifier_runbook = schema.load_by_type_many(schema.Notifier, notifier_data)
         notifier.initialize(runbooks=notifier_runbook)
     run_message = messages.TestRunMessage(
+        runbook_name=builder.partial_resolve(constants.NAME),
         test_project=builder.partial_resolve(constants.TEST_PROJECT),
         test_pass=builder.partial_resolve(constants.TEST_PASS),
         run_name=constants.RUN_NAME,

--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @dataclass
 class MessageBase:
     type: str = "Base"
-    message_time: datetime = datetime.min
+    time: datetime = datetime.min
     elapsed: float = 0
 
 

--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @dataclass
 class MessageBase:
     type: str = "Base"
+    message_time: datetime = datetime.min
     elapsed: float = 0
 
 
@@ -33,6 +34,7 @@ TestRunStatus = Enum(
 class TestRunMessage(MessageBase):
     type: str = "TestRun"
     status: TestRunStatus = TestRunStatus.INITIALIZING
+    runbook_name: str = ""
     test_project: str = ""
     test_pass: str = ""
     tags: Optional[List[str]] = None

--- a/lisa/mixin_modules.py
+++ b/lisa/mixin_modules.py
@@ -13,6 +13,7 @@ import lisa.notifiers.console  # noqa: F401
 import lisa.notifiers.env_stats  # noqa: F401
 import lisa.notifiers.file  # noqa: F401
 import lisa.notifiers.html  # noqa: F401
+import lisa.notifiers.junit  # noqa: F401
 import lisa.notifiers.text_result  # noqa: F401
 import lisa.runners.lisa_runner  # noqa: F401
 import lisa.sut_orchestrator.ready  # noqa: F401

--- a/lisa/notifier.py
+++ b/lisa/notifier.py
@@ -103,7 +103,7 @@ def register_notifier(notifier: Notifier) -> None:
 
 
 def notify(message: MessageBase) -> None:
-    message.message_time = datetime.utcnow()
+    message.time = datetime.utcnow()
 
     # to make sure message get order as possible, use a queue to hold messages.
     with _message_queue_lock:

--- a/lisa/notifier.py
+++ b/lisa/notifier.py
@@ -3,6 +3,7 @@
 
 import copy
 import threading
+from datetime import datetime
 from functools import partial
 from typing import Any, Dict, List, Optional, Type
 
@@ -102,6 +103,8 @@ def register_notifier(notifier: Notifier) -> None:
 
 
 def notify(message: MessageBase) -> None:
+    message.message_time = datetime.utcnow()
+
     # to make sure message get order as possible, use a queue to hold messages.
     with _message_queue_lock:
         _message_queue.append(message)

--- a/lisa/notifiers/env_stats.py
+++ b/lisa/notifiers/env_stats.py
@@ -82,7 +82,7 @@ class EnvironmentStats(notifier.Notifier):
         result_info = self._test_results.get(test_result.id_, None)
         if not result_info:
             result_info = TestResultInformation(
-                id=test_result.id_, name=test_result.name
+                id=test_result.id_, name=test_result.full_name
             )
             self._test_results[test_result.id_] = result_info
         result_info.status = str(test_result.status)

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -1,0 +1,189 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import xml.etree.ElementTree as ET  # noqa: N817
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Any, Dict, List, Type, Union, cast
+
+from dataclasses_json import dataclass_json
+
+from lisa import schema
+from lisa.messages import MessageBase, TestRunMessage, TestRunStatus
+from lisa.notifier import Notifier
+from lisa.testsuite import (
+    TestResultMessage,
+    TestStatus,
+    TestSuiteMessage,
+    TestSuiteStatus,
+)
+from lisa.util import constants
+
+
+@dataclass_json()
+@dataclass
+class JUnitSchema(schema.Notifier):
+    path: str = "lisa.junit.xml"
+
+
+class _TestSuiteInfo:
+    def __init__(self) -> None:
+        self.xml: ET.Element
+        self.test_count: int = 0
+        self.failed_count: int = 0
+
+
+# Outputs tests results in JUnit format.
+# See, https://llg.cubic.org/docs/junit/
+class JUnit(Notifier):
+    @classmethod
+    def type_name(cls) -> str:
+        return "junit"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return JUnitSchema
+
+    def __init__(self, runbook: schema.TypedSchema) -> None:
+        super().__init__(runbook=runbook)
+
+        self._report_path: Path
+        self._report_file: IO[Any]
+        self._testsuites: ET.Element
+        self._testsuites_info: Dict[str, _TestSuiteInfo]
+        self._xml_tree: ET.ElementTree
+
+    # Test runner is initializing.
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        runbook: JUnitSchema = cast(JUnitSchema, self.runbook)
+
+        self._report_path = constants.RUN_LOCAL_LOG_PATH / runbook.path
+
+        # Open file now, to avoid errors occuring after all the tests have completed.
+        self._report_file = open(self._report_path, "wb")
+
+        self._testsuites = ET.Element("testsuites")
+        self._xml_tree = ET.ElementTree(self._testsuites)
+
+        self._testsuites_info = {}
+
+    # Test runner is closing.
+    def finalize(self) -> None:
+        try:
+            self._xml_tree.write(self._report_file, xml_declaration=True)
+
+        finally:
+            self._report_file.close()
+
+        self._log.info(f"JUnit: {self._report_path}")
+
+    # The types of messages that this class supports.
+    def _subscribed_message_type(self) -> List[Type[MessageBase]]:
+        return [TestResultMessage, TestSuiteMessage, TestRunMessage]
+
+    # Handle a message.
+    def _received_message(self, message: MessageBase) -> None:
+        if isinstance(message, TestRunMessage):
+            self._received_test_run(message)
+
+        elif isinstance(message, TestSuiteMessage):
+            self._received_test_suite(message)
+
+        elif isinstance(message, TestResultMessage):
+            self._received_test_result(message)
+
+    # Handle a test run message.
+    def _received_test_run(self, message: TestRunMessage) -> None:
+        if message.status == TestRunStatus.INITIALIZING:
+            self._test_run_started(message)
+
+        elif (
+            message.status == TestRunStatus.FAILED
+            or message.status == TestRunStatus.SUCCESS
+        ):
+            self._test_run_completed(message)
+
+    def _received_test_suite(self, message: TestSuiteMessage) -> None:
+        if message.status == TestSuiteStatus.INITIALIZING:
+            self._test_suite_started(message)
+
+        elif message.status == TestSuiteStatus.COMPLETED:
+            self._test_suite_completed(message)
+
+    # Handle a test case message.
+    def _received_test_result(self, message: TestResultMessage) -> None:
+        if message.status in [TestStatus.PASSED, TestStatus.FAILED, TestStatus.SKIPPED]:
+            self._test_case_completed(message)
+
+    # Test run started message.
+    def _test_run_started(self, message: TestRunMessage) -> None:
+        self._testsuites.attrib["name"] = message.runbook_name
+
+    # Test run completed message.
+    def _test_run_completed(self, message: TestRunMessage) -> None:
+        total_tests = 0
+        total_failures = 0
+
+        for testsuite_info in self._testsuites_info.values():
+            total_tests += testsuite_info.test_count
+            total_failures += testsuite_info.failed_count
+
+        self._testsuites.attrib["time"] = self._get_elapsed_str(message)
+        self._testsuites.attrib["tests"] = str(total_tests)
+        self._testsuites.attrib["failures"] = str(total_failures)
+        self._testsuites.attrib["errors"] = "0"
+
+    # Test suite started message.
+    def _test_suite_started(self, message: TestSuiteMessage) -> None:
+        if message.full_name in self._testsuites_info:
+            return
+
+        # Add test suite.
+        testsuite_info = _TestSuiteInfo()
+
+        testsuite_info.xml = ET.SubElement(self._testsuites, "testsuite")
+        testsuite_info.xml.attrib["name"] = message.full_name
+
+        # Timestamp must not contain timezone information.
+        timestamp = message.message_time.replace(tzinfo=None).isoformat(
+            timespec="seconds"
+        )
+        testsuite_info.xml.attrib["timestamp"] = timestamp
+
+        self._testsuites_info[message.full_name] = testsuite_info
+
+    # Test suite completed message.
+    def _test_suite_completed(self, message: TestSuiteMessage) -> None:
+        testsuite_info = self._testsuites_info[message.full_name]
+
+        testsuite_info.xml.attrib["time"] = self._get_elapsed_str(message)
+        testsuite_info.xml.attrib["tests"] = str(testsuite_info.test_count)
+        testsuite_info.xml.attrib["failures"] = str(testsuite_info.failed_count)
+        testsuite_info.xml.attrib["errors"] = "0"
+
+    # Test case completed message.
+    def _test_case_completed(self, message: TestResultMessage) -> None:
+        testsuite_info = self._testsuites_info[message.suite_full_name]
+
+        testcase = ET.SubElement(testsuite_info.xml, "testcase")
+        testcase.attrib["name"] = message.name
+        testcase.attrib["classname"] = message.suite_full_name
+        testcase.attrib["time"] = self._get_elapsed_str(message)
+
+        if message.status == TestStatus.FAILED:
+            failure = ET.SubElement(testcase, "failure")
+            failure.attrib["message"] = message.message
+            failure.text = message.stacktrace
+
+            testsuite_info.failed_count += 1
+
+        elif message.status == TestStatus.SKIPPED:
+            skipped = ET.SubElement(testcase, "skipped")
+            skipped.attrib["message"] = message.message
+
+        testsuite_info.test_count += 1
+
+    def _get_elapsed_str(
+        self, message: Union[TestResultMessage, TestSuiteMessage, TestRunMessage]
+    ) -> str:
+        return f"{message.elapsed:.3f}"

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -100,11 +100,7 @@ class JUnit(Notifier):
         if message.status == TestStatus.RUNNING:
             self._test_case_running(message)
 
-        elif message.status in [
-            TestStatus.PASSED,
-            TestStatus.FAILED,
-            TestStatus.SKIPPED,
-        ]:
+        elif message.is_completed:
             self._test_case_completed(message)
 
     # Test run started message.
@@ -138,9 +134,7 @@ class JUnit(Notifier):
             testsuite_info.xml.attrib["name"] = message.suite_full_name
 
             # Timestamp must not contain timezone information.
-            timestamp = message.message_time.replace(tzinfo=None).isoformat(
-                timespec="seconds"
-            )
+            timestamp = message.time.replace(tzinfo=None).isoformat(timespec="seconds")
             testsuite_info.xml.attrib["timestamp"] = timestamp
 
             self._testsuites_info[message.suite_full_name] = testsuite_info
@@ -161,7 +155,10 @@ class JUnit(Notifier):
 
             testsuite_info.failed_count += 1
 
-        elif message.status == TestStatus.SKIPPED:
+        elif (
+            message.status == TestStatus.SKIPPED
+            or message.status == TestStatus.ATTEMPTED
+        ):
             skipped = ET.SubElement(testcase, "skipped")
             skipped.attrib["message"] = message.message
 

--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -41,7 +41,7 @@ def print_results(
     output_method("________________________________________")
     result_count_dict: Dict[TestStatus, int] = {}
     for test_result in test_results:
-        result_name = test_result.name
+        result_name = test_result.full_name
         result_status = test_result.status
 
         output_method(

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -584,7 +584,7 @@ class RunnerTestCase(TestCase):
                 )
             else:
                 assert isinstance(test_result, TestResultMessage)
-                test_names.append(test_result.name.split(".")[1])
+                test_names.append(test_result.full_name.split(".")[1])
                 env_names.append(test_result.information.get("environment", ""))
         self.assertListEqual(
             expected_test_order,


### PR DESCRIPTION
1. Add timestamp to all notifier messages.

2. Add stacktrace to test result failure messages.

3. On test result messages, report relative function name (in addition to the fully
qualified name), and fully qualified test suite name.

4. Add new notifier messages for test suite status.

5. Add a new notifier type for outputting test results in the JUnit format.