### PR TITLE
Reduce minimum core count requirement for storage tests

### DIFF
--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -51,7 +51,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=32,
+            min_core_count=64,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
@@ -69,7 +69,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=32,
+            min_core_count=64,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
@@ -89,7 +89,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=32,
+            min_core_count=64,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),

--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -51,7 +51,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=72,
+            min_core_count=32,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
@@ -69,7 +69,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=72,
+            min_core_count=32,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
@@ -89,7 +89,7 @@ class StoragePerformance(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            min_core_count=72,
+            min_core_count=32,
             disk=schema.DiskOptionSettings(
                 disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),


### PR DESCRIPTION
Storage tests currently require 72 cores for some premium storage performance tests. Reduce this to allow running them on all VM size families.