### PR TITLE
Fix to resolve file permissions issue with LTP_Lite test case

### DIFF
--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -125,7 +125,7 @@ class Ltp(Tool):
         self.run(parameters, sudo=True, force_run=True, timeout=12000)
 
         # to avoid no permission issue when copying back files
-        self.node.tools[Chmod].update_folder("/opt/ltp", "a+rwX", sudo=True)
+        self.node.tools[Chmod].update_folder("/opt", "a+rwX", sudo=True)
 
         # write output to log path
         self.node.shell.copy_back(


### PR DESCRIPTION
Changed the file permissions command in the testcase to resolve it failing to move the logs from /opt/ltp.