### PR TITLE
azure: support maximized cap on vm size

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -74,7 +74,7 @@ class Infiniband(Feature):
     def get_ib_interfaces(self) -> List[IBDevice]:
         """Gets the list of Infiniband devices
         excluding any ethernet devices
-        and get their cooresponding network interface
+        and get their corresponding network interface
         Returns list of IBDevice(ib_device_name, nic_name, ip_addr)
         Example IBDevice("mlx5_ib0", "ib0", "172.16.1.23")"""
         ib_devices = []
@@ -308,7 +308,7 @@ class Infiniband(Feature):
 
     def install_intel_mpi(self) -> None:
         node = self._node
-        # Intall Intel MPI
+        # Install Intel MPI
         wget = node.tools[Wget]
         script_path = wget.get(
             "https://partnerpipelineshare.blob.core.windows.net/mpi/"
@@ -324,7 +324,7 @@ class Infiniband(Feature):
 
     def install_open_mpi(self) -> None:
         node = self._node
-        # Intall Open MPI
+        # Install Open MPI
         wget = node.tools[Wget]
         tar_file_path = wget.get(
             "https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.5.tar.gz",
@@ -348,7 +348,7 @@ class Infiniband(Feature):
 
     def install_ibm_mpi(self) -> None:
         node = self._node
-        # Intall Open MPI
+        # Install Open MPI
         wget = node.tools[Wget]
         script_path = wget.get(
             "https://partnerpipelineshare.blob.core.windows.net/mpi/"
@@ -371,7 +371,7 @@ class Infiniband(Feature):
 
     def install_mvapich_mpi(self) -> None:
         node = self._node
-        # Intall Open MPI
+        # Install Open MPI
         wget = node.tools[Wget]
         tar_file_path = wget.get(
             "https://partnerpipelineshare.blob.core.windows.net/"

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -95,6 +95,10 @@ class AzureNodeSchema:
     # It decides the real computer name. It cannot be too long.
     short_name: str = ""
     vm_size: str = ""
+    # Force to maximize capability of the vm size. It bypass requirements on
+    # test cases, and uses to force run performance tests on any vm size.
+    maximize_capability: bool = False
+
     location: str = ""
     # Required by shared gallery images which are present in
     # subscription different from where LISA is run

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -423,7 +423,7 @@ def get_storage_account_name(
     subscription_id: str, location: str, type: str = "s"
 ) -> str:
     subscription_id_postfix = subscription_id[-8:]
-    # name should be shorter than 24 charactor
+    # name should be shorter than 24 character
     return f"lisa{type}{location[0:11]}{subscription_id_postfix}"
 
 

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -419,6 +419,14 @@ class AzurePlatform(Platform):
                             matched_cap = azure_cap
                             matched_score = matcher.ratio()
                     if matched_cap:
+                        # If max capability is set, use the max capability,
+                        # instead of the real capability. It needs to be in the
+                        # loop, to find supported locations.
+                        if node_runbook.maximize_capability:
+                            matched_cap = self._generate_max_capability(
+                                node_runbook.vm_size, location_name
+                            )
+
                         predefined_cost += matched_cap.estimated_cost
 
                         min_cap = self._generate_min_capability(
@@ -1841,13 +1849,9 @@ class AzurePlatform(Platform):
         )
 
         # all nodes support following features
+        all_features = self.supported_features()
         node_space.features.update(
-            [
-                schema.FeatureSettings.create(base_features.Nvme.name()),
-                schema.FeatureSettings.create(features.Gpu.name()),
-                schema.FeatureSettings.create(features.StartStop.name()),
-                schema.FeatureSettings.create(features.SerialConsole.name()),
-            ]
+            [schema.FeatureSettings.create(x.name()) for x in all_features]
         )
         _convert_to_azure_node_space(node_space)
 

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -375,7 +375,7 @@ class AzurePlatform(Platform):
                 )
                 if node_runbook.location:
                     if existing_location:
-                        # if any one has different location, calculate again
+                        # if any one has different location, raise an exception.
                         if existing_location != node_runbook.location:
                             raise LisaException(
                                 f"predefined node must be in same location, "

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -448,7 +448,7 @@ class AzurePlatform(Platform):
                         f"Cannot find vm_size {node_runbook.vm_size} in {location}. "
                         f"Mockup capability to run tests."
                     )
-                    mock_up_capability = self._generate_mockup_capability(
+                    mock_up_capability = self._generate_max_capability(
                         node_runbook.vm_size, location
                     )
                     min_cap = self._generate_min_capability(
@@ -1798,9 +1798,7 @@ class AzurePlatform(Platform):
 
         return plan
 
-    def _generate_mockup_capability(
-        self, vm_size: str, location: str
-    ) -> AzureCapability:
+    def _generate_max_capability(self, vm_size: str, location: str) -> AzureCapability:
 
         # some vm size cannot be queried from API, so use default capability to
         # run with best guess on capability.

--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -28,10 +28,10 @@ from lisa.util.shell import try_connect
     area="kdump",
     category="functional",
     description="""
-    This test suite is used to verify if kernel crash dmup is effect, which is judged
+    This test suite is used to verify if kernel crash dump is effect, which is judged
     through vmcore file is generated after triggering kdump by sysrq.
 
-    It has 7 test cases. They verfy if kdump is effect when:
+    It has 7 test cases. They verify if kdump is effect when:
         1. VM has 1 cpu
         2. VM has 2-8 cpus and trigger kdump on cpu 1
         3. VM has 33-192 cpus and trigger kdump on cpu 32
@@ -51,7 +51,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if kdump is effect when VM has 1 cpu.
+        This test case verifies if kdump is effect when VM has 1 cpu.
         VM need 2G memory at least to make sure it has enough memory to load crash
         kernel.
 
@@ -59,7 +59,7 @@ class KdumpCrash(TestSuite):
         1. Check if vmbus version and kernel configurations support for crash dump.
         2. Specify the memory reserved for crash kernel in kernel cmdline, setting the
             "crashkernel" option to the required value.
-            a. Modify the grub config file to add crashkrenel option or change the
+            a. Modify the grub config file to add crashkernel option or change the
                 value to the required one. (For Redhat 8, no need to modify grub config
                 file. It can specify crashkernel by using grubby command directly)
             b. Update grub config
@@ -86,7 +86,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when VM has 2~8 cpus, and
+        This test case verifies if the kdump is effect when VM has 2~8 cpus, and
         trigger kdump on the second cpu(cpu1), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
@@ -102,7 +102,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when VM has any cores, and
+        This test case verifies if the kdump is effect when VM has any cores, and
         trigger kdump on the random cpu.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
@@ -116,7 +116,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when VM has 33~192 cpus and
+        This test case verifies if the kdump is effect when VM has 33~192 cpus and
         trigger kdump on the 33th cpu(cpu32), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
@@ -130,7 +130,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when VM has 193~415 cpus, and
+        This test case verifies if the kdump is effect when VM has 193~415 cpus, and
         trigger kdump on the 193th cpu(cpu192), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
@@ -144,7 +144,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when VM has more than 415 cpus,
+        This test case verifies if the kdump is effect when VM has more than 415 cpus,
         and trigger kdump on the 416th cpu(cpu415), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
@@ -158,7 +158,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when crashkernel is set auto.
+        This test case verifies if the kdump is effect when crashkernel is set auto.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
         priority=2,
@@ -169,7 +169,7 @@ class KdumpCrash(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case verfies if the kdump is effect when crashkernel is set auto and
+        This test case verifies if the kdump is effect when crashkernel is set auto and
         the memory is more than 2T. With the crashkernel=auto parameter, system will
         reserved a suitable size memory for crash kernel. We want to see if the
         crashkernel=auto can also handle this scenario when the system memory is large.
@@ -216,7 +216,7 @@ class KdumpCrash(TestSuite):
         # CONFIG_KEXEC_AUTO_RESERVE. For version 8, the ifdefine of that config is
         # removed. For these changes we can refer to Centos kernel, gotten according
         # to https://wiki.centos.org/action/show/Sources?action=show&redirect=sources
-        # In addiation, we didn't see upstream kernel has the auto crashkernel feature.
+        # In addition, we didn't see upstream kernel has the auto crashkernel feature.
         # It may be a patch owned by Redhat/Centos.
         config_path = self._get_boot_config_path(node)
         if not (
@@ -273,7 +273,7 @@ class KdumpCrash(TestSuite):
 
         # Wait for the VM dump file and boot up
         # When the crash kernel boots up, port 22 can be connected even if dump file
-        # is not completed. So we cann't use wait_tcp_port_ready function to judge if
+        # is not completed. So we can't use wait_tcp_port_ready function to judge if
         # the dump process is completed and the VM already boots up. We can use
         # try_connect function
         timer = create_timer()

--- a/microsoft/testsuites/lis/lissuite.py
+++ b/microsoft/testsuites/lis/lissuite.py
@@ -95,7 +95,7 @@ class Lis(TestSuite):
             This avoids half / corrupted installations.
 
             Steps:
-            1. Test leaves "bare minimum" size avaialble for LIS install and checks if
+            1. Test leaves "bare minimum" size available for LIS install and checks if
              LIS installation is successful.
         """,
         priority=2,
@@ -151,8 +151,8 @@ class Lis(TestSuite):
         boot_partition_buffer_space = 1048576
         root_partition = df.get_partition_by_mountpoint("/")
         boot_partition = df.get_partition_by_mountpoint("/boot")
-        assert root_partition, "fail to get root artition"
-        assert boot_partition, "fail to get boot artition"
+        assert root_partition, "fail to get root partition"
+        assert boot_partition, "fail to get boot partition"
         ramdisk_size_factor = 1
         if root_partition.name != boot_partition.name:
             ramdisk_size_factor = 2

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -18,10 +18,10 @@ class Fips(TestSuite):
     @TestCaseMetadata(
         description="""
         This test case will
-        1. Check whether FIPS can be enaled on the VM
+        1. Check whether FIPS can be enabled on the VM
         2. Enable FIPS
         3. Restart the VM for the changes to take effect
-        4. Verify that FIPS was enabled propperly
+        4. Verify that FIPS was enabled properly
         """,
         priority=3,
     )
@@ -41,5 +41,5 @@ class Fips(TestSuite):
         result = node.execute("fips-mode-setup --check")
 
         assert_that(result.stdout).described_as(
-            "FIPS was not propperly enabled."
+            "FIPS was not properly enabled."
         ).contains("is enabled")


### PR DESCRIPTION
It's used with vm_size to ignore requirements on test cases. It can force run perf tests on any vm size.