### PR TITLE
Use editable install for example

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ def test(session: nox.Session) -> None:
 @nox.session(python=CURRENT_PYTHON, tags=["test", "all"])
 def example(session: nox.Session) -> None:
     """Run example"""
-    session.install(".")
+    session.install("--editable", ".", "--config-settings", "editable_mode=compat")
     session.run("lisa", "--debug")
 
 


### PR DESCRIPTION
This changes the example session in Nox to use an editable install of Lisa. This allows a developer to run the example session with `nox -vRs example` multiple times with changes without having to reinstall dependencies.
