### PR TITLE
Remove dhclient on bridge interfaces

### DIFF
--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -83,10 +83,7 @@ class Ip(Tool):
 
     def restart_device(self, nic_name: str) -> None:
         self.node.execute(
-            (
-                f"ip link set dev {nic_name} down;ip link set dev {nic_name} up;"
-                "dhclient -r;dhclient"
-            ),
+            (f"ip link set dev {nic_name} down;ip link set dev {nic_name} up;"),
             shell=True,
             sudo=True,
             nohup=True,

--- a/microsoft/testsuites/network/netinterface.py
+++ b/microsoft/testsuites/network/netinterface.py
@@ -101,6 +101,7 @@ class NetInterface(TestSuite):
         while test_count < self.NET_INTERFACE_RELOAD_TEST_COUNT:
             test_count += 1
             ip.restart_device(default_nic)
+            node.tools[Dhclient].renew(default_nic)
             if not node_nic_info.default_nic:
                 # Add default route if missing after running ip link down/up
                 node.execute(f"ip route add {default_route}", shell=True, sudo=True)


### PR DESCRIPTION
This should nested VM errors on Ubuntu 18.04 and Ubuntu 16.04