### PR TITLE
attach one nic if only one nic attached, and select non eth0 nic for testing

### DIFF
--- a/microsoft/testsuites/network/common.py
+++ b/microsoft/testsuites/network/common.py
@@ -213,13 +213,6 @@ def cleanup_iperf3(environment: Environment) -> None:
         kill.by_name("iperf3")
 
 
-def remove_extra_nics(environment: Environment) -> None:
-    for node in environment.nodes.list():
-        node = cast(RemoteNode, node)
-        network_interface_feature = node.features[NetworkInterface]
-        network_interface_feature.remove_extra_nics()
-
-
 def sriov_disable_enable(environment: Environment, times: int = 4) -> None:
     vm_nics = initialize_nic_info(environment)
     sriov_basic_test(environment, vm_nics)
@@ -232,16 +225,31 @@ def sriov_disable_enable(environment: Environment, times: int = 4) -> None:
         network_interface_feature.switch_sriov(enable=(not sriov_is_enabled))
 
 
+def remove_extra_nics_per_node(node: Node) -> None:
+    node = cast(RemoteNode, node)
+    network_interface_feature = node.features[NetworkInterface]
+    network_interface_feature.remove_extra_nics()
+
+
+def remove_extra_nics(environment: Environment) -> None:
+    for node in environment.nodes.list():
+        remove_extra_nics_per_node(node)
+
+
+def restore_extra_nics_per_node(node: Node) -> None:
+    remove_extra_nics_per_node(node)
+    network_interface_feature = node.features[NetworkInterface]
+    network_interface_feature.attach_nics(
+        network_interface_feature.origin_extra_sriov_nics_count,
+        enable_accelerated_networking=True,
+    )
+    network_interface_feature.attach_nics(
+        network_interface_feature.origin_extra_synthetic_nics_count,
+        enable_accelerated_networking=False,
+    )
+
+
 def restore_extra_nics(environment: Environment) -> None:
-    remove_extra_nics(environment)
     # restore nics info into previous status
     for node in environment.nodes.list():
-        network_interface_feature = node.features[NetworkInterface]
-        network_interface_feature.attach_nics(
-            network_interface_feature.origin_extra_sriov_nics_count,
-            enable_accelerated_networking=True,
-        )
-        network_interface_feature.attach_nics(
-            network_interface_feature.origin_extra_synthetic_nics_count,
-            enable_accelerated_networking=False,
-        )
+        restore_extra_nics_per_node(node)


### PR DESCRIPTION
fix two issues from validate_set_static_mac
1. only one nic attached in testing vm at that time => attach one more nic for testing
2. fix for selected nic of testing is eth0 => select non eth0 nic