### PR TITLE
Various fixes for Cloud Hypervisor tests

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -69,7 +69,7 @@ class CloudHypervisorTestSuite(TestSuite):
     ) -> None:
         hypervisor = self._get_hypervisor_param(node)
         node.tools[CloudHypervisorTests].run_tests(
-            result, environment, "integration", hypervisor
+            result, environment, "integration", hypervisor, log_path
         )
 
     @TestCaseMetadata(
@@ -95,7 +95,7 @@ class CloudHypervisorTestSuite(TestSuite):
     ) -> None:
         hypervisor = self._get_hypervisor_param(node)
         node.tools[CloudHypervisorTests].run_tests(
-            result, environment, "integration-live-migration", hypervisor
+            result, environment, "integration-live-migration", hypervisor, log_path
         )
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -36,7 +36,7 @@ class CloudHypervisorTestSuite(TestSuite):
 
     def after_suite(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
-        node.tools[Modprobe].remove("openvswitch")
+        node.tools[Modprobe].remove(["openvswitch"])
 
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]


### PR DESCRIPTION
This PR contains fixes related to collecting dmesg logs and improved sub test reporting in Cloud Hypervisor
tests. Commits are well-defined. Here's a summary:

#### ch_tests_tool: save dmesg logs

  Save dmesg logs after text execution is finished. These logs are
  useful for investigating failures.

#### ch_tests: fix argument to Modprobe.remove()

  Modprobe tool's remove() function accepts module names as a
  `List[str]` but ch_test.py passes a `str`.
  
  Fix by passing a list as argument.
