### PR TITLE
Fixup redhat/fedora usage in testpmd, refactor dpdk stable location

### DIFF
--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -5,6 +5,8 @@ from lisa import Node
 from lisa.operating_system import Debian, Oracle, Redhat, Suse, Ubuntu
 from lisa.util import UnsupportedDistroException
 
+DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
+
 
 def check_dpdk_support(node: Node) -> None:
     # check requirements according to:

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -22,6 +22,7 @@ from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe, Service
 from lisa.util.constants import SIGINT
+from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
 from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
@@ -645,7 +646,7 @@ class Dpdk(TestSuite):
 
     def _force_dpdk_default_source(self, variables: Dict[str, Any]) -> None:
         if not variables.get("dpdk_source", None):
-            variables["dpdk_source"] = "https://dpdk.org/git/dpdk-stable"
+            variables["dpdk_source"] = DPDK_STABLE_GIT_REPO
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -721,6 +721,11 @@ class DpdkTestpmd(Tool):
             )
             return  # appease the type checker
 
+        # DPDK is very sensitive to rdma-core/kernel mismatches
+        # update to latest kernel before instaling dependencies
+        rhel.install_packages("kernel")
+        node.reboot()
+
         if rhel.information.version.major == 7:
             # Add packages for rhel7
             rhel.install_packages(list(["libmnl-devel", "libbpf-devel"]))

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -10,7 +10,7 @@ from semver import VersionInfo
 
 from lisa.executable import Tool
 from lisa.nic import NicInfo
-from lisa.operating_system import Debian, Fedora, Redhat, Ubuntu
+from lisa.operating_system import Debian, Fedora, Ubuntu
 from lisa.tools import (
     Echo,
     Git,
@@ -677,7 +677,7 @@ class DpdkTestpmd(Tool):
             node.os.install_packages(
                 list(self._debian_packages), extra_args=self._debian_backports_args
             )
-        elif isinstance(node.os, Redhat):
+        elif isinstance(node.os, Fedora):
             self._install_redhat_dependencies()
         else:
             raise UnsupportedDistroException(
@@ -714,10 +714,10 @@ class DpdkTestpmd(Tool):
     def _install_redhat_dependencies(self) -> None:
         node = self.node
         rhel = node.os
-        if not isinstance(rhel, Redhat):
+        if not isinstance(rhel, Fedora):
             fail(
                 "_install_redhat_dependencies was called on node "
-                f"which was not Redhat: {node.os.information.full_version}"
+                f"which was not Fedora: {node.os.information.full_version}"
             )
             return  # appease the type checker
 

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -104,7 +104,7 @@ class DpdkTestpmd(Tool):
     # these are the same at the moment but might need tweaking later
     _debian_packages = _ubuntu_packages_2004
 
-    _redhat_packages = [
+    _fedora_packages = [
         "psmisc",
         "numactl-devel.x86_64",
         "librdmacm-devel",
@@ -678,7 +678,7 @@ class DpdkTestpmd(Tool):
                 list(self._debian_packages), extra_args=self._debian_backports_args
             )
         elif isinstance(node.os, Fedora):
-            self._install_redhat_dependencies()
+            self._install_fedora_dependencies()
         else:
             raise UnsupportedDistroException(
                 node.os, "This OS does not have dpdk installation implemented yet."
@@ -711,12 +711,12 @@ class DpdkTestpmd(Tool):
                 extra_args=self._debian_backports_args,
             )
 
-    def _install_redhat_dependencies(self) -> None:
+    def _install_fedora_dependencies(self) -> None:
         node = self.node
         rhel = node.os
         if not isinstance(rhel, Fedora):
             fail(
-                "_install_redhat_dependencies was called on node "
+                "_install_fedora_dependencies was called on node "
                 f"which was not Fedora: {node.os.information.full_version}"
             )
             return  # appease the type checker
@@ -741,7 +741,7 @@ class DpdkTestpmd(Tool):
 
         rhel.group_install_packages("Development Tools")
         rhel.group_install_packages("Infiniband Support")
-        rhel.install_packages(list(self._redhat_packages))
+        rhel.install_packages(list(self._fedora_packages))
 
         # ensure RDMA service is started if present.
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -22,7 +22,7 @@ from lisa.operating_system import OperatingSystem, Ubuntu
 from lisa.tools import Dmesg, Echo, Lsmod, Lspci, Modprobe, Mount
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
-from microsoft.testsuites.dpdk.common import check_dpdk_support
+from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO, check_dpdk_support
 from microsoft.testsuites.dpdk.dpdktestpmd import PACKAGE_MANAGER_SOURCE, DpdkTestpmd
 
 
@@ -91,6 +91,7 @@ def _enable_hugepages(node: Node) -> None:
         ),
         sudo=True,
     )
+
     echo.write_to_file(
         "1",
         node.get_pure_path(
@@ -107,9 +108,7 @@ def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
     # Default to 20.11 unless another version is provided by the
     # user. 20.11 is the latest dpdk version for 18.04.
     if isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
-        variables["dpdk_source"] = variables.get(
-            "dpdk_source", "https://github.com/DPDK/dpdk"
-        )
+        variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
 
 


### PR DESCRIPTION
- Cleanup use of Redhat/Fedora to point to Fedora
- Refactor DPDK_STABLE to a single location for the various uses.

Second commit to force update RHEL to latest kernel before installation to fix rdma-core mismatch issues causing test results to report 0 packets per second.