### PR TITLE
Update link for linux poetry installation to canonical link

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Poetry for Windows
         if: runner.os == 'Windows'
         run: |
-          (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | python - --version 1.1.5
+          (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python - --version 1.1.5
           echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install Python dependencies (Linux-only)
         if: runner.os == 'Linux'

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Install Poetry for Linux
         if: runner.os == 'Linux'
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - --version 1.1.5
+          curl -sSL https://install.python-poetry.org/ | python - --version 1.1.5
           echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install Poetry for Windows
         if: runner.os == 'Windows'
         run: |
-          (Invoke-WebRequest -Uri https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py -UseBasicParsing).Content | python - --version 1.1.5
+          (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | python - --version 1.1.5
           echo "$env:APPDATA\Python\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Install Python dependencies (Linux-only)
         if: runner.os == 'Linux'

--- a/docs/installation_linux.rst
+++ b/docs/installation_linux.rst
@@ -57,7 +57,7 @@ Poetry is used to manage Python dependencies of LISA.
 
 .. code:: bash
 
-   curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+   curl -sSL https://install.python-poetry.org | python3 -
 
 After running this, you should see
 ``Add export PATH="/home/YOURUSERNAME/.local/bin:$PATH" to your shell configuration file``


### PR DESCRIPTION
When installing on Linux, poetry recommends using the https://install.python-poetry.org link for downloading and installing poetry instead of the raw.githubusercontent.com link that is currently being used.