### PR TITLE
Azure: Fix deployment issues with custom rg name input

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1160,11 +1160,11 @@ class AzurePlatform(Platform):
             azure_node_runbook.name = truncate_keep_prefix(
                 f"{name_prefix}-n{index}", 50
             )
-            # It's used as computer name only. Windows doesn't support name more
-            # than 15 chars
-            azure_node_runbook.short_name = truncate_keep_prefix(
-                azure_node_runbook.name, 15
-            )
+        # It's used as computer name only. Windows doesn't support name more
+        # than 15 chars
+        azure_node_runbook.short_name = truncate_keep_prefix(
+            azure_node_runbook.name, 15
+        )
         if not azure_node_runbook.vm_size:
             raise LisaException("vm_size is not detected before deploy")
         if not azure_node_runbook.location:

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1154,16 +1154,18 @@ class AzurePlatform(Platform):
         )
 
         if not azure_node_runbook.name:
-            # the max length of vm name is 64 chars. Below logic takes last 40
-            # chars in resource group name and keep the leading "lisa-". So it's
-            # easy to identify it's a lisa created node.
-            azure_node_runbook.name = truncate_keep_prefix(
-                f"{name_prefix}-n{index}", 50
-            )
+            # the max length of vm name is 64 chars. Below logic takes last 45
+            # chars in resource group name and keep the leading 5 chars.
+            # name_prefix can contain any of customized (existing) or
+            # generated (starts with "lisa-") resource group name,
+            # so, pass the first 5 chars as prefix to truncate_keep_prefix
+            # to handle both cases
+            node_name = f"{name_prefix}-n{index}"
+            azure_node_runbook.name = truncate_keep_prefix(node_name, 50, node_name[:5])
         # It's used as computer name only. Windows doesn't support name more
         # than 15 chars
         azure_node_runbook.short_name = truncate_keep_prefix(
-            azure_node_runbook.name, 15
+            azure_node_runbook.name, 15, azure_node_runbook.name[:5]
         )
         if not azure_node_runbook.vm_size:
             raise LisaException("vm_size is not detected before deploy")


### PR DESCRIPTION
* short_name field is not assigned any value when node name is provided
in runbook. This change will have it assigned a value in all cases.
* Added explicit parameter for prefix for all instances of truncate_keep_prefix function calls.
`def truncate_keep_prefix(content: str, kept_len: int, prefix: str = "lisa-") -> str:`
  the value passed to `content` parameter of `truncate_keep_prefix` doesn't necessarily start with the default `prefix` parameter value `lisa-`. Hence, changed required instances of the function call to pass `content[:5]` as prefix. Otherwise, there's an expection of prefix mismatch.