### PR TITLE
SecurityProfile: Accept empty string in runbook

### DIFF
--- a/lisa/features/security_profile.py
+++ b/lisa/features/security_profile.py
@@ -43,8 +43,18 @@ class SecurityProfileSettings(schema.FeatureSettings):
             ],
         ),
         metadata=field_metadata(
-            decoder=partial(
-                search_space.decode_set_space_by_type, base_type=SecurityProfileType
+            decoder=lambda input: (
+                search_space.decode_set_space_by_type(
+                    data=input, base_type=SecurityProfileType
+                )
+                if input
+                else search_space.SetSpace(
+                    items=[
+                        SecurityProfileType.Standard,
+                        SecurityProfileType.Boot,
+                        SecurityProfileType.CVM,
+                    ]
+                )
             )
         ),
     )


### PR DESCRIPTION
When the runbook has an empty string (important for pipelines), the security profile should use the default requirement.