### PR TITLE
verify_boot_error_warnings refactor to use dmesg filters

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -218,6 +218,32 @@ class AzureImageStandard(TestSuite):
         ),
     ]
 
+    def _process_log_lines(self, log_output: str) -> List[str]:
+        ignored_candidates = list(
+            (
+                set(
+                    [
+                        x
+                        for sublist in find_patterns_in_lines(
+                            log_output, self._error_fail_warnings_ignorable_str_list
+                        )
+                        for x in sublist
+                        if x
+                    ]
+                )
+            )
+        )
+        found_results = [
+            x
+            for sublist in find_patterns_in_lines(
+                log_output, self._error_fail_warnings_pattern
+            )
+            for x in sublist
+            if x and x not in ignored_candidates
+        ]
+
+        return found_results
+
     @TestCaseMetadata(
         description="""
         This test will verify that `Defaults targetpw` is not enabled in the
@@ -791,29 +817,7 @@ class AzureImageStandard(TestSuite):
         log_output = dmesg.get_output(
             force_run=True, log_level=["warn", "err", "emerg", "alert", "crit"]
         )
-
-        ignored_candidates = list(
-            (
-                set(
-                    [
-                        x
-                        for sublist in find_patterns_in_lines(
-                            log_output, self._error_fail_warnings_ignorable_str_list
-                        )
-                        for x in sublist
-                        if x
-                    ]
-                )
-            )
-        )
-        found_results = [
-            x
-            for sublist in find_patterns_in_lines(
-                log_output, self._error_fail_warnings_pattern
-            )
-            for x in sublist
-            if x and x not in ignored_candidates
-        ]
+        found_results = self._process_log_lines(log_output)
         assert_that(found_results).described_as(
             "unexpected error/failure/warnings shown up in bootup log of distro"
             f" {node.os.name} {node.os.information.version}"
@@ -836,36 +840,15 @@ class AzureImageStandard(TestSuite):
         requirement=simple_requirement(supported_platform_type=[AZURE, READY]),
     )
     def verify_boot_error_fail_warnings_syslog(self, node: Node) -> None:
-        dmesg = node.tools[Dmesg]
         cat = node.tools[Cat]
-        log_output = dmesg.get_output(force_run=True, log_level=["warn"])
+        log_output = ""
         if node.shell.exists(node.get_pure_path("/var/log/syslog")):
             log_output += cat.read("/var/log/syslog", force_run=True, sudo=True)
         if node.shell.exists(node.get_pure_path("/var/log/messages")):
             log_output += cat.read("/var/log/messages", force_run=True, sudo=True)
 
-        ignored_candidates = list(
-            (
-                set(
-                    [
-                        x
-                        for sublist in find_patterns_in_lines(
-                            log_output, self._error_fail_warnings_ignorable_str_list
-                        )
-                        for x in sublist
-                        if x
-                    ]
-                )
-            )
-        )
-        found_results = [
-            x
-            for sublist in find_patterns_in_lines(
-                log_output, self._error_fail_warnings_pattern
-            )
-            for x in sublist
-            if x and x not in ignored_candidates
-        ]
+        found_results = self._process_log_lines(log_output)
+
         assert_that(found_results).described_as(
             "unexpected error/failure/warnings shown up in bootup log of distro"
             f" {node.os.name} {node.os.information.version}"

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -775,8 +775,56 @@ class AzureImageStandard(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        This test will check for kernel error, failure, alert messages from demsg.
+        Kenrel only, errors and alerts only. Should never fail.
+
+        Steps:
+        1. Get failure, error, alert messages from dmesg.
+        2. If any unexpected failure, error, warning messages excluding ignorable ones
+         existing, fail the case.
+        """,
+        priority=1,
+        requirement=simple_requirement(supported_platform_type=[AZURE, READY]),
+    )
+    def verify_boot_error_fail_warnings_dmesg(self, node: Node) -> None:
+        dmesg = node.tools[Dmesg]
+        log_output = dmesg.get_output(
+            force_run=True, log_level=["warn", "err", "emerg", "alert", "crit"]
+        )
+
+        ignored_candidates = list(
+            (
+                set(
+                    [
+                        x
+                        for sublist in find_patterns_in_lines(
+                            log_output, self._error_fail_warnings_ignorable_str_list
+                        )
+                        for x in sublist
+                        if x
+                    ]
+                )
+            )
+        )
+        found_results = [
+            x
+            for sublist in find_patterns_in_lines(
+                log_output, self._error_fail_warnings_pattern
+            )
+            for x in sublist
+            if x and x not in ignored_candidates
+        ]
+        assert_that(found_results).described_as(
+            "unexpected error/failure/warnings shown up in bootup log of distro"
+            f" {node.os.name} {node.os.information.version}"
+        ).is_empty()
+
+    @TestCaseMetadata(
+        description="""
         This test will check error, failure, warning messages from demsg,
          /var/log/syslog or /var/log/messages file.
+
+        Includes userspace warnings and application messages, can be noisy.
 
         Steps:
         1. Get failure, error, warning messages from dmesg, /var/log/syslog or
@@ -787,10 +835,10 @@ class AzureImageStandard(TestSuite):
         priority=1,
         requirement=simple_requirement(supported_platform_type=[AZURE, READY]),
     )
-    def verify_boot_error_fail_warnings(self, node: Node) -> None:
+    def verify_boot_error_fail_warnings_syslog(self, node: Node) -> None:
         dmesg = node.tools[Dmesg]
         cat = node.tools[Cat]
-        log_output = dmesg.get_output(force_run=True)
+        log_output = dmesg.get_output(force_run=True, log_level=["warn"])
         if node.shell.exists(node.get_pure_path("/var/log/syslog")):
             log_output += cat.read("/var/log/syslog", force_run=True, sudo=True)
         if node.shell.exists(node.get_pure_path("/var/log/messages")):

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -32,6 +32,7 @@ from lisa.operating_system import (
 )
 from lisa.sut_orchestrator import AZURE, READY
 from lisa.tools import Cat, Dmesg, Lscpu, Pgrep, Ssh, Whoami
+from lisa.tools.dmesg import LogLevel
 from lisa.util import (
     LisaException,
     PassedException,
@@ -814,9 +815,7 @@ class AzureImageStandard(TestSuite):
     )
     def verify_boot_error_fail_warnings_dmesg(self, node: Node) -> None:
         dmesg = node.tools[Dmesg]
-        log_output = dmesg.get_output(
-            force_run=True, log_level=["warn", "err", "emerg", "alert", "crit"]
-        )
+        log_output = dmesg.get_output(force_run=True, log_level=LogLevel.WARN)
         found_results = self._process_log_lines(log_output)
         assert_that(found_results).described_as(
             "unexpected error/failure/warnings shown up in bootup log of distro"


### PR DESCRIPTION
- Break up test into syslog and dmesg flavors to split results by severity
- Add Dmesg tool option to filter by log level and facility
- refactor ignore line filtering into it's own shared function