### PR TITLE
Lagscope: Run server as async instead of '-D'

### DIFF
--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -125,26 +125,18 @@ class Lagscope(Tool, KillableMixin):
         for key in self._busy_pool_keys:
             sysctl.write(key, self._original_settings[key])
 
-    def run_as_server(self, ip: str = "", daemon: bool = True) -> None:
+    def run_as_server_async(self, ip: str = "") -> Process:
         # -r: run as a receiver
         # -rip: run as server mode with specified ip address
-        # -D: run as a daemon
         cmd = ""
-        if daemon:
-            cmd += " -D"
         if ip:
             cmd += f" -r{ip}"
         else:
             cmd += " -r"
-        self.run(
-            cmd,
-            force_run=True,
-            sudo=True,
-            shell=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=f"fail to launch cmd {self.command}"
-            f"{cmd}",
-        )
+        process = self.run_async(cmd, sudo=True, shell=True)
+        if not process.is_running():
+            raise LisaException("lagscope server failed to start")
+        return process
 
     def run_as_client_async(
         self,

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -149,7 +149,7 @@ def perf_tcp_latency(test_result: TestResult) -> List[NetworkLatencyPerformanceM
     try:
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
-        server_lagscope.run_as_server(ip=server.internal_address)
+        server_lagscope.run_as_server_async(ip=server.internal_address)
         latency_perf_messages = client_lagscope.create_latency_performance_messages(
             client_lagscope.run_as_client(server_ip=server.internal_address),
             inspect.stack()[1][3],
@@ -157,6 +157,7 @@ def perf_tcp_latency(test_result: TestResult) -> List[NetworkLatencyPerformanceM
         )
     finally:
         for lagscope in [client_lagscope, server_lagscope]:
+            lagscope.kill()
             lagscope.restore_busy_poll()
 
     return latency_perf_messages
@@ -274,7 +275,7 @@ def perf_ntttcp(
                 client_nic_name if client_nic_name else client.nics.default_nic
             )
             dev_differentiator = "Hypervisor callback interrupts"
-        server_lagscope.run_as_server(ip=server.internal_address)
+        server_lagscope.run_as_server_async(ip=server.internal_address)
         max_server_threads = 64
         perf_ntttcp_message_list: List[
             Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]
@@ -356,6 +357,7 @@ def perf_ntttcp(
         for ntttcp in [client_ntttcp, server_ntttcp]:
             ntttcp.restore_system(udp_mode)
         for lagscope in [client_lagscope, server_lagscope]:
+            lagscope.kill()
             lagscope.restore_busy_poll()
     return perf_ntttcp_message_list
 

--- a/microsoft/testsuites/xdp/performance.py
+++ b/microsoft/testsuites/xdp/performance.py
@@ -313,7 +313,7 @@ class XdpPerformance(TestSuite):
                 run_in_parallel(
                     [server_lagscope.set_busy_poll, client_lagscope.set_busy_poll]
                 )
-                server_lagscope.run_as_server(ip=server_nic.ip_addr)
+                server_lagscope.run_as_server_async(ip=server_nic.ip_addr)
 
                 result = client_lagscope.run_as_client(server_ip=server_nic.ip_addr)
                 lagscope_messages = client_lagscope.create_latency_performance_messages(


### PR DESCRIPTION
This way server logs are also printed and is useful for debugging