### PR TITLE
Test additional Python versions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,19 +9,20 @@ on:
       - main
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }} with python ${{ matrix.python-version }}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
     steps:
       - name: Checkout repository to $GITHUB_WORKSPACE
         uses: actions/checkout@v2
 
-      - name: Setup bootstrap Python
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry for Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository to $GITHUB_WORKSPACE
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ paramiko = "^2.10.1"
 pluggy = "^0.13.1"
 pypiwin32 = {version = "^223", platform = "win32", optional=true}
 pytest-html = "^3.1.1"
-python = "^3.8"
+python = ">=3.8"
 python-dateutil = "^2.8.1"
 retry = "^0.9.2"
 spurplus = "^2.3.4"


### PR DESCRIPTION
The documentation states that Python 3.8 is the tested version, but newer versions are recommended.

This PR adds the newer versions to the test matrix.

pyproject.toml has also been updated as it binds the python version to only the 3.8 series.