### PR TITLE
Pylint: Enable modified-iterating-list

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -34,7 +34,6 @@ disable=
     cyclic-import,
     expression-not-assigned,
     keyword-arg-before-vararg,
-    modified-iterating-list,
     no-member,
     redefined-argument-from-local,
     redefined-outer-name,


### PR DESCRIPTION
Modifying an iterator while iterating over it can have unexpected behavior.
Enables modified-iterating-list check and fixes code.
