### PR TITLE
[fix issue] add retry to wait for waagent restart to bring on ib device

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from assertpy import assert_that
+from retry import retry
 
 from lisa.base_tools import Cat, Sed, Service, Uname, Wget
 from lisa.feature import Feature
@@ -80,6 +81,7 @@ class Infiniband(Feature):
         device_list = lspci.get_devices()
         return any("ConnectX-3" in device.device_info for device in device_list)
 
+    @retry(tries=10, delay=5)
     def get_ib_interfaces(self) -> List[IBDevice]:
         """Gets the list of Infiniband devices
         excluding any ethernet devices


### PR DESCRIPTION
Fix issue `failed. AssertionError: [NIC ibX does not have an ip address.] Expected not empty string, but was empty.`