### PR TITLE
Allow CI tests for BumpDep PRs

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -24,12 +24,13 @@ jobs:
 
     env:
       DEPS_UPDATED: false
-      GH_TOKEN: ${{ github.token }}
       PR_BRANCH: bumpdeps/${{ join(matrix.args, '_') }}_${{ github.run_id }}
       PR_MSG: "BumpDeps: ${{ matrix.name || matrix.args }}"
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.PR_DEPLOY_PRIVATE_KEY }}
 
       - name: Install latest Python
         uses: actions/setup-python@v4
@@ -53,6 +54,8 @@ jobs:
           git diff --quiet || echo "DEPS_UPDATED=true" >> $GITHUB_ENV
 
       - name: Create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -x
           git commit -a -m "$PR_MSG"


### PR DESCRIPTION
Use deploy key SSH credentials to create PR instead of default credentials.

When using the default github-action credential, CI workflows are not triggered on PRs in order to avoid recursive workflows. Using a deploy key works around this limitation.

This was one of several options considered, but the only one we could implement given our desired behavior and the limitations of being in the Microsoft GitHub organization. More details can be found [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs).

[Example of generated PR](https://github.com/microsoft/lisa/pull/2551)

I will close the exist flake8 PRs so we can confirm the expected behavior when the workflow runs automatically on Sunday.