### PR TITLE
Enable the use of existing azure vnet

### DIFF
--- a/docs/run_test/platform.rst
+++ b/docs/run_test/platform.rst
@@ -136,6 +136,9 @@ deployment.
    platform:
    - type: azure
       ...
+      virtual_network_resource_group: $(vnet_resource_group)
+      virtual_network_name: $(vnet_name)
+      subnet_prefix: $(subnet_name)
       requirement:
          ...
          azure:
@@ -144,6 +147,23 @@ deployment.
             vm_size: "<vm size>"
             maximize_capability: "<true or false>"
 
+* **virtual_network_resource_group**. Specify if an existing virtual network
+  should be used. If `virtual_network_resource_group` is not provided, a virtual
+  network will be created in the default resource group. If
+  `virtual_network_resource_group` is provided, an existing virtual network will
+  be used.
+* **virtual_network_name**. Specify the desired virtual network name.  If 
+  `virtual_network_resource_group` is not provided, a virtual network will be
+  created and the resulting virtual network name will be
+  `<virtual_network_name>`.  If `virtual_network_resource_group` is provided,
+  an existing virtual network, with the name equal to `virtual_network_name`,
+  will be used.
+* **subnet_prefix**. Specify the desired subnet prefix.  If 
+  `virtual_network_resource_group` is not provided, a virtual network and
+  subnet will be created and the resulting subnets will look like 
+  `<subnet_profile>0`, `<subnet_profile>1`, and so on.  If 
+  `virtual_network_resource_group` is provided, an existing virtual network and
+  subnet, with the name equal to `subnet_prefix`, will be used.
 * **location**. Specify which locations is used to deploy VMs. It can be one or
   multiple locations. For example, westus3 or westus3,eastus. If multiple
   locations are specified, it means each environment deploys VMs in one of

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -96,11 +96,15 @@
         }
     },
     "variables": {
-        "virtual_network_name": "lisa-virtualNetwork",
-        "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtual_network_name'))]",
+        
+        "virtual_network_name": "bfjelds-lisa-tests-vnet",
+        "virtual_network_resource_group": "bfjelds-lisa-tests",
+        
+        "vnet_id": "[resourceId(variables('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/', variables('virtual_network_name'))]",
         "node_count": "[length(parameters('nodes'))]",
         "availability_set_name": "lisa-availabilitySet",
-        "subnet_prefix": "lisa-subnet-"
+        "subnet_name": "kva-functional-test-subnet",
+        "subnet_ref": "[resourceId(variables('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', variables('virtual_network_name'), variables('subnet_name'))]"
     },
     "resources": [
         {
@@ -129,31 +133,6 @@
             }
         },
         {
-            "apiVersion": "2020-05-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtual_network_name')]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "10.0.0.0/16"
-                    ]
-                },
-                "copy": [
-                    {
-                        "name": "subnets",
-                        "count": "[parameters('subnet_count')]",
-                        "input": {
-                            "name": "[concat(variables('subnet_prefix'), copyIndex('subnets'))]",
-                            "properties": {
-                                "addressPrefix": "[concat('10.0.', copyIndex('subnets'), '.0/24')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2019-10-01",
             "copy": {
@@ -162,8 +141,7 @@
             },
             "name": "[concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-nics')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-public-ip'))]",
-                "[variables('vnet_id')]"
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-public-ip'))]"
             ],
             "properties": {
                 "expressionEvaluationOptions": {
@@ -179,11 +157,8 @@
                     "location": {
                         "value": "[parameters('location')]"
                     },
-                    "vnet_id": {
-                        "value": "[variables('vnet_id')]"
-                    },
-                    "subnet_prefix": {
-                        "value": "[variables('subnet_prefix')]"
+                    "subnet_ref": {
+                        "value": "[variables('subnet_ref')]"
                     },
                     "enable_sriov": {
                         "value": "[parameters('nodes')[copyIndex('nicCopy')]['enable_sriov']]"
@@ -203,10 +178,7 @@
                         "location": {
                             "type": "string"
                         },
-                        "vnet_id": {
-                            "type": "string"
-                        },
-                        "subnet_prefix": {
+                        "subnet_ref": {
                             "type": "string"
                         },
                         "enable_sriov": {
@@ -231,7 +203,7 @@
                                             "privateIPAddressVersion": "IPv4",
                                             "publicIPAddress": "[if(equals(0, copyIndex('internalNicCopy')), network.getPublicIpAddress(parameters('vmName')), json('null'))]",
                                             "subnet": {
-                                                "id": "[concat(parameters('vnet_id'),'/subnets/', concat(parameters('subnet_prefix'), copyIndex('internalNicCopy')))]"
+                                                "id": "[parameters('subnet_ref')]"
                                             },
                                             "privateIPAllocationMethod": "Dynamic"
                                         }

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -70,12 +70,6 @@
                 "description": "tags of availability set"
             }
         },
-        "use_existing_virtual_network": {
-            "type": "bool",
-            "metadata": {
-                "description": "flag to use an existing vnet"
-            }
-        },
         "virtual_network_resource_group": {
             "type": "string",
             "metadata": {
@@ -117,7 +111,7 @@
         "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks/', parameters('virtual_network_name'))]",
         "node_count": "[length(parameters('nodes'))]",
         "availability_set_name": "lisa-availabilitySet",
-        "existing_subnet_ref": "[if(parameters('use_existing_virtual_network'), resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')), '')]"
+        "existing_subnet_ref": "[if(not(empty('virtual_network_resource_group')), resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')), '')]"
     },
     "resources": [
         {
@@ -146,7 +140,7 @@
             }
         },
         {
-            "condition": "[not(parameters('use_existing_virtual_network'))]",
+            "condition": "[empty('virtual_network_resource_group')]",
             "apiVersion": "2020-05-01",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtual_network_name')]",

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -70,10 +70,32 @@
                 "description": "tags of availability set"
             }
         },
-        "user_data_base64": {
-            "type": "string",
+        "use_existing_virtual_network": {
+            "type": "bool",
+            "defaultValue": false,
             "metadata": {
-                "description": "base64 encoded cloud-init user_data to provider ARM"
+                "description": "flag to use an existing vnet"
+            }
+        },
+        "virtual_network_resource_group": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "the name of vnet resource group"
+            }
+        },
+        "virtual_network_name": {
+            "type": "string",
+            "defaultValue": "lisa-virtualNetwork",
+            "metadata": {
+                "description": "the name of vnet"
+            }
+        },
+        "subnet_prefix": {
+            "type": "string",
+            "defaultValue": "lisa-subnet-",
+            "metadata": {
+                "description": "the prefix of the subnets"
             }
         },
         "vm_tags": {
@@ -96,15 +118,10 @@
         }
     },
     "variables": {
-        
-        "virtual_network_name": "bfjelds-lisa-tests-vnet",
-        "virtual_network_resource_group": "bfjelds-lisa-tests",
-        
-        "vnet_id": "[resourceId(variables('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/', variables('virtual_network_name'))]",
+        "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks/', parameters('virtual_network_name'))]",
         "node_count": "[length(parameters('nodes'))]",
         "availability_set_name": "lisa-availabilitySet",
-        "subnet_name": "kva-functional-test-subnet",
-        "subnet_ref": "[resourceId(variables('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', variables('virtual_network_name'), variables('subnet_name'))]"
+        "existing_subnet_ref": "[if(parameters('use_existing_virtual_network'), resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')), '')]"
     },
     "resources": [
         {
@@ -133,6 +150,32 @@
             }
         },
         {
+            "condition": "[not(parameters('use_existing_virtual_network'))]",
+            "apiVersion": "2020-05-01",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('virtual_network_name')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.0.0.0/16"
+                    ]
+                },
+                "copy": [
+                    {
+                        "name": "subnets",
+                        "count": "[parameters('subnet_count')]",
+                        "input": {
+                            "name": "[concat(parameters('subnet_prefix'), copyIndex('subnets'))]",
+                            "properties": {
+                                "addressPrefix": "[concat('10.0.', copyIndex('subnets'), '.0/24')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2019-10-01",
             "copy": {
@@ -141,7 +184,8 @@
             },
             "name": "[concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-nics')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-public-ip'))]"
+                "[resourceId('Microsoft.Network/publicIPAddresses/', concat(parameters('nodes')[copyIndex('nicCopy')]['name'],'-public-ip'))]",
+                "[variables('vnet_id')]"
             ],
             "properties": {
                 "expressionEvaluationOptions": {
@@ -157,8 +201,14 @@
                     "location": {
                         "value": "[parameters('location')]"
                     },
-                    "subnet_ref": {
-                        "value": "[variables('subnet_ref')]"
+                    "vnet_id": {
+                        "value": "[variables('vnet_id')]"
+                    },
+                    "subnet_prefix": {
+                        "value": "[parameters('subnet_prefix')]"
+                    },
+                    "existing_subnet_ref": {
+                        "value": "[variables('existing_subnet_ref')]"
                     },
                     "enable_sriov": {
                         "value": "[parameters('nodes')[copyIndex('nicCopy')]['enable_sriov']]"
@@ -178,7 +228,13 @@
                         "location": {
                             "type": "string"
                         },
-                        "subnet_ref": {
+                        "vnet_id": {
+                            "type": "string"
+                        },
+                        "subnet_prefix": {
+                            "type": "string"
+                        },
+                        "existing_subnet_ref": {
                             "type": "string"
                         },
                         "enable_sriov": {
@@ -203,7 +259,7 @@
                                             "privateIPAddressVersion": "IPv4",
                                             "publicIPAddress": "[if(equals(0, copyIndex('internalNicCopy')), network.getPublicIpAddress(parameters('vmName')), json('null'))]",
                                             "subnet": {
-                                                "id": "[parameters('subnet_ref')]"
+                                                "id": "[if(not(empty(parameters('existing_subnet_ref'))), parameters('existing_subnet_ref'), concat(parameters('vnet_id'),'/subnets/', concat(parameters('subnet_prefix'), copyIndex('internalNicCopy'))))]"
                                             },
                                             "privateIPAllocationMethod": "Dynamic"
                                         }
@@ -308,7 +364,6 @@
                     "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vm_size']]"
                 },
                 "osProfile": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), lisa.getOsProfile( parameters('nodes')[copyIndex('vmCopy')]['short_name'], parameters('admin_username'), or(empty(parameters('admin_key_data')), not(parameters('nodes')[copyIndex('vmCopy')]['is_linux'])), parameters('admin_password'), and(not(empty(parameters('admin_key_data'))), parameters('nodes')[copyIndex('vmCopy')]['is_linux']), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')) ))]",
-                "userData": "[if(not(empty(parameters('user_data_base64'))), parameters('user_data_base64'), json('null'))]",
                 "storageProfile": {
                     "imageReference": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vhd_path']))), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')]))))]",
                     "osDisk": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))),  lisa.getOsDisk(concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk')),  lisa.getOSImage(parameters('nodes')[copyIndex('vmCopy')]) )]",

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -70,6 +70,12 @@
                 "description": "tags of availability set"
             }
         },
