### PR TITLE
Add Tool Install testcase

### DIFF
--- a/microsoft/testsuites/adhoc/tool_install.py
+++ b/microsoft/testsuites/adhoc/tool_install.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List, Union
+
+from lisa import (
+    Logger,
+    RemoteNode,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    tools,
+)
+from lisa.executable import Tool
+from lisa.util import LisaException, SkippedException
+
+
+@TestSuiteMetadata(
+    area="adhoc",
+    category="functional",
+    description="""
+    This test suite includes adhoc tests
+    """,
+)
+class Adhoc(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        This test case will install the tools
+        passed as parameter 'install_tools'
+        """,
+        priority=5,
+    )
+    def tool_install(
+        self, log: Logger, node: RemoteNode, variables: Dict[str, Any]
+    ) -> None:
+        tool_name_parameter = "install_tools"
+        tool_names: List[str] = variables.get(tool_name_parameter, [])
+        if not tool_names:
+            raise SkippedException(f"{tool_name_parameter} is empty")
+        if type(tool_names) != list:
+            raise LisaException(f"{tool_name_parameter} parameter should be List[str]")
+        #  Create mapping from lowercase tool name to actual tool name
+        defined_tool_mapping: Dict[str, str] = {
+            tool.lower(): tool for tool in tools.__all__
+        }
+        for input_tool_name in tool_names:
+            tool_name = defined_tool_mapping.get(input_tool_name.lower())
+            if not tool_name:
+                raise LisaException(f"{input_tool_name} is not a valid tool")
+            tool: Union[None, Tool] = getattr(tools, tool_name)
+            node.tools[tool]  # type: ignore # pylint: disable=W0104

--- a/microsoft/testsuites/utility/tool_install.py
+++ b/microsoft/testsuites/utility/tool_install.py
@@ -13,27 +13,30 @@ from lisa.util import LisaException, SkippedException
 
 
 @TestSuiteMetadata(
-    area="adhoc",
+    area="utility",
     category="functional",
     description="""
-    This test suite includes adhoc tests
+    This suite includes utility test cases and not validations.
     """,
 )
-class Adhoc(TestSuite):
+class Utilities(TestSuite):
     @TestCaseMetadata(
         description="""
         This test case will install the tools
-        passed as parameter 'install_tools'
+        passed as parameter 'case_tool_install'
         """,
         priority=5,
     )
-    def tool_install(
+    def execute_tools_install(
         self, log: Logger, node: RemoteNode, variables: Dict[str, Any]
     ) -> None:
-        tool_name_parameter = "install_tools"
+        tool_name_parameter = "case_tool_install"
         tool_names: List[str] = variables.get(tool_name_parameter, [])
         if not tool_names:
-            raise SkippedException(f"{tool_name_parameter} is empty")
+            raise SkippedException(
+                f"{tool_name_parameter} is empty."
+                f"This test case is not a validation. It is used to deploy tools."
+            )
         if type(tool_names) != list:
             raise LisaException(f"{tool_name_parameter} parameter should be List[str]")
         #  Create mapping from lowercase tool name to actual tool name
@@ -45,4 +48,7 @@ class Adhoc(TestSuite):
             if not tool_name:
                 raise LisaException(f"{input_tool_name} is not a valid tool")
             tool: Union[None, Tool] = getattr(tools, tool_name)
-            node.tools[tool]  # type: ignore # pylint: disable=W0104
+            if tool:
+                node.tools.get(tool)  # type: ignore
+            else:
+                raise LisaException(f"Error fetching tool {input_tool_name}")


### PR DESCRIPTION
Add test case tool_install to install tool by
passing tool names in parameter 'install_tools'

This can be used to create repro environments by installing the 
tools and manually executing the commands