### PR TITLE
Libvirt: Add Installer transformers for Qemu, CH & Libvirt

### DIFF
--- a/lisa/mixin_modules.py
+++ b/lisa/mixin_modules.py
@@ -39,6 +39,7 @@ if platform.system() == "Linux":
         import lisa.sut_orchestrator.libvirt.platform  # noqa: F401
         import lisa.sut_orchestrator.libvirt.qemu_platform  # noqa: F401
         import lisa.sut_orchestrator.libvirt.schema  # noqa: F401
+        import lisa.sut_orchestrator.libvirt.transformers  # noqa: F401
     except ModuleNotFoundError:
         print("libvirt package is not installed")
 

--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -18,6 +18,7 @@ from lisa.tools import QemuImg
 from lisa.util.logger import Logger
 
 from .. import CLOUD_HYPERVISOR
+from .console_logger import QemuConsoleLogger
 from .schema import BaseLibvirtNodeSchema, CloudHypervisorNodeSchema, DiskImageFormat
 
 
@@ -164,7 +165,7 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         assert node_context.domain
         node_context.domain.createWithFlags(0)
 
-        assert node_context.console_logger
+        node_context.console_logger = QemuConsoleLogger()
         node_context.console_logger.attach(
             libvirt_conn, node_context.domain, node_context.console_log_file_path
         )

