### PR TITLE
QEMU: Add support for enabling Secure Boot.

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -87,7 +87,11 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         )
 
     def _create_node_domain_xml(
-        self, environment: Environment, log: Logger, node: Node
+        self,
+        environment: Environment,
+        log: Logger,
+        node: Node,
+        lv_conn: libvirt.virConnect,
     ) -> str:
         node_context = get_node_context(node)
 

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -39,6 +39,8 @@ class NodeContext:
     use_bios_firmware: bool = False
     data_disks: List[DataDiskContext] = field(default_factory=list)
     next_disk_index: int = 0
+    machine_type: Optional[str] = None
+    enable_secure_boot: bool = False
 
     console_logger: Optional[QemuConsoleLogger] = None
     domain: Optional[libvirt.virDomain] = None

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -67,6 +67,14 @@ class BaseLibvirtNodeSchema:
     # Whether to use UEFI or BIOS firmware.
     # Defaults to UEFI.
     firmware_type: str = ""
+    # The machine type to emulate.
+    # Defaults to the system's default (typically: i440fx).
+    # Typical options available include:
+    # - i440fx (legacy, no secure-boot support)
+    # - q35
+    machine_type: str = ""
+    # Whether to enable secure boot.
+    enable_secure_boot: bool = False
 
 
 # QEMU orchestrator's per-node configuration options.


### PR DESCRIPTION
1. Allow the machine type to be specified. This is required as the default of i440fx
   doesn't support secure boot.

2. Allow secure boot to be enabled (or disabled).