### PR TITLE
kvm_unit_tests_tool: Fix permissions for copy_back

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1133,7 +1133,7 @@ class RPMDistro(Linux):
         return False
 
     def _is_package_in_repo(self, package: str) -> bool:
-        command = f"{self._dnf_tool()} --showduplicates list {package} -y"
+        command = f"{self._dnf_tool()} list {package} -y"
         result = self._node.execute(command, sudo=True, shell=True)
         return 0 == result.exit_code
 
@@ -1413,7 +1413,7 @@ class CBLMariner(RPMDistro):
         self._dnf_tool_name: str
 
     def _initialize_package_installation(self) -> None:
-        result = self._node.execute("command -v dnf", no_info_log=True)
+        result = self._node.execute("command -v dnf", no_info_log=True, shell=True)
         if result.exit_code == 0:
             self._dnf_tool_name = "dnf"
             return

--- a/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
+++ b/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
@@ -58,6 +58,9 @@ class KvmUnitTests(Tool):
         return failures
 
     def _save_logs(self, test_names: List[str], log_path: Path) -> None:
+        logs_dir = self.repo_root / "logs"
+        self.node.execute(f"chmod a+x {str(logs_dir)}", shell=True, sudo=True)
+        self.node.execute(f"chmod -R a+r {str(logs_dir)}", shell=True, sudo=True)
         for test_name in test_names:
             self.node.shell.copy_back(
                 self.repo_root / "logs" / f"{test_name}.log",


### PR DESCRIPTION
Since the tests are run as root, copy_back fails on Mariner distro as
the user doesn't have read access to logs. Hence, adding read
permissions.



cc: @anirudhrb 