### PR TITLE
Add modprobe module_exists function

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -34,9 +34,14 @@ class ExecutableResult:
         return self.stdout
 
     def assert_exit_code(
-        self, expected_exit_code: Union[int, List[int]] = 0, message: str = ""
+        self,
+        expected_exit_code: Union[int, List[int]] = 0,
+        message: str = "",
+        include_output: bool = False,
     ) -> AssertionBuilder:
         message = "\n".join([message, f"get unexpected exit code on cmd {self.cmd}"])
+        if include_output:
+            message += "\n".join(["stdout:", self.stdout, "stderr:", self.stderr])
         # make the type checker happy by not using the union
         expected_exit_codes: List[int] = []
         if isinstance(expected_exit_code, int):

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -538,7 +538,17 @@ class DpdkTestpmd(Tool):
             modprobe.load("mlx4_en")
         else:
             raise UnsupportedDistroException(self.node.os)
-        modprobe.load(["ib_core", "ib_uverbs", "rdma_ucm", "ib_umad", "ib_ipoib"])
+        rdma_drivers = [
+            "ib_core",
+            "ib_uverbs",
+            "rdma_ucm",
+        ]
+        # some versions of dpdk require these two, some don't.
+        # some systems have them, some don't. Load if they're there.
+        for module in ["ib_ipoib", "ib_umad"]:
+            if modprobe.module_exists(module):
+                rdma_drivers.append(module)
+        modprobe.load(rdma_drivers)
         modprobe.load(mellanox_drivers)
 
     def _install_dependencies(self) -> None:


### PR DESCRIPTION
Add 'check if module exists' function to modprobe.

-Modprobe allows you to combine --dry-run and -q to check if a module exists and will load on the system. This commit enables use of this feature by adding a 'dry run' boolean and provides a named function to check if a module exists on the system.

-Adding this because testing manual binding for ib drivers is super annoying when trying to build from source and run DPDK on every distro and version. Rather than exploding or special casing every driver we can check if one exists and load it only if it's present (and needs to be loaded).