### PR TITLE
restore nics status into origin one to avoid side-effect for following cases.

### DIFF
--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from functools import partial
-from typing import Type
+from typing import Any, Type
 
 from lisa import schema
 from lisa.feature import Feature
@@ -40,6 +40,10 @@ class NetworkInterface(Feature):
 
     def get_nic_count(self, is_sriov_enabled: bool = True) -> int:
         raise NotImplementedError
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self.origin_extra_synthetic_nics_count: int = 0
+        self.origin_extra_sriov_nics_count: int = 0
 
 
 Sriov = partial(NetworkInterfaceOptionSettings, data_path=schema.NetworkDataPath.Sriov)

--- a/microsoft/testsuites/display/drm.py
+++ b/microsoft/testsuites/display/drm.py
@@ -38,7 +38,6 @@ class Drm(TestSuite):
         2. Check if hyperv_drm exist in the list.
         """,
         priority=2,
-        use_new_environment=True,
     )
     def verify_drm_driver(self, node: Node, log: Logger) -> None:
         lsmod = node.tools[Lsmod]

--- a/microsoft/testsuites/network/common.py
+++ b/microsoft/testsuites/network/common.py
@@ -222,3 +222,18 @@ def sriov_disable_enable(environment: Environment, times: int = 4) -> None:
         if sriov_is_enabled:
             sriov_basic_test(environment, vm_nics)
         network_interface_feature.switch_sriov(enable=(not sriov_is_enabled))
+
+
+def restore_extra_nics(environment: Environment) -> None:
+    remove_extra_nics(environment)
+    # restore nics info into previous status
+    for node in environment.nodes.list():
+        network_interface_feature = node.features[NetworkInterface]
+        network_interface_feature.attach_nics(
+            network_interface_feature.origin_extra_sriov_nics_count,
+            enable_accelerated_networking=True,
+        )
+        network_interface_feature.attach_nics(
+            network_interface_feature.origin_extra_synthetic_nics_count,
+            enable_accelerated_networking=False,
+        )


### PR DESCRIPTION
- use new env for cases which will change nics
- store nics status before testing, restore them after testing, not put it into test case cleanup, since it will affect following cases.