### PR TITLE
Use compat mode editable install for dev environment

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -180,6 +180,9 @@ def dev(session: nox.Session) -> None:
         "install",
         "--editable",
         f".[{extras}]",
+        # Workaround for non-package directories (microsoft, examples)
+        "--config-settings",
+        "editable_mode=compat",
         external=True,
     )
 


### PR DESCRIPTION
This forces the .pth file created by the lisa editable install to be the legacy static format rather than the current dynamic format. This is to resolve a path issue for non-package directories in the root of lisa repot like microsoft. This is a workaround to restore the previous behavior provided by poetry. This only worked with poetry because of a quirk in the order of path evaluation and this behavior is not guaranteed by the Python API, so we'll need to prioritize moving these non-package directories.

run `nox -vs dev` after installing to update the dev virtual environment
