### PR TITLE
Use kernel_version_raw to get the kernel version

### DIFF
--- a/lisa/tools/kernel_config.py
+++ b/lisa/tools/kernel_config.py
@@ -45,5 +45,5 @@ class KernelConfig(Tool):
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         uname_tool = self.node.tools[Uname]
-        kernel_ver = uname_tool.get_linux_information().kernel_version
+        kernel_ver = uname_tool.get_linux_information().kernel_version_raw
         self.config_path: str = f"/boot/config-{kernel_ver}"


### PR DESCRIPTION
We used 'kernel_version' of Uname tool to get the kernel version of the system. The 'kernel_version' is 'VersionInfo' class, which has the standard format of 'major.minor.patch-'.

But for Mariner image, such as microsoftcblmariner cbl-mariner cbl-mariner-2 2.20220426.01, the kernel version is '5.15.32.1-3.cm2', which doesn't have the format of 'VersionInfo' class. We will get a version of '5.15.32-1-3.cm2' , which is not exactly the same as the kernel version. That will cause "The remote path could not be accessed: /boot/config-5.15.32-1-3.cm2".