### PR TITLE
fix: Whitelist bootup log for SGI XFS

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -203,6 +203,7 @@ class AzureImageStandard(TestSuite):
         re.compile(r"(.*was skipped because of a failed condition check.*)$", re.M),
         re.compile(r"^(.*GRUB failed boot detection.*)$", re.M),
         re.compile(r"^(.*nofail.*)$", re.M),
+        re.compile(r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$", re.M)
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -205,7 +205,8 @@ class AzureImageStandard(TestSuite):
         re.compile(r"^(.*nofail.*)$", re.M),
         re.compile(
             r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$",  # noqa: E501
-            re.M)
+            re.M,
+        ),
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -204,7 +204,7 @@ class AzureImageStandard(TestSuite):
         re.compile(r"^(.*GRUB failed boot detection.*)$", re.M),
         re.compile(r"^(.*nofail.*)$", re.M),
         re.compile(
-            r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$", # noqa: E501
+            r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$",  # noqa: E501
             re.M)
     ]
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -203,7 +203,9 @@ class AzureImageStandard(TestSuite):
         re.compile(r"(.*was skipped because of a failed condition check.*)$", re.M),
         re.compile(r"^(.*GRUB failed boot detection.*)$", re.M),
         re.compile(r"^(.*nofail.*)$", re.M),
-        re.compile(r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$", re.M)
+        re.compile(
+            r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$", # noqa: E501
+            re.M)
     ]
 
     @TestCaseMetadata(


### PR DESCRIPTION
verify_boot_error_fail_warnings test fails on Mariner due to SGI XFS log message displayed on bootup. 
Add it to whitelist as the log does not indicate any failures.