### PR TITLE
Increase timeout for case verify_stress_sriov_disable_enable from 4000 to 4500

### DIFF
--- a/microsoft/testsuites/network/stress.py
+++ b/microsoft/testsuites/network/stress.py
@@ -123,7 +123,7 @@ class Stress(TestSuite):
         5. Do step 2 ~ step 4 for 25 times.
         """,
         priority=3,
-        timeout=4000,
+        timeout=4500,
         requirement=simple_requirement(
             min_core_count=4,
             network_interface=features.Sriov(),


### PR DESCRIPTION
Some test results failed for timeout after 4000