### PR TITLE
Fix for PropertyChangeNotAllowed exception during verify_vm_hot_resize_decrease

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1309,7 +1309,7 @@ class Resize(AzureFeatureMixin, features.Resize):
         node_context = get_node_context(self._node)
         node_runbook = self._node.capability.get_extended_runbook(AzureNodeSchema)
 
-        # Get list of vm sizes that the current sku can resize to
+        # Get list of vm sizes that the current resource group can use
         available_sizes = compute_client.virtual_machines.list_available_sizes(
             node_context.resource_group_name, node_context.vm_name
         )

--- a/microsoft/testsuites/core/vm_hot_resize.py
+++ b/microsoft/testsuites/core/vm_hot_resize.py
@@ -80,6 +80,7 @@ class VmHotResize(TestSuite):
                     or "OperationNotAllowed" in str(identifier)
                     or "Allocation failed" in str(identifier)
                     or "AllocationFailed" in str(identifier)
+                    or "PropertyChangeNotAllowed" in str(identifier)
                     or "cannot boot Hypervisor Generation" in str(identifier)
                     or "due to different CPU Architectures" in str(identifier)
                     or "An existing connection was forcibly closed by the remote host"


### PR DESCRIPTION
Sometimes when executing the verify_vm_hot_resize_decrease test, the test may choose an invalid size to change to which cannot be accomplished and raises a PropertyChangeNotAllowed exception. Add this to a catch statement so an alternate destination size can be tried instead.