### PR TITLE
Pylint: Enable implicit-str-concat

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -853,7 +853,7 @@ class NodeSpace(search_space.RequirementMixin, TypedSchema, ExtendableSchemaMixi
             or not capability.memory_mb
         ):
             result.add_reason(
-                "node_count, core_count, memory_mb " "shouldn't be None or zero."
+                "node_count, core_count, memory_mb shouldn't be None or zero."
             )
 
         if isinstance(self.node_count, int) and isinstance(capability.node_count, int):

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -312,7 +312,7 @@ class AzurePlatformSchema:
 
 class AzurePlatform(Platform):
     _diagnostic_storage_container_pattern = re.compile(
-        r"(https:\/\/)(?P<storage_name>.*)([.].*){4}\/" r"(?P<container_name>.*)\/",
+        r"(https:\/\/)(?P<storage_name>.*)([.].*){4}\/(?P<container_name>.*)\/",
         re.M,
     )
     _arm_template: Any = None

--- a/pylintrc
+++ b/pylintrc
@@ -38,7 +38,6 @@ disable=
     eval-used,
     expression-not-assigned,
     global-variable-not-assigned,
-    implicit-str-concat,
     inconsistent-return-statements,
     invalid-overridden-method,
     keyword-arg-before-vararg,


### PR DESCRIPTION
This check protects against errors where `"hello" "world"` is provided rather than `"hello", "world"`
