### PR TITLE
SRIOV: allow old sriov switch behavior that doesn't kill connection

### DIFF
--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -21,7 +21,9 @@ class NetworkInterface(Feature):
     def enabled(self) -> bool:
         return True
 
-    def switch_sriov(self, enable: bool, wait: bool = True) -> None:
+    def switch_sriov(
+        self, enable: bool, wait: bool = True, reset_connections: bool = True
+    ) -> None:
         raise NotImplementedError
 
     def is_enabled_sriov(self) -> bool:

--- a/lisa/sut_orchestrator/aws/features.py
+++ b/lisa/sut_orchestrator/aws/features.py
@@ -167,7 +167,9 @@ class NetworkInterface(AwsFeatureMixin, features.NetworkInterface):
             raise LisaException(f"fail to find primary nic for vm {self._node.name}")
         return nic
 
-    def switch_sriov(self, enable: bool, wait: bool = True) -> None:
+    def switch_sriov(
+        self, enable: bool, wait: bool = True, reset_connections: bool = True
+    ) -> None:
         aws_platform: AwsPlatform = self._platform  # type: ignore
         instance = boto3.resource("ec2").Instance(self._instance_id)
 

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -665,4 +665,5 @@ class Dpdk(TestSuite):
             if modprobe.module_exists("uio_hv_generic"):
                 node.tools[Service].stop_service("vpp")
                 modprobe.remove(["uio_hv_generic"])
+                node.close()
                 modprobe.reload(["hv_netvsc"])

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -333,14 +333,18 @@ def run_testpmd_concurrent(
 
         # disable sriov (and wait for change to apply)
         for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(enable=False, wait=True)
+            node_resources.nic_controller.switch_sriov(
+                enable=False, wait=True, reset_connections=False
+            )
 
         # let run for a bit with SRIOV disabled
         time.sleep(10)
 
         # re-enable sriov
         for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(enable=True, wait=True)
+            node_resources.nic_controller.switch_sriov(
+                enable=True, wait=True, reset_connections=False
+            )
 
         # run for a bit with SRIOV re-enabled
         time.sleep(10)


### PR DESCRIPTION
recent change in switch_sriov ended up killing testpmd during the rescind tests, which breaks their logic.
- Allow tests to skip calling node.close() when switching SRIOV, add use in dpdk sriov rescind tests.
- Add DPDK call to node.close() at the end of the test to cleanup.