### PR TITLE
Fix data_disk_size requirement handling.

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -436,7 +436,7 @@ class DiskOptionSettings(FeatureSettings):
         ),
     )
     data_disk_size: search_space.CountSpace = field(
-        default=None,
+        default_factory=partial(search_space.IntRange, min=1),
         metadata=field_metadata(
             allow_none=True, decoder=search_space.decode_count_space
         ),


### PR DESCRIPTION
An error currently occurs if runbook doesn't specify node data disk size requirements
but the test case does. This occurs because the default is `None` instead of a
`IntRange`.