### PR TITLE
Change in GPU CUDA driver installation

### DIFF
--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -307,6 +307,13 @@ class Gpu(Feature):
         if isinstance(self._node.os, Redhat):
             self._node.os.install_epel()
             self._node.os.install_packages(self._redhat_gpu_dependencies, signed=False)
+            release = self._node.os.information.release.split(".")[0]
+            if release == "7":
+                # vulkan-filesystem is required by CUDA in CentOS 7.x
+                self._node.os._install_package_from_url(
+                    "http://mirror.centos.org/centos/7/os/x86_64/Packages/vulkan-filesystem-1.1.97.0-1.el7.noarch.rpm"
+                )
+
         elif isinstance(self._node.os, Ubuntu):
             self._node.os.install_packages(self._ubuntu_gpu_dependencies, timeout=2000)
         else:

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -221,18 +221,23 @@ class Gpu(Feature):
 
         if isinstance(self._node.os, Redhat):
             release = os_information.release.split(".")[0]
-            cuda_repo_pkg = f"cuda-repo-rhel{release}-{version}.x86_64.rpm"
-            cuda_repo = (
-                "http://developer.download.nvidia.com/"
-                f"compute/cuda/repos/rhel{release}/x86_64/{cuda_repo_pkg}"
-            )
-            try:
-                # download and install the cuda driver package from the repo
-                self._node.os._install_package_from_url(
-                    f"{cuda_repo}", package_name="cuda-drivers.rpm", signed=False
+            if release == "9":
+                self._node.os.add_repository(
+                    "http://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo"
                 )
-            except Exception as e:
-                raise LisaException(f"Failed to install driver from source, {str(e)}")
+            else:
+                cuda_repo_pkg = f"cuda-repo-rhel{release}-{version}.x86_64.rpm"
+                cuda_repo = (
+                    "http://developer.download.nvidia.com/"
+                    f"compute/cuda/repos/rhel{release}/x86_64/{cuda_repo_pkg}"
+                )
+                try:
+                    # download and install the cuda driver package from the repo
+                    self._node.os._install_package_from_url(cuda_repo)
+                except Exception as e:
+                    raise LisaException(
+                        f"Failed to install driver from source, {str(e)}"
+                    )
             self._node.os.install_packages("cuda-drivers", signed=False)
 
         elif isinstance(self._node.os, Ubuntu):
@@ -294,7 +299,7 @@ class Gpu(Feature):
                 self._node.os.install_packages("cuda-drivers-515")
         else:
             raise LisaException(
-                f"Distro {self._node.os.name}" "not supported to install CUDA driver."
+                f"Distro {self._node.os.name} not supported to install CUDA driver."
             )
 
     def _install_gpu_dep(self) -> None:

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -223,7 +223,8 @@ class Gpu(Feature):
             release = os_information.release.split(".")[0]
             if release == "9":
                 self._node.os.add_repository(
-                    "http://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo"
+                    "http://developer.download.nvidia.com/compute/cuda/"
+                    "repos/rhel9/x86_64/cuda-rhel9.repo"
                 )
             else:
                 cuda_repo_pkg = f"cuda-repo-rhel{release}-{version}.x86_64.rpm"
@@ -311,7 +312,8 @@ class Gpu(Feature):
             if release == "7":
                 # vulkan-filesystem is required by CUDA in CentOS 7.x
                 self._node.os._install_package_from_url(
-                    "http://mirror.centos.org/centos/7/os/x86_64/Packages/vulkan-filesystem-1.1.97.0-1.el7.noarch.rpm"
+                    "http://mirror.centos.org/centos/7/os/x86_64/Packages/"
+                    "vulkan-filesystem-1.1.97.0-1.el7.noarch.rpm"
                 )
 
         elif isinstance(self._node.os, Ubuntu):

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -25,7 +25,7 @@ FEATURE_NAME_GPU = "Gpu"
 @dataclass()
 class GpuSettings(schema.FeatureSettings):
     type: str = FEATURE_NAME_GPU
-    install_by_platform: bool = True
+    install_by_platform: bool = False
     is_enabled: bool = False
 
     def __hash__(self) -> int:
@@ -187,6 +187,9 @@ class Gpu(Feature):
 
     @classmethod
     def _install_by_platform(cls, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError()
+
+    def _install_driver_using_platform_feature(self) -> None:
         raise NotImplementedError()
 
     # download and install NVIDIA grid driver

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -240,6 +240,9 @@ class Gpu(Feature):
             # there is no ubuntu2110 and ubuntu2104 folder under nvidia site
             if release in ["2110", "2104"]:
                 release = "2004"
+            # 2210 NVIDIA Drivers are not available, use 2204
+            if release in ["2210"]:
+                release = "2204"
 
             # Public CUDA GPG key is needed to be installed for Ubuntu
             self._node.tools[Wget].get(

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -67,7 +67,7 @@ class Gpu(Feature):
         "libelf-dev",
         "linux-tools-$(uname -r)",
         "linux-cloud-tools-$(uname -r)",
-        "python",
+        "python3",
         "libglvnd-dev",
         "ubuntu-desktop",
     ]
@@ -138,7 +138,10 @@ class Gpu(Feature):
             elif driver == ComputeSDK.CUDA:
                 if not version:
                     version = DEFAULT_CUDA_DRIVER_VERSION
-                    self._install_cuda_driver(version)
+                    try:
+                        self._install_cuda_driver(version)
+                    except Exception as e:
+                        raise LisaException(f"Failed to install CUDA Driver {str(e)}")
                     self.gpu_vendor.add("nvidia")
             else:
                 raise LisaException(f"{driver} is not a valid value of ComputeSDK")
@@ -231,6 +234,7 @@ class Gpu(Feature):
                 release = "2004"
 
             # Public CUDA GPG key is needed to be installed for Ubuntu
+            self._node.execute("apt-get install cuda-keyring", shell=True, sudo=True)
             self._node.execute(
                 "apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/"
                 f"cuda/repos/ubuntu{release}/x86_64/7fa2af80.pub",
@@ -273,8 +277,7 @@ class Gpu(Feature):
                 # dmesg
                 # NVRM: GPU 0001:00:00.0: RmInitAdapter failed! (0x63:0x55:2344)
                 # NVRM: GPU 0001:00:00.0: rm_init_adapter failed, device minor number 0
-                #  switch to use 495
-                self._node.os.install_packages("cuda-drivers-495")
+                self._node.os.install_packages("cuda-drivers-515")
         else:
             raise LisaException(
                 f"Distro {self._node.os.name}" "not supported to install CUDA driver."

--- a/lisa/features/gpu.py
+++ b/lisa/features/gpu.py
@@ -226,10 +226,13 @@ class Gpu(Feature):
                 "http://developer.download.nvidia.com/"
                 f"compute/cuda/repos/rhel{release}/x86_64/{cuda_repo_pkg}"
             )
-            # download and install the cuda driver package from the repo
-            self._node.os._install_package_from_url(
-                f"{cuda_repo}", package_name="cuda-drivers.rpm", signed=False
-            )
+            try:
+                # download and install the cuda driver package from the repo
+                self._node.os._install_package_from_url(
+                    f"{cuda_repo}", package_name="cuda-drivers.rpm", signed=False
+                )
+            except Exception as e:
+                raise LisaException(f"Failed to install driver from source, {str(e)}")
             self._node.os.install_packages("cuda-drivers", signed=False)
 
         elif isinstance(self._node.os, Ubuntu):

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1330,7 +1330,7 @@ class Fedora(RPMDistro):
         )
 
         # replace $releasever to 8 for 8.x
-        if major == 8:
+        if major == 8 or major == 9:
             sed = self._node.tools[Sed]
             sed.substitute("$releasever", "8", "/etc/yum.repos.d/epel*.repo", sudo=True)
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -50,6 +50,7 @@ from lisa.util import (
     NotMeetRequirementException,
     SkippedException,
     check_till_timeout,
+    UnsupportedOperationException,
     constants,
     field_metadata,
     find_patterns_in_lines,
@@ -525,7 +526,7 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         }
         release = self._node.os.information.release
         if release not in supported_versions.get(type(self._node.os), []):
-            raise LisaException("GPUExtensionNotSupported")
+            raise UnsupportedOperationException("GPU Extension not supported")
         extension = self._node.features[AzureExtension]
         result = extension.create_or_update(
             type_="NvidiaGpuDriverLinux",

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -49,8 +49,8 @@ from lisa.util import (
     LisaException,
     NotMeetRequirementException,
     SkippedException,
-    check_till_timeout,
     UnsupportedOperationException,
+    check_till_timeout,
     constants,
     field_metadata,
     find_patterns_in_lines,
@@ -471,7 +471,7 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         if isinstance(node.os, Redhat):
             supported = node.os.information.version >= "7.0.0"
         elif isinstance(node.os, Ubuntu):
-            supported = node.os.information.version >= "18.0.0"
+            supported = node.os.information.version >= "16.0.0"
         elif isinstance(node.os, Suse):
             supported = node.os.information.version >= "15.0.0"
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -526,16 +526,16 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         resources = template["resources"]
 
         # load a copy to avoid side effect.
-        gpu_template = json.loads(cls._gpu_extension_template)
+        # gpu_template = json.loads(cls._gpu_extension_template)
 
         node: Node = environment.nodes[0]
         runbook = node.capability.get_extended_runbook(AzureNodeSchema)
-        if re.match(cls._amd_supported_skus, runbook.vm_size):
-            # skip AMD, because no AMD GPU Linux extension.
-            ...
-        else:
-            gpu_template["properties"] = cls._gpu_extension_nvidia_properties
-            resources.append(gpu_template)
+        # if re.match(cls._amd_supported_skus, runbook.vm_size):
+        #     # skip AMD, because no AMD GPU Linux extension.
+        #     ...
+        # else:
+        #     gpu_template["properties"] = cls._gpu_extension_nvidia_properties
+        #     resources.append(gpu_template)
 
 
 class Infiniband(AzureFeatureMixin, features.Infiniband):

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -5,6 +5,7 @@ import copy
 import json
 import re
 import string
+import sys
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
@@ -519,23 +520,7 @@ class Gpu(AzureFeatureMixin, features.Gpu):
 
     @classmethod
     def _install_by_platform(cls, *args: Any, **kwargs: Any) -> None:
-        template: Any = kwargs.get("template")
-        environment = cast(Environment, kwargs.get("environment"))
-        log = cast(Logger, kwargs.get("log"))
-        log.debug("updating arm template to support GPU extension.")
-        resources = template["resources"]
-
-        # load a copy to avoid side effect.
-        # gpu_template = json.loads(cls._gpu_extension_template)
-
-        node: Node = environment.nodes[0]
-        runbook = node.capability.get_extended_runbook(AzureNodeSchema)
-        # if re.match(cls._amd_supported_skus, runbook.vm_size):
-        #     # skip AMD, because no AMD GPU Linux extension.
-        #     ...
-        # else:
-        #     gpu_template["properties"] = cls._gpu_extension_nvidia_properties
-        #     resources.append(gpu_template)
+        ...
 
 
 class Infiniband(AzureFeatureMixin, features.Infiniband):
@@ -1879,6 +1864,7 @@ class AzureExtension(AzureFeatureMixin, Feature):
         settings: Optional[Dict[str, Any]] = None,
         protected_settings: Any = None,
         suppress_failures: Optional[bool] = None,
+        timeout: int = sys.maxsize,
     ) -> Any:
         platform: AzurePlatform = self._platform  # type: ignore
         compute_client = get_compute_client(platform)
@@ -1908,7 +1894,7 @@ class AzureExtension(AzureFeatureMixin, Feature):
             vm_extension_name=name,
             extension_parameters=extension_parameters,
         )
-        result = wait_operation(operation)
+        result = wait_operation(operation, timeout)
 
         return result
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -519,24 +519,26 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         self._is_nvidia = True
 
     def _install_driver_using_platform_feature(self) -> None:
-        if isinstance(self._node.os, Redhat):
-            release = self._node.os.information.release
-            if release not in ["7.3", "7.4", "7.5", "7.6", "7.7", "7.8"]:
-                raise LisaException("NotSupported")
+        supported_versions: Dict[Any, List[str]] = {
+            Redhat: ["7.3", "7.4", "7.5", "7.6", "7.7", "7.8"],
+            Ubuntu: ["16.04", "18.04", "20.04"],
+            CentOs: ["7.3", "7.4", "7.5", "7.6", "7.7", "7.8"],
+        }
+        release = self._node.os.information.release
+        if release not in supported_versions.get(type(self._node.os), []):
+            raise LisaException("GPUExtensionNotSupported")
         extension = self._node.features[AzureExtension]
-        extension_install_timeout_s = 25 * 60
         result = extension.create_or_update(
             type_="NvidiaGpuDriverLinux",
             publisher="Microsoft.HpcCompute",
             type_handler_version="1.6",
             auto_upgrade_minor_version=True,
             settings={},
-            timeout=extension_install_timeout_s,
         )
         if result["provisioning_state"] == "Succeeded":
             return
         else:
-            raise LisaException("Extension Provisioning Failed")
+            raise LisaException("GPU Extension Provisioning Failed")
 
 
 class Infiniband(AzureFeatureMixin, features.Infiniband):

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -5,7 +5,6 @@ import copy
 import json
 import re
 import string
-import sys
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
@@ -1882,7 +1881,7 @@ class AzureExtension(AzureFeatureMixin, Feature):
         settings: Optional[Dict[str, Any]] = None,
         protected_settings: Any = None,
         suppress_failures: Optional[bool] = None,
-        timeout: int = sys.maxsize,
+        timeout: int = 60 * 25,
     ) -> Any:
         platform: AzurePlatform = self._platform  # type: ignore
         compute_client = get_compute_client(platform)

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -70,11 +70,10 @@ class GpuTestSuite(TestSuite):
         node: Node,
         log_path: Path,
         log: Logger,
-        environment: Environment,
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        _install_driver(node, log_path, log, environment)
+        _install_driver(node, log_path, log)
         _check_driver_installed(node)
 
     @TestCaseMetadata(
@@ -135,6 +134,7 @@ class GpuTestSuite(TestSuite):
         priority=2,
     )
     def verify_gpu_adapter_count(self, node: Node, log_path: Path, log: Logger) -> None:
+        _install_driver(node, log_path, log)
         gpu_feature = node.features[Gpu]
         assert isinstance(node.capability.gpu_count, int)
         expected_count = node.capability.gpu_count
@@ -171,7 +171,13 @@ class GpuTestSuite(TestSuite):
             supported_features=[GpuEnabled()],
         ),
     )
