### PR TITLE
DPDK: GPU and HPC SKUs not supported

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -16,7 +16,7 @@ from lisa import (
     TestSuiteMetadata,
     UnsupportedDistroException,
 )
-from lisa.features import Sriov
+from lisa.features import Gpu, Infiniband, Sriov
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe, Service
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
@@ -70,6 +70,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_build_netvsc(
@@ -91,6 +92,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_build_failsafe(
@@ -107,6 +109,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_ovs(
@@ -150,6 +153,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_nff_go(
@@ -174,6 +178,7 @@ class Dpdk(TestSuite):
         requirement=simple_requirement(
             min_nic_count=3,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_multiprocess(
@@ -270,6 +275,7 @@ class Dpdk(TestSuite):
             min_core_count=8,
             network_interface=Sriov(),
             min_count=2,
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_sriov_rescind_failover_receiver(
@@ -303,6 +309,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_sriov_rescind_failover_send_only(
@@ -361,6 +368,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_vpp(
@@ -395,6 +403,7 @@ class Dpdk(TestSuite):
         priority=2,
         requirement=simple_requirement(
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_ring_ping(
@@ -469,6 +478,7 @@ class Dpdk(TestSuite):
             min_core_count=8,
             network_interface=Sriov(),
             min_count=2,
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
@@ -494,6 +504,7 @@ class Dpdk(TestSuite):
             min_core_count=8,
             network_interface=Sriov(),
             min_count=2,
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_netvsc(
@@ -519,6 +530,7 @@ class Dpdk(TestSuite):
             min_core_count=8,
             network_interface=Sriov(),
             min_count=2,
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_send_receive_failsafe(
@@ -542,6 +554,7 @@ class Dpdk(TestSuite):
             min_core_count=8,
             network_interface=Sriov(),
             min_count=2,
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_send_receive_netvsc(
@@ -567,6 +580,7 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             min_core_count=8,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_uio_binding(


### PR DESCRIPTION
GPU and HPC hardware is incompatible with DPDK tests and not a DPDK use case.