### PR TITLE
[fix test issue] fix verify_serial_console by observing test result

### DIFF
--- a/microsoft/testsuites/core/serial_console.py
+++ b/microsoft/testsuites/core/serial_console.py
@@ -38,5 +38,5 @@ class SerialConsoleSuite(TestSuite):
         output = serial_console.read()
 
         assert_that(
-            output, "output from serial console should be equal to command"
-        ).is_equal_to(command)
+            output, "output from serial console should contain command"
+        ).contains(command)


### PR DESCRIPTION
@somil55 I saw for some failed cases, it has more output flow in besides 'echo back', I think it is expected, let know your thoughts.

e.g.
```
failed. AssertionError: [output from serial console should be equal to command] Expected <echo back[   51.578378] hv_balloon: Max. dynamic memory size: 7168 MB
> to be equal to <echo back>, but was not.
```