### PR TITLE
[fix test issue] fix 'unable to locate package' issue by waiting cloud-init finish init work

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -821,6 +821,12 @@ class Debian(Linux):
         install_result = self._node.execute(
             command, shell=True, sudo=True, timeout=timeout
         )
+        # fix 'unable to locate package' issue
+        if (
+            "Unable to locate package" in install_result.stdout
+            and 100 == install_result.exit_code
+        ):
+            self._initialize_package_installation()
         # get error lines.
         install_result.assert_exit_code(
             0,


### PR DESCRIPTION
Use main branch, encounter this issue 100% when run 20 times.
With this fix, the issue does not repro when run 40 times.

From log, I can see retry with 'apt update' working.