### PR TITLE
DPDK Memory Request fixes

### DIFF
--- a/lisa/tools/free.py
+++ b/lisa/tools/free.py
@@ -4,20 +4,72 @@
 from lisa.executable import Tool
 from lisa.util import LisaException
 
+# example output
+#               total        used        free      shared  buff/cache   available
+# Mem:        16310304      441732    15438492        2448      430080    15600880
+# Swap:        4194304           0     4194304
+
 
 class Free(Tool):
     @property
     def command(self) -> str:
         return "free"
 
-    def get_swap_size(self) -> int:
-        # Return total swap size
+    #     Usage:
+    #  free [options]
+
+    # Options:
+    #  -b, --bytes         show output in bytes
+    #      --kilo          show output in kilobytes
+    #      --mega          show output in megabytes
+    #      --giga          show output in gigabytes
+    #      --tera          show output in terabytes
+    #      --peta          show output in petabytes
+    #  -k, --kibi          show output in kibibytes
+    #  -m, --mebi          show output in mebibytes
+    #  -g, --gibi          show output in gibibytes
+    #      --tebi          show output in tebibytes
+    #      --pebi          show output in pebibytes
+    #  -h, --human         show human-readable output
+    #      --si            use powers of 1000 not 1024
+    #  -l, --lohi          show detailed low and high memory statistics
+    #  -t, --total         show total for RAM + swap
+    #  -s N, --seconds N   repeat printing every N seconds
+    #  -c N, --count N     repeat printing N times, then exit
+    #  -w, --wide          wide output
+
+    # Starter data sizes, use Kibi/Mebi/Gibi
+
+    def _get_header_index(self, header_name: str, header_line: str) -> int:
+        # get index of header based on first line, add one to account
+        # for first label field in the rest of the lines
+        return 1 + header_line.split().index(header_name)
+
+    def _get_field_bytes_kib(self, field_name: str, header_name: str) -> int:
+
         # Example output:
         #         total used free
         # Swap:   0     0    0
-        out = self.run("-m", force_run=True).stdout
-        for line in out.splitlines():
-            if line.startswith("Swap:"):
-                return int(line.split()[1])
 
-        raise LisaException("Failed to get swap size")
+        # get the data
+        out = self.run("-k", force_run=True).stdout
+        lines = out.splitlines()
+
+        # get offset for data when we split the line
+        header_index = self._get_header_index(header_name, lines[0])
+
+        for line in out.splitlines():
+            if line.startswith(f"{field_name}:"):
+                return int(line.split()[header_index])
+
+        raise LisaException(f"Failed to get info for field {field_name}")
+
+    def get_swap_size(self) -> int:
+        # Return total swap size in Mebibytes
+        return self._get_field_bytes_kib("Swap", "total") >> 10
+
+    def get_free_memory_mb(self) -> int:
+        return self._get_field_bytes_kib("Mem", "free") >> 10
+
+    def get_free_memory_gb(self) -> int:
+        return self._get_field_bytes_kib("Mem", "free") >> 20

--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -231,6 +231,11 @@ class Lscpu(Tool):
             )
         return output
 
+    def get_numa_node_count(self) -> int:
+        # get count of numa nodes on the machine, add 1 to account
+        # for 0 indexing
+        return max([int(cpu.numa_node) for cpu in self.get_cpu_info()]) + 1
+
     def is_virtualization_enabled(self) -> bool:
         result = self.run(sudo=True).stdout
         if ("VT-x" in result) or ("AMD-V" in result):


### PR DESCRIPTION
- add get_numa_node_count to fetch how many numa nodes are present in Lscpu
- add Free tool memory check and warnings for DPDK tests when allocating hugepages
- allocate memory per-numa node when multiple are present