### PR TITLE
[fix issue] skip LIS driver installation testing when kernel version is unsupported

### DIFF
--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -14,6 +14,7 @@ from lisa.tools import Gcc, Modinfo, PowerShell, Uname
 from lisa.util import (
     LisaException,
     UnsupportedDistroException,
+    UnsupportedKernelException,
     find_patterns_in_lines,
     get_matched_str,
 )
@@ -236,6 +237,8 @@ class LisDriver(Tool):
 
     def _install(self) -> bool:
         result = self.install_from_iso()
+        if result.stdout == "Unsupported kernel version":
+            raise UnsupportedKernelException(self.node.os)
         result.assert_exit_code(
             0,
             f"Unable to install the LIS RPMs! exit_code: {result.exit_code}"

--- a/microsoft/testsuites/lis/lissuite.py
+++ b/microsoft/testsuites/lis/lissuite.py
@@ -15,6 +15,7 @@ from lisa.util import (
     LisaException,
     SkippedException,
     UnsupportedDistroException,
+    UnsupportedKernelException,
     get_matched_str,
 )
 
@@ -241,7 +242,7 @@ class Lis(TestSuite):
         try:
             lisdriver = node.tools[LisDriver]
             return lisdriver
-        except UnsupportedDistroException as err:
+        except (UnsupportedDistroException, UnsupportedKernelException) as err:
             raise SkippedException(err)
 
     def _clean_up_files(self, node: Node) -> None:


### PR DESCRIPTION
when run lis install case against openlogic centos 7_9 7.9.2022020700, found its release is 7.0.0, since it reads from /etc/os-release.
I used /etc/redhat-release now, it works well. @squirrelsc do you think any risk for this change?