### PR TITLE
fix dd arguments

### DIFF
--- a/microsoft/testsuites/network/common.py
+++ b/microsoft/testsuites/network/common.py
@@ -128,7 +128,7 @@ def sriov_vf_connection_test(
 
     dest_ssh.enable_public_key(source_ssh.generate_key_pairs())
     # generate 200Mb file
-    source_node.execute("dd if=/dev/urandom of=large_file bs=100 count=0 seek=2M")
+    source_node.execute("dd if=/dev/zero of=large_file bs=200M count=1")
     max_retry_times = 10
     for _, source_nic_info in vm_nics[source_node.name].items():
         matched_dest_nic_name = ""


### PR DESCRIPTION
count=0 and seek=big doesn't work on all platforms, and can result in a 0 sized file.

switch to using /dev/zero and a big block size, count =1