### PR TITLE
ch_tests_tool: don't leave sub-tests in RUNNING state

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -301,6 +301,12 @@ class CloudHypervisorTests(Tool):
         for subtest in subtests:
             status = subtest_status[subtest]
             message = messages.get(status, "")
+
+            if status == TestStatus.RUNNING:
+                # Sub-test started running but didn't finish within the stipulated time.
+                # It should be treated as a failure.
+                status = TestStatus.FAILED
+
             results.append(
                 CloudHypervisorTestResult(
                     name=subtest,


### PR DESCRIPTION
If subtests fail to finish within the stipulated time, explicitly mark them as FAILED instead of leaving them in RUNNING state.