### PR TITLE
DPDK: restore min_core_count requirement

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -40,6 +40,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
+            min_core_count=8,
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=2,
@@ -62,6 +63,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
+            min_core_count=8,
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=2,
@@ -84,6 +86,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
+            min_core_count=8,
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=8,
@@ -109,6 +112,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
+            min_core_count=8,
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=2,
@@ -131,6 +135,7 @@ class DpdkPerformance(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
+            min_core_count=8,
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=8,
@@ -156,6 +161,7 @@ class DpdkPerformance(TestSuite):
         priority=3,
         requirement=simple_requirement(
             min_count=2,
+            min_core_count=8,
             network_interface=Sriov(),
             min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
@@ -188,6 +194,7 @@ class DpdkPerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            min_core_count=8,
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
@@ -210,6 +217,7 @@ class DpdkPerformance(TestSuite):
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=2,
+            min_core_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
@@ -233,6 +241,7 @@ class DpdkPerformance(TestSuite):
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=8,
+            min_core_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
@@ -257,6 +266,7 @@ class DpdkPerformance(TestSuite):
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=2,
+            min_core_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
@@ -279,6 +289,7 @@ class DpdkPerformance(TestSuite):
             min_count=2,
             network_interface=Sriov(),
             min_nic_count=8,
+            min_core_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
         ),
@@ -302,6 +313,7 @@ class DpdkPerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            min_core_count=8,
             min_nic_count=8,
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -71,6 +71,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -92,6 +93,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -108,6 +110,7 @@ class Dpdk(TestSuite):
         """,
         priority=4,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -156,6 +159,7 @@ class Dpdk(TestSuite):
         """,
         priority=4,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -278,6 +282,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             min_count=2,
@@ -317,6 +322,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -376,6 +382,7 @@ class Dpdk(TestSuite):
         """,
         priority=4,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
@@ -413,6 +420,7 @@ class Dpdk(TestSuite):
         """,
         priority=4,
         requirement=simple_requirement(
+            min_core_count=8,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],
@@ -486,6 +494,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             min_count=2,
@@ -512,6 +521,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             min_count=2,
@@ -538,6 +548,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             min_count=2,
@@ -562,6 +573,7 @@ class Dpdk(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
+            min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
             min_count=2,


### PR DESCRIPTION
verify_build tests removed isolated resource but still need the min core count requirement.

Defensively add this arg back to the other DPDK tests which require it.