### PR TITLE
Update libvirt-python to latest and fix permission issue

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -26,7 +26,7 @@ from lisa.feature import Feature
 from lisa.node import Node, RemoteNode, local_node_connect
 from lisa.operating_system import CBLMariner
 from lisa.platform_ import Platform
-from lisa.tools import Iptables, Journalctl, Ls, QemuImg, Uname
+from lisa.tools import Chmod, Iptables, Journalctl, Ls, QemuImg, Uname
 from lisa.util import LisaException, constants, get_public_key_data
 from lisa.util.logger import Logger, filter_ansi_escape
 
@@ -522,7 +522,11 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
             source_exists = self.host_node.tools[Ls].path_exists(
                 path=node_context.os_disk_base_file_path, sudo=True
             )
-            if not source_exists:
+            if source_exists:
+                self.host_node.tools[Chmod].chmod(
+                    node_context.os_disk_base_file_path, "a+r", sudo=True
+                )
+            else:
                 self.host_node.shell.copy(
                     Path(node_context.os_disk_source_file_path),
                     Path(node_context.os_disk_base_file_path),

--- a/poetry.lock
+++ b/poetry.lock
@@ -940,7 +940,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "libvirt-python"
-version = "8.6.0"
+version = "8.9.0"
 description = "The libvirt virtualization API python binding"
 category = "main"
 optional = true
@@ -1144,7 +1144,7 @@ name = "oauthlib"
 version = "3.2.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -1968,7 +1968,7 @@ libvirt = ["libvirt-python"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "8de22236b6c14c20931b46ea58c3f0ac0cb3fffc1bbe5fc22c4977a5e6b36459"
+content-hash = "e489037acf90e29272395790404a8f40e499980ea9336b1bb6a206acf46e34d5"
 
 [metadata.files]
 alabaster = [
@@ -2334,7 +2334,7 @@ jmespath = [
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 libvirt-python = [
-    {file = "libvirt-python-8.6.0.tar.gz", hash = "sha256:81f49a648a4f3fbebf4abf3f8d4b1468654689d4df6fd21a303d1c1ca9344871"},
+    {file = "libvirt-python-8.9.0.tar.gz", hash = "sha256:2e1cfc3b9bd288b3cac400a6b03593633814236dbd1ecf5a900057bb90181c65"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ retry = "^0.9.2"
 spurplus = "^2.3.4"
 semver = "^2.13.0"
 types-toml = "^0.1.5"
-libvirt-python = {version = "^8.5.0", platform = 'linux', optional=true}
+libvirt-python = {version = "^8.9.0", platform = 'linux', optional=true}
 pycdlib = "^1.12.0"
 randmac = "^0.1"
 toml = "^0.10.2"


### PR DESCRIPTION
* In `_create_node`, os disk file is copied only when it is not present on the libvirt host. Incase, the file already exists, there could be missing read permission issue. Hence, added read permission when os disk already exists in libvirt host. 

* Updated libvirt-python to latest.

cc: @anirudhrb 