### PR TITLE
NetworkController: add wait skip option for sriov toggling

### DIFF
--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -21,7 +21,7 @@ class NetworkInterface(Feature):
     def enabled(self) -> bool:
         return True
 
-    def switch_sriov(self, enable: bool) -> None:
+    def switch_sriov(self, enable: bool, wait: bool = True) -> None:
         raise NotImplementedError
 
     def is_enabled_sriov(self) -> bool:

--- a/lisa/sut_orchestrator/aws/features.py
+++ b/lisa/sut_orchestrator/aws/features.py
@@ -167,7 +167,7 @@ class NetworkInterface(AwsFeatureMixin, features.NetworkInterface):
             raise LisaException(f"fail to find primary nic for vm {self._node.name}")
         return nic
 
-    def switch_sriov(self, enable: bool) -> None:
+    def switch_sriov(self, enable: bool, wait: bool = True) -> None:
         aws_platform: AwsPlatform = self._platform  # type: ignore
         instance = boto3.resource("ec2").Instance(self._intsance_id)
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -276,7 +276,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         super()._initialize(*args, **kwargs)
         self._initialize_information(self._node)
 
-    def switch_sriov(self, enable: bool) -> None:
+    def switch_sriov(self, enable: bool, wait: bool = True) -> None:
         azure_platform: AzurePlatform = self._platform  # type: ignore
         network_client = get_network_client(azure_platform)
         vm = get_vm(azure_platform, self._node)
@@ -313,7 +313,8 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                 ).is_equal_to(enable)
 
         # wait settings effective
-        self._check_sriov_enabled(enable)
+        if wait:
+            self._check_sriov_enabled(enable)
 
     def is_enabled_sriov(self) -> bool:
         azure_platform: AzurePlatform = self._platform  # type: ignore

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -244,7 +244,7 @@ def run_testpmd_concurrent(
 
         # disable sriov
         for node_resources in test_kits:
-            node_resources.nic_controller.switch_sriov(enable=False)
+            node_resources.nic_controller.switch_sriov(enable=False, wait=False)
 
         # wait for disable to hit the vm
         for node_resources in test_kits:
@@ -258,7 +258,7 @@ def run_testpmd_concurrent(
 
         # re-enable sriov
         for node_resources in test_kits:
-            node_resources.nic_controller.switch_sriov(enable=True)
+            node_resources.nic_controller.switch_sriov(enable=True, wait=False)
 
         # wait for re-enable to hit vms
         for node_resources in test_kits:


### PR DESCRIPTION
Adding an option for tests to skip the added wait for sriov toggling. 

- DPDK tests for failover after sriov rescinding already check for the VF disable/reenable so the check messes with the timeout timing is redundant in that case (and generates a lot of extra logs).