### PR TITLE
DPDK: Mark netvsc pmd tests dirty

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -198,6 +198,11 @@ class Dpdk(TestSuite):
             ],
         )
 
+        if test_kit.testpmd.is_connect_x3:
+            raise SkippedException(
+                "Unsupported Hardware: ConnectX3 does not support secondary process RX"
+            )
+
         # enable hugepages needed for dpdk EAL
         init_hugepages(node)
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -253,6 +253,9 @@ def initialize_node_resources(
 
     # netvsc pmd requires uio_hv_generic to be loaded before use
     if pmd == "netvsc":
+        # this code makes changes to interfaces that will cause later tests to fail.
+        # Therefore we mark the node dirty to prevent future testing on this environment
+        node.mark_dirty()
         enable_uio_hv_generic_for_nic(node, test_nic)
         # if this device is paired, set the upper device 'down'
         if test_nic.lower:


### PR DESCRIPTION
Netvsc pmd tests make changes to the interfaces that cause problems in later tests.

Also skip multiprocess test on ConnectX3 hardware due to unsupported functionality.