### PR TITLE
NIC: add method to wait for sriov enabled in guest

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -268,7 +268,7 @@ class Nics(InitializableMixin):
         self.nics.clear()
         self._initialize()
 
-    @retry(tries=6, delay=20)
+    @retry(tries=12, delay=10)
     def wait_for_sriov_enabled(self) -> None:
         if not self.get_lower_nics():
             self.reload()

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -274,10 +274,10 @@ class Nics(InitializableMixin):
         lspci = self._node.tools[Lspci]
 
         # check for VFs on the guest
-        vfs = lspci.get_devices_by_type(constants.DEVICE_TYPE_SRIOV)
-        assert_that(vfs).described_as(
+        vfs = lspci.get_devices_by_type(constants.DEVICE_TYPE_SRIOV, force_run=True)
+        assert_that(len(vfs)).described_as(
             "Could not identify any SRIOV NICs on the test node."
-        ).is_not_empty()
+        ).is_not_zero()
 
         # check if the NIC driver has finished setting up the
         # failsafe pair, reload if not
@@ -289,6 +289,7 @@ class Nics(InitializableMixin):
                 f"upper: {self.get_upper_nics()} "
                 f"lower: {self.get_lower_nics()} "
                 f"unpaired: {self.get_unpaired_devices()}"
+                f"vfs: {','.join([str(pci) for pci in vfs])}"
             ).is_not_empty()
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -51,6 +51,14 @@ class PciDevice:
     def __init__(self, pci_device_raw: str) -> None:
         self.parse(pci_device_raw)
 
+    def __str__(self) -> str:
+        return (
+            f"PCI device: {self.slot} "
+            f"class {self.device_class} "
+            f"vendor {self.vendor} "
+            f"info: {self.device_info} "
+        )
+
     def parse(self, raw_str: str) -> None:
         matched_pci_device_info = PATTERN_PCI_DEVICE.match(raw_str)
         if matched_pci_device_info:

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -217,12 +217,7 @@ def initialize_node_resources(
         raise SkippedException(err)
 
     # verify SRIOV is setup as-expected on the node after compat check
-    assert_that(node.nics.get_lower_nics()).described_as(
-        "Did not detect any upper/lower sriov paired nics!: "
-        f"upper: {node.nics.get_upper_nics()} "
-        f"lower: {node.nics.get_lower_nics()} "
-        f"unpaired: {node.nics.get_unpaired_devices()}"
-    ).is_not_empty()
+    node.nics.wait_for_sriov_enabled()
 
     # create tool, initialize testpmd tool (installs dpdk)
     testpmd: DpdkTestpmd = node.tools.get(


### PR DESCRIPTION
We previously only allow a wait for SRIOV to be ready in the guest when toggling SRIOV. 
- Add a method to node.nic to perform this wait and reload info if needed.
- add a use in DPDK initialize_node_resources

This fixes a race resulting in erroneous 'SRIOV is not available' errors at the beginning of some tests.