### PR TITLE
Unpin versions for CI tools

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -489,15 +489,13 @@ def load_environments(
 class EnvironmentHookSpec:
     @hookspec
     def get_environment_information(self, environment: Environment) -> Dict[str, str]:
-        ...
+        raise NotImplementedError
 
 
 class EnvironmentHookImpl:
     @hookimpl
     def get_environment_information(self, environment: Environment) -> Dict[str, str]:
-        information: Dict[str, str] = {}
-        information["name"] = environment.name
-
+        information: Dict[str, str] = {"name": environment.name}
         if environment.nodes:
             node = environment.default_node
             try:

--- a/lisa/sut_orchestrator/aws/common.py
+++ b/lisa/sut_orchestrator/aws/common.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from dataclasses_json import dataclass_json
@@ -67,16 +67,15 @@ class AwsNodeSchema:
     data_disk_size: int = 32
     disk_type: str = ""
 
-    # for marketplace image, which need to accept terms
-    _marketplace: InitVar[Optional[AwsVmMarketplaceSchema]] = None
+    def __post_init__(self) -> None:
+
+        # Caching for marketplace image
+        self._marketplace: Optional[AwsVmMarketplaceSchema] = None
 
     @property
     def marketplace(self) -> AwsVmMarketplaceSchema:
-        # this is a safe guard and prevent mypy error on typing
-        if not hasattr(self, "_marketplace"):
-            self._marketplace: Optional[AwsVmMarketplaceSchema] = None
 
-        if not self._marketplace:
+        if self._marketplace is None:
             assert isinstance(
                 self.marketplace_raw, str
             ), f"actual: {type(self.marketplace_raw)}"

--- a/lisa/tools/bzip2.py
+++ b/lisa/tools/bzip2.py
@@ -9,6 +9,7 @@ class Bzip2(Tool):
     def command(self) -> str:
         return "bzip2"
 
+    @property
     def can_install(self) -> bool:
         return True
 

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -142,9 +142,7 @@ class UnsupportedKernelException(LisaException):
         self.version = os.information.full_version
         self.kernel_version = ""
         if hasattr(os, "get_kernel_information"):
-            self.kernel_version = (
-                os.get_kernel_information().raw_version  # type: ignore
-            )
+            self.kernel_version = os.get_kernel_information().raw_version
         self._extended_message = message
 
     def __str__(self) -> str:
@@ -466,18 +464,9 @@ def find_group_in_lines(
 
 
 def deep_update_dict(src: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
-    if (
-        dest is None
-        or isinstance(dest, int)
-        or isinstance(dest, bool)
-        or isinstance(dest, float)
-        or isinstance(dest, str)
-    ):
-        result = dest
-    else:
-        result = dest.copy()
 
-    if isinstance(result, dict):
+    if isinstance(dest, dict):
+        result = dest.copy()
         for key, value in src.items():
             if isinstance(value, dict) and key in dest:
                 value = deep_update_dict(value, dest[key])

--- a/noxfile.py
+++ b/noxfile.py
@@ -99,7 +99,7 @@ def mypy(session: nox.Session) -> None:
         *OPTIONAL_DEPENDENCIES["azure"],
         *OPTIONAL_DEPENDENCIES["typing"],
         *NOX_DEPENDENCIES,
-        "mypy == 0.942",
+        "mypy",
     )
 
     session.run("mypy", "-p", "lisa")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,20 +55,20 @@ azure = [
 ]
 
 docs = [
-    "Sphinx >= 4.1.0",
-    "sphinx-argparse >= 0.2.5",
-    "sphinx-rtd-theme >= 0.5.2",
-    "sphinxemoji >= 0.1.8",
-    "sphinx-copybutton >= 0.4.0",
+    "Sphinx",
+    "sphinx-argparse",
+    "sphinx-rtd-theme",
+    "sphinxemoji",
+    "sphinx-copybutton",
 ]
 
 flake8 = [
-    "flake8 >= 4.0.1",
+    "flake8",
     "Flake8-pyproject",
-    "flake8-black >= 0.3.2",
-    "flake8-bugbear >= 22.3.23",
-    "flake8-isort >= 4.1.1",
-    "pep8-naming >= 0.12.1",
+    "flake8-black",
+    "flake8-bugbear",
+    "flake8-isort",
+    "pep8-naming",
 ]
 
 legacy = [


### PR DESCRIPTION
In order to avoid stale tools and to catch issues early, CI tools should pull the latest version.

This removes version pinning for dev and CI tools and fixes typing errors raised in newer versions of mypy.
