### PR TITLE
Pylint: Enable inconsistent-return-statements

### DIFF
--- a/lisa/util/logger.py
+++ b/lisa/util/logger.py
@@ -162,7 +162,7 @@ def add_handler(
     formatter: Optional[logging.Formatter] = None,
 ) -> None:
     if is_unittest():
-        return None
+        return
 
     if logger is None:
         logger = _get_root_logger()
@@ -178,7 +178,7 @@ def remove_handler(
     log_handler: logging.Handler, logger: Optional[logging.Logger] = None
 ) -> None:
     if is_unittest():
-        return None
+        return
 
     if logger is None:
         logger = _get_root_logger()

--- a/pylintrc
+++ b/pylintrc
@@ -34,7 +34,6 @@ disable=
     cyclic-import,
     eval-used,
     expression-not-assigned,
-    inconsistent-return-statements,
     keyword-arg-before-vararg,
     modified-iterating-list,
     no-member,


### PR DESCRIPTION
Enables inconsistent-return-statements check. This checks to make sure if there is one explicit return value, there are no places where there is an implicit return value. This is a common source of bugs.

There were only two cases found. They were both were cases where an explicit `None` was returned when an implicit `None` should be returned.