### PR TITLE
kernel installer changes for CBLMariner-Dom0

### DIFF
--- a/lisa/tools/cp.py
+++ b/lisa/tools/cp.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 from pathlib import PurePath
-
+from typing import Optional
 from lisa.executable import Tool
 
 
@@ -14,5 +14,18 @@ class Cp(Tool):
     def can_install(self) -> bool:
         return False
 
-    def copy(self, src: PurePath, dest: PurePath, sudo: bool = False) -> None:
-        self.run(f"{src} {dest}", force_run=True, expected_exit_code=0, sudo=sudo)
+    def copy(
+        self,
+        src: PurePath,
+        dest: PurePath,
+        sudo: bool = False,
+        cwd: Optional[PurePath] = None,
+    ) -> None:
+        result = self.run(
+            f"{src} {dest}",
+            force_run=True,
+            expected_exit_code=0,
+            sudo=sudo,
+            cwd=cwd,
+        )
+        result.assert_exit_code()

--- a/lisa/tools/cp.py
+++ b/lisa/tools/cp.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 from pathlib import PurePath
 from typing import Optional
+
 from lisa.executable import Tool
 
 

--- a/lisa/tools/cp.py
+++ b/lisa/tools/cp.py
@@ -14,5 +14,5 @@ class Cp(Tool):
     def can_install(self) -> bool:
         return False
 
-    def copy(self, src: PurePath, dest: PurePath) -> None:
-        self.run(f"{src} {dest}", force_run=True, expected_exit_code=0)
+    def copy(self, src: PurePath, dest: PurePath, sudo: bool = False) -> None:
+        self.run(f"{src} {dest}", force_run=True, expected_exit_code=0, sudo=sudo)

--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -3,7 +3,7 @@
 
 import pathlib
 import re
-from typing import List
+from typing import List, Optional
 
 from assertpy import assert_that
 from semver import VersionInfo
@@ -56,10 +56,15 @@ class Git(Tool):
         ref: str = "",
         dir_name: str = "",
         fail_on_exists: bool = True,
+        auth_token: Optional[str] = None,
     ) -> pathlib.PurePath:
         self.node.shell.mkdir(cwd, exist_ok=True)
+        auth_flag = ""
+        if auth_token:
+            auth_flag = f'-c http.extraheader="AUTHORIZATION: bearer {auth_token}'
 
-        cmd = f"clone {url} {dir_name} --recurse-submodules"
+        cmd = f"clone {auth_flag} {url} {dir_name} --recurse-submodules"
+
         # git print to stderr for normal info, so set no_error_log to True.
         result = self.run(cmd, cwd=cwd, no_error_log=True)
         if get_matched_str(result.stdout, self.CERTIFICATE_ISSUE_PATTERN):

--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -61,7 +61,7 @@ class Git(Tool):
         self.node.shell.mkdir(cwd, exist_ok=True)
         auth_flag = ""
         if auth_token:
-            auth_flag = f'-c http.extraheader="AUTHORIZATION: bearer {auth_token}'
+            auth_flag = f'-c http.extraheader="AUTHORIZATION: bearer {auth_token}"'
 
         cmd = f"clone {auth_flag} {url} {dir_name} --recurse-submodules"
 

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -43,7 +43,7 @@ class LocalLocationSchema(BaseLocationSchema):
             required=True,
         ),
     )
-    
+
 
 @dataclass_json()
 @dataclass

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -139,7 +139,7 @@ class SourceInstaller(BaseInstaller):
             destination_path = f"/boot/efi/{new_kernel_binary}"
             cp = node.tools[Cp]
             cp.copy(
-                src=PurePath(source_path),
+                src=source_path,
                 dest=PurePath(destination_path),
                 sudo=True
             )

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -50,6 +50,12 @@ class RepoLocationSchema(LocalLocationSchema):
     # fail the run if code exists
     fail_on_code_exists: bool = False
     cleanup_code: bool = False
+    auth_token: Optional[str] = field(
+        default=None,
+        metadata=field_metadata(
+            required=False,
+        ),
+    )
 
 
 @dataclass_json()
