### PR TITLE
Add '+' in the match pattern of ntp output for Mariner distro

### DIFF
--- a/Testscripts/Linux/TIMESYNC-NTP.sh
+++ b/Testscripts/Linux/TIMESYNC-NTP.sh
@@ -201,7 +201,7 @@ while [ $isOver == false ]; do
     delay=$(echo "$delay" | sed s'/.$//')
 
     # If the above value is not a number it means the output is an error message and exit loop
-    re='^-?[0-9]+([.][0-9]+)?$'
+    re='^[+-]?[0-9]+([.][0-9]+)?$'
     if ! [[ $delay =~ $re ]] ; then
         ntpqErr="$(ntpq -c rl $loopbackIP 2>&1)"
         LogErr "ntpq returned $ntpqErr. Aborting test."


### PR DESCRIPTION
In Mariner image, the output of “ntpq -c rl 127.0.0.1 | grep offset= | awk -F "=" '{print $3}' | awk '{print $1}'” is like:
+0.170273, 

We need to add '+' in the match pattern.
