### PR TITLE
Whitelist dmesg logs

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -207,6 +207,11 @@ class AzureImageStandard(TestSuite):
             r"^(.*SGI XFS with ACLs, security attributes, realtime, verbose warnings, quota, no debug enabled.*)$",  # noqa: E501
             re.M,
         ),
+        re.compile(
+            r"^(.*platform regulatory\.0: Direct firmware load for regulatory\.db failed with error -2.*)$",
+            re.M,
+        ),
+        re.compile(r"^(.*failed to load regulatory\.db.*)$", re.M),
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -208,10 +208,14 @@ class AzureImageStandard(TestSuite):
             re.M,
         ),
         re.compile(
-            r"^(.*platform regulatory\.0: Direct firmware load for regulatory\.db failed with error -2.*)$",
+            r"^(.*platform regulatory\.0: Direct firmware load for regulatory\.db failed with error -2.*)$",  # noqa: E501
             re.M,
         ),
         re.compile(r"^(.*failed to load regulatory\.db.*)$", re.M),
+        re.compile(
+            r"^(.*This warning is only shown for the first unit using IP firewalling.*)$",  # noqa: E501
+            re.M,
+        ),
     ]
 
     @TestCaseMetadata(


### PR DESCRIPTION

**regulatory.db error**
The error is  benign as they indicate that the "cfg80211 wifi driver"
is not able to find its firmware. Given that there is no wifi device
on the Azure VM platform, it is safe to ignore this error message.