### PR TITLE
DNS improvement for no repo enabled scenario

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1377,6 +1377,9 @@ class Redhat(Fedora):
         r"^(?P<vendor>.*?)?(?: Enterprise)?(?: Linux)?(?: Server)?$"
     )
 
+    # Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d". # noqa: E501
+    _no_repo_enabled = re.compile("There are no enabled repositories", re.M)
+
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
         return re.compile("^rhel|Red|Rocky|Scientific|acronis|Actifio$")
@@ -1405,7 +1408,6 @@ class Redhat(Fedora):
             self._node.execute(
                 "yum update -y --disablerepo='*' --enablerepo='*microsoft*' ",
                 sudo=True,
-                expected_exit_code=0,
             )
 
     def _install_packages(
@@ -1487,7 +1489,9 @@ class Redhat(Fedora):
         #  Basic_A1, Standard_A5, Standard_A1_v2, Standard_D1
         # redhat rhel 7-lvm 7.7.2019102813 Basic_A1 cost 2371.568 seconds
         # redhat rhel 8.1 8.1.2020020415 Basic_A0 cost 2409.116 seconds
-        self._node.execute(command, sudo=True, timeout=3600)
+        output = self._node.execute(command, sudo=True, timeout=3600).stdout
+        if self._no_repo_enabled.search(output):
+            raise RepoNotExistException(self._node.os)
 
     def _dnf_tool(self) -> str:
         return "yum"

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1673,9 +1673,9 @@ class Suse(Linux):
             "zypper --non-interactive --gpg-auto-import-keys refresh", sudo=True
         ).stdout
         if self._no_repo_defined.search(output):
-            raise LisaException(
-                f"There are no enabled repositories defined in "
-                f"{self._node.os.name} {self._node.os.information.version}"
+            raise RepoNotExistException(
+                self._node.os,
+                "There are no enabled repositories defined in this image.",
             )
 
     def _install_packages(

--- a/microsoft/testsuites/core/dns.py
+++ b/microsoft/testsuites/core/dns.py
@@ -13,7 +13,7 @@ from lisa import (
 )
 from lisa.operating_system import Debian, Posix
 from lisa.tools import Ping
-from lisa.util import PassedException, ReleaseEndOfLifeException
+from lisa.util import PassedException, ReleaseEndOfLifeException, RepoNotExistException
 
 
 @TestSuiteMetadata(
@@ -46,9 +46,9 @@ class Dns(TestSuite):
         try:
             self._upgrade_system(node)
 
-        except ReleaseEndOfLifeException as identifier:
-            # If the release is end of life, skip the step of upgrading system.
-            # Continue the following test
+        except (ReleaseEndOfLifeException, RepoNotExistException) as identifier:
+            # If the release is end of life, or there is no repo existing,
+            # then skip the step of upgrading system. Continue the following test
             node.log.debug(identifier)
             raise PassedException(identifier) from identifier
 


### PR DESCRIPTION
1.  Add check of no repo enabled for Redhat image. No need to check the exit code of the command "yum update -y --disablerepo='*' --enablerepo='*microsoft*'" in _initialize_package_installation. Some Redhat-based images don't set rhui repo.
2.  Raise passedException if RepoNotExistException is caught in DNS test.
3. Raise RepoNotExistException if there is no repo enabled in SUSE image