### PR TITLE
Some tweaks for verify_mshv_stress_vm_create

### DIFF
--- a/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -32,7 +32,7 @@ from microsoft.testsuites.mshv.cloud_hypervisor_tool import CloudHypervisor
 )
 class MshvHostTestSuite(TestSuite):
     CONFIG_VARIABLE = "mshv_vm_create_stress_configs"
-    DEFAULT_ITERS = 25
+    DEFAULT_ITERS = 15
     DEFAULT_CPUS_PER_VM = 1
     DEFAULT_MEM_PER_VM_MB = 1024
 
@@ -72,6 +72,7 @@ class MshvHostTestSuite(TestSuite):
         "mshv_vm_create_stress_configs" in the runbook.
         """,
         priority=4,
+        timeout=10800,  # 3 hours
     )
     def verify_mshv_stress_vm_create(
         self,


### PR DESCRIPTION
The current timeout gets easily exceeded in our pipeline. So, make it more generous. In the default configuration, the time taken by this test increase with increase in the number of CPUs in the target machine.

Reduce the default iterations to 15. 25 is too high and time consuming. Higher number of iterations, if needed, can still be configured via the runbook.

Signed-off-by: Anirudh Rayabharam <anrayabh@microsoft.com>