### PR TITLE
Pylint: Enable eval-used

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -553,8 +553,7 @@ class Infiniband(AzureFeatureMixin, features.Infiniband):
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
 
-        value = raw_capabilities.get("RdmaEnabled", None)
-        if value and eval(value) is True:
+        if raw_capabilities.get("RdmaEnabled", None) == "True":
             return schema.FeatureSettings.create(cls.name())
 
         return None
@@ -1495,8 +1494,7 @@ class Hibernation(AzureFeatureMixin, features.Hibernation):
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
 
-        value = raw_capabilities.get("HibernationSupported", None)
-        if value and eval(value) is True:
+        if raw_capabilities.get("HibernationSupported", None) == "True":
             return schema.FeatureSettings.create(cls.name())
 
         return None
@@ -1552,8 +1550,11 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
             "standardMSv2Family",
         ]:
             # https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#how-can-i-find-vm-sizes-that-support-trusted-launch # noqa: E501
-            tvm_disable_value = raw_capabilities.get("TrustedLaunchDisabled", "False")
-            if gen_value and ("V2" in str(gen_value)) and (not eval(tvm_disable_value)):
+            if (
+                gen_value
+                and ("V2" in str(gen_value))
+                and raw_capabilities.get("TrustedLaunchDisabled", "False") == "False"
+            ):
                 capabilities.append(SecurityProfileType.SecureBoot)
         # https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview # noqa: E501
         if cvm_value and resource_sku.family in [

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1527,14 +1527,10 @@ class AzurePlatform(Platform):
             )
             node_space.network_interface.max_nic_count = sku_nic_count
 
-        premium_io_supported = azure_raw_capabilities.get("PremiumIO", None)
-        if premium_io_supported and eval(premium_io_supported) is True:
+        if azure_raw_capabilities.get("PremiumIO", None) == "True":
             node_space.disk.disk_type.add(schema.DiskType.PremiumSSDLRS)
 
-        ephemeral_supported = azure_raw_capabilities.get(
-            "EphemeralOSDiskSupported", None
-        )
-        if ephemeral_supported and eval(ephemeral_supported) is True:
+        if azure_raw_capabilities.get("EphemeralOSDiskSupported", None) == "True":
             # Check if CachedDiskBytes is greater than 30GB
             # We use diff disk as cache disk for ephemeral OS disk
             cached_disk_bytes = azure_raw_capabilities.get("CachedDiskBytes", 0)
@@ -1543,8 +1539,7 @@ class AzurePlatform(Platform):
                 node_space.disk.disk_type.add(schema.DiskType.Ephemeral)
 
         # set AN
-        an_enabled = azure_raw_capabilities.get("AcceleratedNetworkingEnabled", None)
-        if an_enabled and eval(an_enabled) is True:
+        if azure_raw_capabilities.get("AcceleratedNetworkingEnabled", None) == "True":
             # refer
             # https://docs.microsoft.com/en-us/azure/virtual-machines/dcv2-series#configuration
             # https://docs.microsoft.com/en-us/azure/virtual-machines/ncv2-series

--- a/pylintrc
+++ b/pylintrc
@@ -32,7 +32,6 @@ disable=
     abstract-method,
     broad-except,
     cyclic-import,
-    eval-used,
     expression-not-assigned,
     inconsistent-return-statements,
     keyword-arg-before-vararg,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "randmac ~= 0.1",
     "retry ~= 0.9.2",
     "semver ~= 2.13.0",
+    "simpleeval ~= 0.9.12",
     "spurplus ~= 2.3.4",
     "websockets ~= 10.3",
 ]


### PR DESCRIPTION
`eval()` allows arbitrary code execution and should be avoided. This adds a Pylint check and removed cases where is was used. Most of those were simple changes, but `ScriptTransformer` required restricting what user input can do. simpleeval was used as it's close to the implementation of a mini-language without effort of creating one.