### PR TITLE
Increase timeout for LTP tests

### DIFF
--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -28,7 +28,7 @@ from microsoft.testsuites.ltp.ltp import Ltp
     """,
 )
 class LtpTestsuite(TestSuite):
-    _TIME_OUT = 12000
+    _TIME_OUT = 18000
     LTP_LITE_TESTS = ["math", "fsx", "ipc", "mm", "sched", "pty", "fs"]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 


### PR DESCRIPTION
Noticed tests timing out on Mariner and Debian distros