### PR TITLE
Pylint: Enable variable checks

### DIFF
--- a/lisa/sut_orchestrator/aws/features.py
+++ b/lisa/sut_orchestrator/aws/features.py
@@ -158,14 +158,11 @@ class NetworkInterface(AwsFeatureMixin, features.NetworkInterface):
         self._initialize_information(self._node)
 
     def _get_primary(self, nics: List[Any]) -> Any:
-        found_primary = False
         for nic in nics:
             if nic["Attachment"]["DeviceIndex"] == 0:
-                found_primary = True
-                break
-        if not found_primary:
-            raise LisaException(f"fail to find primary nic for vm {self._node.name}")
-        return nic
+                return nic
+
+        raise LisaException(f"failed to find primary nic for vm {self._node.name}")
 
     def switch_sriov(
         self, enable: bool, wait: bool = True, reset_connections: bool = True

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -793,14 +793,11 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
     def _get_primary(
         self, nics: List[NetworkInterfaceReference]
     ) -> NetworkInterfaceReference:
-        found_primary = False
         for nic in nics:
             if nic.primary:
-                found_primary = True
-                break
-        if not found_primary:
-            raise LisaException(f"fail to find primary nic for vm {self._node.name}")
-        return nic
+                return nic
+
+        raise LisaException(f"failed to find primary nic for vm {self._node.name}")
 
     def _get_all_nics(self) -> Any:
         azure_platform: AzurePlatform = self._platform  # type: ignore

--- a/lisa/tools/tar.py
+++ b/lisa/tools/tar.py
@@ -91,7 +91,7 @@ class Tar(Tool):
         # if we need to test anything, add inputs that pass all tests
         if filters:
             for item in content:
-                if all(map(lambda x: x(item), filters)):  # noqa: B023
+                if all(func(item) for func in filters):
                     output.append(item)
             return output
         else:

--- a/pylintrc
+++ b/pylintrc
@@ -33,7 +33,6 @@ disable=
     # Potential bugs
     abstract-method,
     broad-except,
-    cell-var-from-loop,
     cyclic-import,
     eval-used,
     expression-not-assigned,
@@ -52,10 +51,8 @@ disable=
     redefined-outer-name,
     super-init-not-called,
     unbalanced-tuple-unpacking,
-    undefined-loop-variable,
     unspecified-encoding,
     unsubscriptable-object,
-    used-before-assignment,
 
     # Syntax / Logic
     chained-comparison,

--- a/selftests/test_environment.py
+++ b/selftests/test_environment.py
@@ -222,9 +222,9 @@ class EnvironmentTestCase(TestCase):
         for n in env.nodes.list():
             # mock initializing
             n._is_initialized = True
-        self.assertEqual(search_space.IntRange(min=4), n.capability.core_count)
+            self.assertEqual(search_space.IntRange(min=4), n.capability.core_count)
+            self.assertIsNone(n.capability.disk)
 
-        self.assertIsNone(n.capability.disk)
         # check from env capability
         env_cap = env.capability
         self.assertEqual(1, len(env_cap.nodes))


### PR DESCRIPTION
- Enables Pylint checks:
  - used-before-assignment
  - undefined-loop-variable
  - cell-var-from-loop
- Applies fixes to code so checks pass
