### PR TITLE
Fix sshconnection error coming from paramiko exec_command

### DIFF
--- a/lisa/tools/lsblk.py
+++ b/lisa/tools/lsblk.py
@@ -64,8 +64,9 @@ class DiskInfo(object):
     @property
     def is_os_disk(self) -> bool:
         # check if the disk contains boot partition
+        # boot partitions start with /boot/{id}
         for partition in self.partitions:
-            if partition.mountpoint == "/boot":
+            if partition.mountpoint.startswith("/boot"):
                 return True
         return False
 

--- a/lisa/tools/mkfs.py
+++ b/lisa/tools/mkfs.py
@@ -51,6 +51,10 @@ class Mkfs(Tool):
         else:
             raise LisaException(f"Unrecognized file system {file_system}.")
 
+    def _install(self) -> bool:
+        self.node.tools[Mkfsxfs]
+        return self._check_exists()
+
 
 class Mkfsxfs(Mkfs):
     @property


### PR DESCRIPTION
paramiko_client is also throwing SSHException if the tcp ports are not ready. Putting it inside retry makes logic robust