### PR TITLE
CH_tests_tool: Subtest results reporting improvements & support for git ref

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from lisa import (
     Environment,
@@ -66,10 +66,12 @@ class CloudHypervisorTestSuite(TestSuite):
         environment: Environment,
         log_path: Path,
         result: TestResult,
+        variables: Dict[str, Any],
     ) -> None:
         hypervisor = self._get_hypervisor_param(node)
+        ref = variables.get("cloudhypervisor_ref", "")
         node.tools[CloudHypervisorTests].run_tests(
-            result, environment, "integration", hypervisor, log_path
+            result, environment, "integration", hypervisor, log_path, ref
         )
 
     @TestCaseMetadata(
@@ -92,10 +94,12 @@ class CloudHypervisorTestSuite(TestSuite):
         environment: Environment,
         log_path: Path,
         result: TestResult,
+        variables: Dict[str, Any],
     ) -> None:
         hypervisor = self._get_hypervisor_param(node)
+        ref = variables.get("cloudhypervisor_ref", "")
         node.tools[CloudHypervisorTests].run_tests(
-            result, environment, "integration-live-migration", hypervisor, log_path
+            result, environment, "integration-live-migration", hypervisor, log_path, ref
         )
 
     @TestCaseMetadata(
@@ -112,10 +116,12 @@ class CloudHypervisorTestSuite(TestSuite):
         environment: Environment,
         log_path: Path,
         result: TestResult,
+        variables: Dict[str, Any],
     ) -> None:
         hypervisor = self._get_hypervisor_param(node)
+        ref = variables.get("cloudhypervisor_ref", "")
         node.tools[CloudHypervisorTests].run_metrics_tests(
-            result, environment, hypervisor, log_path
+            result, environment, hypervisor, log_path, ref
         )
 
     def _ensure_virtualization_enabled(self, node: Node) -> None:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -31,6 +31,7 @@ class CloudHypervisorTests(Tool):
     # - list subtests before running the tests.
     # - extract sub test results from stdout and report them.
     CASE_TIME_OUT = CMD_TIME_OUT + 1200
+    PERF_CMD_TIME_OUT = 600
 
     repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
 
@@ -126,9 +127,9 @@ class CloudHypervisorTests(Tool):
             trace: str = ""
             try:
                 result = self.run(
-                    f"tests --hypervisor {hypervisor} --metrics -- -- \
-                        --test-filter {testcase}",
-                    timeout=self.CMD_TIME_OUT,
+                    f"tests --hypervisor {hypervisor} --metrics -- --"
+                    f" --test-filter {testcase}",
+                    timeout=self.PERF_CMD_TIME_OUT,
                     force_run=True,
                     cwd=self.repo_root,
                     no_info_log=False,  # print out result of each test
@@ -306,7 +307,7 @@ class CloudHypervisorTests(Tool):
         tests_list = []
         result = self.run(
             f"tests --hypervisor {hypervisor} --metrics -- -- --list-tests",
-            timeout=self.CMD_TIME_OUT,
+            timeout=self.PERF_CMD_TIME_OUT,
             force_run=True,
             cwd=self.repo_root,
             shell=True,

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -57,8 +57,12 @@ class CloudHypervisorTests(Tool):
         test_type: str,
         hypervisor: str,
         log_path: Path,
+        ref: str = "",
         skip: Optional[List[str]] = None,
     ) -> None:
+
+        if ref:
+            self.node.tools[Git].checkout(ref, self.repo_root)
 
         if skip is not None:
             skip_args = " ".join(map(lambda t: f"--skip {t}", skip))
@@ -114,8 +118,13 @@ class CloudHypervisorTests(Tool):
         environment: Environment,
         hypervisor: str,
         log_path: Path,
+        ref: str = "",
         skip: Optional[List[str]] = None,
     ) -> None:
+
+        if ref:
+            self.node.tools[Git].checkout(ref, self.repo_root)
+
         perf_metrics_tests = self._list_perf_metrics_tests(hypervisor=hypervisor)
         failed_testcases = []
 

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -241,6 +241,7 @@ class CloudHypervisorTests(Tool):
                 "started",
                 "ok",
                 "failed",
+                "ignored",
             ]:
                 continue
 
@@ -248,7 +249,12 @@ class CloudHypervisorTests(Tool):
                 started_tests.add(result["name"])
                 continue
 
-            status = TestStatus.PASSED if result["event"] == "ok" else TestStatus.FAILED
+            if result["event"] == "ok":
+                status = TestStatus.PASSED
+            elif result["event"] == "failed":
+                status = TestStatus.FAILED
+            elif result["event"] == "ignored":
+                status = TestStatus.SKIPPED
             results.append(
                 CloudHypervisorTestResult(
                     name=result["name"],

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -234,6 +234,10 @@ class CloudHypervisorTests(Tool):
         # { "type": "test", "event": "ok", "name": "integration::test_vfio" }
         lines = output.split("\n")
         for line in lines:
+            matches = re.findall(r"{.*}", line)
+            if not matches:
+                continue
+            line = matches[0]
             result = {}
             try:
                 result = json.loads(line)


### PR DESCRIPTION
* There might be failure scenarios where some tests are hung and their status is not reported. With this change, all the subtests are kept on track.
* Improve subtests results parsing
* Support running tests on a git ref