### PR TITLE
VPP: use service tool

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkvpp.py
+++ b/microsoft/testsuites/dpdk/dpdkvpp.py
@@ -8,7 +8,7 @@ from assertpy import assert_that
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Fedora, Suse
 from lisa.tools import Gcc, Git, Make, Modprobe, Service
-from lisa.util import SkippedException
+from lisa.util import SkippedException, UnsupportedDistroException
 
 
 class DpdkVpp(Tool):
@@ -87,7 +87,11 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             pkg_type = "rpm"
         else:
-            raise SkippedException(self.node.os, "VPP is not supported on this OS")
+            raise SkippedException(
+                UnsupportedDistroException(
+                    self.node.os, "VPP is not supported on this OS"
+                )
+            )
 
         node.execute(
             (
@@ -113,6 +117,10 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             vpp_packages.append("vpp-plugins")
         else:
-            raise SkippedException(self.node.os, "VPP is not supported on this OS")
+            raise SkippedException(
+                UnsupportedDistroException(
+                    self.node.os, "VPP is not supported on this OS"
+                )
+            )
 
         node.os.install_packages(list(vpp_packages))

--- a/microsoft/testsuites/dpdk/dpdkvpp.py
+++ b/microsoft/testsuites/dpdk/dpdkvpp.py
@@ -7,8 +7,8 @@ from assertpy import assert_that
 
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Fedora, Suse
-from lisa.tools import Gcc, Git, Make, Modprobe
-from lisa.util import UnsupportedDistroException
+from lisa.tools import Gcc, Git, Make, Modprobe, Service
+from lisa.util import SkippedException
 
 
 class DpdkVpp(Tool):
@@ -56,12 +56,7 @@ class DpdkVpp(Tool):
         # this will force the reload if it's already started
         # or start it if it hasn't started yet.
         modprobe.load("uio_hv_generic")
-        node.execute(
-            "service vpp restart",
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=("Could not start/restart vpp service"),
-        )
+        node.tools[Service].restart_service("vpp")
 
         time.sleep(3)  # give it a moment to start up
 
@@ -92,7 +87,7 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             pkg_type = "rpm"
         else:
-            raise UnsupportedDistroException(self.node.os)
+            raise SkippedException(self.node.os)
 
         node.execute(
             (
@@ -118,6 +113,6 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             vpp_packages.append("vpp-plugins")
         else:
-            raise UnsupportedDistroException(self.node.os)
+            raise SkippedException(self.node.os)
 
         node.os.install_packages(list(vpp_packages))

--- a/microsoft/testsuites/dpdk/dpdkvpp.py
+++ b/microsoft/testsuites/dpdk/dpdkvpp.py
@@ -87,7 +87,7 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             pkg_type = "rpm"
         else:
-            raise SkippedException(self.node.os)
+            raise SkippedException(self.node.os, "VPP is not supported on this OS")
 
         node.execute(
             (
@@ -113,6 +113,6 @@ class DpdkVpp(Tool):
         elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
             vpp_packages.append("vpp-plugins")
         else:
-            raise SkippedException(self.node.os)
+            raise SkippedException(self.node.os, "VPP is not supported on this OS")
 
         node.os.install_packages(list(vpp_packages))


### PR DESCRIPTION
VPP: switch to using the service tool to restart the VPP service. This was causing issues on OS's which don't support the 'service servicename restart' syntax

Convert Unsupported Distro to Skip since we can install on any supported distros that VPP supports.