### PR TITLE
Add Cloud Hypervisor tests

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from typing import Any
 
-from assertpy.assertpy import assert_that
-
 from lisa import (
     Environment,
     Logger,
@@ -63,10 +61,7 @@ class CloudHypervisorTestSuite(TestSuite):
         log_path: Path,
         result: TestResult,
     ) -> None:
-        failures = node.tools[CloudHypervisorTests].run_tests(
-            result, environment, "integration"
-        )
-        assert_that(failures, f"Unexpected failures: {failures}").is_empty()
+        node.tools[CloudHypervisorTests].run_tests(result, environment, "integration")
 
     @TestCaseMetadata(
         description="""
@@ -88,10 +83,9 @@ class CloudHypervisorTestSuite(TestSuite):
         log_path: Path,
         result: TestResult,
     ) -> None:
-        failures = node.tools[CloudHypervisorTests].run_tests(
+        node.tools[CloudHypervisorTests].run_tests(
             result, environment, "integration-live-migration"
         )
-        assert_that(failures, f"Unexpected failures: {failures}").is_empty()
 
     def _ensure_virtualization_enabled(self, node: Node) -> None:
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -15,7 +15,7 @@ from lisa import (
     schema,
     search_space,
 )
-from lisa.tools import Lscpu
+from lisa.tools import Lscpu, Modprobe
 from lisa.util import SkippedException
 from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
 
@@ -29,6 +29,14 @@ from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorT
     """,
 )
 class CloudHypervisorTestSuite(TestSuite):
+    def before_suite(self, log: Logger, **kwargs: Any) -> None:
+        node = kwargs["node"]
+        node.tools[Modprobe].load("openvswitch")
+
+    def after_suite(self, log: Logger, **kwargs: Any) -> None:
+        node = kwargs["node"]
+        node.tools[Modprobe].remove("openvswitch")
+
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
         self._ensure_virtualization_enabled(node)
@@ -40,7 +48,8 @@ class CloudHypervisorTestSuite(TestSuite):
         priority=3,
         requirement=node_requirement(
             node=schema.NodeSpace(
-                min_core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+                core_count=search_space.IntRange(min=16),
+                memory_mb=search_space.IntRange(min=16 * 1024),
             ),
         ),
     )
@@ -57,7 +66,8 @@ class CloudHypervisorTestSuite(TestSuite):
         priority=3,
         requirement=node_requirement(
             node=schema.NodeSpace(
-                min_core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+                core_count=search_space.IntRange(min=16),
+                memory_mb=search_space.IntRange(min=16 * 1024),
             ),
         ),
     )

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from pathlib import Path
+
+from assertpy.assertpy import assert_that
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests 
+
+
+@TestSuiteMetadata(
+    area="kvm",
+    category="community",
+    description="""
+    This test suite is for executing the tests maintained in the
+    upstream cloud-hypervisor repo.
+    """,
+)
+class CloudHypervisorTestSuite(TestSuite):
+    @TestCaseMetadata(
+        description="""
+            Runs cloud-hypervisor integration tests.
+        """,
+        priority=3,
+    )
+    def verify_cloud_hypervisor_integration_tests(
+        self,
+        log: Logger,
+        node: Node,
+        log_path: Path
+    ) -> None:
+        excluded_tests = [ "test_vfio" ]
+        failures = node.tools[CloudHypervisorTests].run_tests(
+            "integration",
+            excluded_tests
+        )
+        assert_that(failures).is_empty()
+
+    @TestCaseMetadata(
+        description="""
+            Runs cloud-hypervisor live migration tests.
+        """,
+        priority=3,
+    )
+    def verify_cloud_hypervisor_live_migration_tests(
+        self,
+        log: Logger,
+        node: Node,
+        log_path: Path
+    ) -> None:
+        failures = node.tools[CloudHypervisorTests].run_tests(
+            "integration-live-migration"
+        )
+        assert_that(failures).is_empty()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -66,9 +66,7 @@ class CloudHypervisorTestSuite(TestSuite):
         failures = node.tools[CloudHypervisorTests].run_tests(
             result, environment, "integration"
         )
