### PR TITLE
Azure: Round os disk size up to account for megabyte alignment

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -4,6 +4,7 @@
 import copy
 import json
 import logging
+import math
 import os
 import re
 from copy import deepcopy
@@ -2115,7 +2116,9 @@ class AzurePlatform(Platform):
         vhd_blob = container_client.get_blob_client(result_dict["blob_name"])
         properties = vhd_blob.get_blob_properties()
         assert properties.size, f"fail to get blob size of {blob_url}"
-        return int(properties.size / 1024 / 1024 / 1024)
+        # Azure requires only megabyte alignment of vhds, round size up
+        # for cases where the size is megabyte aligned
+        return math.ceil(properties.size / 1024 / 1024 / 1024)
 
     def _get_sig_info(
         self, shared_image: SharedImageGallerySchema


### PR DESCRIPTION
Testing with OS disks I've noticed sometimes lisa thinks the OS disk is too large. This is due to a rounding error in cases where the disk size is megabyte aligned. Previously any extra bytes would get ignored, switch to applying ceil after dividing.