### PR TITLE
[xdp] fix internal module package not existing issue

### DIFF
--- a/microsoft/testsuites/xdp/pktgen.py
+++ b/microsoft/testsuites/xdp/pktgen.py
@@ -6,8 +6,8 @@ from typing import Any, List, Type, cast
 
 from lisa.base_tools import Wget
 from lisa.executable import Tool
-from lisa.operating_system import Fedora, Posix
-from lisa.tools import KernelConfig, Modprobe
+from lisa.operating_system import Fedora, Oracle, Posix
+from lisa.tools import KernelConfig, Modprobe, Uname
 from lisa.util import (
     LisaException,
     UnsupportedKernelException,
@@ -89,10 +89,20 @@ class Pktgen(Tool):
         returns the packets count supposes to be sent.
         """
         if isinstance(self.node.os, Fedora):
-            module_full_path = self._tool_path / self._module_name
+            if isinstance(self.node.os, Oracle):
+                kernel_ver = (
+                    self.node.tools[Uname].get_linux_information().kernel_version
+                )
+                # by default, pktgen.ko.xz exists in Oracle
+                # contained in kernel-uek-core-$(uname -r) package
+                module_full_path = (
+                    f"/usr/lib/modules/{kernel_ver}/kernel/net/core/pktgen.ko.xz"
+                )
+            else:
+                module_full_path = str(self._tool_path / self._module_name)
             modprobe = self.node.tools[Modprobe]
-            modprobe.remove([str(module_full_path)], ignore_error=True)
-            modprobe.load_by_file(str(module_full_path))
+            modprobe.remove([module_full_path], ignore_error=True)
+            modprobe.load_by_file(module_full_path)
 
         if thread_count == 1:
             command = self._single_thread_entry
@@ -123,7 +133,7 @@ class Pktgen(Tool):
 
     def _install(self) -> bool:
         wget = self.node.tools[Wget]
-        if isinstance(self.node.os, Fedora):
+        if isinstance(self.node.os, Fedora) and not isinstance(self.node.os, Oracle):
             self._install_fedora()
         else:
             if not self.node.tools[KernelConfig].is_enabled("CONFIG_NET_PKTGEN"):

--- a/microsoft/testsuites/xdp/pktgen.py
+++ b/microsoft/testsuites/xdp/pktgen.py
@@ -8,7 +8,11 @@ from lisa.base_tools import Wget
 from lisa.executable import Tool
 from lisa.operating_system import Fedora, Posix
 from lisa.tools import KernelConfig, Modprobe
-from lisa.util import UnsupportedKernelException, find_patterns_groups_in_lines
+from lisa.util import (
+    LisaException,
+    UnsupportedKernelException,
+    find_patterns_groups_in_lines,
+)
 
 
 @dataclass
@@ -147,25 +151,59 @@ class Pktgen(Tool):
         parts = kernel_information.version_parts[:]
 
         # Full example:
+        # https://repo.almalinux.org/almalinux/9.1/devel/x86_64/os/Packages/
+        # kernel-modules-internal-5.14.0-162.12.1.el9_1.x86_64.rpm
+        # Full example:
         # https://koji.mbox.centos.org/pkgs/packages/kernel-plus/4.18.0/
         #   240.1.1.el8_3.centos.plus/x86_64/kernel-plus-modules-internal-
         #   4.18.0-240.1.1.el8_3.centos.plus.x86_64.rpm",
-        rpm_location = (
-            f"https://koji.mbox.centos.org/pkgs/packages/kernel-plus/4.18.0/"
-            f"{'.'.join(parts[3:-1])}.centos.plus/{parts[-1]}/kernel-plus-modules-"
-            f"internal-4.18.0-{'.'.join(parts[3:-1])}.centos.plus.{parts[-1]}.rpm"
-        )
+        rpm_locations = [
+            (
+                "https://repo.almalinux.org/almalinux/"
+                f"{'.'.join(parts[-2].replace('el','').split('_'))}/devel/{parts[-1]}/"
+                "os/Packages/kernel-modules-internal-"
+                f"{'.'.join(parts[0:3])}-{'.'.join(parts[3:-1])}.{parts[-1]}.rpm"
+            ),
+            (
+                "https://repo.almalinux.org/vault/"
+                f"{'.'.join(parts[-2].replace('el','').split('_'))}/devel/{parts[-1]}/"
+                "os/Packages/kernel-modules-internal-"
+                f"{'.'.join(parts[0:3])}-{'.'.join(parts[3:-1])}.{parts[-1]}.rpm"
+            ),
+            (
+                "https://koji.mbox.centos.org/pkgs/packages/kernel-plus/4.18.0/"
+                f"{'.'.join(parts[3:-1])}.centos.plus/{parts[-1]}/"
+                "kernel-plus-modules-internal-4.18.0-"
+                f"{'.'.join(parts[3:-1])}.centos.plus.{parts[-1]}.rpm"
+            ),
+        ]
         # Install pkggen from CentOS for redhat, because there is no free
         # download for Redhat.
         package_file_name = "kernel-plus-modules-internal.rpm"
 
-        wget = self.node.tools[Wget]
-        modules_file = wget.get(
-            url=rpm_location,
-            file_path=str(self._tool_path),
-            filename=package_file_name,
-            overwrite=True,
-        )
+        is_download_success = False
+        for rpm_location in rpm_locations:
+            wget = self.node.tools[Wget]
+            try:
+                modules_file = wget.get(
+                    url=rpm_location,
+                    file_path=str(self._tool_path),
+                    filename=package_file_name,
+                    overwrite=True,
+                )
+                self.node.log.debug(f"download {rpm_location} successfully")
+                is_download_success = True
+                break
+            except LisaException as ex:
+                self.node.log.debug(f"fail to download {rpm_location}, exception {ex}")
+                if "cannot find file path" in str(ex):
+                    continue
+        if not is_download_success:
+            raise LisaException(
+                "fail to download kernel-plus-modules-internal.rpm from given locations"
+                ", please double check"
+            )
+
         # extract pktgen.ko.xz
         self.node.execute(
             f"rpm2cpio {modules_file} | "

--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -101,9 +101,9 @@ class XdpDump(Tool):
     def start_async(self, nic_name: str = "", timeout: int = 5) -> Process:
         try:
             self._disable_lro(nic_name)
-            command = ""
+            command = "ulimit -l unlimited && "
             if timeout > 0:
-                command = f"timeout {timeout}"
+                command += f"timeout {timeout}"
             command = f"{command} {self.command} -i {nic_name}"
             xdpdump_process = self.node.execute_async(
                 command,


### PR DESCRIPTION
- I found some pktgen package for centos 8.4/8.5/9/9.1 and uploaded them and the ones from koji.mbox.centos.org into partnerpipelineshare.
- in oracle, the pktgen exists by default.

Test pass on 
- redhat rhel 8-lvm 8.7.2023022813
- redhat rhel 9_0 latest 
- redhat rhel 9-lvm latest
- redhat rhel 9-lvm 9.0.2022090601
- almalinux almalinux-hpc 8_6-hpc 8.6.2023012402
- oracle oracle-linux ol85-lvm 8.5.6
- oracle oracle-linux ol84-lvm-gen2 8.4.11 
- oracle oracle-linux ol79 7.9.30
- oracle oracle-linux ol83-lvm-gen2 8.3.14
- oracle oracle-linux ol86-lvm 8.6.5 
- oracle oracle-linux ol9-lvm 9.0.3
- openlogic centos-lvm 8-lvm 8.5.2022101400