-        assert_that(
-            failures, f"Unexpected failures: {failures}"
-        ).is_empty()
+        assert_that(failures, f"Unexpected failures: {failures}").is_empty()
 
     @TestCaseMetadata(
         description="""
@@ -93,9 +91,7 @@ class CloudHypervisorTestSuite(TestSuite):
         failures = node.tools[CloudHypervisorTests].run_tests(
             result, environment, "integration-live-migration"
         )
-        assert_that(
-            failures, f"Unexpected failures: {failures}"
-        ).is_empty()
+        assert_that(failures, f"Unexpected failures: {failures}").is_empty()
 
     def _ensure_virtualization_enabled(self, node: Node) -> None:
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -4,8 +4,17 @@ from pathlib import Path
 
 from assertpy.assertpy import assert_that
 
-from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
-from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests 
+from lisa import (
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    node_requirement,
+    schema,
+    search_space,
+)
+from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
 
 
 @TestSuiteMetadata(
@@ -22,18 +31,17 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor integration tests.
         """,
         priority=3,
+        requirement=node_requirement(
+            node=schema.NodeSpace(
+                core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+            ),
+        ),
     )
     def verify_cloud_hypervisor_integration_tests(
-        self,
-        log: Logger,
-        node: Node,
-        log_path: Path
+        self, log: Logger, node: Node, log_path: Path
     ) -> None:
-        excluded_tests = [ "test_vfio" ]
-        failures = node.tools[CloudHypervisorTests].run_tests(
-            "integration",
-            excluded_tests
-        )
+        skip_tests = ["test_vfio"]
+        failures = node.tools[CloudHypervisorTests].run_tests("integration", skip_tests)
         assert_that(failures).is_empty()
 
     @TestCaseMetadata(
@@ -41,12 +49,14 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor live migration tests.
         """,
         priority=3,
+        requirement=node_requirement(
+            node=schema.NodeSpace(
+                core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+            ),
+        ),
     )
     def verify_cloud_hypervisor_live_migration_tests(
-        self,
-        log: Logger,
-        node: Node,
-        log_path: Path
+        self, log: Logger, node: Node, log_path: Path
     ) -> None:
         failures = node.tools[CloudHypervisorTests].run_tests(
             "integration-live-migration"

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -6,6 +6,7 @@ from typing import Any
 from assertpy.assertpy import assert_that
 
 from lisa import (
+    Environment,
     Logger,
     Node,
     TestCaseMetadata,
@@ -15,6 +16,7 @@ from lisa import (
     schema,
     search_space,
 )
+from lisa.testsuite import TestResult
 from lisa.tools import Lscpu, Modprobe
 from lisa.util import SkippedException
 from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
@@ -54,10 +56,19 @@ class CloudHypervisorTestSuite(TestSuite):
         ),
     )
     def verify_cloud_hypervisor_integration_tests(
-        self, log: Logger, node: Node, log_path: Path
+        self,
+        log: Logger,
+        node: Node,
+        environment: Environment,
+        log_path: Path,
+        result: TestResult,
     ) -> None:
-        failures = node.tools[CloudHypervisorTests].run_tests("integration")
-        assert_that(failures).described_as("Unexpected failures").is_empty()
+        failures = node.tools[CloudHypervisorTests].run_tests(
+            result, environment, "integration"
+        )
+        assert_that(
+            failures, f"Unexpected failures: {failures}"
+        ).is_empty()
 
     @TestCaseMetadata(
         description="""
@@ -72,12 +83,19 @@ class CloudHypervisorTestSuite(TestSuite):
         ),
     )
     def verify_cloud_hypervisor_live_migration_tests(
-        self, log: Logger, node: Node, log_path: Path
+        self,
+        log: Logger,
+        node: Node,
+        environment: Environment,
+        log_path: Path,
+        result: TestResult,
     ) -> None:
         failures = node.tools[CloudHypervisorTests].run_tests(
-            "integration-live-migration"
+            result, environment, "integration-live-migration"
         )
-        assert_that(failures).described_as("Unexpected failures").is_empty()
+        assert_that(
+            failures, f"Unexpected failures: {failures}"
+        ).is_empty()
 
     def _ensure_virtualization_enabled(self, node: Node) -> None:
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -15,7 +15,7 @@ from lisa import (
     search_space,
 )
 from lisa.tools import Lscpu
-from lisa.utils import SkippedException
+from lisa.util import SkippedException
 from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
 
 
@@ -42,7 +42,7 @@ class CloudHypervisorTestSuite(TestSuite):
     def verify_cloud_hypervisor_integration_tests(
         self, log: Logger, node: Node, log_path: Path
     ) -> None:
-        self._ensure_virtualization_enabled()
+        self._ensure_virtualization_enabled(node)
         skip_tests = ["test_vfio"]
         failures = node.tools[CloudHypervisorTests].run_tests("integration", skip_tests)
         assert_that(failures).is_empty()
