### PR TITLE
runner: add raise identifier

### DIFF
--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -224,6 +224,7 @@ class RootRunner(Action):
                 "canceling runner due to exception", exc_info=identifier
             )
             cancel()
+            raise identifier
         finally:
             self._cleanup()
 


### PR DESCRIPTION
No sure why last time this line is removed. It looks like an incident. If not to raise the identifier, LISA printed the test results as normal, so some fatal errors are not easy to discover.