### PR TITLE
GPU Provision test with Min and max gpu count

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -332,6 +332,7 @@ def node_requirement(
 def simple_requirement(
     min_count: int = 1,
     min_core_count: int = 1,
+    min_gpu_count: int = 0,
     min_nic_count: Optional[int] = None,
     min_data_disk_count: Optional[int] = None,
     disk: Optional[schema.DiskOptionSettings] = None,
@@ -354,6 +355,7 @@ def simple_requirement(
     node = schema.NodeSpace()
     node.node_count = search_space.IntRange(min=min_count)
     node.core_count = search_space.IntRange(min=min_core_count)
+    node.gpu_count = search_space.IntRange(min=min_gpu_count)
 
     if min_data_disk_count or disk:
         if not disk:

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -110,10 +110,10 @@ class GpuTestSuite(TestSuite):
 
         """,
         timeout=TIMEOUT,
-        # min_gpu_count is 8 since it is currently the max GPU count supported
-        # in Azure, 'Standard_ND96asr_v4'
+        # min_gpu_count is 8 since it is current
+        # max GPU count available in Azure
         requirement=simple_requirement(min_gpu_count=8),
-        priority=1,
+        priority=3,
     )
     def verify_max_gpu_provision(self, node: Node, log: Logger) -> None:
         start_stop = node.features[StartStop]


### PR DESCRIPTION
Test to very VM provisioning with min and max GPU and count PCI devices of type GPU
8 is used as max gpu count since it the current maximum available in Azure.