### PR TITLE
DPDK: sriov rescind test fixes

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -292,6 +292,10 @@ class Dpdk(TestSuite):
 
         sender, receiver = test_kits
 
+        # Want to only switch receiver sriov to avoid timing weirdness
+        receiver.switch_sriov = True
+        sender.switch_sriov = False
+
         kit_cmd_pairs = generate_send_receive_run_info("failsafe", sender, receiver)
 
         run_testpmd_concurrent(

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -201,6 +201,13 @@ def initialize_node_resources(
         f"SRIOV was not enabled for this test node ({node.name})"
     ).is_true()
 
+    assert_that(node.nics.get_lower_nics()).described_as(
+        "Did not detect any upper/lower sriov paired nics!: "
+        f"upper: {node.nics.get_upper_nics()} "
+        f"lower: {node.nics.get_lower_nics()} "
+        f"unpaired: {node.nics.get_unpaired_devices()}"
+    ).is_not_empty()
+
     # dump some info about the pci devices before we start
     lspci = node.tools[Lspci]
     log.info(f"Node[{node.name}] LSPCI Info:\n{lspci.run().stdout}\n")


### PR DESCRIPTION
After comparing rescind test failures across kernel+dpdk+rdma_core+host verisons,
apply some fixes based on the investigation.

- Switch to DPDK 21.11 on Ubuntu 18.04 (more stable across test matrix)
- Remove dmesg wait and async timeout
- Add secondary regex for hotplug to cover EAL version differences in
output
- Add forceful quit for unresponsive (but functional) testpmd by reloading
hv_netvsc