### PR TITLE
Revert: QEMU: Ensure secure-boot is disabled.

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -714,10 +714,6 @@ class BaseLibvirtPlatform(Platform):
         if not node_context.use_bios_firmware:
             os.attrib["firmware"] = "efi"
 
-            # Ensure secure-boot is disabled.
-            os_loader = ET.SubElement(os, "loader")
-            os_loader.attrib["secure"] = "no"
-
         os_type = ET.SubElement(os, "type")
         os_type.text = "hvm"
 


### PR DESCRIPTION
Turns out the "QEMU: Ensure secure-boot is disabled" change doesn't actually do
anything.