### PR TITLE
Provide an option to capture libvirt debug logs

### DIFF
--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from pathlib import PurePath
+
 from lisa.executable import Tool
 
 
@@ -46,6 +48,19 @@ class Sed(Tool):
         text = text.replace('"', '\\"')
         result = self.run(
             f"-i.bak '$a{text}' {file}",
+            force_run=True,
+            no_error_log=True,
+            no_info_log=True,
+            sudo=sudo,
+            shell=True,
+        )
+        result.assert_exit_code(message=result.stdout)
+
+    def delete_lines(self, pattern: str, file: PurePath, sudo: bool = False) -> None:
+        expression = f"/{pattern}/d"
+        cmd = f'-i.bak "{expression}" {file}'
+        result = self.run(
+            cmd,
             force_run=True,
             no_error_log=True,
             no_info_log=True,

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -97,6 +97,13 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
     def _get_environment_information(self, environment: Environment) -> Dict[str, str]:
         return {}
 
+    def _cleanup(self) -> None:
+        """
+        Called when the platform is being discarded.
+        Perform any platform level cleanup work here.
+        """
+        pass
+
     @hookimpl
     def get_environment_information(self, environment: Environment) -> Dict[str, str]:
         assert environment.platform
@@ -192,6 +199,9 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
         else:
             log.debug("deleting")
             self._delete_environment(environment, log)
+
+    def cleanup(self) -> None:
+        self._cleanup()
 
 
 def load_platform(platforms_runbook: List[schema.Platform]) -> Platform:

--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -160,6 +160,7 @@ class LisaRunner(BaseRunner):
         if hasattr(self, "environments") and self.environments:
             for environment in self.environments:
                 self._delete_environment_task(environment, [])
+        self.platform.cleanup()
         super().close()
 
     def _dispatch_test_result(

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -47,6 +47,8 @@ class BaseLibvirtPlatformSchema:
     # Specified in seconds. Default: 30s.
     network_boot_timeout: Optional[float] = None
 
+    capture_libvirt_debug_logs: bool = False
+
 
 # Possible disk image formats
 class DiskImageFormat(Enum):


### PR DESCRIPTION
Introduce a new option capture_libvirt_debug_logs in LibvirtPlatformSchema that tells LISA to capture libvirt debug logs during environment teardown.

Debug logs are enabled by using the log_outputs option in /etc/libvirt/libvirtd.conf. Here, we configure libvirt to write the debug logs to /var/log/libvirt/libvirtd.log.

We have been seeing multiple libvirt related errors in the pipeline and these logs can help in debugging those.

This is an opt-in feature since all users of libvirt platform might not be interested in debug level logs.