### PR TITLE
DPDK: node.close() before hv_netvsc reset in rescind kill

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -214,7 +214,9 @@ class DpdkTestpmd(Tool):
                 vdev_flags = f"iface={nic.upper},force=1"
             else:
                 vdev_name = "net_failsafe"
-                vdev_flags = f"dev({nic.pci_slot}),dev(net_tap0,iface={nic.upper})"
+                vdev_flags = (
+                    f"dev({nic.pci_slot}),dev(net_tap0,iface={nic.upper},force=1)"
+                )
             if nic.bound_driver == "hv_netvsc":
                 vdev_info += f'--vdev="{vdev_name}{vdev_id},{vdev_flags}" '
             elif nic.bound_driver == "uio_hv_generic":
@@ -349,16 +351,23 @@ class DpdkTestpmd(Tool):
         return len(pids) > 0
 
     def kill_previous_testpmd_command(self) -> None:
-        # kill testpmd early
 
+        # kill testpmd early
         self.node.tools[Kill].by_name(self.command, ignore_not_exist=True)
         if self.check_testpmd_is_running():
             self.node.log.debug(
-                "Testpmd is not responding to signals, attempt reload of hv_netvsc."
+                "Testpmd is not responding to signals, "
+                "attempt network connection reset."
             )
-            self.node.close()  # reset node connection, should kill testpmd
+
+            # reset node connections (quicker and less risky than netvsc reset)
+            self.node.close()
             if not self.check_testpmd_is_running():
                 return
+
+            self.node.log.debug(
+                "Testpmd is not responding to signals, attempt reload of hv_netvsc."
+            )
             # if this somehow didn't kill it, reset netvsc
             self.node.tools[Modprobe].reload(["hv_netvsc"])
             if self.check_testpmd_is_running():

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -356,6 +356,10 @@ class DpdkTestpmd(Tool):
             self.node.log.debug(
                 "Testpmd is not responding to signals, attempt reload of hv_netvsc."
             )
+            self.node.close()  # reset node connection, should kill testpmd
+            if not self.check_testpmd_is_running():
+                return
+            # if this somehow didn't kill it, reset netvsc
             self.node.tools[Modprobe].reload(["hv_netvsc"])
             if self.check_testpmd_is_running():
                 raise LisaException("Testpmd has hung, killing the test.")


### PR DESCRIPTION
node.close() seems to be more reliable for killing the unresponsive process, so attempt node.close before resetting the network interface. after_case already performs this reset anyway so doing it twice it pointless if we can avoid it.