### PR TITLE
Fix XDP test cases issues

### DIFF
--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -73,7 +73,7 @@ class XdpDump(Tool):
                 "clang llvm libelf-dev build-essential libbpfcc-dev"
             )
         elif isinstance(self.node.os, Fedora):
-            self.node.os.install_packages("git llvm clang elfutils-devel make")
+            self.node.os.install_packages("git llvm clang elfutils-devel make gcc")
         else:
             raise UnsupportedDistroException(self.node.os)
 

--- a/microsoft/testsuites/xdp/xdptools.py
+++ b/microsoft/testsuites/xdp/xdptools.py
@@ -112,7 +112,7 @@ class XdpTool(Tool):
             self.node.os.install_packages(
                 "llvm-toolset elfutils-devel m4 wireshark perf make gcc tc "
                 # pcaplib
-                "http://rpmfind.net/linux/centos/8.5.2111/PowerTools/"
+                "https://vault.centos.org/centos/8/PowerTools/"
                 "x86_64/os/Packages/libpcap-devel-1.9.1-5.el8.x86_64.rpm"
             )
         else:

--- a/microsoft/testsuites/xdp/xdptools.py
+++ b/microsoft/testsuites/xdp/xdptools.py
@@ -109,11 +109,19 @@ class XdpTool(Tool):
             config_envs.update({"CLANG": "clang-10", "LLC": "llc-10"})
 
         elif isinstance(self.node.os, Fedora):
+            if self.node.os.information.version >= "9.0.0":
+                self.node.os.install_packages(
+                    "http://mirror.stream.centos.org/9-stream/AppStream/"
+                    "x86_64/os/Packages/libpcap-devel-1.10.0-4.el9.x86_64.rpm"
+                )
+            else:
+                self.node.os.install_packages(
+                    "tc https://vault.centos.org/centos/8/PowerTools/"
+                    "x86_64/os/Packages/libpcap-devel-1.9.1-5.el8.x86_64.rpm"
+                )
             self.node.os.install_packages(
-                "llvm-toolset elfutils-devel m4 wireshark perf make gcc tc "
+                "llvm-toolset elfutils-devel m4 wireshark perf make gcc"
                 # pcaplib
-                "https://vault.centos.org/centos/8/PowerTools/"
-                "x86_64/os/Packages/libpcap-devel-1.9.1-5.el8.x86_64.rpm"
             )
         else:
             raise UnsupportedDistroException(self.node.os)


### PR DESCRIPTION
one more issue need fix.
```
redhat rhel 8.1 8.1.2020110711 Need LLVM version 10+, 'clang' is version 8
```