### PR TITLE
fix xdp compile issue on mariner 1.0

### DIFF
--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -77,7 +77,7 @@ class XdpDump(Tool):
         elif isinstance(self.node.os, CBLMariner):
             self.node.os.install_packages(
                 "git llvm clang elfutils-devel make gcc kernel-headers binutils "
-                "glibc-devel zlib-devel cmake"
+                "glibc-devel zlib-devel cmake clang-devel"
             )
         else:
             raise UnsupportedDistroException(self.node.os)


### PR DESCRIPTION
two compile errors are fixed in this PR.
```
failed. AssertionError: [Failed to make
get unexpected exit code on cmd ['sh', '-c', 'export CFLAGS="-D __ACTION_TX__ -I../libbpf/src/root/usr/include"; yes \'\' | make -j8 ']] Expected <[0]> to contain item <2>, but did not.

failed. AssertionError: [Failed to make
get unexpected exit code on cmd ['sh', '-c', "yes '' | make -j8 "]] Expected <[0]> to contain item <2>, but did not.
```