### PR TITLE
Move the kernel config check to the first so it can determine if the distro supports kdump by introducing the KdumpBase tool

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -190,6 +190,7 @@ class KdumpBase(Tool):
 
     @classmethod
     def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
+        # FreeBSD image doesn't support kdump since the kernel has no DDB option
         if isinstance(node.os, Redhat):
             return KdumpRedhat(node)
         elif isinstance(node.os, Debian):

--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -204,6 +204,10 @@ class KdumpCrash(TestSuite):
         self._kdump_test(node, log_path, log)
 
     def _check_supported(self, node: Node) -> None:
+        # Check the kernel config for kdump supported
+        kdump = node.tools[KdumpBase]
+        kdump.check_required_kernel_config()
+
         # Check the VMBus version for kdump supported
         dmesg = node.tools[Dmesg]
         vmbus_version = dmesg.get_vmbus_version()
@@ -232,10 +236,6 @@ class KdumpCrash(TestSuite):
                 "CONFIG_KEXEC_AUTO_RESERVE"
             ):
                 raise SkippedException("crashkernel=auto doesn't work for the distro.")
-
-        # Check the kernel config for kdump supported
-        kdump = node.tools[KdumpBase]
-        kdump.check_required_kernel_config()
 
     def _get_resource_disk_dump_path(self, node: Node) -> str:
         if node.shell.exists(


### PR DESCRIPTION
We move the kernel config check to the first, so we can determine if the distro supports kdump by introducing the KdumpBase tool.