### PR TITLE
mark Ubuntu < 18.04 as not supported

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -557,18 +557,12 @@ class DpdkTestpmd(Tool):
 
         if isinstance(node.os, Ubuntu):
             node.os.add_repository("ppa:canonical-server/server-backports")
-            if node.os.information.version < "16.4.0":
+            if node.os.information.version < "18.4.0":
                 raise SkippedException(
-                    f"Ubuntu {str(node.os.information.version)} is EOL and "
-                    "if not supported by dpdk tests",
+                    f"Ubuntu {str(node.os.information.version)} is not supported. "
+                    "Minimum documented version for DPDK support is >=18.04"
                 )
-            elif node.os.information.version < "18.4.0":
-                raise UnsupportedDistroException(
-                    node.os,
-                    "16.04 install is not supported yet."
-                    "The installation must be adjusted to only install dpdk 18.11."
-                    "Current install from source only supports >19.11",
-                )
+
             elif node.os.information.version < "20.4.0":
                 node.os.install_packages(list(self._ubuntu_packages_1804))
                 # ubuntu 18 has some issue with the packaged versions of meson


### PR DESCRIPTION
Marking 16.04 as 'skip' since it is not supported.

https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#supported-operating-systems-minimum-versions