### PR TITLE
Fix MSHV VM create stress test

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -20,6 +20,7 @@ from .bzip2 import Bzip2
 from .chmod import Chmod
 from .chown import Chown
 from .chrony import Chrony
+from .cp import Cp
 from .date import Date
 from .df import Df
 from .dhclient import Dhclient
@@ -115,6 +116,7 @@ __all__ = [
     "Chmod",
     "Chown",
     "Chrony",
+    "Cp",
     "Date",
     "Df",
     "Dhclient",

--- a/lisa/tools/cp.py
+++ b/lisa/tools/cp.py
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from pathlib import PurePath
+
+from lisa.executable import Tool
+
+
+class Cp(Tool):
+    @property
+    def command(self) -> str:
+        return "cp"
+
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    def copy(self, src: PurePath, dest: PurePath) -> None:
+        self.run(f"{src} {dest}", force_run=True, expected_exit_code=0)


### PR DESCRIPTION
VM creation is failing due to the "readonly=on" flag passed in cloud-hypervisor's disk config.

Don't use readonly disks for the VMs. Instead, create a copy of the disk image for each VM.

Signed-off-by: Anirudh Rayabharam <anrayabh@microsoft.com>