### PR TITLE
Add fix for ping error "sendmsg: Operation not permitted"

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -246,7 +246,7 @@ class KdumpBase(Tool):
         ):
             crash_kernel = "128M"
         elif "T" in total_memory and float(total_memory.strip("T")) > 1:
-            self.crash_kernel = "2G"
+            crash_kernel = "2G"
         else:
             crash_kernel = "512M"
         return crash_kernel

--- a/lisa/tools/ping.py
+++ b/lisa/tools/ping.py
@@ -20,6 +20,14 @@ class Ping(Tool):
         re.M,
     )
 
+    # ping: sendmsg: Operation not permitted
+    # The message indicates that the ICMP echo request packet has not been sent and is
+    # blocked by the Control Plane ACL. Run "iptables --list" to
+    _no_sendmsg_permission_pattern = re.compile(
+        r"ping: sendmsg: Operation not permitted",
+        re.M,
+    )
+
     @property
     def command(self) -> str:
         return "ping"

--- a/microsoft/testsuites/core/dns.py
+++ b/microsoft/testsuites/core/dns.py
@@ -13,7 +13,12 @@ from lisa import (
 )
 from lisa.operating_system import Debian, Posix
 from lisa.tools import Ping
-from lisa.util import PassedException, ReleaseEndOfLifeException, RepoNotExistException
+from lisa.util import (
+    LisaException,
+    PassedException,
+    ReleaseEndOfLifeException,
+    RepoNotExistException,
+)
 
 
 @TestSuiteMetadata(
@@ -59,7 +64,15 @@ class Dns(TestSuite):
     @retry(tries=10, delay=0.5)
     def _check_dns_name_resolution(self, node: Node) -> None:
         ping = node.tools[Ping]
-        ping.ping(target="bing.com")
+        try:
+            ping.ping(target="bing.com")
+        except Exception as identifier:
+            if ping._no_sendmsg_permission_pattern.findall(str(identifier)):
+                # ping ICMP packet might be blocked by control plane ACL
+                # Use "nslookup bing.com" command to check
+                node.execute("nslookup bing.com", expected_exit_code=0, timeout=30)
+            else:
+                raise LisaException(identifier)
 
     def _upgrade_system(self, node: Node) -> None:
         if not isinstance(node.os, Posix):


### PR DESCRIPTION
Some images may have iptables settings for rejecting ICMP packets. When running the ping command, it has "ping: sendmsg: Operation not permitted". The message indicates that the ICMP echo request packet has not been sent and is blocked by the control plane ACL. 

This PR adds a try-except to catch this error. If encountering this error, it means ping ICMP packet is not supported in this system, then use another way (nslookup bing.com) to check the DNS name resolution. 
