### PR TITLE
Update transformer: override other repos

### DIFF
--- a/lisa/transformers/upgrade_packages.py
+++ b/lisa/transformers/upgrade_packages.py
@@ -15,15 +15,9 @@ from lisa.util.logger import Logger, get_logger
 @dataclass_json()
 @dataclass
 class UpgradeInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
-    repo_url: str = field(
-        default="",
-        metadata=field_metadata(required=True),
-    )
+    repo_url: str = field(default="")
 
-    proposed: bool = field(
-        default=False,
-        metadata=field_metadata(required=True),
-    )
+    proposed: bool = field(default=False)
 
 
 @dataclass_json
@@ -54,7 +48,7 @@ class UpgradeInstaller(subclasses.BaseClassWithRunbookMixin):
     def validate(self) -> None:
         raise NotImplementedError()
 
-    def install(self) -> None:
+    def install(self) -> List[str]:
         raise NotImplementedError()
 
 
@@ -118,11 +112,11 @@ class UnattendedUpgradeInstaller(UpgradeInstaller):
             f"The current os is {self._node.os.name}"
         )
 
-    def install(self) -> None:
+    def install(self) -> List[str]:
         if self.runbook.repo_url.strip():
             self._update_repo()
 
-        self._update_packages()
+        return self._update_packages()
 
     def _update_repo(self) -> None:
         node: Node = self._node


### PR DESCRIPTION
When a repo url is provided, override the other repos. This allows us to guarantee that the packages are being pulled from the repo we intend. We had to leave the main repo because tests may need to install packages that come from that repo, but there should not be any updates in that repo.

Other changes allow the transformer to be more general purpose. Examples:
Update packages with default repos: repo_url:""
Update from specific repo: repo_url:"$url"
Update from proposed repo: repo_url:"$url" proposed:True