@@ -61,13 +61,13 @@ class CloudHypervisorTestSuite(TestSuite):
     def verify_cloud_hypervisor_live_migration_tests(
         self, log: Logger, node: Node, log_path: Path
     ) -> None:
-        self._ensure_virtualization_enabled()
+        self._ensure_virtualization_enabled(node)
         failures = node.tools[CloudHypervisorTests].run_tests(
             "integration-live-migration"
         )
         assert_that(failures).is_empty()
 
-    def _ensure_virtualization_support(self) -> None:
-        virtualization_enabled = self.node.tools[Lscpu].is_virtualization_enabled()
+    def _ensure_virtualization_enabled(self, node: Node) -> None:
+        virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
         if not virtualization_enabled:
             raise SkippedException("Virtualization is not enabled in hardware")

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -18,7 +18,7 @@ from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorT
 
 
 @TestSuiteMetadata(
-    area="kvm",
+    area="cloud-hypervisor",
     category="community",
     description="""
     This test suite is for executing the tests maintained in the

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -40,7 +40,7 @@ class CloudHypervisorTestSuite(TestSuite):
         priority=3,
         requirement=node_requirement(
             node=schema.NodeSpace(
-                core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+                min_core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
             ),
         ),
     )
@@ -57,7 +57,7 @@ class CloudHypervisorTestSuite(TestSuite):
         priority=3,
         requirement=node_requirement(
             node=schema.NodeSpace(
-                core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
+                min_core_count=16, memory_mb=search_space.IntRange(min=16 * 1024)
             ),
         ),
     )

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1,17 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import re
-import string
-from pathlib import Path, PurePath
-from typing import Any, List, Type, cast
+from pathlib import PurePath
+from typing import Any, List, Type
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Posix
-from lisa.tools import Git, Docker, Modprobe
+from lisa.operating_system import CBLMariner
+from lisa.tools import Docker, Git, Modprobe
+
 
 class CloudHypervisorTests(Tool):
-    TIME_OUT = 3600
-    
+    TIME_OUT = 1800
+
     repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
 
     cmd_path: PurePath
@@ -29,43 +29,48 @@ class CloudHypervisorTests(Tool):
     def dependencies(self) -> List[Type[Tool]]:
         return [Git, Docker]
 
-    def run_tests(self, test_type: str, exclude: List[str] = []) -> None:
+    def run_tests(self, test_type: str, skip: List[str] = None) -> List[str]:
         self.node.tools[Modprobe].load("openvswitch")
-        self.node.tools[Docker].start()
 
-        skip_args = ' '.join(map(lambda t: f"--skip {t}", excluded_tests))
+        if skip is not None:
+            skip_args = " ".join(map(lambda t: f"--skip {t}", skip))
+        else:
+            skip_args = ""
+
         result = self.run(
             f"tests --{test_type} -- -- {skip_args}",
             timeout=self.TIME_OUT,
             force_run=True,
             cwd=self.repo_root,
             no_info_log=False,  # print out result of each test
-            # expected_exit_code=0,
+            expected_exit_code=0,
         )
 
-        return self._extract_failed_tests(result.stdout);
-        
+        return self._extract_failed_tests(result.stdout)
+
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         tool_path = self.get_tool_path(use_global=True)
         self.repo_root = tool_path / "cloud-hypervisor"
         self.cmd_path = self.repo_root / "scripts" / "dev_cli.sh"
         print(str(self.cmd_path))
- 
+
     def _install(self) -> bool:
         git = self.node.tools[Git]
         git.clone(self.repo, self.get_tool_path(use_global=True))
         if isinstance(self.node.os, CBLMariner):
             daemon_json_file = "/etc/docker/daemon.json"
-            daemon_json = '{"default-ulimits":{"nofile":{"Hard":65535,"Name":"nofile","Soft":65535}}}'
+            daemon_json = '{"default-ulimits":{"nofile":{"Hard":65535,"Name":"nofile","Soft":65535}}}'  # noqa: E501
             self.node.execute(
                 f"echo '{daemon_json}' | sudo tee {daemon_json_file}",
-                shell=True,sudo=True
+                shell=True,
+                sudo=True,
             )
+        self.node.tools[Docker].start()
 
         return self._check_exists()
 
     def _extract_failed_tests(self, output: str) -> List[str]:
-        lines = output.split('\n')
+        lines = output.split("\n")
         failures = []
         found_failures = False
         failure_re = re.compile("\\s+(\\S+)")
@@ -80,6 +85,4 @@ class CloudHypervisorTests(Tool):
                     found_failures = False
                     continue
                 failures.append(matches.group(1))
-        print(failures)
         return failures
-

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -65,13 +65,6 @@ class CloudHypervisorTests(Tool):
             self.node.tools[Echo].write_to_file(
                 daemon_json, daemon_json_file, sudo=True
             )
-            """
-            self.node.execute(
-                f"echo '{daemon_json}' | sudo tee {daemon_json_file}",
-                shell=True,
-                sudo=True,
-            )
-            """
         self.node.tools[Docker].start()
 
         return self._check_exists()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -63,7 +63,7 @@ class CloudHypervisorTests(Tool):
         )
 
         results = self._extract_test_results(result.stdout)
-        failures = list(filter(lambda r: r.status == TestStatus.FAILED, results))
+        failures = [r.name for r in results if r.status == TestStatus.FAILED]
         if not failures:
             result.assert_exit_code()
 
@@ -75,8 +75,7 @@ class CloudHypervisorTests(Tool):
                 r.status,
             )
 
-        failure_names = list(map(lambda x: x.name, failures))
-        assert_that(failures, f"Unexpected failures: {failure_names}").is_empty()
+        assert_that(failures, f"Unexpected failures: {failures}").is_empty()
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         tool_path = self.get_tool_path(use_global=True)

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -65,7 +65,7 @@ class CloudHypervisorTests(Tool):
                 daemon_json, daemon_json_file, sudo=True
             )
 
-        self.node.execute("groupadd -f docker")
+        self.node.execute("groupadd -f docker", expected_exit_code=0)
         username = self.node.tools[Whoami].get_username()
         res = self.node.execute("getent group docker", expected_exit_code=0)
         if username not in res.stdout:  # if current user is not in docker group

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1,0 +1,85 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import re
+import string
+from pathlib import Path, PurePath
+from typing import Any, List, Type, cast
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner, Posix
+from lisa.tools import Git, Docker, Modprobe
+
+class CloudHypervisorTests(Tool):
+    TIME_OUT = 3600
+    
+    repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
+
+    cmd_path: PurePath
+    repo_root: PurePath
+
+    @property
+    def command(self) -> str:
+        return str(self.cmd_path)
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    @property
+    def dependencies(self) -> List[Type[Tool]]:
+        return [Git, Docker]
+
+    def run_tests(self, test_type: str, exclude: List[str] = []) -> None:
+        self.node.tools[Modprobe].load("openvswitch")
+        self.node.tools[Docker].start()
+
+        skip_args = ' '.join(map(lambda t: f"--skip {t}", excluded_tests))
+        result = self.run(
+            f"tests --{test_type} -- -- {skip_args}",
+            timeout=self.TIME_OUT,
+            force_run=True,
+            cwd=self.repo_root,
+            no_info_log=False,  # print out result of each test
+            # expected_exit_code=0,
+        )
+
+        return self._extract_failed_tests(result.stdout);
+        
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        tool_path = self.get_tool_path(use_global=True)
+        self.repo_root = tool_path / "cloud-hypervisor"
+        self.cmd_path = self.repo_root / "scripts" / "dev_cli.sh"
+        print(str(self.cmd_path))
+ 
+    def _install(self) -> bool:
+        git = self.node.tools[Git]
+        git.clone(self.repo, self.get_tool_path(use_global=True))
+        if isinstance(self.node.os, CBLMariner):
+            daemon_json_file = "/etc/docker/daemon.json"
+            daemon_json = '{"default-ulimits":{"nofile":{"Hard":65535,"Name":"nofile","Soft":65535}}}'
+            self.node.execute(
+                f"echo '{daemon_json}' | sudo tee {daemon_json_file}",
+                shell=True,sudo=True
+            )
+
+        return self._check_exists()
+
+    def _extract_failed_tests(self, output: str) -> List[str]:
+        lines = output.split('\n')
+        failures = []
+        found_failures = False
+        failure_re = re.compile("\\s+(\\S+)")
+        for line in lines:
+            if line.startswith("failures:"):
+                found_failures = True
+                continue
+
+            if found_failures:
+                matches = failure_re.match(line)
+                if matches is None:
+                    found_failures = False
+                    continue
+                failures.append(matches.group(1))
+        print(failures)
+        return failures
+


### PR DESCRIPTION
Add testcases to run the `integration` and `integration-live-migration` tests from the `cloud-hypervisor` repository.