### PR TITLE
Couple of fixes for MshvHostTestSuite

### DIFF
--- a/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
+++ b/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
@@ -22,10 +22,12 @@ class CloudHypervisor(Tool):
         memory_mb: int,
         disk_path: str,
         disk_readonly: bool = False,
+        sudo: bool = False,
     ) -> Process:
         opt_disk_readonly = "on" if disk_readonly else "off"
         return self.run_async(
             f'--kernel {kernel} --cpus boot={cpus} --memory size={memory_mb}M --disk "path={disk_path},readonly={opt_disk_readonly}" --net "tap=,mac=,ip=,mask="',  # noqa: E501
             force_run=True,
             shell=True,
+            sudo=sudo,
         )

--- a/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -124,6 +124,7 @@ class MshvHostTestSuite(TestSuite):
                 self._send_subtest_msg(
                     result, environment, test_name, TestStatus.FAILED, repr(e)
                 )
+        self._save_dmesg_logs(node, log_path)
         assert_that(failures).is_equal_to(0)
         return
 
@@ -183,10 +184,6 @@ class MshvHostTestSuite(TestSuite):
             disk_img_file = node.working_path / f"VM{i}_{self.DISK_IMG_NAME}"
             node.tools[Rm].remove_file(str(disk_img_file))
 
-        dmesg_str = node.tools[Dmesg].get_output()
-        dmesg_path = log_path / f"dmesg_{times}_{cpus_per_vm}_{mem_per_vm_mb}"
-        with open(str(dmesg_path), "w") as f:
-            f.write(dmesg_str)
         assert_that(failures).is_equal_to(0)
 
     def _send_subtest_msg(
@@ -207,3 +204,9 @@ class MshvHostTestSuite(TestSuite):
         )
 
         notifier.notify(subtest_msg)
+
+    def _save_dmesg_logs(self, node: Node, log_path: Path) -> None:
+        dmesg_str = node.tools[Dmesg].get_output()
+        dmesg_path = log_path / "dmesg"
+        with open(str(dmesg_path), "w") as f:
+            f.write(dmesg_str)


### PR DESCRIPTION
This PR has the following commits:

**mshv_root_tests: save dmesg at the correct place**

dmesg logs are not saved for some error paths which throw before
reaching the code that saves the logs.

Move this code to the correct place in verify_mshv_stress_vm_create.

**mshv_root_tests: use Azure temp disk for storing large files**

The testcase makes a copy of the disk image for each VM it
spawns. It is easy to run of space in OS disk especially
when the default value of 30GB is used.

Use the Azure temporary disk that is automatically mounted
at /mnt to store copies of the disk image.