### PR TITLE
Adjust Ubuntu crash kernel size and kdump cases' priority

### DIFF
--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -79,7 +79,7 @@ class KdumpCrash(TestSuite):
         6. Check if vmcore is generated under the dump path we configure after system
             boot up.
         """,
-        priority=1,
+        priority=2,
         requirement=node_requirement(
             node=schema.NodeSpace(
                 core_count=1, memory_mb=search_space.IntRange(min=2048)
@@ -97,7 +97,7 @@ class KdumpCrash(TestSuite):
         trigger kdump on the second cpu(cpu1), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=1,
         requirement=node_requirement(
             node=schema.NodeSpace(
                 core_count=search_space.IntRange(min=2, max=8),
@@ -113,7 +113,7 @@ class KdumpCrash(TestSuite):
         trigger kdump on the random cpu.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=1,
     )
     def kdumpcrash_validate_on_random_cpu(
         self, node: Node, log_path: Path, log: Logger
@@ -129,7 +129,7 @@ class KdumpCrash(TestSuite):
         trigger kdump on the 33th cpu(cpu32), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=1,
         requirement=node_requirement(
             node=schema.NodeSpace(core_count=search_space.IntRange(min=33, max=192))
         ),
@@ -161,7 +161,7 @@ class KdumpCrash(TestSuite):
         and trigger kdump on the 416th cpu(cpu415), which is designed by a known issue.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=4,
         requirement=node_requirement(
             node=schema.NodeSpace(core_count=search_space.IntRange(min=416))
         ),
@@ -176,7 +176,7 @@ class KdumpCrash(TestSuite):
         This test case verifies if the kdump is effect when crashkernel is set auto.
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=3,
     )
     def kdumpcrash_validate_auto_size(
         self, node: Node, log_path: Path, log: Logger
@@ -193,7 +193,7 @@ class KdumpCrash(TestSuite):
 
         The test steps are same as `kdumpcrash_validate_single_core`.
         """,
-        priority=2,
+        priority=3,
         requirement=node_requirement(
             node=schema.NodeSpace(memory_mb=search_space.IntRange(min=2097152)),
         ),

--- a/microsoft/testsuites/kdump/kdumpcrash.py
+++ b/microsoft/testsuites/kdump/kdumpcrash.py
@@ -206,7 +206,7 @@ class KdumpCrash(TestSuite):
 
     # This method might stuck after triggering crash,
     # so use timeout to recycle it faster.
-    @func_set_timeout(5)  # type: ignore
+    @func_set_timeout(10)  # type: ignore
     def _try_connect(self, remote_node: RemoteNode) -> Any:
         return try_connect(remote_node._connection_info)
 


### PR DESCRIPTION
1.  Change the timeout time of _try_connect func to 10s
2. Adjust the crash kernel size for Ubuntu, Debian images
The default crash kernel size is "512M-:192M". That means when the system memory is bigger than 512M, then reserve memory 192M for crash kernel. This default setting works well for most Gen1 images, but for Gen2 images, some have out of memory error. When increasing the size as 512M, the error disappeared. 
3. Adjust the priority of kdump cases