### PR TITLE
Instead of using hardcoded x86_64 identifiers, use the detected arch

### DIFF
--- a/microsoft/testsuites/display/modetest.py
+++ b/microsoft/testsuites/display/modetest.py
@@ -36,17 +36,18 @@ class Modetest(Tool):
 
     def _install_dep_packages(self) -> None:
         if isinstance(self.node.os, Redhat):
+            arch = self.node.os.get_kernel_information().hardware_platform
             self.node.os.install_packages(
                 (
                     "git",
                     "make",
                     "autoconf",
                     "automake",
-                    "libpciaccess-devel.x86_64",
+                    f"libpciaccess-devel.{arch}",
                     "libtool",
-                    "http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/xorg-x11-util-macros-1.19.3-4.el9.noarch.rpm",  # noqa: E501
-                    "http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/ninja-build-1.10.2-6.el9.x86_64.rpm",  # noqa: E501
-                    "http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/meson-0.58.2-1.el9.noarch.rpm",  # noqa: E501
+                    f"http://mirror.stream.centos.org/9-stream/CRB/{arch}/os/Packages/xorg-x11-util-macros-1.19.3-4.el9.noarch.rpm",  # noqa: E501
+                    f"http://mirror.stream.centos.org/9-stream/CRB/{arch}/os/Packages/ninja-build-1.10.2-6.el9.{arch}.rpm",  # noqa: E501
+                    f"http://mirror.stream.centos.org/9-stream/CRB/{arch}/os/Packages/meson-0.58.2-1.el9.noarch.rpm",  # noqa: E501
                 )
             )
         else:

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -217,10 +217,18 @@ class Xfstests(Tool):
             if isinstance(self.node.os, Oracle):
                 posix_os.install_packages("oracle-softwarecollection-release-el7")
             else:
+                arch = self.node.os.get_kernel_information().hardware_platform
+                if arch != "x86_64":
+                    raise LisaException(
+                        f"This test case does not support {arch}."
+                        "This validation is only for x86_64."
+                    )
                 posix_os.install_packages(packages="centos-release-scl")
                 posix_os.install_packages(
-                    "http://mirror.centos.org/centos/7/os/x86_64/Packages/"
-                    "xfsprogs-devel-4.5.0-22.el7.x86_64.rpm"
+                    (
+                        "http://mirror.centos.org/centos/7/os/x86_64/Packages/"
+                        "xfsprogs-devel-4.5.0-22.el7.x86_64.rpm"
+                    )
                 )
             posix_os.install_packages(
                 packages="devtoolset-7-gcc*", extra_args=["--skip-broken"]


### PR DESCRIPTION
For several packages to be installed, we have hardcoded the arch to x86_64 which does not work on ARM64. This is addressed by using the detected arch instead of a hardcoded value.