### PR TITLE
Minor doc cleanup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,7 @@ autodoc_default_options = {
 }
 
 autosectionlabel_prefix_document = True
+autosectionlabel_maxdepth = 2
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/installation_linux.rst
+++ b/docs/installation_linux.rst
@@ -2,7 +2,7 @@ Install LISA on Linux
 =====================
 
 Minimum System Requirement
------------------------
+--------------------------
 1. Your favourite Linux distro supporting Python 3.8+
 2. Dual core processor
 3. 4 GB system memory
@@ -50,7 +50,7 @@ Install Poetry on Linux
 Poetry is used to manage Python dependencies of LISA.
 
 .. warning::
-   
+
    Please enter the root folder of LISA source code to run
    following commands to install poetry, since Poetry manages dependencies
    by the working folder.
@@ -61,18 +61,18 @@ Poetry is used to manage Python dependencies of LISA.
 
 After running this, you should see
 ``Add export PATH="/home/YOURUSERNAME/.local/bin:$PATH" to your shell configuration file``
-message on the console. Follow the message and add the necessary exports to ``$HOME/.profile`` file. 
+message on the console. Follow the message and add the necessary exports to ``$HOME/.profile`` file.
 
 .. code:: bash
 
    source $HOME/.profile
 
 [Optional] Create poetry virtual environment in the same folder as LISA for VS Code to automatically
-pick up the python environment. Run the following commands to update poetry configuration: 
+pick up the python environment. Run the following commands to update poetry configuration:
 
-.. code:: bash 
+.. code:: bash
 
-   poetry config virtualenvs.in-project true 
+   poetry config virtualenvs.in-project true
 
 Install python dependencies
 

--- a/docs/tools/test_spec_gen.py
+++ b/docs/tools/test_spec_gen.py
@@ -78,7 +78,9 @@ def _write_suite(file: TextIO, metadata: Dict[str, str]) -> None:
 
     file.write("    :platform: ``Azure, Ready``\n")  # Platform
     file.write(f"    :area: ``{metadata['area']}``\n")  # Area
-    file.write(f"    :category: ``{metadata['category']}``\n\n")  # Category
+
+    if metadata["category"]:
+        file.write(f"    :category: ``{metadata['category']}``\n\n")  # Category
 
 
 def _write_case(file: TextIO, metadata: Dict[str, str]) -> None:

--- a/docs/tools/test_spec_gen.py
+++ b/docs/tools/test_spec_gen.py
@@ -27,7 +27,7 @@ def update_file() -> None:
     data = load_path(TESTS)
     test_paths = [(base_path / Path(x.get("value", ""))).resolve() for x in data]
 
-    with open(file_path, "w") as test_spec:
+    with open(file_path, "w", encoding="utf-8") as test_spec:
         _write_title(test_spec)
 
         for test_path in test_paths:
@@ -36,9 +36,10 @@ def update_file() -> None:
                     if file.endswith(".py"):
                         # print("Processing " + file)
                         test_name = Path(root) / file
-                        with open(test_name, "r") as f:
-                            contents = f.read()
-                            tree = ast.parse(contents)
+                        tree = ast.parse(
+                            test_name.read_text(encoding="utf-8"),
+                            filename=str(test_name),
+                        )
                         cls_visitor = ClassVisitor()
                         func_visitor = FuncVisitor()
                         cls_visitor.visit(tree)

--- a/docs/tools/test_summary_gen.py
+++ b/docs/tools/test_summary_gen.py
@@ -30,13 +30,11 @@ def update_summary() -> None:
     with open(table_path, "w", encoding="utf-8") as table:
         _write_title(table)
 
-        index = 0
         res = []  # name, priority, platform, category, area etc.
         for test_path in test_paths:
             for root, _, files in os.walk(test_path):
                 for file in files:
                     if file.endswith(".py"):
