### PR TITLE
Skip WaAgentBvt on FreeBSD

### DIFF
--- a/microsoft/testsuites/vm_extensions/waagent.py
+++ b/microsoft/testsuites/vm_extensions/waagent.py
@@ -13,7 +13,9 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
+from lisa.operating_system import FreeBSD
 from lisa.sut_orchestrator.azure.features import AzureExtension
+from lisa.util import SkippedException
 
 
 @TestSuiteMetadata(
@@ -32,6 +34,11 @@ class WaAgentBvt(TestSuite):
         requirement=simple_requirement(supported_features=[AzureExtension]),
     )
     def verify_vm_agent(self, log: Logger, node: Node) -> None:
+        # Some of the most common extensions, including Custom Script, are
+        # not supported on FreeBSD so skip the test on that case.
+        if isinstance(node.os, FreeBSD):
+            raise SkippedException(f"unsupported distro type: {type(node.os)}")
+
         # Any extension will do, use CustomScript for convenience.
         # Use the extension to create a unique file on the test machine.
         unique_name = str(uuid.uuid4())


### PR DESCRIPTION
 Some of the most common extensions, including Custom Script, are currently not supported on FreeBSD so skip the test on that case.