### PR TITLE
dpdk nff-go skip EOL ubuntu and debian

### DIFF
--- a/microsoft/testsuites/dpdk/dpdknffgo.py
+++ b/microsoft/testsuites/dpdk/dpdknffgo.py
@@ -54,8 +54,8 @@ class DpdkNffGo(Tool):
             (isinstance(os, Ubuntu) and version >= "18.4.0")
             or (isinstance(os, Debian) and version >= "10.0.0")
         ):
-            raise SkippedException(
-                "NFF-GO test is not supported on EOL debian or Ubuntu"
+            raise UnsupportedDistroException(
+                os, "NFF-GO test is not supported on EOL debian or Ubuntu"
             )
         node = self.node
         git = node.tools[Git]

--- a/microsoft/testsuites/dpdk/dpdknffgo.py
+++ b/microsoft/testsuites/dpdk/dpdknffgo.py
@@ -6,7 +6,7 @@ from typing import List, Type
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Ubuntu
 from lisa.tools import Echo, Git, Make, Tar, Wget
-from lisa.util import SkippedException, UnsupportedDistroException
+from lisa.util import UnsupportedDistroException
 
 
 class DpdkNffGo(Tool):

--- a/microsoft/testsuites/dpdk/dpdknffgo.py
+++ b/microsoft/testsuites/dpdk/dpdknffgo.py
@@ -4,9 +4,9 @@
 from typing import List, Type
 
 from lisa.executable import Tool
-from lisa.operating_system import Debian
+from lisa.operating_system import Debian, Ubuntu
 from lisa.tools import Echo, Git, Make, Tar, Wget
-from lisa.util import UnsupportedDistroException
+from lisa.util import SkippedException, UnsupportedDistroException
 
 
 class DpdkNffGo(Tool):
@@ -48,6 +48,15 @@ class DpdkNffGo(Tool):
         return isinstance(self.node.os, Debian)
 
     def _install(self) -> bool:
+        os = self.node.os
+        version = os.information.version
+        if not (
+            (isinstance(os, Ubuntu) and version >= "18.4.0")
+            or (isinstance(os, Debian) and version >= "10.0.0")
+        ):
+            raise SkippedException(
+                "NFF-GO test is not supported on EOL debian or Ubuntu"
+            )
         node = self.node
         git = node.tools[Git]
         echo = node.tools[Echo]


### PR DESCRIPTION
NFF-GO test shouldn't run on EOL distros, add skip for EOL Debian and Ubuntu