### PR TITLE
Add timeout for CLH Performance metrics tests

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -150,8 +150,16 @@ class CloudHypervisorTestSuite(TestSuite):
             "ch_perf_tests_included",
             "ch_perf_tests_excluded",
         )
+        subtest_timeout = variables.get("ch_perf_subtest_timeout", None)
         node.tools[CloudHypervisorTests].run_metrics_tests(
-            result, environment, hypervisor, log_path, ref, include_list, exclude_list
+            result,
+            environment,
+            hypervisor,
+            log_path,
+            ref,
+            include_list,
+            exclude_list,
+            subtest_timeout,
         )
 
     def _ensure_virtualization_enabled(self, node: Node) -> None:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -127,6 +127,7 @@ class CloudHypervisorTests(Tool):
         ref: str = "",
         only: Optional[List[str]] = None,
         skip: Optional[List[str]] = None,
+        subtest_timeout: Optional[int] = None,
     ) -> None:
         if ref:
             self.node.tools[Git].checkout(ref, self.repo_root)
@@ -150,10 +151,15 @@ class CloudHypervisorTests(Tool):
             status: TestStatus = TestStatus.QUEUED
             metrics: str = ""
             trace: str = ""
+            cmd_args: str = (
+                f"tests --hypervisor {hypervisor} --metrics -- --"
+                f" --test-filter {testcase}"
+            )
+            if subtest_timeout:
+                cmd_args = f"{cmd_args} --timeout {subtest_timeout}"
             try:
                 result = self.run(
-                    f"tests --hypervisor {hypervisor} --metrics -- --"
-                    f" --test-filter {testcase}",
+                    cmd_args,
                     timeout=self.PERF_CMD_TIME_OUT,
                     force_run=True,
                     cwd=self.repo_root,


### PR DESCRIPTION
These changes will allow user to parse timeout for all CLH performance metrics tests as per the requirement from runbook. This will help for MSHV CLH Performance metrics tests run which were getting failed due to timeout and not able to produce the performance metrics result.