### PR TITLE
Pylint: Enable invalid-overridden-method

### DIFF
--- a/lisa/tools/bzip2.py
+++ b/lisa/tools/bzip2.py
@@ -9,6 +9,7 @@ class Bzip2(Tool):
     def command(self) -> str:
         return "bzip2"
 
+    @property
     def can_install(self) -> bool:
         return True
 

--- a/pylintrc
+++ b/pylintrc
@@ -36,7 +36,6 @@ disable=
     expression-not-assigned,
     global-variable-not-assigned,
     inconsistent-return-statements,
-    invalid-overridden-method,
     keyword-arg-before-vararg,
     missing-timeout,
     modified-iterating-list,


### PR DESCRIPTION
Enables invalid-overridden-method check. This verifies methods overwritten in subclasses have matching definitions to their parents.