-    def verify_gpu_rescind_validation(self, node: Node) -> None:
+    def verify_gpu_rescind_validation(
+        self,
+        node: Node,
+        log_path: Path,
+        log: Logger,
+    ) -> None:
+        _install_driver(node, log_path, log)
         _check_driver_installed(node)
 
         lspci = node.tools[Lspci]
@@ -203,7 +209,13 @@ class GpuTestSuite(TestSuite):
             supported_features=[GpuEnabled()],
         ),
     )
-    def verify_gpu_cuda_with_pytorch(self, node: Node) -> None:
+    def verify_gpu_cuda_with_pytorch(
+        self,
+        node: Node,
+        log_path: Path,
+        log: Logger,
+    ) -> None:
+        _install_driver(node, log_path, log)
         _check_driver_installed(node)
 
         _install_cudnn(node)
@@ -290,9 +302,7 @@ def _install_cudnn(node: Node) -> None:
 
 # We use platform to install the driver by default. If in future, it needs to
 # install independently, this logic can be reused.
-def _install_driver(
-    node: Node, log_path: Path, log: Logger, environment: Environment
-) -> None:
+def _install_driver(node: Node, log_path: Path, log: Logger) -> None:
     gpu_feature = node.features[Gpu]
     if gpu_feature.is_module_loaded():
         return

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -23,7 +23,7 @@ from lisa.features.gpu import ComputeSDK
 from lisa.operating_system import AlmaLinux, Debian, Oracle, Suse, Ubuntu
 from lisa.sut_orchestrator.azure.features import AzureExtension
 from lisa.tools import Lspci, NvidiaSmi, Pip, Python, Reboot, Service, Tar, Wget
