### PR TITLE
Raise skip on images which aren't receiving floppy fixes

### DIFF
--- a/microsoft/testsuites/core/floppy.py
+++ b/microsoft/testsuites/core/floppy.py
@@ -41,7 +41,7 @@ class Floppy(TestSuite):
         is_centos = isinstance(node.os, CentOs)
         if is_centos and os_version < "7.8.0":
             raise SkippedException(
-                "CentOS below 7.8 are not receiving fixes for this issue."
+                "CentOS <= 7.7 are not receiving fixes for block listing the floppy module."
             )
         modprobe = node.tools[Modprobe]
 

--- a/microsoft/testsuites/core/floppy.py
+++ b/microsoft/testsuites/core/floppy.py
@@ -3,7 +3,14 @@
 
 from assertpy import assert_that
 
-from lisa import RemoteNode, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa import (
+    RemoteNode,
+    SkippedException,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+)
+from lisa.operating_system import CentOs
 from lisa.tools import Modprobe
 
 
@@ -30,6 +37,12 @@ class Floppy(TestSuite):
         priority=1,
     )
     def verify_floppy_module_is_blacklisted(self, node: RemoteNode) -> None:
+        os_version = node.os.information.version
+        is_centos = isinstance(node.os, CentOs)
+        if is_centos and os_version < "7.8.0":
+            raise SkippedException(
+                "CentOS below 7.8 are not receiving fixes for this issue."
+            )
         modprobe = node.tools[Modprobe]
 
         assert_that(modprobe.is_module_loaded("floppy")).described_as(

--- a/microsoft/testsuites/core/floppy.py
+++ b/microsoft/testsuites/core/floppy.py
@@ -41,7 +41,10 @@ class Floppy(TestSuite):
         is_centos = isinstance(node.os, CentOs)
         if is_centos and os_version < "7.8.0":
             raise SkippedException(
-                "CentOS <= 7.7 are not receiving fixes for block listing the floppy module."
+                (
+                    "CentOS <= 7.7 are not receiving fixes"
+                    " for block listing the floppy module."
+                )
             )
         modprobe = node.tools[Modprobe]
 


### PR DESCRIPTION
Raise a SKIP on unmaintained images which aren't going to receive changes to remove the floppy driver.