### PR TITLE
Change the crashkernel size for Distros

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -246,7 +246,7 @@ class KdumpBase(Tool):
         ):
             crash_kernel = "128M"
         elif "T" in total_memory and float(total_memory.strip("T")) > 1:
-            self.crash_kernel = "2G"
+            crash_kernel = "2G"
         else:
             crash_kernel = "512M"
         return crash_kernel

--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -419,6 +419,7 @@ class KdumpCrash(TestSuite):
                             serial_console.get_console_log(
                                 saved_path=log_path, force_run=True
                             )
+                            node.execute("df -h")
                             raise LisaException(
                                 "The vmcore file is incomplete with file size"
                                 f" {round(incomplete_file_size/1024/1024, 2)}MB"


### PR DESCRIPTION
1. Change the crashkernel size for Distros
2. Check the disk space before raising an exception