### PR TITLE
Set rust default toolchain to run cargo

### DIFF
--- a/lisa/tools/cargo.py
+++ b/lisa/tools/cargo.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import os
+import re
 from pathlib import PurePath
-from typing import List, Optional, Type, cast
+from typing import Any, List, Optional, Type, cast
 
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner, Posix, Ubuntu
@@ -9,14 +11,28 @@ from lisa.tools.curl import Curl
 from lisa.tools.echo import Echo
 from lisa.tools.gcc import Gcc
 from lisa.tools.ln import Ln
-from lisa.util import UnsupportedDistroException
+from lisa.tools.rm import Rm
+from lisa.util import LisaException, UnsupportedDistroException
 from lisa.util.process import ExecutableResult
 
 
 class Cargo(Tool):
+    # cargo 1.67.1 (8ecd4f20a 2023-01-10)
+    _version_pattern = re.compile(
+        r"cargo (?P<major>\d+).(?P<minor>(\d+)).(?P<patch>(\d+)) ",
+        re.M,
+    )
+
+    # stable-x86_64-unknown-linux-gnu (default)
+    _rust_toolchain_pattern = re.compile(
+        r"\w+-\w+-\w+-\w+-\w+",
+        re.M,
+    )
+    toolchain: str = ""
+
     @property
     def command(self) -> str:
-        return "cargo"
+        return self._command
 
     @property
     def can_install(self) -> bool:
@@ -26,10 +42,13 @@ class Cargo(Tool):
     def dependencies(self) -> List[Type[Tool]]:
         return [Gcc]
 
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self._command = "cargo"
+
     def _install(self) -> bool:
-        os = self.node.os
+        node_os = self.node.os
         cargo_source_url = "https://sh.rustup.rs"
-        if isinstance(os, CBLMariner) or isinstance(os, Ubuntu):
+        if isinstance(node_os, CBLMariner) or isinstance(node_os, Ubuntu):
             self.__install_dependencies()
 
             # install cargo/rust
@@ -56,15 +75,37 @@ class Cargo(Tool):
                 target=f"{home_dir}/.cargo/bin/cargo",
                 link="/usr/local/bin/cargo",
             )
+            ln.create_link(
+                is_symbolic=True,
+                target=f"{home_dir}/.cargo/bin/rustup",
+                link="/usr/local/bin/rustup",
+            )
         else:
-            raise UnsupportedDistroException(os)
-        return self._check_exists()
+            raise UnsupportedDistroException(node_os)
+        is_installed = self._check_exists()
+
+        # Point cargo from stable toolchain of rust after installation
+        if is_installed:
+            self.node.execute("rustup default stable", shell=True)
+            self.toolchain = self.__get_rust_toolchain()
+            self._log.debug(f"Rust toolchain: {self.toolchain}")
+            self._command = f"{home_dir}/.rustup/toolchains/{self.toolchain}/bin/cargo"
+
+        self.node.tools[Rm].remove_file(
+            "/usr/local/bin/cargo",
+            sudo=True,
+        )
+        self.node.tools[Rm].remove_file(
+            "/usr/local/bin/rustup",
+            sudo=True,
+        )
+        return is_installed
 
     def __install_dependencies(self) -> None:
-        os: Posix = cast(Posix, self.node.os)
+        node_os: Posix = cast(Posix, self.node.os)
 
         # install prerequisites
-        os.install_packages(["build-essential", "cmake"])
+        node_os.install_packages(["build-essential", "cmake"])
 
         gcc = self.node.tools[Gcc]
         gcc_version_info = gcc.get_version()
@@ -81,26 +122,24 @@ class Cargo(Tool):
     ) -> ExecutableResult:
         err_msg = "Cargo build failed"
         echo = self.node.tools[Echo]
-        original_path = echo.run(
+        path = echo.run(
             "$PATH",
             shell=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="failure to grab $PATH via echo",
         ).stdout
-        home_path = echo.run(
-            "$HOME",
-            shell=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message="failure to grab $HOME path",
-        ).stdout
-        new_path = f"{home_path}/.cargo/bin:{original_path}"
+
+        if os.path.dirname(self._command) not in path:
+            path = f"{os.path.dirname(self._command)}:{path}"
+
         result = self.run(
             "build",
             expected_exit_code=0,
             expected_exit_code_failure_message=err_msg,
             sudo=sudo,
             cwd=cwd,
-            update_envs={"PATH": new_path},
+            update_envs={"PATH": path},
+            shell=True,
         )
         return result
 
@@ -110,23 +149,44 @@ class Cargo(Tool):
         cwd: Optional[PurePath] = None,
     ) -> ExecutableResult:
         echo = self.node.tools[Echo]
-        original_path = echo.run(
+        path = echo.run(
             "$PATH",
             shell=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="failure to grab $PATH via echo",
         ).stdout
-        home_path = echo.run(
-            "$HOME",
-            shell=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message="failure to grab $HOME path",
-        ).stdout
-        new_path = f"{home_path}/.cargo/bin:{original_path}"
+
+        if os.path.dirname(self._command) not in path:
+            path = f"{os.path.dirname(self._command)}:{path}"
+
         result = self.run(
-            "test",
+            "-v test",
             sudo=sudo,
             cwd=cwd,
-            update_envs={"PATH": new_path},
+            update_envs={"PATH": path},
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="cargo test failed",
         )
         return result
+
+    def __get_rust_toolchain(
+        self,
+        sudo: bool = False,
+        shell: bool = False,
+        cwd: Optional[PurePath] = None,
+    ) -> str:
+        err_msg = "Error occurred in getting rust toolchain info"
+        output = self.node.execute(
+            "rustup default",
+            expected_exit_code=0,
+            expected_exit_code_failure_message=err_msg,
+            sudo=sudo,
+            cwd=cwd,
+            shell=shell,
+        ).stdout
+
+        matched_toolchain = self._rust_toolchain_pattern.match(output)
+        if matched_toolchain:
+            return matched_toolchain.group(0)
+        raise LisaException("fail to get rust toolchain")


### PR DESCRIPTION
These changes will set the default toolchain for rust setup and point stable toolchain for cargo binary to run the LISA tool. We will also run **cargo test** with verbose for better log.

This will resolve issue of **"rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured."**  This is for testcase **verify_rust_vmm_mshv_tests**