### PR TITLE
Fix regression on merging features

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -687,6 +687,35 @@ class LisaRunner(BaseRunner):
                             schema.NodeSpace, node_requirement_data
                         )
 
+                        # Manage the union of the platform requirements and the node
+                        # requirements before taking the intersection of
+                        # the rest of the requirements.
+                        platform_requirement.features = search_space.SetSpace(
+                            True,
+                            (
+                                platform_requirement.features.items
+                                if platform_requirement.features
+                                else []
+                            )
+                            + (
+                                original_node_requirement.features.items
+                                if original_node_requirement.features
+                                else []
+                            ),
+                        )
+                        platform_requirement.excluded_features = search_space.SetSpace(
+                            False,
+                            (
+                                platform_requirement.excluded_features.items
+                                if platform_requirement.excluded_features
+                                else []
+                            )
+                            + (
+                                original_node_requirement.excluded_features.items
+                                if original_node_requirement.excluded_features
+                                else []
+                            ),
+                        )
                         platform_requirement.excluded_features = None
 
                         try:

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -982,13 +982,10 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
         elif method_name == search_space.RequirementMethod.intersect and (
             capability.features or self.features
         ):
-            # join for intersect between test requirement and runbook
-            # requirement, and should be handled in platform.
-            value.features = search_space.SetSpace[FeatureSettings](
-                is_allow_set=True,
-                items=(self.features.items if self.features else [])
-                + (capability.features.items if capability.features else []),
-            )
+            # This is a hack to work with lisa_runner. The capability features
+            # are joined case req and runbook req. Here just take the results
+            # from capability.
+            value.features = capability.features
 
         if (
             capability.excluded_features
@@ -1016,15 +1013,10 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
         elif method_name == search_space.RequirementMethod.intersect and (
             capability.excluded_features or self.excluded_features
         ):
-            value.excluded_features = search_space.SetSpace[FeatureSettings](
-                is_allow_set=True,
-                items=(self.excluded_features.items if self.excluded_features else [])
-                + (
-                    capability.excluded_features.items
-                    if capability.excluded_features
-                    else []
-                ),
-            )
+            # This is a hack to work with lisa_runner. The capability features
+            # are joined case req and runbook req. Here just take the results
+            # from capability.
+            value.excluded_features = capability.excluded_features
 
         return value
 


### PR DESCRIPTION
When features are merged, the check is called to make sure the overlap of intersect is right scope on each req. But the feature is special, it needs some hacks on current infra to merge correctly.

With this fix,
1. The features will be concatenated into platform req in lisa runner.
2. The platform features is taken in node space intersect.
3. The features are actually merged in the azure platform.