### PR TITLE
Enable MOD_STRIP in kernel source installer

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -137,7 +137,9 @@ class SourceInstaller(BaseInstaller):
         make = node.tools[Make]
         make.make(arguments="modules", cwd=code_path, sudo=True)
 
-        make.make(arguments="modules_install", cwd=code_path, sudo=True)
+        make.make(
+            arguments="INSTALL_MOD_STRIP=1 modules_install", cwd=code_path, sudo=True
+        )
 
         make.make(arguments="install", cwd=code_path, sudo=True)
 


### PR DESCRIPTION
Set INSTALL_MOD_STRIP=1 for kernel source installer.
The initrd file of new kernel is close to 512M (initrd of older kernel being ~25M) since the debug modules are enabled.
This causes few tests to fail eg: kdump and smoke test in small SKU etc.