### PR TITLE
Pylint: Enable global-variable-not-assigned

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -66,7 +66,6 @@ def _get_environment_id() -> int:
     """
     Return an unique id crossing threads, runners.
     """
-    global _global_environment_id_lock
     global _global_environment_id
 
     with _global_environment_id_lock:

--- a/lisa/main.py
+++ b/lisa/main.py
@@ -31,8 +31,6 @@ _runtime_root = Path("runtime").absolute()
 
 
 def _normalize_path(path_type: str, path: Optional[Path] = None) -> Path:
-    global _runtime_root
-
     # Layout the run time folder structure.
     if path:
         # if log path is relative path, join with root.
@@ -89,8 +87,6 @@ def initialize_runtime_folder(
     working_path: Optional[Path] = None,
     run_id: str = "",
 ) -> None:
-    global _runtime_root
-
     cache_path = _runtime_root.joinpath("cache")
     cache_path.mkdir(parents=True, exist_ok=True)
     constants.CACHE_PATH = cache_path

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1023,7 +1023,6 @@ def check_or_create_resource_group(
     log: Logger,
 ) -> None:
     with get_resource_management_client(credential, subscription_id) as rm_client:
-        global global_credential_access_lock
         with global_credential_access_lock:
             az_shared_rg_exists = rm_client.resource_groups.check_existence(
                 resource_group_name

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1905,7 +1905,6 @@ class AzurePlatform(Platform):
         full_vhd_path = f"{container_client.url}/{vhd_path}"
 
         # lock here to prevent a vhd is copied in multi-thread
-        global _global_sas_vhd_copy_lock
         cached_key: Optional[bytearray] = None
         with _global_sas_vhd_copy_lock:
             blobs = container_client.list_blobs(name_starts_with=vhd_path)

--- a/pylintrc
+++ b/pylintrc
@@ -34,7 +34,6 @@ disable=
     cyclic-import,
     eval-used,
     expression-not-assigned,
-    global-variable-not-assigned,
     inconsistent-return-statements,
     invalid-overridden-method,
     keyword-arg-before-vararg,


### PR DESCRIPTION
Enables global-variable-not-assigned not assigned check. This protects against a global variable can be unintentionally changed in the future. It fails when the `global` keyword is used, but the variable is not assigned.