--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -1,0 +1,523 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from dataclasses import dataclass, field
+from pathlib import PurePath
+from typing import Any, Dict, List, Optional, Type, cast
+
+from dataclasses_json import dataclass_json
+
+from lisa import schema
+from lisa.node import Node, quick_connect
+from lisa.operating_system import CBLMariner, Linux, Ubuntu
+from lisa.tools import Echo, Git, Wget
+from lisa.transformer import Transformer
+from lisa.transformers.kernel_source_installer import _get_code_path
+from lisa.util import field_metadata, filter_ansi_escape, subclasses
+from lisa.util.logger import Logger
+
+
+@dataclass_json()
+@dataclass
+class BaseInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
+    ...
+
+
+@dataclass_json()
+@dataclass
+class PackageInstallerSchema(BaseInstallerSchema):
+    ...
+
+
+@dataclass_json()
+@dataclass
+class ReleaseInstallerSchema(BaseInstallerSchema):
+    ...
+
+
+@dataclass_json()
+@dataclass
+class SourceInstallerSchema(BaseInstallerSchema):
+    # source code repo
+    repo: str = ""
+    ref: str = ""
+    # where to clone the repo
+    path: str = field(
+        default="",
+        metadata=field_metadata(
+            required=True,
+        ),
+    )
+
+
+@dataclass_json
+@dataclass
+class InstallerTransformerSchema(schema.Transformer):
+    # SSH connection information to the node
+    connection: Optional[schema.RemoteNode] = field(
+        default=None, metadata=field_metadata(required=True)
+    )
+    # installer's parameters.
+    installer: Optional[BaseInstallerSchema] = field(
+        default=None, metadata=field_metadata(required=True)
+    )
+
+
+class BaseInstaller(subclasses.BaseClassWithRunbookMixin):
+    def __init__(
+        self,
+        runbook: Any,
+        node: Node,
+        log: Logger,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(runbook, *args, **kwargs)
+        self._node = node
+        self._log = log
+
+    def validate(self) -> None:
+        raise NotImplementedError()
+
+    def install(self) -> str:
+        raise NotImplementedError()
+
+
+class LibvirtInstallerTransformer(Transformer):
+    @classmethod
+    def type_name(cls) -> str:
+        return "libvirt_installer"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return InstallerTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: InstallerTransformerSchema = self.runbook
+        assert runbook.connection, "connection must be defined."
+        assert runbook.installer, "installer must be defined."
+
+        node = quick_connect(runbook.connection, "libvirt_installer_node")
+
+        factory = subclasses.Factory[BaseInstaller](BaseInstaller)
+        installer = factory.create_by_runbook(
+            runbook=runbook.installer,
+            node=node,
+            log=self._log,
+        )
+        libvirt_version = installer.install()
+        self._log.info(f"installed libvirt version: {libvirt_version}")
+
+        if isinstance(node.os, Ubuntu):
+            node.execute("systemctl disable apparmor", shell=True, sudo=True)
+        node.execute("systemctl enable libvirtd", shell=True, sudo=True)
+        node.reboot()
+        return {}
+
+
+class QemuInstallerTransformer(Transformer):
+    @classmethod
+    def type_name(cls) -> str:
+        return "qemu_installer"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return InstallerTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: InstallerTransformerSchema = self.runbook
+        assert runbook.connection, "connection must be defined."
+        assert runbook.installer, "installer must be defined."
+
+        node = quick_connect(runbook.connection, "qemu_installer_node")
+
+        factory = subclasses.Factory[BaseInstaller](BaseInstaller)
+        installer = factory.create_by_runbook(
+            runbook=runbook.installer,
+            node=node,
+            log=self._log,
+        )
+        qemu_version = installer.install()
+        self._log.info(f"installed qemu version: {qemu_version}")
+
+        node.reboot()
+        return {}
+
+
+class CloudHypervisorInstallerTransformer(Transformer):
+    @classmethod
+    def type_name(cls) -> str:
+        return "cloudhypervisor_installer"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return InstallerTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: InstallerTransformerSchema = self.runbook
+        assert runbook.connection, "connection must be defined."
+        assert runbook.installer, "installer must be defined."
+
+        node = quick_connect(runbook.connection, "cloudhypervisor_installer_node")
+
+        factory = subclasses.Factory[BaseInstaller](BaseInstaller)
+        installer = factory.create_by_runbook(
+            runbook=runbook.installer,
+            node=node,
+            log=self._log,
+        )
+        ch_version = installer.install()
+        self._log.info(f"installed qemu version: {ch_version}")
+
+        node.reboot()
+        return {}
+
+
+class LibvirtPackageInstaller(BaseInstaller):
+
+    __distro_package_mapping = {
+        Ubuntu.__name__: ["libvirt-daemon-system"],
+        CBLMariner.__name__: ["dnsmasq", "ebtables", "libvirt"],
+    }
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "libvirt_package"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return PackageInstallerSchema
+
+    def validate(self) -> None:
+        assert type(self._node.os).__name__ in self.__distro_package_mapping, (
+            f"'{self.type_name()}' installer does not support {self._node.os.name} os",
+        )
+
+    def install(self) -> str:
+        node: Node = self._node
+        linux: Linux = cast(Linux, node.os)
+        packages_list = self.__distro_package_mapping[type(linux).__name__]
+        self._log.info(f"installing packages: {packages_list}")
+        linux.install_packages(list(packages_list))
+        version = self._get_version()
+        return version
+
+    def _get_version(self) -> str:
+        return _get_package_version(self._node, "libvirtd")
+
+
+class QemuPackageInstaller(BaseInstaller):
+
+    __distro_package_mapping = {
+        Ubuntu.__name__: ["qemu-kvm"],
+        CBLMariner.__name__: ["qemu-kvm"],
+    }
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "qemu_package"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return PackageInstallerSchema
+
+    def validate(self) -> None:
+        assert type(self._node.os).__name__ in self.__distro_package_mapping, (
+            f"'{self.type_name()}' installer does not support {self._node.os.name} os",
+        )
+
+    def install(self) -> str:
+        node: Node = self._node
+        linux: Linux = cast(Linux, node.os)
+        packages_list = self.__distro_package_mapping[type(linux).__name__]
+        self._log.info(f"installing packages: {packages_list}")
+        linux.install_packages(list(packages_list))
+        version = self._get_version()
+        return version
+
+    def _get_version(self) -> str:
+        return _get_package_version(self._node, "qemu-system-x86_64")
+
+
+class CloudHypervisorPackageInstaller(BaseInstaller):
+
+    __distro_package_mapping = {
+        CBLMariner.__name__: ["cloud-hypervisor"],
+    }
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "cloudhypervisor_package"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return PackageInstallerSchema
+
+    def validate(self) -> None:
+        assert type(self._node.os).__name__ in self.__distro_package_mapping, (
+            f"'{self.type_name()}' installer does not support {self._node.os.name} os",
+        )
+
+    def install(self) -> str:
+        node: Node = self._node
+        linux: Linux = cast(Linux, node.os)
+        packages_list = self.__distro_package_mapping[type(linux).__name__]
+        self._log.info(f"installing packages: {packages_list}")
+        linux.install_packages(list(packages_list))
+        version = self._get_version()
+        return version
+
+    def _get_version(self) -> str:
+        return _get_package_version(self._node, "cloud-hypervisor")
+
+
+class LibvirtSourceInstaller(BaseInstaller):
+
+    __distro_package_mapping = {
+        Ubuntu.__name__: [
+            "ninja-build",
+            "dnsmasq-base",
+            "libxml2-utils",
+            "xsltproc",
+            "python3-docutils",
+            "libglib2.0-dev",
+            "libgnutls28-dev",
+            "libxml2-dev",
+            "libnl-3-dev",
+            "libnl-route-3-dev",
+            "libtirpc-dev",
+            "libyajl-dev",
+            "libcurl4-gnutls-dev",
+            "python3-pip",
+        ],
+        CBLMariner.__name__: [
+            "ninja-build",
+            "build-essential",
+            "rpcsvc-proto",
+            "python3-docutils",
+            "glibc-devel",
+            "gnutls-devel",
+            "libnl3-devel",
+            "libtirpc-devel",
+            "curl-devel",
+            "ebtables",
+            "yajl-devel",
+            "python3-pip",
+        ],
+    }
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "libvirt_source"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return SourceInstallerSchema
+
+    def validate(self) -> None:
+        assert isinstance(self._node.os, Linux), (
+            f"The '{self.type_name()}' installer only support Linux Distros. "
+            f"The current os is {self._node.os.name}"
+        )
+
+    def _build_and_install(self, code_path: PurePath) -> None:
+        self._node.execute(
+            "meson build -D driver_ch=enabled -D driver_qemu=disabled \\"
+            "-D driver_openvz=disabled -D driver_esx=disabled \\"
+            "-D driver_vmware=disabled  -D driver_lxc=disabled \\"
+            "-D driver_libxl=disabled -D driver_vbox=disabled \\"
+            "-D selinux=disabled -D system=true --prefix=/usr \\"
+            "-D git_werror=disabled",
+            cwd=code_path,
+            shell=True,
+            sudo=True,
+        )
+        result = self._node.execute(
+            "ninja -C build",
+            shell=True,
+            sudo=True,
+            cwd=code_path,
+        )
+        assert not result.exit_code, "'ninja -C build' command failed."
+        result = self._node.execute(
+            "ninja -C build install",
+            shell=True,
+            sudo=True,
+            cwd=code_path,
+        )
+        assert not result.exit_code, "'ninja -C build' command failed."
+        self._node.execute("ldconfig", shell=True, sudo=True)
+
+    def _install_dependencies(self) -> None:
+        linux: Linux = cast(Linux, self._node.os)
+        dep_packages_list = self.__distro_package_mapping[type(linux).__name__]
+        linux.install_packages(list(dep_packages_list))
+        result = self._node.execute("pip3 install meson", shell=True, sudo=True)
+        assert not result.exit_code, "Failed to install meson"
+
+    def install(self) -> str:
+        runbook: SourceInstallerSchema = self.runbook
+        self._log.info("Installing dependencies for Libvirt...")
+        self._install_dependencies()
+        self._log.info("Cloning source code of Libvirt...")
+        code_path = _get_source_code(runbook, self._node, self.type_name(), self._log)
+        self._log.info("Building source code of Libvirt...")
+        self._build_and_install(code_path)
+        return _get_package_version(self._node, "libvirtd")
+
+
+class CloudHypervisorSourceInstaller(BaseInstaller):
+
+    __distro_package_mapping = {
+        Ubuntu.__name__: ["gcc"],
+        CBLMariner.__name__: ["gcc", "binutils", "glibc-devel"],
+    }
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "cloudhypervisor_source"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return SourceInstallerSchema
+
+    def _build_and_install(self, code_path: PurePath) -> None:
+        result = self._node.execute(
+            "cargo build --release",
+            shell=True,
+            sudo=False,
+            cwd=code_path,
+        )
+        assert not result.exit_code, "Failed to build cloud-hypervisor"
+        self._node.execute(
+            "cp ./target/release/cloud-hypervisor /usr/local/bin",
+            shell=True,
+            sudo=True,
+            cwd=code_path,
+        )
+        self._node.execute(
+            "chmod a+rx /usr/local/bin/cloud-hypervisor",
+            shell=True,
+            sudo=True,
+        )
+        self._node.execute(
+            "setcap cap_net_admin+ep /usr/local/bin/cloud-hypervisor",
+            shell=True,
+            sudo=True,
+        )
+
+    def _install_dependencies(self) -> None:
+        linux: Linux = cast(Linux, self._node.os)
+        packages_list = self.__distro_package_mapping[type(linux).__name__]
+        linux.install_packages(list(packages_list))
+        result = self._node.execute(
+            "curl https://sh.rustup.rs -sSf | sh -s -- -y",
+            shell=True,
+            sudo=False,
+        )
+        assert not result.exit_code, "Failed to install Rust & Cargo"
+        self._node.execute("source ~/.cargo/env", shell=True, sudo=False)
+        if isinstance(self._node.os, Ubuntu):
+            output = self._node.execute("echo $HOME", shell=True)
+            path = self._node.get_pure_path(output.stdout)
+            self._node.execute(
+                "cp .cargo/bin/* /usr/local/bin/",
+                shell=True,
+                sudo=True,
+                cwd=path,
+            )
+        self._node.execute("cargo --version", shell=True)
+
+    def install(self) -> str:
+        runbook: SourceInstallerSchema = self.runbook
+        self._log.info("Installing dependencies for Cloudhypervisor...")
+        self._install_dependencies()
+        self._log.info("Cloning source code of Cloudhypervisor ...")
+        code_path = _get_source_code(runbook, self._node, self.type_name(), self._log)
+        self._log.info("Building source code of Cloudhypervisor...")
+        self._build_and_install(code_path)
+        return _get_package_version(self._node, "cloud-hypervisor")
+
+
+class CloudHypervisorReleaseInstaller(BaseInstaller):
+    @classmethod
+    def type_name(cls) -> str:
+        return "cloudhypervisor_latest_release"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return ReleaseInstallerSchema
+
+    def install(self) -> str:
+        linux: Linux = cast(Linux, self._node.os)
+        linux.install_packages("jq")
+        command = (
+            "curl -s https://api.github.com/repos/cloud-hypervisor/"
+            "cloud-hypervisor/releases/latest | jq -r '.tag_name'"
+        )
+        latest_release_tag = self._node.execute(command, shell=True)
+        self._log.debug(f"latest tag: {latest_release_tag}")
+        wget = self._node.tools[Wget]
+        file_url = (
+            "https://github.com/cloud-hypervisor/cloud-hypervisor/"
+            f"releases/download/{latest_release_tag}/cloud-hypervisor"
+        )
+        file_path = wget.get(
+            url=file_url,
+            executable=True,
+            filename="cloud-hypervisor",
+        )
+        self._node.execute(f"cp {file_path} /usr/local/bin", sudo=True)
+        self._node.execute(
+            "chmod a+rx /usr/local/bin/cloud-hypervisor",
+            shell=True,
+            sudo=True,
+        )
+        self._node.execute(
+            "setcap cap_net_admin+ep /usr/local/bin/cloud-hypervisor",
+            sudo=True,
+        )
+        return _get_package_version(self._node, "cloud-hypervisor")
+
+
+def _get_source_code(
+    runbook: SourceInstallerSchema, node: Node, default_name: str, log: Logger
+) -> PurePath:
+    code_path = _get_code_path(runbook.path, node, default_name)
+
+    echo = node.tools[Echo]
+    echo_result = echo.run(str(code_path), shell=True)
+    code_path = node.get_pure_path(echo_result.stdout)
+
+    if not node.shell.exists(code_path):
+        # create and give permission on code folder
+        node.execute(f"mkdir -p {code_path}")
+        node.execute(f"chmod -R 777 {code_path}")
+
+    log.debug(f"cloning code from {runbook.repo} to {code_path}...")
+    git = node.tools[Git]
+    code_path = git.clone(url=runbook.repo, cwd=code_path)
+    git.fetch(cwd=code_path)
+    if runbook.ref:
+        log.debug(f"checkout code from: '{runbook.ref}'")
+        git.checkout(ref=runbook.ref, cwd=code_path)
+
+    return code_path
+
+
+def _get_package_version(node: Node, package: str) -> str:
+    result = node.execute(f"{package} --version", shell=True)
+    result_output = filter_ansi_escape(result.stdout)
+    return result_output

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -5,7 +5,6 @@ from typing import cast
 
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner, Linux, Ubuntu
-from lisa.util import LisaException
 
 
 class QemuImg(Tool):
@@ -24,10 +23,10 @@ class QemuImg(Tool):
         linux: Linux = cast(Linux, self.node.os)
         if isinstance(self.node.os, CBLMariner):
             linux.install_packages("qemu-img")
-        elif isinstance(self.node.os, CBLMariner):
+        elif isinstance(self.node.os, Ubuntu):
             linux.install_packages("qemu-utils")
         else:
-            raise LisaException("Missing QemuImg tool install impl for {linux} os")
+            raise NotImplementedError(f"Missing QemuImg tool install impl for {linux}")
         return self._check_exists()
 
     def create_new_qcow2(self, output_img_path: str, size_mib: int) -> None:

--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -1,13 +1,34 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from typing import cast
+
 from lisa.executable import Tool
+from lisa.operating_system import CBLMariner, Linux, Ubuntu
+from lisa.util import LisaException
 
 
 class QemuImg(Tool):
     @property
     def command(self) -> str:
         return "qemu-img"
+
+    @property
+    def can_install(self) -> bool:
+        for _os in [CBLMariner, Ubuntu]:
+            if isinstance(self.node.os, _os):
+                return True
+        return False
+
+    def _install(self) -> bool:
+        linux: Linux = cast(Linux, self.node.os)
+        if isinstance(self.node.os, CBLMariner):
+            linux.install_packages("qemu-img")
+        elif isinstance(self.node.os, CBLMariner):
+            linux.install_packages("qemu-utils")
+        else:
+            raise LisaException("Missing QemuImg tool install impl for {linux} os")
+        return self._check_exists()
 
     def create_new_qcow2(self, output_img_path: str, size_mib: int) -> None:
         self.run(


### PR DESCRIPTION
Transformer schemas

```YAML 
transformer:
  - type: qemu_installer
    connection:
      address: $(address)
      username: $(username)
      private_key_file: $(admin_private_key_file)
    installer:
      type: package
    libvirt:
      # type: package

      # type: source
      # repo: https://github.com/cloud-hypervisor/libvirt
      # ref: origin/ch

  - type: cloudhypervisor_installer
    connection:
      address: $(address)
      username: $(username)
      private_key_file: $(admin_private_key_file)
    installer:
      # type: binary

      # type: package

      # type: source
      # repo: https://github.com/cloud-hypervisor/cloud-hypervisor
      # ref: origin/main

    libvirt:
      # type: package

      # type: source
      # repo: https://github.com/cloud-hypervisor/libvirt
      # ref: origin/ch
```

cc: @anirudhrb @vyadavmsft 
