### PR TITLE
fix: VM Resize with StopStart

### DIFF
--- a/microsoft/testsuites/core/vm_resize.py
+++ b/microsoft/testsuites/core/vm_resize.py
@@ -154,9 +154,10 @@ class VmResize(TestSuite):
                 else:
                     raise identifier
                 time.sleep(1)
+            finally:
+                if not hot_resize:
+                    start_stop.start()
         assert expected_vm_capability, "fail to find proper vm size"
-        if not hot_resize:
-            start_stop.start()
 
         test_result.information["final_vm_size"] = final_vm_size
         test_result.information["origin_vm_size"] = origin_vm_size


### PR DESCRIPTION
VM Resize testcase with StopStart leaves VM in Stop state if Resize raises an exception.
This PR is to Start VM before raising an exception