### PR TITLE
libvirt: save libvirtd logs during environment delete

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -26,7 +26,7 @@ from lisa.feature import Feature
 from lisa.node import Node, RemoteNode, local_node_connect
 from lisa.operating_system import CBLMariner
 from lisa.platform_ import Platform
-from lisa.tools import Iptables, Ls, QemuImg, Uname
+from lisa.tools import Iptables, Journalctl, Ls, QemuImg, Uname
 from lisa.util import LisaException, constants, get_public_key_data
 from lisa.util.logger import Logger, filter_ansi_escape
 
@@ -161,6 +161,10 @@ class BaseLibvirtPlatform(Platform):
         self._delete_nodes(environment, log)
         if self.host_node.is_remote:
             self._stop_port_forwarding(environment, log)
+        libvirt_log = self.host_node.tools[Journalctl].logs_for_unit("libvirtd")
+        libvirt_log_path = self.host_node.local_log_path / "libvirtd.log"
+        with open(str(libvirt_log_path), "w") as f:
+            f.write(libvirt_log)
 
     def _configure_environment(self, environment: Environment, log: Logger) -> None:
         environment_context = get_environment_context(environment)

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -32,6 +32,7 @@ from .hyperv import HyperV
 from .interrupt_inspector import InterruptInspector
 from .ip import Ip
 from .iperf3 import Iperf3
+from .journalctl import Journalctl
 from .kdump import KdumpBase
 from .kernel_config import KernelConfig
 from .kill import Kill
@@ -130,6 +131,7 @@ __all__ = [
     "Ip",
     "Iperf3",
     "Iptables",
+    "Journalctl",
     "KdumpBase",
     "KernelConfig",
     "Kill",

--- a/lisa/tools/journalctl.py
+++ b/lisa/tools/journalctl.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from lisa.executable import Tool
+
+
+class Journalctl(Tool):
+    @property
+    def command(self) -> str:
+        return "journalctl"
+
+    def _check_exists(self) -> bool:
+        return True
+
+    def logs_for_unit(self, unit_name: str) -> str:
+        result = self.run(
+            f"--no-pager -u {unit_name}",
+            sudo=True,
+            force_run=True,
+            no_debug_log=True,  # don't flood LISA logs
+            expected_exit_code=0,
+        )
+
+        return result.stdout


### PR DESCRIPTION
libvirtd logs are useful for debugging libvirt related issues that might happen while executing testcases. So, retreive the logs using journalctl and write them to the host node's log path. Also introduce a new tool for working with the `journalctl` command.

Signed-off-by: Anirudh Rayabharam <anrayabh@microsoft.com>