### PR TITLE
[fix test issue] no need to set task max and reboot VM when connection less than 20480

### DIFF
--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -138,7 +138,7 @@ class Ntttcp(Tool):
     def can_install(self) -> bool:
         return True
 
-    def setup_system(self, udp_mode: bool = False) -> None:
+    def setup_system(self, udp_mode: bool = False, set_task_max: bool = True) -> None:
         sysctl = self.node.tools[Sysctl]
         sys_list = self.sys_list_tcp
         if udp_mode:
@@ -146,7 +146,8 @@ class Ntttcp(Tool):
         for sys in sys_list:
             for variable, value in sys.items():
                 sysctl.write(variable, value)
-        self._set_tasks_max()
+        if set_task_max:
+            self._set_tasks_max()
         firewall = self.node.tools[Firewall]
         firewall.stop()
 

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -253,8 +253,13 @@ def perf_ntttcp(
                 lambda: server.tools[Lagscope],  # type: ignore
             ]
         )
+        # no need to set task max and reboot VM when connection less than 20480
+        if max(connections) >= 20480:
+            set_task_max = True
+        else:
+            set_task_max = False
         for ntttcp in [client_ntttcp, server_ntttcp]:
-            ntttcp.setup_system(udp_mode)
+            ntttcp.setup_system(udp_mode, set_task_max)
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
         data_path = get_nic_datapath(client)


### PR DESCRIPTION
setup_system will reboot VM, nics will be initialized in every reboot, to avoid issue and save time, not set task max (reboot VM) when connection less than 20480, since this change is for bigger connections.