### PR TITLE
Enable verbose output for stress-ng

### DIFF
--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -66,10 +66,13 @@ class StressNg(Tool):
         class_name: str,
         num_workers: int = 0,
         timeout_secs: int = 60,
+        verbose: bool = True,
         sudo: bool = False,
     ) -> Process:
+        v_flag = "-v" if verbose else ""
         return self.run_async(
-            f"--sequential {num_workers} --class {class_name} --timeout {timeout_secs}",
+            f"{v_flag} --sequential {num_workers} --class {class_name} "
+            f"--timeout {timeout_secs}",
             sudo=sudo,
         )
 


### PR DESCRIPTION
The "-v" flag for stress-ng causes it to print detailed progress information to stdout. This is helpful for the stress-ng suite since they are long running tests and without this flag it is hard to tell what the tool is doing. It is also helpful for debugging hung tests as we get to know what exactly stress-ng was doing before it hung.

Make it a configurable option so that the users of the tool can opt out if needed.