### PR TITLE
Notify results of kvm-unit-tests using CommunityTestMessage

### DIFF
--- a/microsoft/testsuites/kvm/kvm_unit_tests.py
+++ b/microsoft/testsuites/kvm/kvm_unit_tests.py
@@ -2,9 +2,15 @@
 # Licensed under the MIT license.
 from pathlib import Path
 
-from assertpy.assertpy import assert_that
-
-from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa import (
+    Environment,
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+)
+from lisa.testsuite import TestResult
 from lisa.tools import Lscpu
 from lisa.util import SkippedException
 from microsoft.testsuites.kvm.kvm_unit_tests_tool import KvmUnitTests
@@ -25,28 +31,17 @@ class KvmUnitTestSuite(TestSuite):
         """,
         priority=3,
     )
-    def verify_kvm_unit_tests(self, log: Logger, node: Node, log_path: Path) -> None:
+    def verify_kvm_unit_tests(
+        self,
+        log: Logger,
+        node: Node,
+        environment: Environment,
+        log_path: Path,
+        result: TestResult,
+    ) -> None:
         # ensure virtualization is enabled in hardware before running tests
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
         if not virtualization_enabled:
             raise SkippedException("Virtualization is not enabled in hardware")
 
-        # TODO: These failures need to be investigated to figure out the exact
-        # cause.
-        expected_failures = [
-            "pmu_lbr",
-            "svm_pause_filter",
-            "vmx",
-            "ept",
-            "debug",
-        ]
-
-        failures = node.tools[KvmUnitTests].run_tests(log_path)
-        if failures:
-            log.info(f"Failed tests: {failures}")
-
-        unexpected_failures = list(
-            filter(lambda x: x not in expected_failures, failures)
-        )
-
-        assert_that(unexpected_failures).is_empty()
+        node.tools[KvmUnitTests].run_tests(result, environment, log_path)

--- a/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
+++ b/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import string
 from dataclasses import dataclass
 from pathlib import Path, PurePath
 from typing import Any, List, Type, cast


### PR DESCRIPTION
Enhance parsing logic to also extract passed and skipped tests and notify the result of each test by sending a `CommunityTestMessage`.