### PR TITLE
 Change the kernel cmdline parameters for a sigle boot entry

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -367,7 +367,10 @@ class KdumpRedhat(KdumpBase):
 
     def _get_crashkernel_update_cmd(self, crashkernel: str) -> str:
         if self.node.os.information.version >= "8.0.0-0":
-            return f'grubby --update-kernel=ALL --args="crashkernel={crashkernel}"'
+            return (
+                "grubby --update-kernel=/boot/vmlinuz-$(uname -r)"
+                f' --args="crashkernel={crashkernel}"'
+            )
         else:
             if self.node.shell.exists(PurePosixPath("/sys/firmware/efi")):
                 # System with UEFI firmware


### PR DESCRIPTION
The original command 'grubby --update-kernel=ALL --args="crashkernel={crashkernel}"' is not suitable for all the version 8 RedHat distros. Such as "oracle oracle-linux ol82-gen2 8.2.01","redhat rhel 8-lvm-gen2 8.1.20200902".

 Using command 'grubby --update-kernel=/boot/vmlinuz-$(uname -r) --args="crashkernel={crashkernel}"' is more stable.