@@ -455,7 +461,10 @@ class RepoLocation(BaseLocation):
         self._log.info(f"cloning code from {runbook.repo} to {code_path}...")
         git = self._node.tools[Git]
         code_path = git.clone(
-            url=runbook.repo, cwd=code_path, fail_on_exists=runbook.fail_on_code_exists
+            url=runbook.repo,
+            cwd=code_path,
+            fail_on_exists=runbook.fail_on_code_exists,
+            auth_token=runbook.auth_token,
         )
 
         git.fetch(cwd=code_path)

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -218,7 +218,7 @@ class SourceInstaller(BaseInstaller):
         uname = node.tools[Uname]
         kernel_information = uname.get_linux_information()
 
-        if kconfig_path and len(kconfig_path) > 0:
+        if kconfig_path:
             kernel_config = code_path.joinpath(kconfig_path)
             err_msg = f"cannot find config path: {kernel_config}"
             assert node.shell.exists(kernel_config), err_msg

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -157,20 +157,20 @@ class SourceInstaller(BaseInstaller):
             result = node.execute(
                 "make kernelrelease 2>/dev/null",
                 cwd=code_path,
-                shell=True
+                shell=True,
             )
 
             kernel_version = result.stdout
             result.assert_exit_code(
                 0,
-                f"failed on get kernel version: {kernel_version}"
+                f"failed on get kernel version: {kernel_version}",
             )
 
             # copy current config back to system folder.
             result = node.execute(
                 f"cp .config /boot/config-{kernel_version}",
                 cwd=code_path,
-                sudo=True
+                sudo=True,
             )
             result.assert_exit_code()
 

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -144,7 +144,7 @@ class SourceInstaller(BaseInstaller):
         )
         result.assert_exit_code()
 
-        if config_path and len(config_path) > 0:
+        if config_path:
             # If it is dom0,
             # Name of the current kernel should be vmlinuz-<kernel version>
             uname = node.tools[Uname]

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -364,7 +364,7 @@ class Dom0Installer(SourceInstaller):
         # Copy the kernel to /boot/efi from : arch/x86/boot/bzImage
         current_kernel_binary = f"vmlinuz-{current_kernel}"
         new_kernel_binary = f"vmlinuz-{kernel_version}"
-        source_path = code_path.joinpath("arch/x86/boot/bzImage")
+        source_path = node.get_pure_path(f"/boot/{new_kernel_binary}")
         destination_path = node.get_pure_path(f"/boot/efi/{new_kernel_binary}")
         cp = node.tools[Cp]
         cp.copy(

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -91,12 +91,6 @@ class SourceInstallerSchema(BaseInstallerSchema):
     )
 
 
-@dataclass_json()
-@dataclass
-class Dom0InstallerSchema(SourceInstallerSchema):
-    ...
-
-
 class SourceInstaller(BaseInstaller):
     @classmethod
     def type_name(cls) -> str:
@@ -342,7 +336,7 @@ class Dom0Installer(SourceInstaller):
 
     @classmethod
     def type_schema(cls) -> Type[schema.TypedSchema]:
-        return Dom0InstallerSchema
+        return SourceInstallerSchema
 
     @property
     def _output_names(self) -> List[str]:
@@ -350,7 +344,7 @@ class Dom0Installer(SourceInstaller):
 
     def install(self) -> str:
         node = self._node
-        runbook: Dom0InstallerSchema = self.runbook
+        runbook: SourceInstallerSchema = self.runbook
         assert runbook.location, "the repo must be defined."
 
         kernel_version = super().install()

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -76,7 +76,7 @@ class SourceInstallerSchema(BaseInstallerSchema):
     # Steps to modify code by patches and others.
     modifier: List[BaseModifierSchema] = field(default_factory=list)
 
