### PR TITLE
Change CommunityTest name to SubTest

### DIFF
--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -89,9 +89,9 @@ class TestResultMessage(TestResultMessageBase):
 
 
 @dataclass
-class CommunityTestMessage(TestResultMessageBase):
+class SubTestMessage(TestResultMessageBase):
     hardware_platform: str = ""
-    type: str = "CommunityTestResult"
+    type: str = "SubTestResult"
 
 
 class NetworkProtocol(str, Enum):

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -9,7 +9,7 @@ from assertpy.assertpy import assert_that
 
 from lisa import Environment, notifier
 from lisa.executable import Tool
-from lisa.messages import CommunityTestMessage, TestStatus, create_test_result_message
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.operating_system import CBLMariner
 from lisa.testsuite import TestResult
 from lisa.tools import Docker, Echo, Git, Whoami
@@ -68,7 +68,7 @@ class CloudHypervisorTests(Tool):
             result.assert_exit_code()
 
         for r in results:
-            self._send_community_test_msg(
+            self._send_subtest_msg(
                 test_result.id_,
                 environment,
                 r.name,
@@ -140,19 +140,19 @@ class CloudHypervisorTests(Tool):
 
         return results
 
-    def _send_community_test_msg(
+    def _send_subtest_msg(
         self,
         test_id: str,
         environment: Environment,
         test_name: str,
         test_status: TestStatus,
     ) -> None:
-        community_msg = create_test_result_message(
-            CommunityTestMessage,
+        subtest_msg = create_test_result_message(
+            SubTestMessage,
             test_id,
             environment,
             test_name,
             test_status,
         )
 
-        notifier.notify(community_msg)
+        notifier.notify(subtest_msg)

--- a/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
+++ b/microsoft/testsuites/kvm/kvm_unit_tests_tool.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 
 from lisa import Environment, notifier
 from lisa.executable import Tool
-from lisa.messages import CommunityTestMessage, TestStatus, create_test_result_message
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.operating_system import Posix
 from lisa.testsuite import TestResult
 from lisa.tools import Git, Make
@@ -81,15 +81,15 @@ class KvmUnitTests(Tool):
         for result in results:
             if result.status == TestStatus.FAILED:
                 failed_tests.append(result.name)
-            community_message = create_test_result_message(
-                CommunityTestMessage,
+            subtest_message = create_test_result_message(
+                SubTestMessage,
                 test_result.id_,
                 environment,
                 result.name,
                 result.status,
             )
 
-            notifier.notify(community_message)
+            notifier.notify(subtest_message)
 
         self._save_logs(failed_tests, failure_logs_path)
         assert_that(failed_tests, f"Unexpected failures: {failed_tests}").is_empty()

--- a/microsoft/testsuites/libvirt/libvirt_tck_tool.py
+++ b/microsoft/testsuites/libvirt/libvirt_tck_tool.py
@@ -9,7 +9,7 @@ from assertpy.assertpy import assert_that
 
 from lisa import Environment, notifier
 from lisa.executable import Tool
-from lisa.messages import CommunityTestMessage, TestStatus, create_test_result_message
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.operating_system import Posix
 from lisa.testsuite import TestResult
 from lisa.tools import Git
@@ -83,7 +83,7 @@ class LibvirtTck(Tool):
             result.assert_exit_code()
 
         for r in results:
-            self._send_community_test_msg(
+            self._send_subtest_msg(
                 test_result.id_,
                 environment,
                 r.name,
@@ -171,19 +171,19 @@ class LibvirtTck(Tool):
 
         return results
 
-    def _send_community_test_msg(
+    def _send_subtest_msg(
         self,
         test_id: str,
         environment: Environment,
         test_name: str,
         test_status: TestStatus,
     ) -> None:
-        community_msg = create_test_result_message(
-            CommunityTestMessage,
+        subtest_msg = create_test_result_message(
+            SubTestMessage,
             test_id,
             environment,
             test_name,
             test_status,
         )
 
-        notifier.notify(community_msg)
+        notifier.notify(subtest_msg)

--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -10,7 +10,7 @@ from assertpy import assert_that
 
 from lisa import Environment, notifier
 from lisa.executable import Tool
-from lisa.messages import CommunityTestMessage, TestStatus, create_test_result_message
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.operating_system import CBLMariner, Debian, Fedora, Posix, Redhat, Suse
 from lisa.testsuite import TestResult
 from lisa.tools import (
@@ -152,8 +152,8 @@ class Ltp(Tool):
             info["information"] = {}
             info["information"]["version"] = result.version
             info["information"]["exit_value"] = result.exit_value
-            community_message = create_test_result_message(
-                CommunityTestMessage,
+            subtest_message = create_test_result_message(
+                SubTestMessage,
                 test_result.id_,
                 environment,
                 result.name,
@@ -161,8 +161,8 @@ class Ltp(Tool):
                 other_fields=info,
             )
 
-            # notify community test result
-            notifier.notify(community_message)
+            # notify subtest result
+            notifier.notify(subtest_message)
 
         # assert that none of the tests failed
         assert_that(

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Type, cast
 
 from lisa import notifier
 from lisa.executable import Tool
-from lisa.messages import CommunityTestMessage, TestStatus, create_test_result_message
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.operating_system import CBLMariner, Debian, Posix, Redhat, Suse, Ubuntu
 from lisa.testsuite import TestResult
 from lisa.tools import Cat, Echo
@@ -301,7 +301,7 @@ class Xfstests(Tool):
             echo = self.node.tools[Echo]
             echo.write_to_file(exclude_tests, exclude_file_path)
 
-    def create_send_community_test_msg(
+    def create_send_subtest_msg(
         self,
         test_result: TestResult,
         raw_message: str,
@@ -337,8 +337,8 @@ class Xfstests(Tool):
             info["information"] = {}
             info["information"]["test_type"] = test_type
             info["information"]["data_disk"] = data_disk
-            community_message = create_test_result_message(
-                CommunityTestMessage,
+            subtest_message = create_test_result_message(
+                SubTestMessage,
                 test_result.id_,
                 environment,
                 result.name,
@@ -346,8 +346,8 @@ class Xfstests(Tool):
                 other_fields=info,
             )
 
-            # notify community test result
-            notifier.notify(community_message)
+            # notify subtest result
+            notifier.notify(subtest_message)
 
     def check_test_results(
         self,
@@ -357,7 +357,7 @@ class Xfstests(Tool):
         result: TestResult,
         data_disk: str = "",
     ) -> None:
-        self.create_send_community_test_msg(result, raw_message, test_type, data_disk)
+        self.create_send_subtest_msg(result, raw_message, test_type, data_disk)
         xfstests_path = self.get_xfstests_path()
         results_path = xfstests_path / "results/check.log"
         if not self.node.shell.exists(results_path):


### PR DESCRIPTION
The SubTest framework in LISA can be used for any test which needs to send out muliple subtest results