### PR TITLE
Modify dump file check command

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -10,7 +10,7 @@ from semver import VersionInfo
 
 from lisa.base_tools import Cat, Sed, Wget
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Debian, Posix, Redhat, Suse, Ubuntu
+from lisa.operating_system import CBLMariner, Debian, Posix, Redhat, Suse
 from lisa.tools import Find, Gcc
 from lisa.tools.make import Make
 from lisa.tools.service import Service
@@ -246,13 +246,6 @@ class KdumpBase(Tool):
         """
         return "grub2-mkconfig -o /boot/grub2/grub.cfg"
 
-    def get_dumpfile_name(self) -> str:
-        """
-        Returns name of the dump file. If distro has a different file name,
-        override the method
-        """
-        return "vmcore"
-
     def config_crashkernel_memory(
         self,
         crashkernel: str,
@@ -443,12 +436,6 @@ class KdumpDebian(KdumpBase):
 
     def _get_crashkernel_update_cmd(self, crashkernel: str) -> str:
         return "update-grub"
-
-    def get_dumpfile_name(self) -> str:
-        if isinstance(self.node.os, Ubuntu):
-            return "dump.*"
-        else:
-            return "vmcore.*"
 
     def enable_kdump_service(self) -> None:
         service = self.node.tools[Service]

--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -352,7 +352,6 @@ class KdumpCrash(TestSuite):
 
             # After trigger kdump, the VM will reboot. We need to close and initialize
             node.close()
-            dump_file = kdump.get_dumpfile_name()
             saved_dumpfile_size = 0
             while True:
                 try:
@@ -360,7 +359,8 @@ class KdumpCrash(TestSuite):
                     # We should check the stdout. If the stdout is not null, then
                     # the dump file is generated.
                     result = node.execute(
-                        f"find {kdump.dump_path} -name {dump_file} -type f -size +10M",
+                        f"find {kdump.dump_path} -type f -size +10M "
+                        "-name vmcore -o -name dump.* -o -name vmcore.*",
                         shell=True,
                         sudo=True,
                     )
@@ -382,7 +382,7 @@ class KdumpCrash(TestSuite):
                     )
                     system_disconnected = True
                     break
-                if result.exit_code == 0:
+                if result.stdout:
                     incomplete_file = result.stdout
                     stat = node.tools[Stat]
                     incomplete_file_size = stat.get_total_size(incomplete_file)


### PR DESCRIPTION
Different versions of the Debian distro have different dump file names. For Debian 10, the dump file name is vmcore.2022xx, for Debian sid, the name is dump.2022xx. We delete get_dumpfile_name function, and modified the dump file check command to "find /var/crash -type f -size +10M -name vmcore -o -name dump.* -o -name vmcore.*".