### PR TITLE
SRIOV tests, verify at runtime SRIOV is active before start

### DIFF
--- a/microsoft/testsuites/network/common.py
+++ b/microsoft/testsuites/network/common.py
@@ -48,6 +48,7 @@ def initialize_nic_info(
             ).is_greater_than(0)
         node_nic_info = Nics(node)
         node_nic_info.initialize()
+        node_nic_info.wait_for_sriov_enabled()
         for _, node_nic in node_nic_info.nics.items():
             assert_that(node_nic.ip_addr).described_as(
                 f"This interface {node_nic.upper} does not have a IP address."

--- a/microsoft/testsuites/network/common.py
+++ b/microsoft/testsuites/network/common.py
@@ -36,6 +36,12 @@ def initialize_nic_info(
     for node in environment.nodes.list():
         if is_sriov:
             network_interface_feature = node.features[NetworkInterface]
+            # verify SRIOV in environment is enabled, wait for enable if not.
+            if not network_interface_feature.is_enabled_sriov():
+                network_interface_feature.switch_sriov(
+                    enable=True, wait=True, reset_connections=True
+                )
+
             sriov_count = network_interface_feature.get_nic_count()
             assert_that(sriov_count).described_as(
                 f"there is no sriov nic attached to VM {node.name}"


### PR DESCRIPTION
Noticed some tests failing with an error that no SRIOV interface is present, in DPDK tests I verify it's on and wait for the interface if not. Adding two commits:

- Adding a line to verify SRIOV is enabled on Azure side.
- Add a line to wait for SRIOV on test node side.