### PR TITLE
Manually add NVMe support

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1330,7 +1330,7 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 			#region virtualMachines
 			Write-LogInfo "Adding Virtual Machine $vmName"
 			Add-Content -Value "$($indents[2]){" -Path $jsonFile
-			Add-Content -Value "$($indents[3])^apiVersion^: ^2020-12-01^," -Path $jsonFile
+			Add-Content -Value "$($indents[3])^apiVersion^: ^2021-11-01^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^type^: ^Microsoft.Compute/virtualMachines^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^name^: ^$vmName^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^location^: ^[variables('location')]^," -Path $jsonFile
@@ -1632,6 +1632,10 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 				}
 			}
 			Add-Content -Value "$($indents[5])]" -Path $jsonFile
+			if ($CurrentTestData.SetupConfig.OverrideVMSize -match "Standard_E[0-9]+bs_v5") {
+				Add-Content -Value "$($indents[5])," -Path $jsonFile
+				Add-Content -Value "$($indents[5])^diskControllerType^: ^NVMe^" -Path $jsonFile
+			}
 			Add-Content -Value "$($indents[4])}" -Path $jsonFile
 			Add-Content -Value "$($indents[4])," -Path $jsonFile
 			#endregion


### PR DESCRIPTION
Manually add NVMe support for New VM SKU E96bs_v5 in the generated template.

I don't think there is a good way to detect NVMe support at this time. This change to the template may not be required in the future if NVMe capable SKUs use NVMe be default. It is unknown whether SCSI will remain a supported deployment option for these SKUs.

I am making this change so that I can start testing the New SKU.