### PR TITLE
Support concurrency in qemu/ch platforms

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -73,10 +73,11 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         log: Logger,
     ) -> None:
         if node_context.firmware_source_path:
-            self.host_node.shell.copy(
-                Path(node_context.firmware_source_path),
-                Path(node_context.firmware_path),
-            )
+            with self._host_node_lock:
+                self.host_node.shell.copy(
+                    Path(node_context.firmware_source_path),
+                    Path(node_context.firmware_path),
+                )
 
         super()._create_node(
             node,


### PR DESCRIPTION
* Changed locks and port forwarding variables to static so that there is consistency when concurrency is used or with multiple lisa runners.
* Using lock to to perform certain host_node.<operation> atomically