### PR TITLE
Save serial log after testcase completion 

### DIFF
--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -107,6 +107,14 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
         """
         pass
 
+    def _save_console_log(
+        self,
+        environment: Environment,
+        log: Logger,
+        dir_name: str,
+    ) -> None:
+        ...
+
     @hookimpl
     def get_environment_information(self, environment: Environment) -> Dict[str, str]:
         assert environment.platform

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -640,6 +640,13 @@ class TestSuite:
                 log=case_log,
             )
 
+            if environment.platform:
+                environment.platform._save_console_log(
+                    environment=environment,
+                    log=self.__log,
+                    dir_name=f"{case_unique_name}",
+                )
+
             case_log.info(
                 f"result: {case_result.status.name}, " f"elapsed: {total_timer}"
             )


### PR DESCRIPTION
Save serial log of VMs after testcase completes.

Example log file path: 
1. runtime\log\20230410\20230410-095213-491\environments\20230410-095223-846-generated_0\lisa-remote1234-20230410-095213-491-e0-n0
2. runtime\log\20230410\20230410-095213-491\environments\20230410-095223-846-generated_0\lisa-remote1234-20230410-095213-491-e0-n1