### PR TITLE
Environment: fix failure on log path exists.

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -255,7 +255,7 @@ class Environment(ContextMixin, InitializableMixin):
 
         if not self._log_path:
             self._log_path = constants.RUN_LOCAL_LOG_PATH / self.environment_part_path
-            self._log_path.mkdir(parents=True)
+            self._log_path.mkdir(parents=True, exist_ok=True)
 
         return self._log_path
 
@@ -268,7 +268,7 @@ class Environment(ContextMixin, InitializableMixin):
             self._working_path = (
                 constants.RUN_LOCAL_WORKING_PATH / self.environment_part_path
             )
-            self._working_path.mkdir(parents=True)
+            self._working_path.mkdir(parents=True, exist_ok=True)
 
         return self._working_path
 


### PR DESCRIPTION
The log path may be created by node's logic, so env should be fine if
the path exists.