### PR TITLE
[fix issue] set extended runbook after resizing cases

### DIFF
--- a/lisa/features/resize.py
+++ b/lisa/features/resize.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from enum import Enum
+from typing import Tuple
 
 from lisa.feature import Feature
 from lisa.schema import NodeSpace
@@ -31,5 +32,5 @@ class Resize(Feature):
 
     def resize(
         self, resize_action: ResizeAction = ResizeAction.IncreaseCoreCount
-    ) -> NodeSpace:
+    ) -> Tuple[NodeSpace, str, str]:
         raise NotImplementedError()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1251,11 +1251,11 @@ class Resize(AzureFeatureMixin, features.Resize):
 
     def resize(
         self, resize_action: ResizeAction = ResizeAction.IncreaseCoreCount
-    ) -> schema.NodeSpace:
+    ) -> Tuple[schema.NodeSpace, str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         compute_client = get_compute_client(platform)
         node_context = get_node_context(self._node)
-        new_vm_size_info = self._select_vm_size(resize_action)
+        origin_vm_size, new_vm_size_info = self._select_vm_size(resize_action)
 
         # Creating parameter for VM Operations API call
         hardware_profile = HardwareProfile(vm_size=new_vm_size_info.vm_size)
@@ -1274,11 +1274,11 @@ class Resize(AzureFeatureMixin, features.Resize):
         self._node.close()
         new_capability = copy.deepcopy(new_vm_size_info.capability)
         self._node.capability = cast(schema.Capability, new_capability)
-        return new_capability
+        return new_capability, origin_vm_size, new_vm_size_info.vm_size
 
     def _select_vm_size(
         self, resize_action: ResizeAction = ResizeAction.IncreaseCoreCount
-    ) -> "AzureCapability":
+    ) -> Tuple[str, "AzureCapability"]:
         platform: AzurePlatform = self._platform  # type: ignore
         compute_client = get_compute_client(platform)
         node_context = get_node_context(self._node)
@@ -1366,9 +1366,13 @@ class Resize(AzureFeatureMixin, features.Resize):
 
         # Choose random size from the list to resize to
         index = randint(0, len(avail_eligible_intersect) - 1)
-        resize_vm_size = avail_eligible_intersect[index]
-        self._log.info(f"New vm size: {resize_vm_size.vm_size}")
-        return resize_vm_size
+        resize_vm_size_info = avail_eligible_intersect[index]
+        origin_vm_size = node_runbook.vm_size
+        node_runbook.vm_size = resize_vm_size_info.vm_size
+        node_runbook.location = resize_vm_size_info.location
+        resize_vm_size_info.capability.set_extended_runbook(node_runbook)
+        self._log.info(f"New vm size: {resize_vm_size_info.vm_size}")
+        return origin_vm_size, resize_vm_size_info
 
 
 class Hibernation(AzureFeatureMixin, features.Hibernation):

--- a/microsoft/testsuites/core/vm_resize.py
+++ b/microsoft/testsuites/core/vm_resize.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import time
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from assertpy import assert_that
 
@@ -18,6 +18,7 @@ from lisa.features import Resize, ResizeAction, StartStop
 from lisa.schema import NodeSpace
 from lisa.testsuite import TestResult
 from lisa.tools import Lscpu
+from lisa.util.logger import Logger
 
 
 @TestSuiteMetadata(
@@ -170,3 +171,9 @@ class VmResize(TestSuite):
             f"incorrect. Expected {expected_core_count} cores but actually had "
             f"{actual_core_count} cores"
         ).is_equal_to(expected_core_count)
+
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        # resize cases will change vm size
+        # therefore we mark the node dirty to prevent future testing on this environment
+        node = kwargs["node"]
+        node.mark_dirty()


### PR DESCRIPTION
This will fix the image, location and vmsize are empty after running resize test cases. And vmsize will be filled as vmsize after resizing vm.