### PR TITLE
Libvirt: Support concurrency in ch/qemu platforms

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -195,11 +195,11 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
         if self.host_node.is_remote:
             self._stop_port_forwarding(environment, log)
 
-        self._capture_libvirt_logs()
-
     def _cleanup(self) -> None:
         if self.platform_runbook.capture_libvirt_debug_logs:
             self._disable_libvirt_debug_log()
+
+        self._capture_libvirt_logs()
 
         if self.host_node.is_remote:
             dmesg_output = self.host_node.tools[Dmesg].get_output(force_run=True)

--- a/lisa/sut_orchestrator/libvirt/qemu_platform.py
+++ b/lisa/sut_orchestrator/libvirt/qemu_platform.py
@@ -39,19 +39,19 @@ class QemuPlatform(BaseLibvirtPlatform):
         self, environment: Environment, log: Logger, node: Node
     ) -> None:
         node_context = get_node_context(node)
-        self.host_node.tools[QemuImg].create_diff_qcow2(
-            node_context.os_disk_file_path, node_context.os_disk_base_file_path
-        )
+        with self.host_node_object.lock() as host_node:
+            host_node.tools[QemuImg].create_diff_qcow2(
+                node_context.os_disk_file_path, node_context.os_disk_base_file_path
+            )
 
-    def _get_vmm_version(self) -> str:
+    def _get_vmm_version(self, host_node: Node) -> str:
         result = "Unknown"
-        if self.host_node:
-            output = self.host_node.execute(
-                "qemu-system-x86_64 --version",
-                shell=True,
-            ).stdout
-            output = filter_ansi_escape(output)
-            match = re.search(QEMU_VERSION_PATTERN, output.strip())
-            if match:
-                result = match.group("qemu_version")
+        output = host_node.execute(
+            "qemu-system-x86_64 --version",
+            shell=True,
+        ).stdout
+        output = filter_ansi_escape(output)
+        match = re.search(QEMU_VERSION_PATTERN, output.strip())
+        if match:
+            result = match.group("qemu_version")
         return result

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -5,14 +5,18 @@ import random
 import re
 import string
 import sys
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 from time import sleep
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Generator,
+    Generic,
     Iterable,
     List,
     Optional,
@@ -350,6 +354,29 @@ class SwitchableMixin:
 
     def enable(self) -> None:
         self._switch(True)
+
+
+class MutexObject(Generic[T]):
+    """
+    This is a wrapper class which can be used to perform actions of any objects in
+    atomic manner. This is helpful in synchronization when a single object is shared
+    with multiple threads.
+    For example,
+        obj = MutexObject(someObject)
+        with obj.lock() as mutexobj:
+            mutexobj.method()
+
+    This is same as doing someObject.method() atomically.
+    """
+
+    def __init__(self, obj: T) -> None:
+        self.__object: T = obj
+        self.__lock: Lock = Lock()
+
+    @contextmanager
+    def lock(self) -> Generator[T, None, None]:
+        with self.__lock:
+            yield self.__object
 
 
 def get_date_str(current: Optional[datetime] = None) -> str:


### PR DESCRIPTION
Introduced a new convention of using host_node.operations for atomicity as concurrnecy and combinators deal with multiple instances threads and instances of Platform.