### PR TITLE
NOHUP: change sudo/nohup ordering

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -189,10 +189,10 @@ class Process:
                 split_command = ["cmd", "/c", command]
             else:
                 split_command = []
-                if nohup:
-                    split_command += ["nohup"]
                 if sudo:
                     split_command += ["sudo"]
+                if nohup:
+                    split_command += ["nohup"]
                 envs = _create_exports(update_envs=update_envs)
                 if envs:
                     command = f"{envs} {command}"


### PR DESCRIPTION
Nohup before sudo can raise a permissions error due to broken pipe from writing to nohup.out. Swap to running sudo first when using nohup.