### PR TITLE
Fio l2 guest vm changes

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -786,7 +786,7 @@ class Debian(Linux):
     def _initialize_package_installation(self) -> None:
         # wait running system package process.
         self.wait_running_package_process()
-        result = self._node.execute("apt-get update", sudo=True)
+        result = self._node.execute("apt-get update", sudo=True, timeout=1800)
         if self._repo_not_exist_pattern.search(result.stdout):
             raise RepoNotExistException(self._node.os)
         result.assert_exit_code(message="\n".join(self.get_apt_error(result.stdout)))

--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -24,7 +24,7 @@ from lisa.features.network_interface import Sriov, Synthetic
 from lisa.messages import DiskSetupType, DiskType
 from lisa.node import RemoteNode
 from lisa.operating_system import SLES, Debian, Redhat
-from lisa.testsuite import TestResult
+from lisa.testsuite import TestResult, node_requirement
 from lisa.tools import FileSystem, Lscpu, Mkfs, Mount, NFSClient, NFSServer, Sysctl
 from lisa.util import SkippedException
 from microsoft.testsuites.performance.common import (
@@ -187,9 +187,16 @@ class StoragePerformance(TestSuite):
     @TestCaseMetadata(
         description="""
         This test case uses fio to test data disk performance.
+        This will give flexibility to run FIO by runbook param.
+        If nothing is passed, it will run FIO with default param.
         """,
         priority=3,
         timeout=TIME_OUT,
+        requirement=node_requirement(
+            node=schema.NodeSpace(
+                memory_mb=search_space.IntRange(min=2 * 1024),
+            ),
+        ),
     )
     def perf_storage_generic_fio_test(
         self,

--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -189,6 +189,11 @@ class StoragePerformance(TestSuite):
         This test case uses fio to test data disk performance.
         This will give flexibility to run FIO by runbook param.
         If nothing is passed, it will run FIO with default param.
+
+        There is no system resource info on FIO-Man-page, FIO-readdocs.
+        We have faced OOM with 512 MB memory.
+        We deploy host azure VM with 64 GB in pipeline.
+        So, Keeping memory need as 2 GB.
         """,
         priority=3,
         timeout=TIME_OUT,


### PR DESCRIPTION
This PR is raised to update RAM for L2 guest vm we spin up to test FIO testcases. We are using ubuntu image for L2 guest. Also, timeout is increased for apt-update command which run before installing FIO.