### PR TITLE
fix repo not available issue for L2 vm

### DIFF
--- a/microsoft/testsuites/nested/common.py
+++ b/microsoft/testsuites/nested/common.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from lisa import RemoteNode, schema
+from lisa.base_tools import Sed
 from lisa.features.network_interface import Synthetic
 from lisa.operating_system import Debian, Fedora, Suse
 from lisa.schema import Node
@@ -107,6 +108,14 @@ def qemu_connect_nested_vm(
 
     # wait for nested vm ssh connection to be ready
     try_connect(connection_info)
+
+    # temp workaround when nested vm repos are not available
+    nested_vm.tools[Sed].substitute(
+        regexp="sg.archive",
+        replacement="archive",
+        file="/etc/apt/sources.list",
+        sudo=True,
+    )
 
     return nested_vm
 


### PR DESCRIPTION
in our made qcow2 image, the repo is `sg.archive.ubuntu.com`, sometimes, it is unavailable. so, replace it into `archive.ubuntu.com`