### PR TITLE
Fix DNS test for some SUSE-based images

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -567,7 +567,8 @@ class Posix(OperatingSystem, BaseClassMixin):
         timeout = 60 * timeout
         timer = create_timer()
         while timeout > timer.elapsed(False):
-            cmd_result = self._node.execute(f"pidof {process_name}")
+            # Some SUSE-based images need sudo privilege to run below command
+            cmd_result = self._node.execute(f"pidof {process_name}", sudo=True)
             if cmd_result.exit_code == 1:
                 # not found dpkg or zypper process, it's ok to exit.
                 break

--- a/lisa/tools/ping.py
+++ b/lisa/tools/ping.py
@@ -13,8 +13,10 @@ INTERNET_PING_ADDRESS = "8.8.8.8"
 
 class Ping(Tool):
     # ping: SO_BINDTODEVICE: Operation not permitted
+    # ping: icmp open socket: Operation not permitted
+    # ping: socket: Operation not permitted
     _no_permission_pattern = re.compile(
-        r"ping: SO_BINDTODEVICE: Operation not permitted",
+        r"ping: .* Operation not permitted",
         re.M,
     )
 


### PR DESCRIPTION
1. Modify _no_permission_pattern of ping.py to suit more scenarios
2. Add sudo=True when running the command of "pidof ping" for SUSE-based images