### PR TITLE
Update dpdk_nff_go Distro checks

### DIFF
--- a/microsoft/testsuites/dpdk/dpdknffgo.py
+++ b/microsoft/testsuites/dpdk/dpdknffgo.py
@@ -45,19 +45,28 @@ class DpdkNffGo(Tool):
     @property
     def can_install(self) -> bool:
         # nff-go only implemented for debain in lisav2
-        return isinstance(self.node.os, Debian)
+        # but this will be tested for during _install function
+        return True
 
     def _install(self) -> bool:
-        os = self.node.os
-        version = os.information.version
-        if not (
-            (isinstance(os, Ubuntu) and version >= "18.4.0")
-            or (isinstance(os, Debian) and version >= "10.0.0")
-        ):
-            raise UnsupportedDistroException(
-                os, "NFF-GO test is not supported on EOL debian or Ubuntu"
-            )
         node = self.node
+        os = node.os
+        version = os.information.version
+        if isinstance(os, Ubuntu):
+            if version < "18.4.0":
+                raise UnsupportedDistroException(
+                    os, "NFF-GO test is not supported on EOL Ubuntu"
+                )
+        elif isinstance(os, Debian):
+            if version < "10.0.0":
+                raise UnsupportedDistroException(
+                    os, "NFF-GO test is not supported on EOL Debian"
+                )
+        else:
+            raise UnsupportedDistroException(
+                os, "NFF-GO test not implemented on this OS"
+            )
+
         git = node.tools[Git]
         echo = node.tools[Echo]
         wget = node.tools[Wget]

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -14,6 +14,7 @@ from lisa import (
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
+    UnsupportedDistroException,
 )
 from lisa.features import Sriov
 from lisa.testsuite import simple_requirement
@@ -154,7 +155,11 @@ class Dpdk(TestSuite):
     def verify_dpdk_nff_go(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        nff_go = node.tools[DpdkNffGo]
+        try:
+            nff_go = node.tools[DpdkNffGo]
+        except UnsupportedDistroException as err:
+            raise SkippedException(err)
+
         # hugepages needed for dpdk tests
         init_hugepages(node)
         # run the nff-go tests
@@ -270,8 +275,8 @@ class Dpdk(TestSuite):
 
         try:
             check_send_receive_compatibility(test_kits)
-        except UnsupportedPackageVersionException:
-            raise SkippedException(UnsupportedPackageVersionException)
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
 
         sender, receiver = test_kits
 


### PR DESCRIPTION
Previous check allowed Ubuntu 16.04 to run because Ubuntu is a subclass of Debian and version > 10.0.0

Unsupported distros are now skipped instead of failing

Small refactoring