### PR TITLE
DPDK: fix check for source built binary

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -469,9 +469,10 @@ class DpdkTestpmd(Tool):
         self.dpdk_path = self.node.working_path.joinpath(self._dpdk_repo_path_name)
 
         if self.find_testpmd_binary(
-            assert_on_fail=False
+            assert_on_fail=False, check_path="/usr/local/bin"
         ):  # tools are already installed
             return True
+
         git_tool = node.tools[Git]
         echo_tool = node.tools[Echo]
 


### PR DESCRIPTION
Previous check looked for any installed binary, since a package manager could have been used for a previous test we need to check for the source build specifically.
The currently running test will know to use the built binary, but we need to mark the environment as dirty for the next test in this case.