-    # This is absolute path where kernel config file is located
+    # This is relative path where kernel source code is located
     kernel_config_file: str = field(
         default="",
         metadata=field_metadata(
@@ -200,10 +200,11 @@ class SourceInstaller(BaseInstaller):
 
         cp = node.tools[Cp]
         if kconfig_file:
-            err_msg = f"cannot find config path: {kconfig_file}"
-            assert node.shell.exists(node.get_pure_path(kconfig_file)), err_msg
+            kernel_config = code_path.joinpath(kconfig_file)
+            err_msg = f"cannot find kernel config path: {kernel_config}"
+            assert node.shell.exists(kernel_config), err_msg
             cp.copy(
-                src=node.get_pure_path(kconfig_file),
+                src=kernel_config,
                 dest=PurePath(".config"),
                 cwd=code_path,
             )

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -357,7 +357,7 @@ class Dom0Installer(SourceInstaller):
         # Name of the current kernel should be vmlinuz-<kernel version>
         uname = node.tools[Uname]
         current_kernel = uname.get_linux_information().kernel_version_raw
-        
+
         # Copy the kernel to /boot/efi from : arch/x86/boot/bzImage
         current_kernel_binary = f"vmlinuz-{current_kernel}"
         new_kernel_binary = f"vmlinuz-{kernel_version}"
@@ -393,7 +393,7 @@ class Dom0Installer(SourceInstaller):
             file=ll_conf_file,
             sudo=True,
         )
-        
+
         # Modify the linuxloader.conf to point new initrd binary
         sed.substitute(
             regexp=f"INITRD_PATH={current_initrd_binary}",

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -141,7 +141,7 @@ class SourceInstaller(BaseInstaller):
             cp.copy(
                 src=source_path,
                 dest=PurePath(destination_path),
-                sudo=True
+                sudo=True,
             )
 
             # Modify the linuxloader.conf to point new kernel binary

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import uuid
 
 from dataclasses import dataclass, field
 from pathlib import PurePath
@@ -10,10 +11,11 @@ from dataclasses_json import dataclass_json
 from lisa import schema
 from lisa.base_tools import Mv
 from lisa.node import Node
-from lisa.operating_system import Redhat, Ubuntu
+from lisa.operating_system import CBLMariner, Redhat, Ubuntu
 from lisa.tools import Echo, Git, Make, Sed, Uname
 from lisa.util import LisaException, field_metadata, subclasses
 from lisa.util.logger import Logger, get_logger
+from lisa.tools import Cp, Ls
 
 from .kernel_installer import BaseInstaller, BaseInstallerSchema
 
@@ -37,6 +39,12 @@ class LocalLocationSchema(BaseLocationSchema):
         default="",
         metadata=field_metadata(
             required=True,
+        ),
+    )
+    config_type: str = field(
+        default="",
+        metadata=field_metadata(
+            required=False,
         ),
     )
 
@@ -114,22 +122,48 @@ class SourceInstaller(BaseInstaller):
         # modify code
         self._modify_code(node=node, code_path=code_path)
 
-        self._build_code(node=node, code_path=code_path)
+        config_type = source.get_config_type()
+        self._build_code(node=node, code_path=code_path, config_type=config_type)
 
         self._install_build(node=node, code_path=code_path)
 
-        result = node.execute(
-            "make kernelrelease 2>/dev/null", cwd=code_path, shell=True
-        )
+        kernel_version = ""
+        if self.__is_dom0(node) and config_type == "dom0":
+            # If it is dom0,
+            # Name of the current kernel should be vmlinuz-<kernel version>
+            uname = node.tools[Uname]
+            current_kernel = uname.get_linux_information().kernel_version_raw
+            current_kernel_binary = f"vmlinuz-{current_kernel}"
 
-        kernel_version = result.stdout
-        result.assert_exit_code(0, f"failed on get kernel version: {kernel_version}")
+            # Copy the binary to /boot/efi from : arch/x86/boot/bzImage
+            source_path = code_path.joinpath("arch/x86/boot/bzImage")
+            new_kernel_binary = "vmlinuz-%s" % str(uuid.uuid4())
+            destination_path = f"/boot/efi/{new_kernel_binary}"
+            cp = node.tools[Cp]
+            cp.copy(src=PurePath(source_path), dest=PurePath(destination_path), sudo=True)
 
-        # copy current config back to system folder.
-        result = node.execute(
-            f"cp .config /boot/config-{kernel_version}", cwd=code_path, sudo=True
-        )
-        result.assert_exit_code()
+            # Modify the linuxloader.conf to point new kernel binary
+            ll_conf_file = "/boot/efi/linuxloader.conf"
+            sed = self._node.tools[Sed]
+            sed.substitute(
+                regexp=current_kernel_binary,
+                replacement=new_kernel_binary,
+                file=ll_conf_file,
+                sudo=True,
+            )
+        else:
+            result = node.execute(
+                "make kernelrelease 2>/dev/null", cwd=code_path, shell=True
+            )
+
+            kernel_version = result.stdout
+            result.assert_exit_code(0, f"failed on get kernel version: {kernel_version}")
+
+            # copy current config back to system folder.
+            result = node.execute(
+                f"cp .config /boot/config-{kernel_version}", cwd=code_path, sudo=True
+            )
+            result.assert_exit_code()
 
         return kernel_version
 
@@ -171,17 +205,24 @@ class SourceInstaller(BaseInstaller):
             self._log.debug(f"modifying code by {modifier.type_name()}")
             modifier.modify()
 
-    def _build_code(self, node: Node, code_path: PurePath) -> None:
+    def _build_code(self, node: Node, code_path: PurePath, config_type: str) -> None:
         self._log.info("building code...")
 
         uname = node.tools[Uname]
         kernel_information = uname.get_linux_information()
 
-        result = node.execute(
-            f"cp /boot/config-{kernel_information.kernel_version_raw} .config",
-            cwd=code_path,
-        )
-        result.assert_exit_code()
+        if self.__is_dom0(node) and config_type == "dom0":
+            result = node.execute(
+                "cp arch/x86/configs/mshv_defconfig .config",
+                cwd=code_path,
+            )
+            result.assert_exit_code()
+        else:
+            result = node.execute(
+                f"cp /boot/config-{kernel_information.kernel_version_raw} .config",
+                cwd=code_path,
+            )
+            result.assert_exit_code()
 
         config_path = code_path.joinpath(".config")
         sed = self._node.tools[Sed]
@@ -269,11 +310,37 @@ class SourceInstaller(BaseInstaller):
                     "ccache",
                 ]
             )
