### PR TITLE
Add some enhancement in kdump test case for Redhat image

### DIFF
--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -220,8 +220,12 @@ class KdumpCrash(TestSuite):
         # to https://wiki.centos.org/action/show/Sources?action=show&redirect=sources
         # In addition, we didn't see upstream kernel has the auto crashkernel feature.
         # It may be a patch owned by Redhat/Centos.
+        # Note that crashkernel=auto option in the boot command line is no longer
+        # supported on RHEL 9 and later releases
         if not (
-            isinstance(node.os, Redhat) and node.os.information.version >= "8.0.0-0"
+            isinstance(node.os, Redhat)
+            and node.os.information.version >= "8.0.0-0"
+            and node.os.information.version < "9.0.0-0"
         ):
             if self.crash_kernel == "auto" and not node.tools[KernelConfig].is_built_in(
                 "CONFIG_KEXEC_AUTO_RESERVE"


### PR DESCRIPTION
1. Redhat 9 no longer supports crashkerne=auto option, the auto_size case should be skipped for this image.
2. After configuring kdump and rebooting the system, a restart of the kdump service is needed to make sure the crash kernel is loaded.