### PR TITLE
add optional filter function for callers using git.get_tag

### DIFF
--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -170,6 +170,7 @@ class Git(Tool):
         sort_by: str = "v:refname",
         contains: str = "",
         return_last: bool = True,
+        filter: str = "",
     ) -> str:
         sort_arg = ""
         contains_arg = ""
@@ -191,8 +192,17 @@ class Git(Tool):
                 "check sort and commit arguments are correct"
             ),
         ).stdout.splitlines()
+        if filter:
+            filter_re = re.compile(filter)
+            tags = [x for x in tags if filter_re.search(x)]
+
+        # build some nice error info for failure cases
+        error_info = f"sortby:{sort_by} contains:{contains}"
+        if filter:
+            error_info += f" filter:{filter}"
         assert_that(len(tags)).described_as(
-            "Error: could not find any tags with this sort or filter setting"
+            "Error: could not find any tags with this sort or "
+            f"filter setting: {error_info}"
         ).is_greater_than(0)
 
         if return_last:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -444,9 +444,12 @@ class DpdkTestpmd(Tool):
                 dir_name=self._dpdk_repo_path_name,
             )
             if not self._dpdk_branch:
+
                 # dpdk stopped using a default branch
                 # if a branch is not specified, get latest version tag.
-                self._dpdk_branch = git_tool.get_tag(self.dpdk_path)
+                self._dpdk_branch = git_tool.get_tag(
+                    self.dpdk_path, filter=r"^v.*"  # starts w 'v'
+                )
 
             git_tool.checkout(self._dpdk_branch, cwd=self.dpdk_path)
             self.set_version_info_from_source_install(


### PR DESCRIPTION
Tag naming conventions vary from project to project, add an optional function parameter to git.get_tags to let callers define which types of tags to pick in a more flexible way. Filter can now intake a function that ingests and returns a list of strings while retaining the version number sorted order from the git tag result.

This commit also adds:
- a nicer format for error messages to bubble up the settings for this call after a failure.
- a use of the new function in DPDK suite which was used to test.