### PR TITLE
DPDK: cleanup sriov enabled status in after-case

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -662,13 +662,13 @@ class Dpdk(TestSuite):
         environment: Environment = kwargs.pop("environment")
         for node in environment.nodes.list():
             interface = node.features[NetworkInterface]
+            if not interface.is_enabled_sriov():
+                log.debug("DPDK detected SRIOV was left disabled during cleanup.")
+                interface.switch_sriov(enable=True, wait=False, reset_connections=True)
             modprobe = node.tools[Modprobe]
             # cleanup driver changes
             if modprobe.module_exists("uio_hv_generic"):
                 node.tools[Service].stop_service("vpp")
                 modprobe.remove(["uio_hv_generic"])
-                node.close()
                 modprobe.reload(["hv_netvsc"])
             # reset SRIOV to enabled if left disabled
-            if not interface.is_enabled_sriov():
-                interface.switch_sriov(enable=True, wait=False, reset_connections=False)

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -18,7 +18,7 @@ from lisa import (
     schema,
     search_space,
 )
-from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
+from lisa.features import Gpu, Infiniband, IsolatedResource, NetworkInterface, Sriov
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe, Service
 from lisa.util.constants import SIGINT
@@ -661,9 +661,14 @@ class Dpdk(TestSuite):
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")
         for node in environment.nodes.list():
+            interface = node.features[NetworkInterface]
             modprobe = node.tools[Modprobe]
+            # cleanup driver changes
             if modprobe.module_exists("uio_hv_generic"):
                 node.tools[Service].stop_service("vpp")
                 modprobe.remove(["uio_hv_generic"])
                 node.close()
                 modprobe.reload(["hv_netvsc"])
+            # reset SRIOV to enabled if left disabled
+            if not interface.is_enabled_sriov():
+                interface.switch_sriov(enable=True, wait=False, reset_connections=False)


### PR DESCRIPTION
Make sure to clean up and re-enable SRIOV on the node in after_case. Defensive coding in the event the test fails while SRIOV is disabled.