### PR TITLE
DPDK: add duration variable to enable longer tests

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -447,6 +447,10 @@ def verify_dpdk_send_receive(
             raise SkippedException()
     log.debug((f"\nsender:{external_ips[0]}\nreceiver:{external_ips[1]}\n"))
 
+    # get test duration variable if set
+    # enables long-running tests to shakeQoS and SLB issue
+    test_duration: int = variables.get("dpdk_test_duration", 15)
+
     test_kits = init_nodes_concurrent(environment, log, variables, pmd)
 
     check_send_receive_compatibility(test_kits)
@@ -461,7 +465,7 @@ def verify_dpdk_send_receive(
         use_service_cores=use_service_cores,
     )
 
-    results = run_testpmd_concurrent(kit_cmd_pairs, 15, log)
+    results = run_testpmd_concurrent(kit_cmd_pairs, test_duration, log)
 
     # helpful to have the outputs labeled
     log.debug(f"\nSENDER:\n{results[sender]}")
@@ -492,6 +496,10 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     use_service_cores: int = 1,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
 
+    # get test duration variable if set
+    # enables long-running tests to shakeQoS and SLB issue
+    test_duration: int = variables.get("dpdk_test_duration", 15)
+
     test_kits = init_nodes_concurrent(environment, log, variables, pmd)
 
     check_send_receive_compatibility(test_kits)
@@ -508,7 +516,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
         use_service_cores=use_service_cores,
     )
 
-    results = run_testpmd_concurrent(kit_cmd_pairs, 15, log)
+    results = run_testpmd_concurrent(kit_cmd_pairs, test_duration, log)
 
     # helpful to have the outputs labeled
     log.debug(f"\nSENDER:\n{results[sender]}")


### PR DESCRIPTION
Testing for longer durations in TiP sessions will help shake out QoS and SLB issues, adding an option
to run for longer than 15 seconds to enable this testing when not running in prod.