### PR TITLE
Configurable LTP version from LISA Runbook

### DIFF
--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -593,7 +593,7 @@ class Tools:
                 cast_tool_type = cast(Type[Tool], tool_type)
                 tool = cast_tool_type.create(self._node, *args, **kwargs)
 
-            tool.initialize(*args, **kwargs)
+            tool.initialize()
 
             if not tool.exists:
                 tool_log.debug(f"'{tool.name}' not installed")

--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -593,7 +593,7 @@ class Tools:
                 cast_tool_type = cast(Type[Tool], tool_type)
                 tool = cast_tool_type.create(self._node, *args, **kwargs)
 
-            tool.initialize()
+            tool.initialize(*args, **kwargs)
 
             if not tool.exists:
                 tool_log.debug(f"'{tool.name}' not installed")

--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -49,7 +49,7 @@ class Ltp(Tool):
     _RESULT_LTP_ARCH_REGEX = re.compile(r"Machine Architecture: (.*)\s+")
 
     LTP_DIR_NAME = "ltp"
-    LTP_TESTS_GIT_TAG = "20200930"
+    LTP_TESTS_GIT_TAG = "20230127"
     LTP_GIT_URL = "https://github.com/linux-test-project/ltp.git"
     BUILD_REQUIRED_DISK_SIZE_IN_GB = 2
     LTP_RESULT_PATH = "/opt/ltp/ltp-results.log"

--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -49,7 +49,7 @@ class Ltp(Tool):
     _RESULT_LTP_ARCH_REGEX = re.compile(r"Machine Architecture: (.*)\s+")
 
     LTP_DIR_NAME = "ltp"
-    LTP_TESTS_GIT_TAG = "20230127"
+    LTP_TESTS_GIT_TAG = "20200930"
     LTP_GIT_URL = "https://github.com/linux-test-project/ltp.git"
     BUILD_REQUIRED_DISK_SIZE_IN_GB = 2
     LTP_RESULT_PATH = "/opt/ltp/ltp-results.log"
@@ -68,6 +68,11 @@ class Ltp(Tool):
     @property
     def can_install(self) -> bool:
         return True
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        git_tag = kwargs.get("git_tag")
+        if git_tag:
+            self.LTP_TESTS_GIT_TAG = git_tag
 
     def run_test(
         self,

--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -49,7 +49,7 @@ class Ltp(Tool):
     _RESULT_LTP_ARCH_REGEX = re.compile(r"Machine Architecture: (.*)\s+")
 
     LTP_DIR_NAME = "ltp"
-    LTP_TESTS_GIT_TAG = "20200930"
+    DEFAULT_LTP_TESTS_GIT_TAG = "20200930"
     LTP_GIT_URL = "https://github.com/linux-test-project/ltp.git"
     BUILD_REQUIRED_DISK_SIZE_IN_GB = 2
     LTP_RESULT_PATH = "/opt/ltp/ltp-results.log"
@@ -70,9 +70,8 @@ class Ltp(Tool):
         return True
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
-        git_tag = kwargs.get("git_tag")
-        if git_tag:
-            self.LTP_TESTS_GIT_TAG = git_tag
+        git_tag = kwargs.get("git_tag", "")
+        self._git_tag = git_tag if git_tag else self.DEFAULT_LTP_TESTS_GIT_TAG
 
     def run_test(
         self,
@@ -349,7 +348,7 @@ class Ltp(Tool):
         )
 
         # checkout tag
-        git.checkout(ref=f"tags/{self.LTP_TESTS_GIT_TAG}", cwd=ltp_path)
+        git.checkout(ref=f"tags/{self._git_tag}", cwd=ltp_path)
 
         # build ltp in /opt/ltp since this path is used by some
         # tests, e.g, block_dev test
@@ -380,7 +379,7 @@ class Ltp(Tool):
         for result in matched[1]:
             parsed_result.append(
                 LtpResult(
-                    version=self.LTP_TESTS_GIT_TAG,
+                    version=self._git_tag,
                     name=result[0].strip(),
                     status=self._parse_status_to_test_status(result[1].strip()),
                     exit_value=int(result[2].strip()),

--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -11,6 +11,7 @@ from assertpy import assert_that
 from lisa import Environment, notifier
 from lisa.executable import Tool
 from lisa.messages import SubTestMessage, TestStatus, create_test_result_message
+from lisa.node import Node
 from lisa.operating_system import CBLMariner, Debian, Fedora, Posix, Redhat, Suse
 from lisa.testsuite import TestResult
 from lisa.tools import (
@@ -69,7 +70,8 @@ class Ltp(Tool):
     def can_install(self) -> bool:
         return True
 
-    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, node: Node, *args: Any, **kwargs: Any) -> None:
+        super().__init__(node, args, kwargs)
         git_tag = kwargs.get("git_tag", "")
         self._git_tag = git_tag if git_tag else self.DEFAULT_LTP_TESTS_GIT_TAG
 

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -57,6 +57,7 @@ class LtpTestsuite(TestSuite):
         # parse variables
         tests = variables.get("ltp_test", "")
         skip_tests = variables.get("ltp_skip_test", "")
+        ltp_tests_git_tag = variables.get("ltp_tests_git_tag")
 
         # block device is required for few ltp tests
         # If not provided, we will find a disk with enough space
@@ -83,7 +84,8 @@ class LtpTestsuite(TestSuite):
             )
 
         # run ltp lite tests
-        node.tools[Ltp].run_test(
+        ltp: Ltp = node.tools.get(Ltp, git_tag=ltp_tests_git_tag)
+        ltp.run_test(
             result,
             environment,
             test_list,

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -57,7 +57,7 @@ class LtpTestsuite(TestSuite):
         # parse variables
         tests = variables.get("ltp_test", "")
         skip_tests = variables.get("ltp_skip_test", "")
-        ltp_tests_git_tag = variables.get("ltp_tests_git_tag")
+        ltp_tests_git_tag = variables.get("ltp_tests_git_tag", "")
 
         # block device is required for few ltp tests
         # If not provided, we will find a disk with enough space


### PR DESCRIPTION
The below variable can be added to runbook to
override default LTP version used for LTP tests
  - name: ltp_tests_git_tag
    value: 20230127
    is_case_visible: true