### PR TITLE
Get the console log if the kdump test fails

### DIFF
--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -399,6 +399,9 @@ class KdumpCrash(TestSuite):
                     else:
                         retries = retries + 1
                         if retries >= max_retries:
+                            serial_console.get_console_log(
+                                saved_path=log_path, force_run=True
+                            )
                             raise LisaException(
                                 "The vmcore file is incomplete with file size"
                                 f" {round(incomplete_file_size/1024/1024, 2)}MB"
@@ -406,17 +409,22 @@ class KdumpCrash(TestSuite):
                 else:
                     retries = retries + 1
                     if retries >= max_retries:
+                        serial_console.get_console_log(
+                            saved_path=log_path, force_run=True
+                        )
                         raise LisaException(
                             "No vmcore or vmcore-incomplete is found under "
                             f"{kdump.dump_path} with file size greater than 10M."
                         )
                 if timer.elapsed(False) > self.timeout_of_dump_crash:
+                    serial_console.get_console_log(saved_path=log_path, force_run=True)
                     raise LisaException(
                         "Timeout to dump vmcore file. The size of vmcore-incomplete is"
                         f" {round(incomplete_file_size/1024/1024, 2)}MB"
                     )
                 time.sleep(5)
         if system_disconnected:
+            serial_console.get_console_log(saved_path=log_path, force_run=True)
             raise LisaException("Timeout to connect the VM after triggering kdump.")
 
     def _trigger_kdump_on_specified_cpu(


### PR DESCRIPTION
We need to save the console log if the kdump test fails. In this commit, the get_console_log is added before throwing an exception.