### PR TITLE
Fix /dev/mshv permission issue on HyperV root partition

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -16,7 +16,7 @@ from lisa import (
 )
 from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.testsuite import TestResult
-from lisa.tools import Ls, Lscpu, Modprobe
+from lisa.tools import Ls, Lscpu, Modprobe, Usermod
 from lisa.util import SkippedException
 from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
 
@@ -123,6 +123,9 @@ class CloudHypervisorTestSuite(TestSuite):
         mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)
         if not virtualization_enabled and not mshv_exists:
             raise SkippedException("Virtualization is not enabled in hardware")
+        # add user to mshv group for access to /dev/mshv
+        if mshv_exists:
+            node.tools[Usermod].add_user_to_group("mshv", sudo=True)
 
     def _get_hypervisor_param(self, node: Node) -> str:
         mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)

--- a/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -17,7 +17,7 @@ from lisa import (
 )
 from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
 from lisa.testsuite import TestResult
-from lisa.tools import Cp, Dmesg, Free, Ls, Lscpu, QemuImg, Rm, Ssh, Wget
+from lisa.tools import Cp, Dmesg, Free, Ls, Lscpu, QemuImg, Rm, Ssh, Usermod, Wget
 from lisa.util import SkippedException
 from microsoft.testsuites.mshv.cloud_hypervisor_tool import CloudHypervisor
 
@@ -43,6 +43,9 @@ class MshvHostTestSuite(TestSuite):
         node = kwargs["node"]
         if not node.tools[Ls].path_exists("/dev/mshv", sudo=True):
             raise SkippedException("This suite is for MSHV root partition only")
+
+        # add user to mshv group for access to /dev/mshv
+        node.tools[Usermod].add_user_to_group("mshv", sudo=True)
 
         working_path = node.get_working_path()
         node.tools[Wget].get(


### PR DESCRIPTION
`mshv` is the owning group of `/dev/mshv` in linux root partition. CH tests and mshv tests requires the user to have access to `/dev/msh`. Hence adding the user to `mshv` group.