### PR TITLE
Add custom_blob_name in VhdTransformerSchema and try-except to catch the error of waagent in transformer

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -993,7 +993,7 @@ def wait_copy_blob(
     if timeout_timer.elapsed() >= timeout:
         raise LisaException(f"wait copying VHD timeout: {vhd_path}")
 
-    log.debug("vhd copied")
+    log.info("vhd copied")
 
 
 def get_share_service_client(

--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -45,7 +45,12 @@ class Waagent(Tool):
         return False
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
-        self._command = "waagent"
+        if isinstance(self.node.os, CoreOs):
+            self._command = (
+                "/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent"
+            )
+        else:
+            self._command = "waagent"
         self._distro_version: Optional[str] = None
 
     def get_version(self) -> str:

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -77,6 +77,9 @@ class VhdTransformerSchema(schema.Transformer):
     storage_account_name: str = ""
     container_name: str = DEFAULT_EXPORTED_VHD_CONTAINER_NAME
     file_name_part: str = ""
+    # Users may want to export VHD with the name they defined. For example,
+    # OpenLogic-CentOS-7.9-20221227.vhd, or OpenLogic/CentOS/7.9/20221227.vhd
+    custom_blob_name: str = ""
 
     # restore environment or not
     restore: bool = False
@@ -194,7 +197,10 @@ class VhdTransformer(Transformer):
             resource_group_name=runbook.shared_resource_group_name,
         )
 
-        path = _generate_vhd_path(container_client, runbook.file_name_part)
+        if runbook.custom_blob_name:
+            path = runbook.custom_blob_name
+        else:
+            path = _generate_vhd_path(container_client, runbook.file_name_part)
         vhd_path = f"{container_client.url}/{path}"
         blob_client = container_client.get_blob_client(path)
         blob_client.start_copy_from_url(sas_url, metadata=None, incremental_copy=False)


### PR DESCRIPTION
1. Add custom_blob_full_name in VhdTransformerSchema. So users can define their own blob name.
2. Change the level of log "vhd copied" into info. 
3. Ignore any error when running waagent deprovision in transformer. So the image which has an error when running waagent deprovison can still continue to export VHD .