### PR TITLE
restore env after testing

### DIFF
--- a/lisa/tools/modprobe.py
+++ b/lisa/tools/modprobe.py
@@ -72,7 +72,7 @@ class Modprobe(Tool):
             modules_str = modules
         command = f"{modules_str}"
         if dry_run:
-            command = "--dry-run" + command
+            command = f"--dry-run {command}"
         result = self.run(
             command,
             force_run=True,

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -17,7 +17,7 @@ from lisa import (
 )
 from lisa.features import Sriov
 from lisa.testsuite import simple_requirement
-from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe
+from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe, Service
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
 from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
@@ -609,3 +609,11 @@ class Dpdk(TestSuite):
     def _force_dpdk_default_source(self, variables: Dict[str, Any]) -> None:
         if not variables.get("dpdk_source", None):
             variables["dpdk_source"] = "https://dpdk.org/git/dpdk-stable"
+
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        node: Node = kwargs.pop("node")
+        modprobe = node.tools[Modprobe]
+        if modprobe.module_exists("uio_hv_generic"):
+            node.tools[Service].stop_service("vpp")
+            modprobe.remove(["uio_hv_generic"])
+            modprobe.reload(["hv_netvsc"])

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -302,7 +302,7 @@ class DpdkTestpmd(Tool):
 
     def check_testpmd_is_running(self) -> bool:
         pids = self.node.tools[Pidof].get_pids(self.command, sudo=True)
-        return len(pids) == 0
+        return len(pids) > 0
 
     def kill_previous_testpmd_command(self) -> None:
         # kill testpmd early


### PR DESCRIPTION
@mcgov check_testpmd_is_running my understanding is that when there is pids returned then indicates testpmd is running otherwise there is no testpmd running, correct?