-                        # print("Processing " + file)
                         filename = Path(root) / file
                         tree = ast.parse(
                             filename.read_text(encoding="utf-8"), filename=str(filename)
@@ -53,13 +51,12 @@ def update_summary() -> None:
                                 suite["suite_name"] = suite["name"]
                                 del suite["name"]
                                 res.append({**suite, **case})  # merge two dicts
-        for node in res:
-            index += 1
+        for index, node in enumerate(res, start=1):
             _update_line(table, node, index)
 
         link = "https://github.com/microsoft/lisa/blob/master/Documents/LISAv2-TestCase-Statistics.md"  # noqa: E501
         table.write(".. seealso::\n")
-        table.write("    `LISAv2 Tests <" + link + ">`__\n")
+        table.write(f"    `LISAv2 Tests <{link}>`__\n")
         table.write("\n")
 
 
@@ -70,16 +67,11 @@ def _write_title(file: TextIO) -> None:
     Args:
         file (TextIO): test table
     """
-    title = "Test Cases"
-    file.write(title + "\n")
-    file.write("=" * len(title) + "\n")
-    file.write("\n")
+    file.write("Test Cases\n==========\n\n")
 
     file.write(".. list-table::\n")
     # file.write("    :widths: 5 5 25 5 10 10 10\n")  # can be configured manually
-    file.write("    :header-rows: 1\n")
-    file.write("\n")
-
+    file.write("    :header-rows: 1\n\n")
     file.write("    * - Index\n")
     file.write("      - Test Suite Name\n")
     file.write("      - Test Case Name\n")
@@ -98,24 +90,14 @@ def _update_line(file: TextIO, metadata: Dict[str, str], index: int) -> None:
         metadata (Dict[str, str]): test case metadata
         index (int): no.# of test case
     """
-    file.write("    * - " + str(index) + "\n")  # Index
+    file.write(f"    * - {index}\n")  # Index
     file.write(
-        "      - "
-        + ":ref:`"
-        + metadata["suite_name"]
-        + " <"
-        + metadata["suite_name"]
-        + ">`\n"
+        f"      - :ref:`{metadata['suite_name']} <{metadata['suite_name']}>`\n"
     )  # Test Suite Name
     file.write(
-        "      - "
-        + ":ref:`"
-        + metadata["case_name"]
-        + " <"
-        + metadata["case_name"]
-        + ">`\n"
+        f"      - :ref:`{metadata['case_name']} <{metadata['case_name']}>`\n"
     )  # Test Case Name
-    file.write("      - " + str(metadata.get("priority", 2)) + "\n")  # Priority
-    file.write("      - " + "Azure, Ready" + "\n")  # Platform - defaults to both
-    file.write("      - " + metadata["category"] + "\n")  # Category
-    file.write("      - " + metadata["area"] + "\n")  # Area
+    file.write(f"      - {metadata.get('priority', 2)}\n")  # Priority
+    file.write("      - Azure, Ready\n")  # Platform - defaults to both
+    file.write(f"      - {metadata['category']}\n")  # Category
+    file.write(f"      - {metadata['area']}\n")  # Area

--- a/docs/tools/test_summary_gen.py
+++ b/docs/tools/test_summary_gen.py
@@ -27,7 +27,7 @@ def update_summary() -> None:
 
     data = load_path(TESTS)
     test_paths = [(base_path / Path(x.get("value", ""))).resolve() for x in data]
-    with open(table_path, "w") as table:
+    with open(table_path, "w", encoding="utf-8") as table:
         _write_title(table)
 
         index = 0
@@ -38,9 +38,9 @@ def update_summary() -> None:
                     if file.endswith(".py"):
                         # print("Processing " + file)
                         filename = Path(root) / file
-                        with open(filename, "r") as f:
-                            contents = f.read()
-                            tree = ast.parse(contents)
+                        tree = ast.parse(
+                            filename.read_text(encoding="utf-8"), filename=str(filename)
+                        )
                         cls_visitor = ClassVisitor()
                         func_visitor = FuncVisitor()
                         cls_visitor.visit(tree)


### PR DESCRIPTION
This moves the doc fixes from #2353 
Includes:
- Cleanup of strings in test doc generation
- Fixes errors and warning reported by Sphinx when generating docs
- Adds missing encoding so docs build correctly on Windows
 
