### PR TITLE
Fix generation in hyperv platform

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1199,7 +1199,12 @@ class AzurePlatform(Platform):
             image_info = self._get_image_info(
                 azure_node_runbook.location, azure_node_runbook.marketplace
             )
-            azure_node_runbook.hyperv_generation = image_info.hyper_v_generation
+
+            # HyperVGenerationTypes return "V1"/"V2", so we need to strip "V"
+            azure_node_runbook.hyperv_generation = int(
+                image_info.hyper_v_generation.strip("V")
+            )
+
             # retrieve the os type for arm template.
             if azure_node_runbook.is_linux is None:
                 if image_info.os_disk_image.operating_system == "Windows":


### PR DESCRIPTION
`image_info.hyper_v_generation` can sometime contain value "V1/V2" instead of "1/2"