### PR TITLE
Enable sriov before SRIOV test cases

### DIFF
--- a/microsoft/testsuites/network/sriov.py
+++ b/microsoft/testsuites/network/sriov.py
@@ -63,6 +63,9 @@ class Sriov(TestSuite):
         environment: Environment = kwargs.pop("environment")
         for node in environment.nodes.list():
             node.tools[Firewall].stop()
+            node.features[NetworkInterface].switch_sriov(
+                enable=True, wait=True, reset_connections=True
+            )
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
A lot of sriov tests assume SRIOV is enabled, add enable in before_case.