### PR TITLE
Add AddAptRepository tool as it is missing in Ubuntu 22.10 minimal

### DIFF
--- a/lisa/base_tools/__init__.py
+++ b/lisa/base_tools/__init__.py
@@ -1,3 +1,4 @@
+from .apt_add_repository import AptAddRepository
 from .cat import Cat
 from .mv import Mv
 from .rpm import Rpm
@@ -18,4 +19,5 @@ __all__ = [
     "ServiceInternal",
     "Mv",
     "Systemctl",
+    "AptAddRepository",
 ]

--- a/lisa/base_tools/apt_add_repository.py
+++ b/lisa/base_tools/apt_add_repository.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import TYPE_CHECKING, cast
+
+from lisa.executable import Tool
+
+if TYPE_CHECKING:
+    from lisa.operating_system import Ubuntu
+
+
+class AptAddRepository(Tool):
+    @property
+    def command(self) -> str:
+        return "apt-add-repository"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def install(self) -> bool:
+        ubuntu_os: Ubuntu = cast(Ubuntu, self.node.os)
+        package_name = "software-properties-common"
+        ubuntu_os.install_packages(package_name)
+        return self._check_exists()
+
+    def add_repository(self, repo: str) -> None:
+        self.run(
+            f'-y "{repo}"',
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="fail to add repository",
+        )

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -24,7 +24,15 @@ from assertpy import assert_that
 from retry import retry
 from semver import VersionInfo
 
-from lisa.base_tools import Cat, Sed, Service, Uname, Wget, YumConfigManager
+from lisa.base_tools import (
+    AptAddRepository,
+    Cat,
+    Sed,
+    Service,
+    Uname,
+    Wget,
+    YumConfigManager,
+)
 from lisa.executable import Tool
 from lisa.util import (
     BaseClassMixin,
@@ -766,12 +774,8 @@ class Debian(Linux):
         # This command will trigger apt update too, so it doesn't need to update
         # repos again.
 
-        self._node.execute(
-            cmd=f'apt-add-repository -y "{repo}"',
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message="fail to add repository",
-        )
+        aptaddrepository = self._node.tools[AptAddRepository]
+        aptaddrepository.add_repository(repo)
 
         # apt update will not be triggered on Debian during add repo
         if type(self._node.os) == Debian:

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -3,6 +3,7 @@
 
 
 from lisa.base_tools import (
+    AptAddRepository,
     Cat,
     Mv,
     Rpm,
@@ -108,6 +109,7 @@ from .who import Who
 from .whoami import Whoami
 
 __all__ = [
+    "AptAddRepository",
     "Aria",
     "Blkid",
     "Bzip2",


### PR DESCRIPTION
The add-apt-repository command is missing from the ubuntu 22.10 minimal image. Add a tool for this.