### PR TITLE
ASAP NVMe Support

### DIFF
--- a/Libraries/Azure.psm1
+++ b/Libraries/Azure.psm1
@@ -1330,7 +1330,7 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 			#region virtualMachines
 			Write-LogInfo "Adding Virtual Machine $vmName"
 			Add-Content -Value "$($indents[2]){" -Path $jsonFile
-			Add-Content -Value "$($indents[3])^apiVersion^: ^2020-12-01^," -Path $jsonFile
+			Add-Content -Value "$($indents[3])^apiVersion^: ^2021-11-01^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^type^: ^Microsoft.Compute/virtualMachines^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^name^: ^$vmName^," -Path $jsonFile
 			Add-Content -Value "$($indents[3])^location^: ^[variables('location')]^," -Path $jsonFile
@@ -1632,6 +1632,10 @@ Function Invoke-AllResourceGroupDeployments($SetupTypeData, $CurrentTestData, $R
 				}
 			}
 			Add-Content -Value "$($indents[5])]" -Path $jsonFile
+			if ($CurrentTestData.SetupConfig.OverrideVMSize -match "Standard_E[0-9]+bs_v5") {
+				Add-Content -Value "$($indents[5])," -Path $jsonFile
+				Add-Content -Value "$($indents[5])^diskControllerType^: ^NVMe^" -Path $jsonFile
+			}
 			Add-Content -Value "$($indents[4])}" -Path $jsonFile
 			Add-Content -Value "$($indents[4])," -Path $jsonFile
 			#endregion

--- a/Libraries/CommonFunctions.psm1
+++ b/Libraries/CommonFunctions.psm1
@@ -2580,6 +2580,19 @@ Function Get-DeviceName
     return $ret
 }
 
+Function Is-ASAP
+{
+    param (
+        [String] $ip,
+        [String] $port,
+        [String] $username,
+        [String] $password
+    )
+    $ret = Run-LinuxCmd -ip $ip -port $port -username $username -password $password `
+        -command ". utils.sh; is_asap_vmsku" -runAsSudo
+    return $ret
+}
+
 # This function will return expected devices count and keyword which part of output from command lspci based on provided device type
 # NVME - Disk count = vCPU/8
 #    size Standard_L8s_v2, vCPU 8, NVMe Disk 1

--- a/Testscripts/Linux/utils.sh
+++ b/Testscripts/Linux/utils.sh
@@ -3067,7 +3067,11 @@ function create_raid0() {
 	do
 		LogMsg "Partition disk /dev/${disk}"
 		(echo d; echo n; echo p; echo 1; echo; echo; echo t; echo fd; echo w;) | fdisk /dev/${disk}
-		raidDevices="${raidDevices} /dev/${disk}1"
+		if [[ $(is_asap_vmsku) == 1 ]]; then
+			raidDevices="${raidDevices} /dev/${disk}p1"
+		else
+			raidDevices="${raidDevices} /dev/${disk}1"
+		fi
 		count=$(( $count + 1 ))
 	done
 	LogMsg "Creating RAID of ${count} devices."


### PR DESCRIPTION
1. Change the template to specify NVMe disk controller type for Ebsv5
2. Change VERIFY-DISK-WITH-NOBARRIER to detect ASAP VM SKU and use NVMe disk naming schemes