### PR TITLE
Add Standard Dv5 VM to list of VMs without a resource disk

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1576,6 +1576,7 @@ class AzurePlatform(Platform):
             "standardEv4Family",
             "standardESv4Family",
             "standardEASv4Family",
+            "standardDv5Family",
             "standardEASv5Family",
             "standardESv5Family",
             "standardEADSv5Family",


### PR DESCRIPTION
This PR adds the Standard Dv5 VM series to the list of VMs that do not have a resource disk. Prior to this change, the `verify_resource_disk_io` test failed on a D-Series VM due to a resource disk not being found.

`AssertionError: [Exactly one partition with mount point /mnt should be present] Expected <[]> to be of length <1>, but was <0>.
2022-10-28 17:45:58.082[14656][INFO] lisa.suite[Storage].case[verify_resource_disk_io] result: FAILED, elapsed: 36.822 sec
2022-10-28 17:46:03.022[14656][INFO] lisa.[azure].del[generated_0] deleting resource group: lisa-azure-default-20221028-173955-689-e0, wait: False
2022-10-28 17:46:04.394[18200][INFO] lisa.RootRunner ________________________________________
2022-10-28 17:46:04.395[18200][INFO] lisa.RootRunner                    Storage.verify_resource_disk_io: FAILED   failed. AssertionError: [Exactly one partition with mount point /mnt should be present] Expected <[]> to be of length <1>, but was <0>.`

Now the test is skipped since LISA recognizes that the VM does not have a resource disk. 
 
`2022-10-28 17:46:28.713[14704][INFO] lisa.RootRunner                    Storage.verify_resource_disk_io: SKIPPED  deployment skipped: ["no available vm size found on 'centraluseuap'."], runbook: Environment(name='generated_0', topology='subnet', nodes_raw=None, nodes_requirement=[type:requirement,name:,default:False,count:1,core:[2,],mem:[512,],disk:has_resource_disk: True,disk_type: allowed:True,items:[DiskType.Ephemeral,DiskType.StandardHDDLRS,DiskType.StandardSSDLRS,DiskType.PremiumSSDLRS],count: [0,],caching: None,iops: [0,],size: [0,],max_data_disk_count: None,network interface: data_path:allowed:False,items:[NetworkDataPath.Synthetic,NetworkDataPath.Sriov], nic_count:[1,], max_nic_count:[1,], gpu:[0,],f:None,ef:None,NodeSpace(type='requirement')], _original_nodes_requirement=[type:requirement,name:,default:False,count:1,core:[2,],mem:[512,],disk:has_resource_disk: True,disk_type: allowed:True,items:[DiskType.Ephemeral,DiskType.StandardHDDLRS,DiskType.StandardSSDLRS,DiskType.PremiumSSDLRS],count: [0,],caching: None,iops: [0,],size: [0,],max_data_disk_count: None,network interface: data_path:allowed:False,items:[NetworkDataPath.Synthetic,NetworkDataPath.Sriov], nic_count:[1,], max_nic_count:[1,], gpu:[0,],f:None,ef:None,NodeSpace(type='requirement')]).`