### PR TITLE
DPDK: use package manager by default

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -35,7 +35,6 @@ from microsoft.testsuites.dpdk.dpdkvpp import DpdkVpp
 
 VDEV_TYPE = "net_vdev_netvsc"
 MAX_RING_PING_LIMIT_NS = 200000
-DPDK_STABLE_GIT = "http://dpdk.org/git/dpdk-stable"
 DPDK_VF_REMOVAL_MAX_TEST_TIME = 60 * 10
 
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -23,8 +23,6 @@ from lisa.util import perf_timer
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
 
-DPDK_STABLE_GIT = "http://dpdk.org/git/dpdk-stable"
-
 
 class DpdkTestResources:
     def __init__(self, _node: Node, _testpmd: DpdkTestpmd) -> None:
@@ -186,7 +184,7 @@ def initialize_node_resources(
     pmd: str,
     sample_apps: Union[List[str], None] = None,
 ) -> DpdkTestResources:
-    dpdk_source = variables.get("dpdk_source", DPDK_STABLE_GIT)
+    dpdk_source = variables.get("dpdk_source", "package_manager")
     dpdk_branch = variables.get("dpdk_branch", "")
     log.info(
         "Dpdk initialize_node_resources running"


### PR DESCRIPTION
Swap back to using the package manager as the default installation source for DPDK for basic functionality testing.

For our broad validation tests we should be using the package manager to pull in matching dependencies and a certified version of DPDK rather than attempting to special case each version and distro.