### PR TITLE
DPDK: fix rescind test timing and regex issues

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -35,7 +35,7 @@ from microsoft.testsuites.dpdk.dpdkvpp import DpdkVpp
 
 VDEV_TYPE = "net_vdev_netvsc"
 MAX_RING_PING_LIMIT_NS = 200000
-DPDK_VF_REMOVAL_MAX_TEST_TIME = 60 * 10
+DPDK_VF_REMOVAL_MAX_TEST_TIME = 200
 
 
 @TestSuiteMetadata(

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -260,20 +260,14 @@ class DpdkTestpmd(Tool):
             cmd,
             sudo=True,
         )
-        self.timer_proc.wait_result()
         proc_result = testpmd_proc.wait_result()
         self._last_run_output = proc_result.stdout
         self.populate_performance_data()
         return proc_result.stdout
 
     def kill_previous_testpmd_command(self) -> None:
-        # kill testpmd early, then kill the timer proc that is still running
-        assert_that(self.timer_proc).described_as(
-            "Timer process was not initialized before "
-            "calling kill_previous_testpmd_command"
-        ).is_not_none()
+        # kill testpmd early
         self.node.execute(f"killall -s INT {self.command}", sudo=True, shell=True)
-        self.timer_proc.kill()
 
     def get_data_from_testpmd_output(
         self,

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -35,9 +35,9 @@ class DpdkTestResources:
         test_nic = self.node.nics.get_nic_by_index()
         # generate hotplug pattern for this specific nic
         self.vf_hotplug_regex = re.compile(
-            f"{test_nic.upper}: Data path switched to VF: {test_nic.lower}"
+            f"{test_nic.upper}: Data path switched to VF:"
         )
-        self.vf_slot_removal_regex = re.compile(f"VF unregistering: {test_nic.lower}")
+        self.vf_slot_removal_regex = re.compile(f"{test_nic.upper}: VF unregistering:")
 
     def wait_for_dmesg_output(self, wait_for: str, timeout: int) -> bool:
         search_pattern = None


### PR DESCRIPTION
A couple of changes to the rescind test:
- Shorten the max timeout.
- Reduce number of processes we wait on. Previously there was a mashup of a few timers to kill testpmd. We don't actually care which one kills testpmd and it's possible one or the other will fail. Since we only care that testpmd returns and gives us output we can just wait on testpmd.
- Fix the regexes to not assume the VF will be named the same thing after hotplug. We already filter the old hotplug messages during the search, so it's enough to look for the VF being associated with the preexisting synthetic interface.

