### PR TITLE
KVM: fix qemu killing issue

### DIFF
--- a/lisa/tools/qemu.py
+++ b/lisa/tools/qemu.py
@@ -129,7 +129,9 @@ class Qemu(Tool):
     def delete_vm(self, timeout: int = 300) -> None:
         # stop vm
         kill = self.node.tools[Kill]
-        kill.by_name("qemu")
+        qemu_processes = self.node.tools[Pgrep].get_processes("qemu")
+        for process in qemu_processes:
+            kill.by_pid(process.id)
 
         # `Qemu` is not stopped immediately after `kill` is called.
         # Wait until we find no running qemu processes.


### PR DESCRIPTION
Qemu can launch an executable named something other than qemu or even qemu-system-x86_64, etc. I noted a failure instance where qemu-system-x86 was active after killing 'qemu' due to the naming issue, even when you'd expect x86_64 to be launched.

To fix this, use the same method we use to find the remaining process to get the process ids, then kill those process IDs.

You can repro the situation on WSL ubuntu 20.04, installing qemu, run qemu-system-x86_64, qemu-system-x86 is the process name that runs.