### PR TITLE
increase wait time for sriov enable check

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -446,7 +446,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         modprobe_tool = self._node.tools[Modprobe]
         modprobe_tool.reload(["hv_netvsc"])
 
-    @retry(tries=60, delay=2)
+    @retry(tries=60, delay=10)
     def _check_sriov_enabled(self, enabled: bool) -> None:
         self._node.nics.reload()
 


### PR DESCRIPTION
SRIOV enable/disable can take longer than a couple of minutes in some cases. Increase the polling interval to increase the potential minimum timeout (timing is not guaranteed with this retry decorator).