### PR TITLE
Address sshd service not existing on ubuntu 22.10 minimal

### DIFF
--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -65,7 +65,12 @@ class Ssh(Tool):
         sed = self.node.tools[Sed]
         sed.append(f"MaxSessions {count}", config_path, sudo=True)
         service = self.node.tools[Service]
-        service.restart_service("sshd")
+        if service.check_service_exists("sshd"):
+            service.restart_service("sshd")
+        elif service.check_service_exists("ssh"):
+            service.restart_service("ssh")
+        else:
+            raise LisaException("could not find ssh or sshd service")
 
         # The above changes take effect only for *new* connections. So,
         # close the current connection.


### PR DESCRIPTION
The sshd service does not exist on the Ubuntu 22.10 minimal image. The ssh service does so attempt to restart the sshd service if it exists, if not, check for the existence of ssh service, and otherwise raise an exception