### PR TITLE
libvirt platform: collect host dmesg logs

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -26,7 +26,7 @@ from lisa.feature import Feature
 from lisa.node import Node, RemoteNode, local_node_connect
 from lisa.operating_system import CBLMariner
 from lisa.platform_ import Platform
-from lisa.tools import Chmod, Iptables, Journalctl, Ls, QemuImg, Uname
+from lisa.tools import Chmod, Dmesg, Iptables, Journalctl, Ls, QemuImg, Uname
 from lisa.util import LisaException, constants, get_public_key_data
 from lisa.util.logger import Logger, filter_ansi_escape
 
@@ -174,6 +174,11 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
         libvirt_log_path = self.host_node.local_log_path / "libvirtd.log"
         with open(str(libvirt_log_path), "w") as f:
             f.write(libvirt_log)
+
+        dmesg_output = self.host_node.tools[Dmesg].get_output(force_run=True)
+        dmesg_path = self.host_node.local_log_path / "dmesg.txt"
+        with open(str(dmesg_path), "w") as f:
+            f.write(dmesg_output)
 
     def _configure_environment(self, environment: Environment, log: Logger) -> None:
         environment_context = get_environment_context(environment)


### PR DESCRIPTION
Collect dmesg logs during cleanup. Same as libvirtd logs.