### PR TITLE
Pylint: Enable pointless statement checks

### DIFF
--- a/examples/testsuites/helloworld.py
+++ b/examples/testsuites/helloworld.py
@@ -64,8 +64,7 @@ class HelloWorld(TestSuite):
         priority=1,
     )
     def bye(self, node: Node) -> None:
-        # use it once like this way before use short cut
-        node.tools[Echo]
+        node.tools.get(Echo)  # Ensure echo is in cache
         assert_that(str(node.tools.echo("bye!"))).is_equal_to("bye!")
 
     def before_suite(self, log: Logger, **kwargs: Any) -> None:

--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -220,8 +220,8 @@ class Tool(InitializableMixin):
         # check dependencies
         if self.dependencies:
             self._log.info("installing dependencies")
-        for dependency in self.dependencies:
-            self.node.tools[dependency]
+            map(self.node.tools.get, self.dependencies)
+
         return self._install()
 
     def run_async(
@@ -560,7 +560,7 @@ class Tools:
 
     def get(
         self,
-        tool_type: Union[Type[T], CustomScriptBuilder, str],
+        tool_type: Union[Type[T], Type[Tool], CustomScriptBuilder, str],
         *args: Any,
         **kwargs: Any,
     ) -> T:

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1,6 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+"""
+Schema is dealt with three components,
+1. dataclasses. It's a builtin class, uses to define schema of an instance. field()
+   function uses to describe a field.
+2. dataclasses_json. Serializer. config() function customizes this component.
+3. marshmallow. Validator. It's wrapped by dataclasses_json. config(mm_field=xxx)
+   function customizes this component.
+"""
+
 import copy
 from dataclasses import dataclass, field
 from enum import Enum
@@ -27,16 +36,6 @@ from lisa.util import (
     field_metadata,
     strip_strs,
 )
-
-"""
-Schema is dealt with three components,
-1. dataclasses. It's a builtin class, uses to define schema of an instance. field()
-   function uses to describe a field.
-2. dataclasses_json. Serializer. config() function customizes this component.
-3. marshmallow. Validator. It's wrapped by dataclasses_json. config(mm_field=xxx)
-   function customizes this component.
-"""
-
 
 T = TypeVar("T")
 

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -102,7 +102,7 @@ class Kexec(Tool):
             tool_path, name_pattern="kexec-tools*", file_type="d"
         )
         code_path = tool_path.joinpath(kexec_source_folder[0])
-        self.node.tools[Gcc]
+        self.node.tools.get(Gcc)  # Ensure gcc is installed
         make = self.node.tools[Make]
         self.node.execute(
             "./configure",

--- a/lisa/tools/lsvmbus.py
+++ b/lisa/tools/lsvmbus.py
@@ -130,7 +130,7 @@ class Lsvmbus(Tool):
         cmd_result = self.node.execute("which python", sudo=True)
         if 0 != cmd_result.exit_code:
             ln = self.node.tools[Ln]
-            self.node.tools[Python]
+            self.node.tools.get(Python)
             ln.create_link("/bin/python3", "/usr/bin/python")
 
     def _check_exists(self) -> bool:

--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -80,7 +80,7 @@ class StressNg(Tool):
         tool_path = self.get_tool_path()
         git = self.node.tools[Git]
         git.clone(self.repo, tool_path, ref=self.branch)
-        self.node.tools[Gcc]
+        self.node.tools.get(Gcc)  # Ensure gcc is installed
         make = self.node.tools[Make]
         code_path = tool_path.joinpath("stress-ng")
         make.make_install(cwd=code_path)

--- a/lisa/tools/vdsotest.py
+++ b/lisa/tools/vdsotest.py
@@ -66,7 +66,7 @@ class Vdsotest(Tool):
         tool_path = self.get_tool_path()
         git = self.node.tools[Git]
         git.clone(self.repo, tool_path, ref=self.branch)
-        self.node.tools[Gcc]
+        self.node.tools.get(Gcc)
         make = self.node.tools[Make]
         code_path = tool_path.joinpath("vdsotest")
         self.node.execute("./autogen.sh", cwd=code_path).assert_exit_code()

--- a/lisa/util/package.py
+++ b/lisa/util/package.py
@@ -1,14 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import importlib
-import importlib.util
-import sys
-from pathlib import Path
-from typing import Iterable, Optional
-
-from lisa.util.logger import Logger, get_logger
-
 """
 Reasons to import packages in LISA:
 
@@ -23,6 +15,14 @@ Steps,
 2. Go through all files, and check if it exists in sys.modules. If it's not, import it.
 
 """
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+from lisa.util.logger import Logger, get_logger
 
 
 def _import_module(

--- a/microsoft/testsuites/acc/bvt.py
+++ b/microsoft/testsuites/acc/bvt.py
@@ -148,10 +148,10 @@ class ACCBasicTest(TestSuite):
         # <cp -r /opt/openenclave/share/openenclave/samples ~/mysamples>
 
         samples_folder = node.get_working_path() / "mysamples"
-        copy_cmd = "cp -r /opt/openenclave/share/openenclave/samples " + str(
-            samples_folder
+        node.execute(
+            f"cp -r /opt/openenclave/share/openenclave/samples {samples_folder}",
+            shell=True,
         )
-        node.execute(copy_cmd, shell=True)
 
         # Run Hello World and Remote Attestation
         helloworld_dir = samples_folder / "helloworld"
@@ -159,7 +159,7 @@ class ACCBasicTest(TestSuite):
         source_command = ". /opt/openenclave/share/openenclave/openenclaverc"
         fail_msg = "HELLO WORLD TEST FAILED"
 
-        node.tools[Make]
+        node.tools.get(Make)  # Ensure make is installed
         result = node.execute(
             f"{source_command} && make build && make run",
             cwd=helloworld_dir,

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -224,7 +224,7 @@ class HvModule(TestSuite):
         if isinstance(node.os, Redhat):
             try:
                 log.debug("Checking LIS installation before reload.")
-                node.tools[LisDriver]
+                node.tools.get(LisDriver)
             except Exception:
                 log.debug("Updating LIS failed. Moving on to attempt reload.")
 

--- a/microsoft/testsuites/network/sriov.py
+++ b/microsoft/testsuites/network/sriov.py
@@ -691,10 +691,10 @@ class Sriov(TestSuite):
                 ):
                     matched_server_nic_info = server_nic_info
                     break
-            assert (
-                matched_server_nic_info
-            ), "not found the server nic has the same subnet of"
-            f" {client_nic_info.ip_addr}"
+            assert matched_server_nic_info, (
+                "not found the server nic has the same subnet of"
+                f" {client_nic_info.ip_addr}"
+            )
 
             # 3. Start iperf3 for 120 seconds with 128 threads on client node.
             client_iperf3.run_as_client(

--- a/pylintrc
+++ b/pylintrc
@@ -43,8 +43,6 @@ disable=
     missing-timeout,
     modified-iterating-list,
     no-member,
-    pointless-statement,
-    pointless-string-statement,
     redefined-argument-from-local,
     redefined-outer-name,
     super-init-not-called,


### PR DESCRIPTION
Pointless statements are code identified by the linter as having no effect, for example lookup a variable without using it. There can be false positives, especially when look-ups are used for cache-priming, but these checks are particularly good for finding cases where some syntax is technically valid, but unexpected.