+        elif isinstance(os, CBLMariner):
+            os.install_packages(
+                [
+                    "build-essential",
+                    "bison",
+                    "flex",
+                    "bc",
+                    "ccache",
+                    "elfutils-libelf",
+                    "elfutils-libelf-devel",
+                    "ncurses-libs",
+                    "ncurses-compat",
+                    "xz",
+                    "xz-devel",
+                    "xz-libs",
+                    "openssl-libs",
+                    "openssl-devel",
+                ]
+            )
         else:
             raise LisaException(
                 f"os '{os.name}' doesn't support in {self.type_name()}. "
                 f"Implement its build dependencies installation there."
             )
+
+    def __is_dom0(self, node: Node) -> bool:
+        if isinstance(node.os, CBLMariner):
+            mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)
+            if mshv_exists:
+                return True
+        return False
 
 
 class BaseLocation(subclasses.BaseClassWithRunbookMixin):
@@ -290,6 +357,9 @@ class BaseLocation(subclasses.BaseClassWithRunbookMixin):
         self._log = get_logger("kernel_builder", parent=parent_log)
 
     def get_source_code(self) -> PurePath:
+        raise NotImplementedError()
+
+    def get_config_type(self) -> str:
         raise NotImplementedError()
 
 
@@ -336,6 +406,10 @@ class RepoLocation(BaseLocation):
 
         return code_path
 
+    def get_config_type(self) -> str:
+        runbook: RepoLocationSchema = self.runbook
+        return runbook.config_type
+
 
 class LocalLocation(BaseLocation):
     @classmethod
@@ -349,6 +423,10 @@ class LocalLocation(BaseLocation):
     def get_source_code(self) -> PurePath:
         runbook: LocalLocationSchema = self.runbook
         return self._node.get_pure_path(runbook.path)
+
+    def get_config_type(self) -> str:
+        runbook: LocalLocationSchema = self.runbook
+        return runbook.config_type
 
 
 class BaseModifier(subclasses.BaseClassWithRunbookMixin):


### PR DESCRIPTION
These changes contain modification in kernel_installer transformer to add CBLMariner-Dom0 support. Also added sudo, cwd param to lisa tool Cp->copy() function.

We have modified the Git tool as well to accommodate auth_token so lisa can be use system token while we run it in pipeline where we need lisa to checkout the private azure repo