### PR TITLE
DPDK send/recv check for invalid package

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkovs.py
+++ b/microsoft/testsuites/dpdk/dpdkovs.py
@@ -107,7 +107,7 @@ class DpdkOvs(Tool):
         return True
 
     def _check_ovs_dpdk_compatibility(self, dpdk_tool: DpdkTestpmd) -> None:
-        dpdk_version = dpdk_tool.get_dpdk_branch()
+        dpdk_version = dpdk_tool.get_dpdk_version()
         # confirm supported ovs:dpdk version pairing based on
         # https://docs.openvswitch.org/en/latest/faq/releases/
         # to account for minor releases check release is below a major version threshold

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -17,6 +17,8 @@ from lisa.tools import Lscpu
 from lisa.util import constants
 from microsoft.testsuites.dpdk.dpdkutil import (
     DpdkTestResources,
+    SkippedException,
+    UnsupportedPackageVersionException,
     verify_dpdk_send_receive,
     verify_dpdk_send_receive_multi_txrx_queue,
 )
@@ -251,14 +253,17 @@ class DpdkPerformance(TestSuite):
         else:
             core_count_argument = 0  # expected default, test will use 2 cores.
 
-        if use_queues:
-            send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, pmd
-            )
-        else:
-            send_kit, receive_kit = verify_dpdk_send_receive(
-                environment, log, variables, pmd, core_count_argument
-            )
+        try:
+            if use_queues:
+                send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
+                    environment, log, variables, pmd
+                )
+            else:
+                send_kit, receive_kit = verify_dpdk_send_receive(
+                    environment, log, variables, pmd, core_count_argument
+                )
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
         # gather the performance data into message format
         result_messages = self._create_pps_performance_results(

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -10,6 +10,7 @@ from lisa import (
     Environment,
     Logger,
     Node,
+    SkippedException,
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
@@ -20,7 +21,9 @@ from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
 from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
+    UnsupportedPackageVersionException,
     bind_nic_to_dpdk_pmd,
+    check_send_receive_compatibility,
     enable_uio_hv_generic_for_nic,
     generate_send_receive_run_info,
     init_hugepages,
@@ -264,6 +267,12 @@ class Dpdk(TestSuite):
     ) -> None:
 
         test_kits = init_nodes_concurrent(environment, log, variables, "failsafe")
+
+        try:
+            check_send_receive_compatibility(test_kits)
+        except UnsupportedPackageVersionException:
+            raise SkippedException(UnsupportedPackageVersionException)
+
         sender, receiver = test_kits
 
         kit_cmd_pairs = generate_send_receive_run_info("failsafe", sender, receiver)
@@ -455,9 +464,12 @@ class Dpdk(TestSuite):
     def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        verify_dpdk_send_receive_multi_txrx_queue(
-            environment, log, variables, "failsafe"
-        )
+        try:
+            verify_dpdk_send_receive_multi_txrx_queue(
+                environment, log, variables, "failsafe"
+            )
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
     @TestCaseMetadata(
         description="""
@@ -477,7 +489,12 @@ class Dpdk(TestSuite):
     def verify_dpdk_send_receive_multi_txrx_queue_netvsc(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        verify_dpdk_send_receive_multi_txrx_queue(environment, log, variables, "netvsc")
+        try:
+            verify_dpdk_send_receive_multi_txrx_queue(
+                environment, log, variables, "netvsc"
+            )
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
     @TestCaseMetadata(
         description="""
@@ -497,7 +514,10 @@ class Dpdk(TestSuite):
     def verify_dpdk_send_receive_failsafe(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        verify_dpdk_send_receive(environment, log, variables, "failsafe")
+        try:
+            verify_dpdk_send_receive(environment, log, variables, "failsafe")
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
     @TestCaseMetadata(
         description="""
@@ -517,7 +537,11 @@ class Dpdk(TestSuite):
     def verify_dpdk_send_receive_netvsc(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        verify_dpdk_send_receive(environment, log, variables, "netvsc")
+
+        try:
+            verify_dpdk_send_receive(environment, log, variables, "netvsc")
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -125,8 +125,19 @@ class DpdkTestpmd(Tool):
     def set_dpdk_branch(self, dpdk_branch: str) -> None:
         self._dpdk_branch = dpdk_branch
 
-    def get_dpdk_branch(self) -> VersionInfo:
+    def get_dpdk_version(self) -> VersionInfo:
         return self._dpdk_version_info
+
+    def has_tx_ip_flag(self) -> bool:
+        dpdk_version = self.get_dpdk_version()
+        if not dpdk_version:
+            fail(
+                "Test suite bug: dpdk version was not set prior "
+                "to querying the version information."
+            )
+
+        # black doesn't like to direct return VersionInfo comparison
+        return bool(dpdk_version >= "19.11.0")  # appease the type checker
 
     def use_package_manager_install(self) -> bool:
         assert_that(hasattr(self, "_dpdk_source")).described_as(


### PR DESCRIPTION
Send/recv tests need a flag that was introduced in 19.11 and there is no check if the installed DPDK is older than that.

-Add an exception for this condition so we don't have to catch LisaException.
-Add try/except in the test logic to explicitly catch this issue and skip.