### PR TITLE
[fix issue] support detect vhd and gallery image vm generation.

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -119,6 +119,14 @@ class SharedImageGallerySchema:
     image_definition: str = ""
     image_version: str = ""
 
+    def __hash__(self) -> int:
+        return hash(
+            f"/subscriptions/{self.subscription_id}/resourceGroups/"
+            f"{self.resource_group_name}/providers/Microsoft.Compute/galleries/"
+            f"{self.image_gallery}/images/{self.image_definition}/versions/"
+            f"{self.image_version}"
+        )
+
 
 @dataclass_json()
 @dataclass

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1153,7 +1153,7 @@ class AzurePlatform(Platform):
         elif azure_node_runbook.shared_gallery:
             azure_node_runbook.marketplace = None
             azure_node_runbook.shared_gallery = self._parse_shared_gallery_image(
-                azure_node_runbook.location, azure_node_runbook.shared_gallery
+                azure_node_runbook.shared_gallery
             )
         elif not azure_node_runbook.marketplace:
             # set to default marketplace, if nothing specified
@@ -1719,7 +1719,7 @@ class AzurePlatform(Platform):
 
     @lru_cache(maxsize=10)  # noqa: B019
     def _parse_shared_gallery_image(
-        self, location: str, shared_image: SharedImageGallerySchema
+        self, shared_image: SharedImageGallerySchema
     ) -> SharedImageGallerySchema:
         new_shared_image = copy.copy(shared_image)
         compute_client = get_compute_client(self)
@@ -2480,7 +2480,7 @@ class AzurePlatform(Platform):
             node_space.features.add(features.VhdGenerationSettings(gen=generation))
         elif azure_runbook.shared_gallery:
             azure_runbook.shared_gallery = self._parse_shared_gallery_image(
-                azure_runbook.location, azure_runbook.shared_gallery
+                azure_runbook.shared_gallery
             )
             generation = _get_gallery_image_generation(
                 self._get_detailed_sig(azure_runbook.shared_gallery)

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2486,10 +2486,12 @@ class AzurePlatform(Platform):
                 self._get_detailed_sig(azure_runbook.shared_gallery)
             )
             node_space.features.add(features.VhdGenerationSettings(gen=generation))
-        else:
+        elif azure_runbook.vhd:
             node_space.features.add(
                 features.VhdGenerationSettings(gen=azure_runbook.hyperv_generation)
             )
+        else:
+            ...
 
     def _load_image_features(self, node_space: schema.NodeSpace) -> None:
         # This method does the same thing as _convert_to_azure_node_space


### PR DESCRIPTION
We can get hyperv generation from API for marketplace image and gallery image.
For vhd format, we rely on customers' input, otherwise use default value gen1.