### PR TITLE
Fix timeout in perf_nvme

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -10,7 +10,7 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from dataclasses_json import dataclass_json
 from marshmallow import validate
@@ -335,8 +335,8 @@ class Environment(ContextMixin, InitializableMixin):
 
         return node
 
-    def get_information(self, force_run: bool = True) -> Dict[str, str]:
-        if self._information_cache and not force_run:
+    def get_information(self, force_run: bool = True) -> Union[Dict[str, str], None]:
+        if self._information_cache is None and not force_run:
             self.log.info("Returning cached Environment Information")
             return self._information_cache
         self._information_cache = {}

--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -10,7 +10,7 @@ from enum import Enum
 from functools import partial
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from dataclasses_json import dataclass_json
 from marshmallow import validate
@@ -335,10 +335,10 @@ class Environment(ContextMixin, InitializableMixin):
 
         return node
 
-    def get_information(self, force_run: bool = True) -> Union[Dict[str, str], None]:
+    def get_information(self, force_run: bool = True) -> Dict[str, str]:
         if self._information_cache is None and not force_run:
             self.log.info("Returning cached Environment Information")
-            return self._information_cache
+            return {}
         self._information_cache = {}
         informations: List[
             Dict[str, str]

--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -277,7 +277,7 @@ def create_perf_message(
     test_result: "TestResult",
     test_case_name: str = "",
     other_fields: Optional[Dict[str, Any]] = None,
-    env_info: Dict[str, str] = {},
+    env_info: Optional[Dict[str, str]] = None,
 ) -> T:
     environment = test_result.environment
     assert environment, "fail to get environment from testresult"

--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -277,6 +277,7 @@ def create_perf_message(
     test_result: "TestResult",
     test_case_name: str = "",
     other_fields: Optional[Dict[str, Any]] = None,
+    env_info: Dict[str, str] = {},
 ) -> T:
     environment = test_result.environment
     assert environment, "fail to get environment from testresult"
@@ -287,7 +288,10 @@ def create_perf_message(
     ):
         data_path = node.capability.network_interface.data_path.value
     message = message_type()
-    dict_to_fields(environment.get_information(), message)
+    if env_info:
+        dict_to_fields(env_info, message)
+    else:
+        dict_to_fields(environment.get_information(), message)
     message.test_case_name = test_case_name
     message.data_path = data_path
     message.test_result_id = test_result.id_

--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -277,7 +277,6 @@ def create_perf_message(
     test_result: "TestResult",
     test_case_name: str = "",
     other_fields: Optional[Dict[str, Any]] = None,
-    env_info: Optional[Dict[str, str]] = None,
 ) -> T:
     environment = test_result.environment
     assert environment, "fail to get environment from testresult"
@@ -288,10 +287,7 @@ def create_perf_message(
     ):
         data_path = node.capability.network_interface.data_path.value
     message = message_type()
-    if env_info:
-        dict_to_fields(env_info, message)
-    else:
-        dict_to_fields(environment.get_information(), message)
+    dict_to_fields(environment.get_information(force_run=False), message)
     message.test_case_name = test_case_name
     message.data_path = data_path
     message.test_result_id = test_result.id_

--- a/lisa/tools/fio.py
+++ b/lisa/tools/fio.py
@@ -213,6 +213,7 @@ class Fio(Tool):
             temp["numjob"] = int(fio_result.qdepth / fio_result.iodepth)
             mode_iops_latency[fio_result.qdepth] = temp
 
+        env_info = test_result.environment.get_information()
         for result in mode_iops_latency.values():
             result_copy = result.copy()
             result_copy["tool"] = constants.DISK_PERFORMANCE_TOOL_FIO
@@ -224,6 +225,7 @@ class Fio(Tool):
                 test_result,
                 test_name,
                 result_copy,
+                env_info,
             )
             fio_message.append(fio_result_message)
         return fio_message

--- a/lisa/tools/fio.py
+++ b/lisa/tools/fio.py
@@ -202,6 +202,7 @@ class Fio(Tool):
     ) -> List[DiskPerformanceMessage]:
         fio_message: List[DiskPerformanceMessage] = []
         mode_iops_latency: Dict[int, Dict[str, Any]] = {}
+        env_info = None
         for fio_result in fio_results_list:
             temp: Dict[str, Any] = {}
             if fio_result.qdepth in mode_iops_latency.keys():
@@ -213,7 +214,8 @@ class Fio(Tool):
             temp["numjob"] = int(fio_result.qdepth / fio_result.iodepth)
             mode_iops_latency[fio_result.qdepth] = temp
 
-        env_info = test_result.environment.get_information()
+        if test_result.environment:
+            env_info = test_result.environment.get_information()
         for result in mode_iops_latency.values():
             result_copy = result.copy()
             result_copy["tool"] = constants.DISK_PERFORMANCE_TOOL_FIO

--- a/lisa/tools/fio.py
+++ b/lisa/tools/fio.py
@@ -202,7 +202,6 @@ class Fio(Tool):
     ) -> List[DiskPerformanceMessage]:
         fio_message: List[DiskPerformanceMessage] = []
         mode_iops_latency: Dict[int, Dict[str, Any]] = {}
-        env_info = None
         for fio_result in fio_results_list:
             temp: Dict[str, Any] = {}
             if fio_result.qdepth in mode_iops_latency.keys():
@@ -214,20 +213,13 @@ class Fio(Tool):
             temp["numjob"] = int(fio_result.qdepth / fio_result.iodepth)
             mode_iops_latency[fio_result.qdepth] = temp
 
-        if test_result.environment:
-            env_info = test_result.environment.get_information()
         for result in mode_iops_latency.values():
             result_copy = result.copy()
             result_copy["tool"] = constants.DISK_PERFORMANCE_TOOL_FIO
             if other_fields:
                 result_copy.update(other_fields)
             fio_result_message = create_perf_message(
-                DiskPerformanceMessage,
-                self.node,
-                test_result,
-                test_name,
-                result_copy,
-                env_info,
+                DiskPerformanceMessage, self.node, test_result, test_name, result_copy
             )
             fio_message.append(fio_result_message)
         return fio_message


### PR DESCRIPTION
Creation of perf messages invokes multiple calls to environment.get_information() even though the environment details does not change. This leads to increased test execution time which might lead to timeout. 
This change reduces the number of calls to environment.get_information() from Fio tool.

The reduction in execution time will be observed for some duration and then will be changed for other tests/tools