### PR TITLE
Fix for verify_uio_binding test to check the prerequisite for enabling the uio_hv_generic driver

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -20,7 +20,17 @@ from lisa import (
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
-from lisa.tools import Dmesg, Echo, Free, Lscpu, Lsmod, Lspci, Modprobe, Mount, KernelConfig
+from lisa.tools import (
+    Dmesg,
+    Echo,
+    Free,
+    Lscpu,
+    Lsmod,
+    Lspci,
+    Modprobe,
+    Mount,
+    KernelConfig,
+)
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO, check_dpdk_support

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -17,6 +17,7 @@ from lisa import (
     UnsupportedDistroException,
     constants,
 )
+from lisa.base_tools.uname import Uname
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
@@ -24,12 +25,12 @@ from lisa.tools import (
     Dmesg,
     Echo,
     Free,
+    KernelConfig,
     Lscpu,
     Lsmod,
     Lspci,
     Modprobe,
     Mount,
-    KernelConfig,
 )
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
@@ -230,14 +231,21 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
     echo = node.tools[Echo]
     lsmod = node.tools[Lsmod]
     modprobe = node.tools[Modprobe]
-    kernelcfg = node.tools[KernelConfig]
+    kconfig = node.tools[KernelConfig]
+    uname = node.tools[Uname]
 
     # check if kernel config for Hyper-V VMBus is enabled
     config = "CONFIG_UIO_HV_GENERIC"
-    if not kernelcfg.is_enabled(config):
-        raise LisaException(
-            f"The kernel config {config} is not set."
-        )
+    if not kconfig.is_enabled(config):
+        kversion = uname.get_linux_information().kernel_version_raw
+        if kversion < "4.10":
+            raise SkippedException(
+                f"The kernel config {config} found in Linux kernels >= 4.10"
+            )
+        else:
+            raise LisaException(
+                f"The kernel config {config} is not set in kernel version {kversion}."
+            )
 
     # enable if it is not already enabled
     if not lsmod.module_exists("uio_hv_generic", force_run=True):

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -20,7 +20,7 @@ from lisa import (
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
-from lisa.tools import Dmesg, Echo, Free, Lscpu, Lsmod, Lspci, Modprobe, Mount
+from lisa.tools import Dmesg, Echo, Free, Lscpu, Lsmod, Lspci, Modprobe, Mount, kernel_config
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO, check_dpdk_support
@@ -220,6 +220,15 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
     echo = node.tools[Echo]
     lsmod = node.tools[Lsmod]
     modprobe = node.tools[Modprobe]
+    kernelcfg = node.tools[kernel_config.KernelConfig]
+
+    # check if kernel config for Hyper-V VMBus is enabled
+    config = "CONFIG_UIO_HV_GENERIC"
+    if not kernelcfg.is_enabled(config):
+        raise LisaException(
+            f"The kernel config {config} is not set."
+        )
+
     # enable if it is not already enabled
     if not lsmod.module_exists("uio_hv_generic", force_run=True):
         modprobe.load("uio_hv_generic")

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -20,7 +20,7 @@ from lisa import (
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
-from lisa.tools import Dmesg, Echo, Free, Lscpu, Lsmod, Lspci, Modprobe, Mount, kernel_config
+from lisa.tools import Dmesg, Echo, Free, Lscpu, Lsmod, Lspci, Modprobe, Mount, KernelConfig
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO, check_dpdk_support
@@ -220,7 +220,7 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
     echo = node.tools[Echo]
     lsmod = node.tools[Lsmod]
     modprobe = node.tools[Modprobe]
-    kernelcfg = node.tools[kernel_config.KernelConfig]
+    kernelcfg = node.tools[KernelConfig]
 
     # check if kernel config for Hyper-V VMBus is enabled
     config = "CONFIG_UIO_HV_GENERIC"

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -15,6 +15,7 @@ from lisa import (
     RemoteNode,
     SkippedException,
     UnsupportedDistroException,
+    UnsupportedKernelException,
     constants,
 )
 from lisa.base_tools.uname import Uname
@@ -237,11 +238,9 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
     # check if kernel config for Hyper-V VMBus is enabled
     config = "CONFIG_UIO_HV_GENERIC"
     if not kconfig.is_enabled(config):
-        kversion = uname.get_linux_information().kernel_version_raw
-        if kversion < "4.10":
-            raise SkippedException(
-                f"The kernel config {config} found in Linux kernels >= 4.10"
-            )
+        kversion = uname.get_linux_information().kernel_version
+        if kversion < "4.10.0":
+            raise UnsupportedKernelException(node.os)
         else:
             raise LisaException(
                 f"The kernel config {config} is not set in kernel version {kversion}."


### PR DESCRIPTION
This PR adds a check for "CONFIG_UIO_HV_GENERIC" kernel config before enabling its driver. In case this config is not enabled the test will fail gracefully and will print out the follow error message:

Dpdk.verify_uio_binding: FAILED   failed. LisaException: The kernel config CONFIG_UIO_HV_GENERIC is not set.