### PR TITLE
Retry to install packages with --allow-unauthenticated

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -322,7 +322,7 @@ class Posix(OperatingSystem, BaseClassMixin):
     def install_packages(
         self,
         packages: Union[str, Tool, Type[Tool], List[Union[str, Tool, Type[Tool]]]],
-        signed: bool = True,
+        signed: bool = False,
         timeout: int = 600,
         extra_args: Optional[List[str]] = None,
     ) -> None:


### PR DESCRIPTION
In some old debian distro, will see this issue. 