### PR TITLE
xdp: install xdpdump firstly to by pass some skip cases

### DIFF
--- a/microsoft/testsuites/xdp/performance.py
+++ b/microsoft/testsuites/xdp/performance.py
@@ -362,15 +362,15 @@ class XdpPerformance(TestSuite):
 
         # install pktgen on sender, and xdpdump on receiver.
         try:
-            tools: List[Any] = run_in_parallel(
-                [partial(sender.tools.get, Pktgen), partial(get_xdpdump, receiver)]
-            )
+            tools: List[Any] = []
+            tools.append(get_xdpdump(receiver))
+            tools.append(sender.tools[Pktgen])
         except UnsupportedKernelException as identifier:
             raise SkippedException(identifier)
 
         # type annotations
-        pktgen: Pktgen = tools[0]
-        xdpdump: XdpDump = tools[1]
+        xdpdump: XdpDump = tools[0]
+        pktgen: Pktgen = tools[1]
 
         sender_nic = sender.nics.get_nic_by_index(1)
         receiver_nic = receiver.nics.get_nic_by_index(1)


### PR DESCRIPTION
We can invoke get_xdpdump firstly, since for some distro versions, they don't support XDP, but in current design, it also enters into install pktgen logic. This is the case for centos 79 arm64 image. @squirrelsc thoughts?

![image](https://user-images.githubusercontent.com/10083705/227881401-1a289eff-73b9-44d9-a79b-48dc3434b548.png)
