### PR TITLE
Add tool to copy back folders from remote machine

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -88,6 +88,7 @@ from .python import Pip, Python
 from .qemu import Qemu
 from .qemu_img import QemuImg
 from .reboot import Reboot
+from .remote_copy import RemoteCopy
 from .rm import Rm
 from .sar import Sar
 from .ssh import Ssh
@@ -198,6 +199,7 @@ __all__ = [
     "Qemu",
     "QemuImg",
     "Reboot",
+    "RemoteCopy",
     "Rpm",
     "Rm",
     "Sar",

--- a/lisa/tools/chown.py
+++ b/lisa/tools/chown.py
@@ -46,6 +46,7 @@ class Chown(Tool):
             parameters=" ".join(arguments),
             shell=True,
             sudo=True,
+            force_run=True,
             expected_exit_code=0,
             expected_exit_code_failure_message=(
                 f"Chown failed to change owner for {file}"

--- a/lisa/tools/cp.py
+++ b/lisa/tools/cp.py
@@ -21,12 +21,23 @@ class Cp(Tool):
         dest: PurePath,
         sudo: bool = False,
         cwd: Optional[PurePath] = None,
+        recur: bool = False,
     ) -> None:
+        cmd = f"{src} {dest}"
+        if recur:
+            cmd = f"-r {cmd}"
         result = self.run(
-            f"{src} {dest}",
+            cmd,
             force_run=True,
-            expected_exit_code=0,
             sudo=sudo,
             cwd=cwd,
+            shell=True,
         )
+
+        # cp copies all the files except folders in the source
+        # directory to the destination directory when we do not
+        # specify -r when source is a directory. Though it throws
+        # an error which we can ignore.
+        if "omitting directory" in result.stdout and not recur:
+            return
         result.assert_exit_code()

--- a/lisa/tools/remote_copy.py
+++ b/lisa/tools/remote_copy.py
@@ -1,0 +1,127 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import os
+from pathlib import PurePath
+
+from lisa.executable import Tool
+from lisa.tools.chown import Chown
+from lisa.tools.cp import Cp
+from lisa.tools.ls import Ls
+from lisa.tools.mkdir import Mkdir
+from lisa.tools.rm import Rm
+from lisa.tools.whoami import Whoami
+
+
+class RemoteCopy(Tool):
+    @property
+    def command(self) -> str:
+        return ""
+
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    def _prepare_tmp_copy(
+        self,
+        src: PurePath,
+        is_file: bool = False,
+        recurse: bool = False,
+    ) -> PurePath:
+        # copy file/folder to a temp location
+        tmp_location = PurePath("/tmp")
+
+        if is_file:
+            # we want to copy file at
+            # location : <tmp_location>/<src.parent.name>/<src.name>
+            tmp_dir = tmp_location / src.parent.name
+            tmp_location = tmp_dir / src.name
+            self.node.tools[Mkdir].create_directory(str(tmp_dir), sudo=True)
+        elif not recurse:
+            # we want to copy only the files in `src` folder at
+            # location : <tmp_location>/<src.name>
+            tmp_dir = tmp_location / src.name
+            tmp_location = tmp_dir
+            src = src / "*"
+            self.node.tools[Mkdir].create_directory(str(tmp_dir), sudo=True)
+        else:
+            # we want to copy the folder at
+            # location : <tmp_location>
+            tmp_dir = tmp_location
+            tmp_location = tmp_dir / src.name
+
+        # copy the required file/folder to the temp directory
+        self.node.tools[Cp].copy(src, tmp_dir, sudo=True, recur=recurse)
+
+        # change the owner of the temp directory
+        username = self.node.tools[Whoami].get_username()
+        self.node.tools[Chown].change_owner(
+            tmp_location, user=username, group=username, recurse=True
+        )
+
+        return tmp_location
+
+    def _copy(
+        self,
+        src: PurePath,
+        dest: PurePath,
+        is_file: bool = False,
+        recurse: bool = False,
+    ) -> None:
+
+        if is_file:
+            destination_dir = dest
+            dirs = []
+            files = [src]
+        else:
+            # create the destination directory if it doesn't exist
+            destination_dir = dest / src.name
+            if not os.path.exists(destination_dir):
+                os.makedirs(destination_dir)
+
+            # get list of files and folders in the source directory
+            contents = self.node.tools[Ls].list(str(src))
+            dirs = (
+                [PurePath(content) for content in contents if content.endswith("/")]
+                if recurse
+                else []
+            )
+            files = [
+                PurePath(content) for content in contents if not content.endswith("/")
+            ]
+
+        # copy files
+        for file in files:
+            self.node.shell.copy_back(file, destination_dir / file.name)
+
+        # copy sub folders
+        for dir_ in dirs:
+            self._copy(dir_, destination_dir, recurse=recurse)
+
+    def copy_to_local(
+        self,
+        src: PurePath,
+        dest: PurePath,
+        recurse: bool = False,
+    ) -> None:
+        # check if the source is a file or a directory
+        is_file = self.node.tools[Ls].is_file(src, sudo=True)
+
+        # recurse shpuld be false for files
+        recurse = recurse and not is_file
+
+        try:
+            self._copy(src, dest, recurse=recurse, is_file=is_file)
+        except Exception as e:
+            self._log.debug(
+                f"Failed to copy files to {dest} with error: {e}, trying again "
+                "with sudo"
+            )
+
+            # copy files to a temp directory with updated permissions
+            tmp_location = self._prepare_tmp_copy(src, recurse=recurse, is_file=is_file)
+
+            # copy files from the temp directory and remove the temp directory
+            try:
+                self._copy(tmp_location, dest, recurse=recurse, is_file=is_file)
+            finally:
+                self.node.tools[Rm].remove_directory(str(tmp_location), sudo=True)


### PR DESCRIPTION
Sample test:
```
@TestCaseMetadata(
        description="""
            """,
        priority=2,
    )
    def check_remote_copy(
        self,
        node: Node,
        log: Logger,
        log_path: str,
    ) -> None:
        # setup a 3 level directory structure with files and folders
        mkdir = node.tools[Mkdir]
        mkdir.create_directory("test")
        mkdir.create_directory("test/helloworld1")
        mkdir.create_directory("test/helloworld1/helloworld2")
        mkdir.create_directory("test/helloworld1/helloworld2/helloworld3")

        # create a file in all the directories
        echo = node.tools[Echo]
        echo.write_to_file("hello world", PurePosixPath("test/helloworld1/file1.txt"))
        echo.write_to_file(
            "hello world", PurePosixPath("test/helloworld1/helloworld2/file2.txt")
        )
        echo.write_to_file(
            "hello world",
            PurePosixPath("test/helloworld1/helloworld2/helloworld3/file3.txt"),
        )
        remote_copy = node.tools[RemoteCopy]
        remote_copy.copy_to_local(
            PurePosixPath("test/helloworld1"),
            PurePath(log_path),
            recurse=True,
        )
        remote_copy.copy_to_local(
            PurePosixPath("/boot"),
            PurePath(log_path),
            recurse=False,
        )
        remote_copy.copy_to_local(
            PurePosixPath("/boot"),
            PurePath(log_path) / "boot_with_recurse",
            recurse=True,
        )
        remote_copy.copy_to_local(
            PurePosixPath("test/helloworld1/helloworld2/file2.txt"),
            PurePath(log_path) / "singleton_file",
        )
        remote_copy.copy_to_local(
            PurePosixPath("/boot/vmlinuz-5.4.0-1100-azure"),
            PurePath(log_path),
            recurse=True,
        )
 ```