### PR TITLE
Set Ephermeral disk present only if above threshold size

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1533,7 +1533,12 @@ class AzurePlatform(Platform):
             "EphemeralOSDiskSupported", None
         )
         if ephemeral_supported and eval(ephemeral_supported) is True:
-            node_space.disk.disk_type.add(schema.DiskType.Ephemeral)
+            # Check if CachedDiskBytes is greater than 30GB
+            # We use diffdisk as cache disk for ephemeral OS disk
+            cached_disk_bytes = azure_raw_capabilities.get("CachedDiskBytes", 0)
+            cached_disk_bytes_gb = int(cached_disk_bytes) / 1024 / 1024 / 1024
+            if cached_disk_bytes_gb >= 30:
+                node_space.disk.disk_type.add(schema.DiskType.Ephemeral)
 
         # set AN
         an_enabled = azure_raw_capabilities.get("AcceleratedNetworkingEnabled", None)


### PR DESCRIPTION
Fix errors on VM without cache disk: 

```
deployment failed. LisaException: NotSupported: The Diff Disk Placement of type 'CacheDisk' is not supported for VM size Standard_D48d_v4. Please request with different DiffDiskPlacement or use a different VM Sku which supports the current DiffDiskPlacement in the request.
```