### PR TITLE
Handle error in kill if pid is not found

### DIFF
--- a/microsoft/testsuites/cpu/cpusuite.py
+++ b/microsoft/testsuites/cpu/cpusuite.py
@@ -112,7 +112,7 @@ class CPUSuite(TestSuite):
             ).is_true()
         finally:
             # kill fio process
-            node.tools[Kill].by_name("fio")
+            node.tools[Kill].by_name("fio", ignore_not_exist=True)
 
     @TestCaseMetadata(
         description="""
@@ -147,8 +147,8 @@ class CPUSuite(TestSuite):
             ).is_true()
         finally:
             # kill fio process
-            server.tools[Kill].by_name("iperf3")
-            client.tools[Kill].by_name("iperf3")
+            server.tools[Kill].by_name("iperf3", ignore_not_exist=True)
+            client.tools[Kill].by_name("iperf3", ignore_not_exist=True)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
This can happen if parent process is killed, automatically killing child processes