### PR TITLE
HyperV Module Reload use Nohup

### DIFF
--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -241,6 +241,7 @@ class HvModule(TestSuite):
             "ip link set eth0 down; ip link set eth0 up; dhclient eth0",
             sudo=True,
             shell=True,
+            nohup=True,
         )
 
         if "is in use" in result.stdout:


### PR DESCRIPTION
- reload_hyperv_modules can fail when connection is reset, use nohup when calling the reload/interface reset/ ip renew calls