### PR TITLE
Use kernel_version_raw of uname tool when getting kernel version

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -199,7 +199,7 @@ class KdumpBase(Tool):
 
     def check_required_kernel_config(self, config_path: str) -> None:
         for config in self.required_kernel_config:
-            result = self.node.execute(f"grep {config}=y {config_path}")
+            result = self.node.execute(f"grep {config}=y {config_path}", sudo=True)
             result.assert_exit_code(
                 message=f"The kernel config {config} is not set."
                 "Kdump is not supported."


### PR DESCRIPTION
1. We used 'kernel_version' of Uname tool to get the kernel version of the system.  The 'kernel_version' is 'VersionInfo' class, which has the standard format of 'major.minor.patch-'. 

But for Mariner image, such as microsoftcblmariner cbl-mariner cbl-mariner-2 2.20220426.01, the kernel version is '5.15.32`.`1-3.cm2', which doesn't have the format of 'VersionInfo' class. We will get a version of '5.15.32`-`1-3.cm2' , which is not exactly the same as the kernel version. That will cause "The remote path could not be accessed: /boot/config-5.15.32`-`1-3.cm2".

We can use 'kernel_version_raw' to fix this issue.

2. Change to use "ls.path_exists" instead of "node.shell.exists(PurePosixPath())". For Mariner image, the /boot/config-$(uname -r) file is rw just for root user. Using "ls.path_exists" can support "sudo".