+        "user_data_base64": {
+            "type": "string",
+            "metadata": {
+                "description": "base64 encoded cloud-init user_data to provider ARM"
+            }
+        },
         "vm_tags": {
             "type": "object",
             "metadata": {
@@ -330,6 +336,7 @@
                     "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vm_size']]"
                 },
                 "osProfile": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), lisa.getOsProfile( parameters('nodes')[copyIndex('vmCopy')]['short_name'], parameters('admin_username'), or(empty(parameters('admin_key_data')), not(parameters('nodes')[copyIndex('vmCopy')]['is_linux'])), parameters('admin_password'), and(not(empty(parameters('admin_key_data'))), parameters('nodes')[copyIndex('vmCopy')]['is_linux']), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')) ))]",
+                "userData": "[if(not(empty(parameters('user_data_base64'))), parameters('user_data_base64'), json('null'))]",
                 "storageProfile": {
                     "imageReference": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vhd_path']))), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')]))))]",
                     "osDisk": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))),  lisa.getOsDisk(concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk')),  lisa.getOSImage(parameters('nodes')[copyIndex('vmCopy')]) )]",

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -72,28 +72,24 @@
         },
         "use_existing_virtual_network": {
             "type": "bool",
-            "defaultValue": false,
             "metadata": {
                 "description": "flag to use an existing vnet"
             }
         },
         "virtual_network_resource_group": {
             "type": "string",
-            "defaultValue": "[resourceGroup().name]",
             "metadata": {
                 "description": "the name of vnet resource group"
             }
         },
         "virtual_network_name": {
             "type": "string",
-            "defaultValue": "lisa-virtualNetwork",
             "metadata": {
                 "description": "the name of vnet"
             }
         },
         "subnet_prefix": {
             "type": "string",
-            "defaultValue": "lisa-subnet-",
             "metadata": {
                 "description": "the prefix of the subnets"
             }

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -111,7 +111,7 @@
         "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks/', parameters('virtual_network_name'))]",
         "node_count": "[length(parameters('nodes'))]",
         "availability_set_name": "lisa-availabilitySet",
-        "existing_subnet_ref": "[if(not(empty('virtual_network_resource_group')), resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')), '')]"
+        "existing_subnet_ref": "[if(not(empty(parameters('virtual_network_resource_group'))), resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')), '')]"
     },
     "resources": [
         {
@@ -140,7 +140,7 @@
             }
         },
         {
-            "condition": "[empty('virtual_network_resource_group')]",
+            "condition": "[empty(parameters('virtual_network_resource_group'))]",
             "apiVersion": "2020-05-01",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtual_network_name')]",

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -74,8 +74,8 @@ if TYPE_CHECKING:
     from .platform_ import AzurePlatform
 
 AZURE_SHARED_RG_NAME = "lisa_shared_resource"
-AZURE_NEW_VIRTUAL_NETWORK = "lisa-virtualNetwork"
-AZURE_NEW_SUBNET_PREFIX = "lisa-subnet-"
+AZURE_VIRTUAL_NETWORK_NAME = "lisa-virtualNetwork"
+AZURE_SUBNET_PREFIX = "lisa-subnet-"
 
 
 PATTERN_NIC_NAME = re.compile(r"Microsoft.Network/networkInterfaces/(.*)", re.M)
@@ -498,9 +498,9 @@ class AzureArmParameter:
     use_availability_sets: bool = False
     vm_tags: Dict[str, Any] = field(default_factory=dict)
     
-    virtual_network_resource_group: str = ""
-    virtual_network_name: str = AZURE_NEW_VIRTUAL_NETWORK
-    subnet_prefix: str = AZURE_NEW_SUBNET_PREFIX
+    virtual_network_resource_group: str = AZURE_SHARED_RG_NAME
+    virtual_network_name: str = AZURE_VIRTUAL_NETWORK_NAME
+    subnet_prefix: str = AZURE_SUBNET_PREFIX
     use_existing_virtual_network: bool = False
 
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -494,7 +494,11 @@ class AzureArmParameter:
     data_disks: List[DataDiskSchema] = field(default_factory=list)
     use_availability_sets: bool = False
     vm_tags: Dict[str, Any] = field(default_factory=dict)
-    user_data_base64: str = ""
+    
+    virtual_network_resource_group: str = ""
+    virtual_network_name: str = "lisa-virtualNetwork"
+    subnet_prefix: str = "lisa-subnet-"
+    use_existing_virtual_network: bool = False
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.admin_username, PATTERN_HEADTAIL)

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1210,7 +1210,7 @@ def save_console_log(
 
 
 def load_environment(
-    platform: "AzurePlatform", resource_group_name: str, use_private_ip: bool, log: Logger
+    platform: "AzurePlatform", resource_group_name: str, log: Logger
 ) -> Environment:
     """
     reverse load environment from a resource group.
@@ -1252,16 +1252,9 @@ def load_environment(
         ) = get_primary_ip_addresses(
             platform, resource_group_name, vms_map[node_context.vm_name]
         )
-
-        connection_public_ip = node_context.public_ip_address
-        if use_private_ip:
-            # setting public_address to empty causes set_connection_info
-            # to use address (the private ip)
-            connection_public_ip = ''
-
         node.set_connection_info(
             address=node_context.private_ip_address,
-            public_address=connection_public_ip,
+            public_address=node_context.public_ip_address,
             username=node_context.username,
             password=node_context.password,
             private_key_file=node_context.private_key_file,

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -497,11 +497,10 @@ class AzureArmParameter:
     data_disks: List[DataDiskSchema] = field(default_factory=list)
     use_availability_sets: bool = False
     vm_tags: Dict[str, Any] = field(default_factory=dict)
-    
+
     virtual_network_resource_group: str = ""
     virtual_network_name: str = AZURE_VIRTUAL_NETWORK_NAME
     subnet_prefix: str = AZURE_SUBNET_PREFIX
-
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.admin_username, PATTERN_HEADTAIL)

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -494,6 +494,7 @@ class AzureArmParameter:
     data_disks: List[DataDiskSchema] = field(default_factory=list)
     use_availability_sets: bool = False
     vm_tags: Dict[str, Any] = field(default_factory=dict)
+    user_data_base64: str = ""
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.admin_username, PATTERN_HEADTAIL)
@@ -1244,7 +1245,8 @@ def load_environment(
         )
         node.set_connection_info(
             address=node_context.private_ip_address,
-            public_address=node_context.public_ip_address,
+            # public_address=node_context.public_ip_address,
+            public_address="",
             username=node_context.username,
             password=node_context.password,
             private_key_file=node_context.private_key_file,

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -498,10 +498,9 @@ class AzureArmParameter:
     use_availability_sets: bool = False
     vm_tags: Dict[str, Any] = field(default_factory=dict)
     
-    virtual_network_resource_group: str = AZURE_SHARED_RG_NAME
+    virtual_network_resource_group: str = ""
     virtual_network_name: str = AZURE_VIRTUAL_NETWORK_NAME
     subnet_prefix: str = AZURE_SUBNET_PREFIX
-    use_existing_virtual_network: bool = False
 
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -74,6 +74,9 @@ if TYPE_CHECKING:
     from .platform_ import AzurePlatform
 
 AZURE_SHARED_RG_NAME = "lisa_shared_resource"
+AZURE_NEW_VIRTUAL_NETWORK = "lisa-virtualNetwork"
+AZURE_NEW_SUBNET_PREFIX = "lisa-subnet-"
+
 
 PATTERN_NIC_NAME = re.compile(r"Microsoft.Network/networkInterfaces/(.*)", re.M)
 PATTERN_PUBLIC_IP_NAME = re.compile(
@@ -496,9 +499,10 @@ class AzureArmParameter:
     vm_tags: Dict[str, Any] = field(default_factory=dict)
     
     virtual_network_resource_group: str = ""
-    virtual_network_name: str = "lisa-virtualNetwork"
-    subnet_prefix: str = "lisa-subnet-"
+    virtual_network_name: str = AZURE_NEW_VIRTUAL_NETWORK
+    subnet_prefix: str = AZURE_NEW_SUBNET_PREFIX
     use_existing_virtual_network: bool = False
+
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.admin_username, PATTERN_HEADTAIL)
@@ -1206,7 +1210,7 @@ def save_console_log(
 
 
 def load_environment(
-    platform: "AzurePlatform", resource_group_name: str, log: Logger
+    platform: "AzurePlatform", resource_group_name: str, use_private_ip: bool, log: Logger
 ) -> Environment:
     """
     reverse load environment from a resource group.
@@ -1231,6 +1235,7 @@ def load_environment(
     environment = next(x for x in environments.values())
 
     platform_runbook: schema.Platform = platform.runbook
+
     for node in environment.nodes.list():
         assert isinstance(node, RemoteNode)
 
@@ -1247,10 +1252,16 @@ def load_environment(
         ) = get_primary_ip_addresses(
             platform, resource_group_name, vms_map[node_context.vm_name]
         )
+
+        connection_public_ip = node_context.public_ip_address
+        if use_private_ip:
+            # setting public_address to empty causes set_connection_info
+            # to use address (the private ip)
+            connection_public_ip = ''
+
         node.set_connection_info(
             address=node_context.private_ip_address,
-            # public_address=node_context.public_ip_address,
-            public_address="",
+            public_address=connection_public_ip,
             username=node_context.username,
             password=node_context.password,
             private_key_file=node_context.private_key_file,

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -258,10 +258,9 @@ class AzurePlatformSchema:
     vm_tags: Optional[Dict[str, Any]] = field(default=None)
     locations: Optional[Union[str, List[str]]] = field(default=None)
 
-    virtual_network_resource_group: str = field(default=AZURE_SHARED_RG_NAME)
+    virtual_network_resource_group: str = field(default="")
     virtual_network_name: str = field(default=AZURE_VIRTUAL_NETWORK_NAME)
     subnet_prefix: str = field(default=AZURE_SUBNET_PREFIX)
-    use_existing_virtual_network: bool = field(default=False)
 
     # Provisioning error causes by waagent is not ready or other reasons. In
     # smoke test, it can verify some points also. Other tests should use the
@@ -306,7 +305,6 @@ class AzurePlatformSchema:
                 "virtual_network_resource_group",
                 "virtual_network_name",
                 "subnet_prefix",
-                "use_existing_virtual_network",
             ],
         )
 
@@ -983,7 +981,6 @@ class AzurePlatform(Platform):
         arm_parameters.virtual_network_resource_group = self._azure_runbook.virtual_network_resource_group
         arm_parameters.subnet_prefix = self._azure_runbook.subnet_prefix
         arm_parameters.virtual_network_name = self._azure_runbook.virtual_network_name
-        arm_parameters.use_existing_virtual_network = self._azure_runbook.use_existing_virtual_network
 
         is_windows: bool = False
         arm_parameters.admin_username = self.runbook.admin_username

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -76,8 +76,8 @@ from .. import AZURE
 from . import features
 from .common import (
     AZURE_SHARED_RG_NAME,
-    AZURE_NEW_VIRTUAL_NETWORK,
-    AZURE_NEW_SUBNET_PREFIX,
+    AZURE_VIRTUAL_NETWORK_NAME,
+    AZURE_SUBNET_PREFIX,
     AzureArmParameter,
     AzureNodeArmParameter,
     AzureNodeSchema,
@@ -258,9 +258,9 @@ class AzurePlatformSchema:
     vm_tags: Optional[Dict[str, Any]] = field(default=None)
     locations: Optional[Union[str, List[str]]] = field(default=None)
 
-    virtual_network_resource_group: str = field(default="")
-    virtual_network_name: str = field(default=AZURE_NEW_VIRTUAL_NETWORK)
-    subnet_prefix: str = field(default=AZURE_NEW_SUBNET_PREFIX)
+    virtual_network_resource_group: str = field(default=AZURE_SHARED_RG_NAME)
+    virtual_network_name: str = field(default=AZURE_VIRTUAL_NETWORK_NAME)
+    subnet_prefix: str = field(default=AZURE_SUBNET_PREFIX)
     use_existing_virtual_network: bool = field(default=False)
 
     # Provisioning error causes by waagent is not ready or other reasons. In
@@ -980,12 +980,9 @@ class AzurePlatform(Platform):
         ]
         set_filtered_fields(self._azure_runbook, arm_parameters, copied_fields)
 
-        if self._azure_runbook.virtual_network_resource_group:
-            arm_parameters.virtual_network_resource_group = self._azure_runbook.virtual_network_resource_group
-        if self._azure_runbook.subnet_prefix:
-            arm_parameters.subnet_prefix = self._azure_runbook.subnet_prefix
-        if self._azure_runbook.virtual_network_name:
-            arm_parameters.virtual_network_name = self._azure_runbook.virtual_network_name
+        arm_parameters.virtual_network_resource_group = self._azure_runbook.virtual_network_resource_group
+        arm_parameters.subnet_prefix = self._azure_runbook.subnet_prefix
+        arm_parameters.virtual_network_name = self._azure_runbook.virtual_network_name
         arm_parameters.use_existing_virtual_network = self._azure_runbook.use_existing_virtual_network
 
         is_windows: bool = False

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -76,8 +76,8 @@ from .. import AZURE
 from . import features
 from .common import (
     AZURE_SHARED_RG_NAME,
-    AZURE_VIRTUAL_NETWORK_NAME,
     AZURE_SUBNET_PREFIX,
+    AZURE_VIRTUAL_NETWORK_NAME,
     AzureArmParameter,
     AzureNodeArmParameter,
     AzureNodeSchema,
@@ -978,7 +978,9 @@ class AzurePlatform(Platform):
         ]
         set_filtered_fields(self._azure_runbook, arm_parameters, copied_fields)
 
-        arm_parameters.virtual_network_resource_group = self._azure_runbook.virtual_network_resource_group
+        arm_parameters.virtual_network_resource_group = (
+            self._azure_runbook.virtual_network_resource_group
+        )
         arm_parameters.subnet_prefix = self._azure_runbook.subnet_prefix
         arm_parameters.virtual_network_name = self._azure_runbook.virtual_network_name
 

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -249,8 +249,6 @@ class AzurePlatformSchema:
         ),
     )
 
