### PR TITLE
Remove IsolatedResource requirement for the performance tests

### DIFF
--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -19,7 +19,7 @@ from lisa import (
     search_space,
     simple_requirement,
 )
-from lisa.features import Disk, IsolatedResource
+from lisa.features import Disk  # , IsolatedResource
 from lisa.features.network_interface import Sriov, Synthetic
 from lisa.messages import DiskSetupType, DiskType
 from lisa.node import RemoteNode
@@ -58,7 +58,7 @@ class StoragePerformance(TestSuite):
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=16),
             ),
-            supported_features=[IsolatedResource],
+            # supported_features=[IsolatedResource],
         ),
     )
     def perf_premium_datadisks_4k(self, node: Node, result: TestResult) -> None:
@@ -76,7 +76,7 @@ class StoragePerformance(TestSuite):
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=16),
             ),
-            supported_features=[IsolatedResource],
+            # supported_features=[IsolatedResource],
         ),
     )
     def perf_premium_datadisks_1024k(self, node: Node, result: TestResult) -> None:
@@ -94,7 +94,7 @@ class StoragePerformance(TestSuite):
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=24),
             ),
-            supported_features=[IsolatedResource],
+            # supported_features=[IsolatedResource],
         ),
     )
     def perf_premium_datadisks_io(self, node: Node, result: TestResult) -> None:


### PR DESCRIPTION
If a user overrides vm_size and specifies a vm_size which cannot work with the IsolatedResource requirement, we should still allow the test to proceed with the users requested vm_size despite the potential for them not being able to acquire an isolated hardware resource.

The thought being that if a user requests a specific vm_size, we should honor that request and not deny them the ability to run tests on their chosen SKU.