### PR TITLE
Add a suite of stress-ng tests

### DIFF
--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from lisa.executable import Tool
 from lisa.operating_system import Posix
+from lisa.util.process import Process
 
 from .gcc import Gcc
 from .git import Git
@@ -31,7 +32,7 @@ class StressNg(Tool):
             self._install_from_src()
         return self._check_exists()
 
-    def launch(
+    def launch_vm_stressor(
         self, num_workers: int = 0, vm_bytes: str = "", timeout_in_seconds: int = 0
     ) -> None:
         # --vm N, start N workers spinning on anonymous mmap
@@ -56,6 +57,21 @@ class StressNg(Tool):
 
         cmd += f" --timeout {timeout_in_seconds} "
         self.run(cmd, force_run=True, timeout=timeout_in_seconds)
+
+    def launch_job_async(self, job_file: str, sudo: bool = False) -> Process:
+        return self.run_async(f"--job {job_file}", force_run=True, sudo=sudo)
+
+    def launch_class_async(
+        self,
+        class_name: str,
+        num_workers: int = 0,
+        timeout_secs: int = 60,
+        sudo: bool = False,
+    ) -> Process:
+        return self.run_async(
+            f"--sequential {num_workers} --class {class_name} --timeout {timeout_secs}",
+            sudo=sudo,
+        )
 
     def _install_from_src(self) -> bool:
         tool_path = self.get_tool_path()

--- a/microsoft/testsuites/power/power.py
+++ b/microsoft/testsuites/power/power.py
@@ -192,9 +192,9 @@ class Power(TestSuite):
         node = cast(RemoteNode, environment.nodes[0])
         is_distro_supported(node)
         stress_ng_tool = node.tools[StressNg]
-        stress_ng_tool.launch(16, "100%", 300)
+        stress_ng_tool.launch_vm_stressor(16, "100%", 300)
         verify_hibernation(node, log)
-        stress_ng_tool.launch(16, "100%", 300)
+        stress_ng_tool.launch_vm_stressor(16, "100%", 300)
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")

--- a/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/microsoft/testsuites/stress/stress_ng_suite.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from pathlib import Path, PurePath
+from typing import Any, Dict, List, cast
+
+from lisa import (
+    Environment,
+    RemoteNode,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    notifier,
+)
+from lisa.features import SerialConsole
+from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
+from lisa.testsuite import TestResult
+from lisa.tools import StressNg
+from lisa.util import SkippedException
+from lisa.util.process import Process
+
+
+@TestSuiteMetadata(
+    area="stress",
+    category="stress-ng",
+    description="""
+    A suite for running the various classes of stressors provided
+    by stress-ng.
+    """,
+)
+class StressNgTestSuite(TestSuite):
+    TIME_OUT = 3600
+    CONFIG_VARIABLE = "stress_ng_jobs"
+
+    @TestCaseMetadata(
+        description="""
+        Runs a stress-ng jobfile. The path to the jobfile must be specified using a
+        runbook variable named "stress_ng_jobs". For more info about jobfiles refer:
+        https://manpages.ubuntu.com/manpages/jammy/man1/stress-ng.1.html
+        """,
+        priority=4,
+    )
+    def verify_stress_ng_jobfile(
+        self,
+        variables: Dict[str, Any],
+        environment: Environment,
+        result: TestResult,
+    ) -> None:
+        if self.CONFIG_VARIABLE in variables:
+            jobs = variables[self.CONFIG_VARIABLE]
+            for job_file in jobs:
+                self._run_stress_ng_job(job_file, environment, result)
+        else:
+            raise SkippedException("No jobfile provided for stress-ng")
+
+    @TestCaseMetadata(
+        description="Runs stress-ng's 'cpu' class stressors for 60s each.",
+        priority=4,
+    )
+    def verify_stress_ng_cpu_stressors(
+        self,
+        environment: Environment,
+    ) -> None:
+        self._run_stressor_class(environment, "cpu")
+
+    @TestCaseMetadata(
+        description="Runs stress-ng's 'memory' class stressors for 60s each.",
+        priority=4,
+    )
+    def verify_stress_ng_memory_stressors(
+        self,
+        environment: Environment,
+    ) -> None:
+        self._run_stressor_class(environment, "memory")
+
+    @TestCaseMetadata(
+        description="Runs stress-ng's 'vm' class stressors for 60s each.",
+        priority=4,
+    )
+    def verify_stress_ng_vm_stressors(
+        self,
+        environment: Environment,
+    ) -> None:
+        self._run_stressor_class(environment, "vm")
+
+    @TestCaseMetadata(
+        description="Runs stress-ng's 'io' class stressors for 60s each.",
+        priority=4,
+    )
+    def verify_stress_ng_io_stressors(
+        self,
+        environment: Environment,
+    ) -> None:
+        self._run_stressor_class(environment, "io")
+
+    @TestCaseMetadata(
+        description="Runs stress-ng's 'network' class stressors for 60s each.",
+        priority=4,
+    )
+    def verify_stress_ng_network_stressors(
+        self,
+        environment: Environment,
+    ) -> None:
+        self._run_stressor_class(environment, "network")
+
+    def _run_stressor_class(self, environment: Environment, class_name: str) -> None:
+        nodes = [cast(RemoteNode, node) for node in environment.nodes.list()]
+        procs: List[Process] = []
+        try:
+            for node in nodes:
+                procs.append(node.tools[StressNg].launch_class_async(class_name))
+            for proc in procs:
+                proc.wait_result(timeout=self.TIME_OUT, expected_exit_code=0)
+        except Exception as e:
+            self._check_panic(nodes)
+            raise e
+
+    def _run_stress_ng_job(
+        self,
+        job_file: str,
+        environment: Environment,
+        test_result: TestResult,
+    ) -> None:
+        nodes = [cast(RemoteNode, node) for node in environment.nodes.list()]
+        procs: List[Process] = []
+        job_file_name = Path(job_file).name
+        test_status = TestStatus.QUEUED
+        test_msg = ""
+        try:
+            for node in nodes:
+                remote_working_dir = node.working_path / "stress_ng_jobs"
+                node.shell.mkdir(remote_working_dir, exist_ok=True)
+                job_file_dest = remote_working_dir / job_file_name
+                node.shell.copy(PurePath(job_file), job_file_dest)
+                procs.append(node.tools[StressNg].launch_job_async(str(job_file_dest)))
+            for proc in procs:
+                proc.wait_result(expected_exit_code=0)
+            test_status = TestStatus.PASSED
+        except Exception as e:
+            test_status = TestStatus.FAILED
+            test_msg = repr(e)
+        finally:
+            self._send_subtest_msg(
+                test_result.id_,
+                environment,
+                job_file_name,
+                test_status,
+                test_msg,
+            )
+            self._check_panic(nodes)
+
+    def _check_panic(self, nodes: List[RemoteNode]) -> None:
+        for node in nodes:
+            node.features[SerialConsole].check_panic(saved_path=None, force_run=True)
+
+    def _send_subtest_msg(
+        self,
+        test_id: str,
+        environment: Environment,
+        test_name: str,
+        test_status: TestStatus,
+        test_msg: str = "",
+    ) -> None:
+        subtest_msg = create_test_result_message(
+            SubTestMessage,
+            test_id,
+            environment,
+            test_name,
+            test_status,
+        )
+
+        notifier.notify(subtest_msg)


### PR DESCRIPTION
stress-ng provides various stressors to stess a system in various ways. These stressors are divided into classes like cpu, memory, network etc. Introduce a new suite to run each class of stressors as a test case.

Signed-off-by: Anirudh Rayabharam <anrayabh@microsoft.com>