-from lisa.util import get_matched_str
+from lisa.util import UnsupportedOperationException, get_matched_str
 
 _cudnn_location = (
     "https://partnerpipelineshare.blob.core.windows.net/"
@@ -134,10 +134,11 @@ class GpuTestSuite(TestSuite):
         gpu_feature = node.features[Gpu]
         try:
             gpu_feature._install_driver_using_platform_feature()
-        except LisaException as e:
-            if "GPUExtensionNotSupported" in str(e):
-                raise SkippedException("GPU Extension Installation is not supported")
-            raise e
+        except UnsupportedOperationException:
+            raise SkippedException(
+                "GPU Driver Installation using extension is not supported\n"
+                "https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/hpccompute-gpu-linux"  # noqa: E501
+            )
         reboot_tool = node.tools[Reboot]
         reboot_tool.reboot_and_check_panic(log_path)
         _check_driver_installed(node, log)

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -19,7 +19,6 @@ from lisa import (
     constants,
     simple_requirement,
 )
-from lisa.environment import Environment
 from lisa.features import Gpu, GpuEnabled, SerialConsole, StartStop
 from lisa.features.gpu import ComputeSDK
 from lisa.operating_system import AlmaLinux, Debian, Oracle, Suse, Ubuntu

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -296,8 +296,13 @@ def _check_driver_installed(node: Node, log: Logger) -> None:
 
     try:
         nvidia_smi = node.tools[NvidiaSmi]
-        gpu_count = nvidia_smi.get_gpu_count()
-        log.info(f"GPU count from nvidia-smi: {gpu_count}")
+
+        lspci_gpucount = gpu.get_gpu_count_with_lspci()
+        nvidiasmi_gpucount = nvidia_smi.get_gpu_count()
+        assert_that(lspci_gpucount).described_as(
+            f"GPU count from lspci {lspci_gpucount} not equal to"
+            f"count from nvidia-smi {nvidiasmi_gpucount}"
+        ).is_equal_to(nvidiasmi_gpucount)
     except Exception as identifier:
         raise LisaException(
             f"Cannot find nvidia-smi, make sure the driver installed correctly. "

--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -72,7 +72,7 @@ class GpuTestSuite(TestSuite):
         **kwargs: Any,
     ) -> None:
         _install_driver(node, log_path, log)
-        _check_driver_installed(node)
+        _check_driver_installed(node, log)
 
     @TestCaseMetadata(
         description="""
@@ -140,7 +140,7 @@ class GpuTestSuite(TestSuite):
             raise e
         reboot_tool = node.tools[Reboot]
         reboot_tool.reboot_and_check_panic(log_path)
-        _check_driver_installed(node)
+        _check_driver_installed(node, log)
 
     @TestCaseMetadata(
         description="""
@@ -179,7 +179,7 @@ class GpuTestSuite(TestSuite):
             "Expected device count didn't match Actual device count from lspci",
         ).is_equal_to(expected_count)
 
-        _check_driver_installed(node)
+        _check_driver_installed(node, log)
 
         vendor_cmd_device_count = gpu_feature.get_gpu_count_with_vendor_cmd()
         assert_that(
@@ -206,7 +206,7 @@ class GpuTestSuite(TestSuite):
         log: Logger,
     ) -> None:
         _install_driver(node, log_path, log)
-        _check_driver_installed(node)
+        _check_driver_installed(node, log)
 
         lspci = node.tools[Lspci]
         gpu = node.features[Gpu]
@@ -244,7 +244,7 @@ class GpuTestSuite(TestSuite):
         log: Logger,
     ) -> None:
         _install_driver(node, log_path, log)
-        _check_driver_installed(node)
+        _check_driver_installed(node, log)
 
         _install_cudnn(node)
 
@@ -281,7 +281,7 @@ class GpuTestSuite(TestSuite):
         ).is_equal_to(expected_count)
 
 
-def _check_driver_installed(node: Node) -> None:
+def _check_driver_installed(node: Node, log: Logger) -> None:
     gpu = node.features[Gpu]
 
     if not gpu.is_supported():
@@ -295,7 +295,9 @@ def _check_driver_installed(node: Node) -> None:
         )
 
     try:
-        _ = node.tools[NvidiaSmi]
+        nvidia_smi = node.tools[NvidiaSmi]
+        gpu_count = nvidia_smi.get_gpu_count()
+        log.info(f"GPU count from nvidia-smi: {gpu_count}")
     except Exception as identifier:
         raise LisaException(
             f"Cannot find nvidia-smi, make sure the driver installed correctly. "


### PR DESCRIPTION
CUDA Driver extension installation is only supported in limited number of distro's. For the unsupported distro's the deployment itself fails since the extension is part of ARM.

This PR installs extension after deployment, if the extension provisioning fails, the CUDA driver is installed from source.

A new test case is added for testing installation of GPU driver using extension.