### PR TITLE
Add handling for the blob copy pending scenario

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -10,7 +10,7 @@ import re
 import sys
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from functools import lru_cache, partial
 from pathlib import Path
@@ -189,6 +189,10 @@ STORAGE_CONTAINER_BLOB_PATTERN = re.compile(
     r"/(?P<container>[^/]+)/?/(?P<blob>.*)",
     re.M,
 )
+
+# The timeout hours of the blob with copy pending status
+# If the blob is still copy pending status after the timeout hours, it can be deleted
+BLOB_COPY_PENDING_TIMEOUT_HOURS = 6
 _global_sas_vhd_copy_lock = Lock()
 
 
@@ -1983,26 +1987,50 @@ class AzurePlatform(Platform):
         cached_key: Optional[bytearray] = None
         with _global_sas_vhd_copy_lock:
             blobs = container_client.list_blobs(name_starts_with=vhd_path)
+            blob_client = container_client.get_blob_client(vhd_path)
+            vhd_exists = False
             for blob in blobs:
                 if blob:
                     # check if hash key matched with original key.
                     if blob.content_settings:
                         cached_key = blob.content_settings.get("content_md5", None)
-                    if original_key == cached_key:
-                        # if it exists, return the link, not to copy again.
+                    if self._is_stuck_copying(blob_client, log):
+                        # Delete the stuck vhd.
+                        blob_client.delete_blob(delete_snapshots="include")
+                    elif original_key == cached_key:
+                        # If it exists, return the link, not to copy again.
                         log.debug("the sas url is copied already, use it directly.")
-                        return full_vhd_path
+                        vhd_exists = True
                     else:
                         log.debug("found cached vhd, but the hash key mismatched.")
 
-            blob_client = container_client.get_blob_client(vhd_path)
-            blob_client.start_copy_from_url(
-                original_vhd_path, metadata=None, incremental_copy=False
-            )
+            if not vhd_exists:
+                blob_client.start_copy_from_url(
+                    original_vhd_path, metadata=None, incremental_copy=False
+                )
 
             wait_copy_blob(blob_client, vhd_path, log)
 
         return full_vhd_path
+
+    def _is_stuck_copying(self, blob_client: BlobClient, log: Logger) -> bool:
+        props = blob_client.get_blob_properties()
+        copy_status = props.copy.status
+        if copy_status == "pending":
+            if props.creation_time:
+                delta_hours = (
+                    datetime.now(timezone.utc) - props.creation_time
+                ).seconds / (60 * 60)
+            else:
+                delta_hours = 0
+
+            if delta_hours > BLOB_COPY_PENDING_TIMEOUT_HOURS:
+                log.debug(
+                    "the blob is pending more than "
+                    f"{BLOB_COPY_PENDING_TIMEOUT_HOURS} hours."
+                )
+                return True
+        return False
 
     def _get_vhd_details(self, vhd_path: str) -> Any:
         matched = STORAGE_CONTAINER_BLOB_PATTERN.match(vhd_path)


### PR DESCRIPTION
There is a scenario that two processes are copying the same VHD. It needs to check the copy status if the blob exists. If the status is success, then the copied vhd can be directly used, if not, then need to wait for the copy to complete. 