### PR TITLE
DPDK: Cleanup queue and core count selection logic

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -47,7 +47,7 @@ class DpdkPerformance(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_failsafe_pmd_dual_core(
+    def perf_dpdk_failsafe_pmd_minimal(
         self,
         result: TestResult,
         log: Logger,
@@ -58,7 +58,7 @@ class DpdkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: failsafe mode, maximal core count, default queue settings
+        DPDK Performance: failsafe mode, multiple service cores
         """,
         priority=3,
         requirement=simple_requirement(
@@ -76,33 +76,35 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("failsafe", result, log, variables, use_max_cores=True)
+        self._run_dpdk_perf_test("failsafe", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: failsafe mode, maximal core count, default queue settings
+        DPDK Performance: failsafe mode, multiple service cores, max nics
         """,
         priority=3,
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
-            min_nic_count=2,
+            min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_failsafe_pmd_multi_core_huge_vm(
+    def perf_dpdk_failsafe_pmd_multi_core_max_nic(
         self,
         result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("failsafe", result, log, variables, use_max_cores=True)
+        self._run_dpdk_perf_test(
+            "failsafe", result, log, variables, use_max_nics=True, service_cores=4
+        )
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: failsafe mode, maximum core count, maximum tx/rx queues
+        DPDK Performance: failsafe mode, muliple tx/rx queues
 
         """,
         priority=3,
@@ -125,26 +127,57 @@ class DpdkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: failsafe mode, maximum core count, maximum tx/rx queues
-        Run on a huge machine
+        DPDK Performance: failsafe mode, mutiple tx/rx queues, max nics
         """,
         priority=3,
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
-            min_nic_count=2,
+            min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_failsafe_pmd_multi_queue_huge_vm(
+    def perf_dpdk_failsafe_pmd_multi_queue_max_nics(
         self,
         result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("failsafe", result, log, variables, use_queues=True)
+        self._run_dpdk_perf_test(
+            "failsafe", result, log, variables, use_max_nics=True, use_queues=True
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: failsafe mode, many service cores, many queues, max nics
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2,
+            network_interface=Sriov(),
+            min_nic_count=8,
+            unsupported_features=[Gpu, Infiniband],
+            supported_features=[IsolatedResource],
+        ),
+    )
+    def perf_dpdk_failsafe_pmd_multi_queue_multi_core_max_nics(
+        self,
+        result: TestResult,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test(
+            "failsafe",
+            result,
+            log,
+            variables,
+            service_cores=4,
+            use_max_nics=True,
+            use_queues=True,
+        )
 
     @TestCaseMetadata(
         description="""
@@ -160,18 +193,17 @@ class DpdkPerformance(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_netvsc_pmd_dual_core(
+    def perf_dpdk_netvsc_pmd_minimal(
         self,
         result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._validate_core_counts_are_equal(result)
         self._run_dpdk_perf_test("netvsc", result, log, variables)
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: direct use of VF, maximum core count, default queues
+        DPDK Performance: direct use of VF, multiple service cores
         """,
         priority=3,
         requirement=simple_requirement(
@@ -189,34 +221,36 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("netvsc", result, log, variables, use_max_cores=True)
+        self._run_dpdk_perf_test("netvsc", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: direct use of VF, maximum core count, default queues
+        DPDK Performance: direct use of VF, multiple service cores, max nics
         Run on a big VM
         """,
         priority=3,
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
-            min_nic_count=2,
+            min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_netvsc_pmd_multi_core_huge_vm(
+    def perf_dpdk_netvsc_pmd_multi_core_max_nics(
         self,
         result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("netvsc", result, log, variables, use_max_cores=True)
+        self._run_dpdk_perf_test(
+            "netvsc", result, log, variables, service_cores=4, use_max_nics=True
+        )
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: direct use of VF, maximum core count, maximum tx/rx queues
+        DPDK Performance: direct use of VF, multiple tx/rx queues
         """,
         priority=3,
         requirement=simple_requirement(
@@ -238,26 +272,57 @@ class DpdkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        DPDK Performance: direct use of VF, maximum core count, maximum tx/rx queues,
-        Run on a huge machine
+        DPDK Performance: direct use of VF, multiple tx/rx queues, max nics
         """,
         priority=3,
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
-            min_nic_count=2,
+            min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
     )
-    def perf_dpdk_netvsc_pmd_multi_queue_huge_vm(
+    def perf_dpdk_netvsc_pmd_multi_queue_max_nics(
         self,
         result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
 
-        self._run_dpdk_perf_test("netvsc", result, log, variables, use_queues=True)
+        self._run_dpdk_perf_test(
+            "netvsc", result, log, variables, use_queues=True, use_max_nics=True
+        )
+
+    @TestCaseMetadata(
+        description="""
+        DPDK Performance: direct use of VF, many service cores, many queues, max nics
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            min_count=2,
+            network_interface=Sriov(),
+            min_nic_count=8,
+            unsupported_features=[Gpu, Infiniband],
+            supported_features=[IsolatedResource],
+        ),
+    )
+    def perf_dpdk_netvsc_pmd_multi_queue_multi_core_max_nics(
+        self,
+        result: TestResult,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+
+        self._run_dpdk_perf_test(
+            "netvsc",
+            result,
+            log,
+            variables,
+            service_cores=4,
+            use_max_nics=True,
+            use_queues=True,
+        )
 
     def _run_dpdk_perf_test(
         self,
@@ -265,27 +330,33 @@ class DpdkPerformance(TestSuite):
         test_result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
-        use_max_cores: bool = False,
+        use_max_nics: bool = False,
         use_queues: bool = False,
+        service_cores: int = 1,
     ) -> None:
         environment = test_result.environment
         assert environment, "fail to get environment from testresult"
 
         # run build + validation to populate results
-        max_core_count = self._validate_core_counts_are_equal(test_result)
-        if use_max_cores:
-            core_count_argument = max_core_count
-        else:
-            core_count_argument = 0  # expected default, test will use 2 cores.
-
+        self._validate_core_counts_are_equal(test_result)
         try:
             if use_queues:
                 send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
-                    environment, log, variables, pmd
+                    environment,
+                    log,
+                    variables,
+                    pmd,
+                    use_max_nics=use_max_nics,
+                    use_service_cores=service_cores,
                 )
             else:
                 send_kit, receive_kit = verify_dpdk_send_receive(
-                    environment, log, variables, pmd, core_count_argument
+                    environment,
+                    log,
+                    variables,
+                    pmd,
+                    use_max_nics=use_max_nics,
+                    use_service_cores=service_cores,
                 )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -345,7 +416,7 @@ class DpdkPerformance(TestSuite):
 
         return send_results, receive_results
 
-    def _validate_core_counts_are_equal(self, test_result: TestResult) -> int:
+    def _validate_core_counts_are_equal(self, test_result: TestResult) -> None:
         environment = test_result.environment
         assert environment, "fail to get environment from testresult"
 
@@ -357,4 +428,3 @@ class DpdkPerformance(TestSuite):
             "Nodes contain different core counts, DPDK Suite expects sender "
             "and receiver to have same core count."
         ).contains_only(core_counts[0])
-        return core_counts[0]

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -119,7 +119,8 @@ def generate_send_receive_run_info(
     receiver: DpdkTestResources,
     txq: int = 0,
     rxq: int = 0,
-    core_count: int = 0,
+    use_max_nics: bool = False,
+    use_service_cores: int = 1,
 ) -> Dict[DpdkTestResources, str]:
 
     snd_nic, rcv_nic = [x.node.nics.get_nic_by_index() for x in [sender, receiver]]
@@ -132,7 +133,8 @@ def generate_send_receive_run_info(
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         txq=txq,
         rxq=rxq,
-        use_core_count=core_count,
+        service_cores=use_service_cores,
+        use_max_nics=use_max_nics,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
@@ -141,7 +143,8 @@ def generate_send_receive_run_info(
         pmd,
         txq=txq,
         rxq=rxq,
-        use_core_count=core_count,
+        service_cores=use_service_cores,
+        use_max_nics=use_max_nics,
     )
 
     kit_cmd_pairs = {
@@ -382,7 +385,8 @@ def verify_dpdk_send_receive(
     log: Logger,
     variables: Dict[str, Any],
     pmd: str,
-    core_count: int = 0,
+    use_max_nics: bool = False,
+    use_service_cores: int = 1,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
 
     # helpful to have the public ips labeled for debugging
@@ -403,7 +407,11 @@ def verify_dpdk_send_receive(
     sender, receiver = test_kits
 
     kit_cmd_pairs = generate_send_receive_run_info(
-        pmd, sender, receiver, core_count=core_count
+        pmd,
+        sender,
+        receiver,
+        use_max_nics=use_max_nics,
+        use_service_cores=use_service_cores,
     )
 
     results = run_testpmd_concurrent(kit_cmd_pairs, 15, log)
@@ -429,7 +437,12 @@ def verify_dpdk_send_receive(
 
 
 def verify_dpdk_send_receive_multi_txrx_queue(
-    environment: Environment, log: Logger, variables: Dict[str, Any], pmd: str
+    environment: Environment,
+    log: Logger,
+    variables: Dict[str, Any],
+    pmd: str,
+    use_max_nics: bool = False,
+    use_service_cores: int = 1,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
 
     test_kits = init_nodes_concurrent(environment, log, variables, pmd)
@@ -439,7 +452,13 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     sender, receiver = test_kits
 
     kit_cmd_pairs = generate_send_receive_run_info(
-        pmd, sender, receiver, txq=16, rxq=16
+        pmd,
+        sender,
+        receiver,
+        txq=4,
+        rxq=4,
+        use_max_nics=use_max_nics,
+        use_service_cores=use_service_cores,
     )
 
     results = run_testpmd_concurrent(kit_cmd_pairs, 15, log)


### PR DESCRIPTION
Cleaning up perf test and queue/core selection logic.

Noting here that the multicore/hugevm tests should eventually support multiple nics. Currently we do not make use of multiple nics because it is more complicated to configure them. A future PR will have to implement this support.