### PR TITLE
Fix ssh sessions issue in mshv_stress_vm_create test

### DIFF
--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -68,6 +68,10 @@ class Ssh(Tool):
         service = self.node.tools[Service]
         service.restart_service("sshd")
 
+        # The above changes take effect only for *new* connections. So,
+        # close the current connection.
+        self.node.close()
+
     def get(self, setting: str) -> str:
         config_path = self.get_default_sshd_config_path()
         settings = self.node.tools[Cat].read(config_path, True, True)

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -190,7 +190,6 @@ def perf_tcp_pps(
     if "maxpps" == test_type:
         ssh = client.tools[Ssh]
         ssh.set_max_session()
-        client.close()
         ports = range(30000, 30032)
     else:
         ports = range(30000, 30001)


### PR DESCRIPTION
The mshv_stress_vm_create test runs multiple instances of cloud-hypervisor using the CloudHypervisor tool. In doing so, multiple ssh sessions are created eventually exceeding the `MaxSessions` limit of `sshd`. This results in test failure with following message:

```
lisa.stderr Secsh channel 32 open FAILED: open failed: Connect failed
```

Fix this by setting the `MaxSessions` property in `/etc/ssh/sshd_config` to a high value that is unlikely to be exceeded.