### PR TITLE
Correct regex for CH perf test filter

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -350,10 +350,10 @@ class CloudHypervisorTests(Tool):
 
         # Ex. String for below regex
         # "boot_time_ms" (test_timeout=2s,test_iterations=10)
-        regex = '\\"(.*)\\" \\('
+        regex = '\\"(.*)\\"(.*)test_timeout(.*), test_iterations(.*)\\)'
 
         pattern = re.compile(regex)
-        tests_list = pattern.findall(stdout)
+        tests_list = [match[0] for match in pattern.findall(stdout)]
 
         self._log.debug(f"Testcases found: {tests_list}")
         return set(tests_list)


### PR DESCRIPTION
This change will modify regex used to filter the CH perf testcase names from stdout while listing it at runtime. Recently we have seen some other stdout lines which matched the older regex which lead to fetch garbage value in listing the testcase at runtime.