-    user_data_base64
-
     shared_resource_group_name: str = AZURE_SHARED_RG_NAME
     resource_group_name: str = field(default="")
     # specify shared resource group location

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -258,6 +258,8 @@ class AzurePlatformSchema:
     vm_tags: Optional[Dict[str, Any]] = field(default=None)
     locations: Optional[Union[str, List[str]]] = field(default=None)
 
+    cloud_init_user_data_runcommands_script: str = field(default=None)
+
     # Provisioning error causes by waagent is not ready or other reasons. In
     # smoke test, it can verify some points also. Other tests should use the
     # default False to raise errors to prevent unexpected behavior.
@@ -1101,12 +1103,12 @@ class AzurePlatform(Platform):
             "write_files": [],
             "runcmd": [],
         }
-        if os.path.exists(self.runbook.cloud_init_user_data_runcommands_script):
+        if os.path.exists(self._azure_runbook.cloud_init_user_data_runcommands_script):
             runcommands_script = ""
-            with open(self.runbook.cloud_init_user_data_runcommands_script) as stream:
+            with open(self._azure_runbook.cloud_init_user_data_runcommands_script) as stream:
                 runcommands_script = stream.read()
             if runcommands_script:
-                filename = os.path.basename(self.runbook.cloud_init_user_data_runcommands_script)
+                filename = os.path.basename(self._azure_runbook.cloud_init_user_data_runcommands_script)
                 user_data["write_files"].append({
                     "owner": f"{arm_parameters.admin_username}:{arm_parameters.admin_username}",
                     "path": f"/tmp/{filename}",

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import base64
 import copy
 import json
 import logging
@@ -9,7 +8,6 @@ import math
 import os
 import re
 import sys
-import yaml
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -264,7 +262,6 @@ class AzurePlatformSchema:
     virtual_network_name: str = field(default=AZURE_NEW_VIRTUAL_NETWORK)
     subnet_prefix: str = field(default=AZURE_NEW_SUBNET_PREFIX)
     use_existing_virtual_network: bool = field(default=False)
-    use_private_address_for_vm_connection: bool = field(default=False)
 
     # Provisioning error causes by waagent is not ready or other reasons. In
     # smoke test, it can verify some points also. Other tests should use the
@@ -310,7 +307,6 @@ class AzurePlatformSchema:
                 "virtual_network_name",
                 "subnet_prefix",
                 "use_existing_virtual_network",
-                "use_private_address_for_vm_connection"
             ],
         )
 
