### PR TITLE
Improve handling of process timeout

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -85,7 +85,8 @@ class Process:
         # add a string stream handler to the logger
         self._log_buffer = io.StringIO()
         self._log_handler = logging.StreamHandler(self._log_buffer)
-        add_handler(self._log_handler, self._log)
+        msg_only_format = logging.Formatter(fmt="%(message)s", datefmt="")
+        add_handler(self._log_handler, self._log, msg_only_format)
 
     def start(
         self,
@@ -235,7 +236,10 @@ class Process:
             assert self._process
             if is_timeout:
                 process_result = spur.results.result(
-                    return_code=1, allow_error=True, output="", stderr_output=""
+                    return_code=1,
+                    allow_error=True,
+                    output=self._log_buffer.getvalue(),
+                    stderr_output="",
                 )
             else:
                 process_result = self._process.wait_for_result()

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -29,6 +29,7 @@ class ExecutableResult:
     exit_code: Optional[int]
     cmd: Union[str, List[str]]
     elapsed: float
+    is_timeout: bool = False
 
     def __str__(self) -> str:
         return self.stdout
@@ -262,6 +263,7 @@ class Process:
                 process_result.return_code,
                 self._cmd,
                 self._timer.elapsed(),
+                is_timeout,
             )
 
             self._recycle_resource()

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -51,7 +51,7 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor integration tests.
         """,
         priority=3,
-        timeout=CloudHypervisorTests.TIME_OUT,
+        timeout=CloudHypervisorTests.CASE_TIME_OUT,
         requirement=node_requirement(
             node=schema.NodeSpace(
                 core_count=search_space.IntRange(min=16),
@@ -77,7 +77,7 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor live migration tests.
         """,
         priority=3,
-        timeout=CloudHypervisorTests.TIME_OUT,
+        timeout=CloudHypervisorTests.CASE_TIME_OUT,
         requirement=node_requirement(
             node=schema.NodeSpace(
                 core_count=search_space.IntRange(min=16),
@@ -103,7 +103,7 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor performance metrics tests.
         """,
         priority=3,
-        timeout=CloudHypervisorTests.TIME_OUT,
+        timeout=CloudHypervisorTests.CASE_TIME_OUT,
     )
     def verify_cloud_hypervisor_performance_metrics_tests(
         self,


### PR DESCRIPTION
Has following patches:

**lisa/util/process: return correct stdout for timed out processes**
If a process times out while doing wait_result, no stdout is returned in
the result. This is not correct since the process might have produced
some output before timing out.

The output of the command is already being streamed into
self._log_buffer. Use its contents to populate the stdout field of the
result in case of timeout.

The contents of the _log_buffer also includes the lisa tag as prefix for
each line (timestamp, node/environment info, log level etc.). This is
not required and unexpected since a process result usually includes the
raw stdout of the command and so stdout parsing logic may not have accounted
for the prefix.

The _log_buffer is currently used in wait_for_output() and here too the
logging prefix for each line is not required. It might accidently match
the content in the prefix instead of the actual command stdout.

To fix, instead of using the default formatter, use a separate one that
prints just the message without any prefix.

**lisa/util/process: add is_timeout to ExecutableResult**
Today there is no way to tell from an `ExecutableResult` whether the
process timed out. Add a property `is_timeout` to `ExecutableResult`
to indicate if the process timed out.

**ch_tests_tool: report run test results even when command times out**
The test comamnd timing out doesn't mean that no tests have been
run. It might have run some of the tests and before getting stuck.
In this scenario the results of the tests that were run before
the command stuck should be reported.

But when the test case times out there is no chance to
extract results of the tests that were run. To address this,
define two timemout values. CMD_TIME_OUT is the time within which
the Cloud Hypervisor test command should finish and CASE_TIME_OUT is
the time within which the whole LISA testcase should finish.

Keep the value of CASE_TIME_OUT a slightly higher so that results
can be extracted from the command's stdout when it times out. This
will ensure we have accurate reporting of test cases run even when
the test command times out.