### PR TITLE
Add worklow to update CI dependencies

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -1,0 +1,62 @@
+name: Update Dependencies
+
+on:
+  schedule:
+    # Every Monday at 1 AM
+    - cron: '0 1 * * 1'
+
+jobs:
+  Update_Deps:
+
+    runs-on: ubuntu-latest
+    name: ${{ matrix.name || matrix.args }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        args: [docs, flake8, mypy, pylint]
+
+        # Uncomment to enable base dependency checking
+        # include:
+
+        # - args: '-b'
+        #   name: Base Dependencies
+
+    env:
+      DEPS_UPDATED: false
+      GH_TOKEN: ${{ github.token }}
+      PR_BRANCH: bumpdeps/${{ join(matrix.args, '_') }}_${{ github.run_id }}
+      PR_MSG: "BumpDeps: ${{ matrix.name || matrix.args }}"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install latest Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Install bumpdeps
+        run: pip install bumpdeps
+
+      - name: Setup Git
+        run: |
+          set -x
+          git config --global user.name "BumpDeps"
+          git config --global user.email "<>"
+          git checkout -b $PR_BRANCH
+
+      - name: Update deps
+        run: |
+          set -x
+          bumpdeps ${{ matrix.args }}
+          git diff --quiet || echo "DEPS_UPDATED=true" >> $GITHUB_ENV
+
+      - name: Create PR
+        run: |
+          set -x
+          git commit -a -m "$PR_MSG"
+          git --no-pager log -n 2
+          git push -u origin $PR_BRANCH
+          gh pr create -B main -H $PR_BRANCH --title "$PR_MSG" --body "Created by Github Action"
+        if: env.DEPS_UPDATED == 'true'

--- a/noxfile.py
+++ b/noxfile.py
@@ -100,8 +100,8 @@ def pylint(session: nox.Session) -> None:
         *OPTIONAL_DEPENDENCIES["aws"],
         *OPTIONAL_DEPENDENCIES["azure"],
         *OPTIONAL_DEPENDENCIES["libvirt"],
+        *OPTIONAL_DEPENDENCIES["pylint"],
         *OPTIONAL_DEPENDENCIES["typing"],
-        "pylint",
     )
     session.run(
         "pylint",
@@ -124,9 +124,9 @@ def mypy(session: nox.Session) -> None:
     session.install(
         *DEPENDENCIES,
         *OPTIONAL_DEPENDENCIES["azure"],
+        *OPTIONAL_DEPENDENCIES["mypy"],
         *OPTIONAL_DEPENDENCIES["typing"],
         *NOX_DEPENDENCIES,
-        "mypy == 0.942",
     )
 
     session.run("mypy", "-p", "lisa")
@@ -219,11 +219,11 @@ def dev(session: nox.Session) -> None:
         "-m",
         "pip",
         "install",
-        "mypy",
         "black",
         "isort",
-        "pylint",
         *OPTIONAL_DEPENDENCIES["flake8"],
+        *OPTIONAL_DEPENDENCIES["mypy"],
+        *OPTIONAL_DEPENDENCIES["pylint"],
         *OPTIONAL_DEPENDENCIES["typing"],
         *NOX_DEPENDENCIES,
         external=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ libvirt = [
     "pycdlib ~= 1.12.0; platform_system != 'Windows'",
 ]
 
+mypy = [
+    "mypy == 0.942",
+]
+
+pylint = [
+    "pylint ~= 2.15.10"
+]
+
 test = [
 ]
 


### PR DESCRIPTION
Pins tools used in CI workflow and creates a new workflow, scheduled to run weekly, which creates a PR when a newer version of a dependency is available.

[Example of workflow](https://github.com/avylove/lisa/actions/runs/3951949608)
Examples of generated PRs: [flake8](https://github.com/avylove/lisa/pull/4), [mypy](https://github.com/avylove/lisa/pull/5)

This PR also adds the capability to generate PRs for base dependencies and other extras (optional dependency groups), but that has not been enabled. The plan is to update CI tools first and then enable for LISA dependencies later.