@@ -1491,19 +1487,11 @@ class AzurePlatform(Platform):
             public_address, private_address = get_primary_ip_addresses(
                 self, resource_group_name, vm
             )
-
-            connection_public_ip = node_context.public_ip_address
-            if self._azure_runbook.use_private_address_for_vm_connection:
-                # setting public_address to empty causes set_connection_info
-                # to use address (the private ip)
-                connection_public_ip = ''
-
-            index = index + 1
             assert isinstance(node, RemoteNode)
             node.set_connection_info(
                 address=private_address,
                 port=22,
-                public_address=connection_public_ip,
+                public_address=public_address,
                 public_port=22,
                 username=node_context.username,
                 password=node_context.password,

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -37,7 +37,7 @@ from .common import (
     wait_copy_blob,
     wait_operation,
 )
-from .platform_ import AzurePlatform
+from .platform_ import AzurePlatform, AzurePlatformSchema
 from .tools import Waagent
 
 DEFAULT_EXPORTED_VHD_CONTAINER_NAME = "lisa-vhd-exported"
@@ -122,7 +122,11 @@ class VhdTransformer(Transformer):
         runbook: VhdTransformerSchema = self.runbook
         platform = _load_platform(self._runbook_builder, self.type_name())
 
-        environment = load_environment(platform, runbook.resource_group_name, self._log)
+        azure_runbook: AzurePlatformSchema = self.runbook.get_extended_runbook(
+            AzurePlatformSchema
+        )
+
+        environment = load_environment(platform, runbook.resource_group_name, azure_runbook.use_private_address_for_vm_connection, self._log)
 
         if runbook.vm_name:
             node = next(

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -37,7 +37,7 @@ from .common import (
     wait_copy_blob,
     wait_operation,
 )
-from .platform_ import AzurePlatform, AzurePlatformSchema
+from .platform_ import AzurePlatform
 from .tools import Waagent
 
 DEFAULT_EXPORTED_VHD_CONTAINER_NAME = "lisa-vhd-exported"
@@ -122,11 +122,7 @@ class VhdTransformer(Transformer):
         runbook: VhdTransformerSchema = self.runbook
         platform = _load_platform(self._runbook_builder, self.type_name())
 
-        azure_runbook: AzurePlatformSchema = self.runbook.get_extended_runbook(
-            AzurePlatformSchema
-        )
-
-        environment = load_environment(platform, runbook.resource_group_name, azure_runbook.use_private_address_for_vm_connection, self._log)
+        environment = load_environment(platform, runbook.resource_group_name, self._log)
 
         if runbook.vm_name:
             node = next(


### PR DESCRIPTION
# Scenario 
Enable LISA to create Azure virtual machines that utilize an existing virtual network and subnet.

This will allow a test runner (that is attached to an existing virtual network) to use LISA to create and communicate with azure virtual machines (attached to the same virtual network).

# Changes
* Update the LISA ARM template to allow for the use of an existing vnet/subnet.
* Enable the use of existing vnet/subnet through a runbook
