### PR TITLE
Add fix for ping error "sendmsg: Operation not permitted"

### DIFF
--- a/lisa/tools/ping.py
+++ b/lisa/tools/ping.py
@@ -20,6 +20,14 @@ class Ping(Tool):
         re.M,
     )
 
+    # ping: sendmsg: Operation not permitted
+    # The message indicates that the ICMP echo request packet has not been sent and is
+    # blocked by the Control Plane ACL. Run "iptables --list" to check.
+    no_sendmsg_permission_pattern = re.compile(
+        r"ping: sendmsg: Operation not permitted",
+        re.M,
+    )
+
     @property
     def command(self) -> str:
         return "ping"


### PR DESCRIPTION
Some images may have iptables settings for rejecting ICMP packets. When running the ping command, it has "ping: sendmsg: Operation not permitted". The message indicates that the ICMP echo request packet has not been sent and is blocked by the control plane ACL.

This PR adds a try-except to catch this error. If encountering this error, it means ping ICMP packet is not supported in this system, then use another way (nslookup bing.com) to check the DNS name resolution.