### PR TITLE
Pylint: Enable some import checks

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from assertpy import assert_that
 from retry import retry
 
-import lisa.util.constants as constants
 from lisa.tools import Echo, Ip, Lspci
-from lisa.util import InitializableMixin, LisaException, find_groups_in_lines
+from lisa.util import InitializableMixin, LisaException, constants, find_groups_in_lines
 
 if TYPE_CHECKING:
     from lisa import Node

--- a/lisa/variable.py
+++ b/lisa/variable.py
@@ -4,7 +4,6 @@
 import os
 import re
 from dataclasses import dataclass
-from distutils.util import strtobool
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
@@ -54,14 +53,13 @@ def _try_convert_type(original_value: Any, new_value: Any) -> Any:
     if original_type == new_type:
         return new_value
 
-    if new_type is not str:
-        target_type = new_type
-    else:
-        target_type = original_type
-
+    target_type = new_type if new_type is not str else original_type
     try:
         if target_type is bool:
-            new_value = bool(strtobool(new_value))
+            if new_value.lower() in ("y", "yes", "t", "true", "on", "1"):
+                new_value = True
+            elif new_value.lower() in ("n", "no", "f", "false", "off", "0"):
+                new_value = False
         else:
             new_value = target_type(new_value)
     except Exception:

--- a/pylintrc
+++ b/pylintrc
@@ -24,8 +24,6 @@ disable=
     missing-module-docstring,
 
     # Imports
-    consider-using-from-import,
-    deprecated-module,
     import-outside-toplevel,
     unused-import,
     wrong-import-position,


### PR DESCRIPTION
Enables consider-using-from-import and deprecated-module checks
consider-using-from-import check for things like import `lisa.util.constants as constants`
The deprecated-module check found one use of distutils which was deprecated in 3.10 and will be removed in 3.12. The only use is a simple function, so I added equivalent logic instead.
