### PR TITLE
Fixes for KVM, Cloud Hypervisor & libvirt tests

### DIFF
--- a/lisa/tools/chmod.py
+++ b/lisa/tools/chmod.py
@@ -9,5 +9,8 @@ class Chmod(Tool):
     def command(self) -> str:
         return "chmod"
 
+    def chmod(self, path: str, permission: str, sudo: bool = False) -> None:
+        self.run(f"{permission} {path}", sudo=sudo, force_run=True)
+
     def update_folder(self, path: str, permission: str, sudo: bool = False) -> None:
         self.run(f"-R {permission} {path}", sudo=sudo, force_run=True)

--- a/lisa/tools/ls.py
+++ b/lisa/tools/ls.py
@@ -24,6 +24,21 @@ class Ls(Tool):
         )
         return 0 == cmd_result.exit_code
 
+    def list(self, path: str, sudo: bool = False) -> List[str]:
+        cmd_result = self.run(
+            f"-d {path}/*",
+            force_run=True,
+            sudo=sudo,
+            shell=True,
+        )
+
+        # can fail due to insufficient permissions, non existent
+        # files/dirs etc.
+        if cmd_result.exit_code == 0:
+            return cmd_result.stdout.split()
+        else:
+            return []
+
     def list_dir(self, path: str, sudo: bool = False) -> List[str]:
         cmd_result = self.node.execute(
             f"{self.command} -d {path}/*/",

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -14,6 +14,7 @@ from lisa import (
     schema,
     search_space,
 )
+from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.testsuite import TestResult
 from lisa.tools import Lscpu, Modprobe
 from lisa.util import SkippedException
@@ -39,6 +40,10 @@ class CloudHypervisorTestSuite(TestSuite):
 
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
+        if not isinstance(node.os, (CBLMariner, Ubuntu)):
+            raise SkippedException(
+                f"Cloud Hypervisor tests are not implemented in LISA for {node.os.name}"
+            )
         self._ensure_virtualization_enabled(node)
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -22,7 +22,7 @@ class CloudHypervisorTestResult:
 
 
 class CloudHypervisorTests(Tool):
-    TIME_OUT = 3600
+    TIME_OUT = 7200
 
     repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
 

--- a/microsoft/testsuites/kvm/kvm_unit_tests.py
+++ b/microsoft/testsuites/kvm/kvm_unit_tests.py
@@ -10,6 +10,7 @@ from lisa import (
     TestSuite,
     TestSuiteMetadata,
 )
+from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.testsuite import TestResult
 from lisa.tools import Lscpu
 from lisa.util import SkippedException
@@ -43,5 +44,9 @@ class KvmUnitTestSuite(TestSuite):
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
         if not virtualization_enabled:
             raise SkippedException("Virtualization is not enabled in hardware")
+        if not isinstance(node.os, (CBLMariner, Ubuntu)):
+            raise SkippedException(
+                f"KVM unit tests are not implemented in LISA for {node.os.name}"
+            )
 
         node.tools[KvmUnitTests].run_tests(result, environment, log_path)


### PR DESCRIPTION
- Skip Cloud Hypervisor, libvirt, KVM tests for distributions other than
  Ubuntu and CBLMariner. Lots of failures in other distros leading to
  exceedingly high failure rate. Other distros can be enabled after
  fixing the issues seen in those distros.
- Increase timeout for Cloud Hypervisor tests since timeout failures
  were seen during some runs.
- In KVM unit tests, if the tool is killed due to timeout, we don't
  get any stdout. In this case copy all log files from the logs dir.

Signed-off-by: Anirudh Rayabharam <anrayabh@microsoft.com>