### PR TITLE
fix ibm mpi installation issue on redhat

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -469,6 +469,8 @@ class Infiniband(Feature):
 
     def install_ibm_mpi(self) -> None:
         node = self._node
+        if isinstance(node.os, Redhat):
+            node.os.install_packages("libstdc++.i686")
         # Install Open MPI
         wget = node.tools[Wget]
         script_path = wget.get(


### PR DESCRIPTION
test passed on rhel7.8, ol7.9, ol8.6, centos8.5

still fail on rhel9/ol9 for `Error: BOZ literal constant at (1) is neither a data-stmt-constant nor an actual argument to INT, REAL, DBLE, or CMPLX intrinsic function [see ‘-fno-allow-invalid-boz’]`

ubuntu failed for `java/lang/OutOfMemoryError`