### PR TITLE
feature: add IaaS feature

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1387,6 +1387,15 @@ class Resize(AzureFeatureMixin, features.Resize):
         # Get list of vm sizes available in the current location
         location_info = platform.get_location_info(node_runbook.location, self._log)
         capabilities = [value for _, value in location_info.capabilities.items()]
+        filter_capabilities = []
+        # Filter out the vm sizes that are not available for IaaS deployment
+        for capability in capabilities:
+            if any(
+                cap
+                for cap in capability.resource_sku["capabilities"]
+                if cap["name"] == "VMDeploymentTypes" and "IaaS" in cap["value"]
+            ):
+                filter_capabilities.append(capability)
         sorted_sizes = platform.get_sorted_vm_sizes(capabilities, self._log)
 
         current_vm_size = next(

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2236,3 +2236,16 @@ class Architecture(AzureFeatureMixin, Feature):
 
     def enabled(self) -> bool:
         return True
+
+
+class IaaS(AzureFeatureMixin, Feature):
+    @classmethod
+    def create_setting(
+        cls, *args: Any, **kwargs: Any
+    ) -> Optional[schema.FeatureSettings]:
+        raw_capabilities: Any = kwargs.get("raw_capabilities")
+        deployment_types = raw_capabilities.get("VMDeploymentTypes", None)
+        if deployment_types and "IaaS" in deployment_types:
+            return schema.FeatureSettings.create(cls.name())
+
+        return None

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -338,6 +338,7 @@ class AzurePlatform(Platform):
             features.NetworkInterface,
             features.Resize,
             features.StartStop,
+            features.IaaS,
             features.Infiniband,
             features.Hibernation,
             features.SecurityProfile,
@@ -2039,7 +2040,18 @@ class AzurePlatform(Platform):
                 continue
 
             if vm_size in caps:
-                candidate_caps.append(caps[vm_size])
+                cap_features = caps[vm_size].capability.features
+                # Azure platform offers SaaS, PaaS, IaaS.
+                # VMs can only been created with the VM Skus which have IaaS capability.
+                # Below exception will be thrown out
+                # if the VM Sku doesn't provide IaaS capability.
+                # BadRequest: Requested operation cannot be performed because VM size
+                # XXX does not support IaaS deployments.
+                if not cap_features or (
+                    cap_features
+                    and [x for x in cap_features if features.IaaS.name() == x.type]
+                ):
+                    candidate_caps.append(caps[vm_size])
 
         return candidate_caps
 

--- a/selftests/azure/azure_locations_australiaeast.json
+++ b/selftests/azure/azure_locations_australiaeast.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -223,7 +227,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -402,6 +410,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },

--- a/selftests/azure/azure_locations_brazilsouth.json
+++ b/selftests/azure/azure_locations_brazilsouth.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -223,7 +227,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -402,6 +410,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },

--- a/selftests/azure/azure_locations_eastus.json
+++ b/selftests/azure/azure_locations_eastus.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -224,7 +228,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -403,6 +411,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },
@@ -581,7 +592,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -775,7 +790,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -939,7 +958,11 @@
                 "gpu_count": 4,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false

--- a/selftests/azure/azure_locations_northeurope.json
+++ b/selftests/azure/azure_locations_northeurope.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -223,7 +227,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -402,6 +410,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },

--- a/selftests/azure/azure_locations_uksouth.json
+++ b/selftests/azure/azure_locations_uksouth.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -223,7 +227,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -402,6 +410,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },

--- a/selftests/azure/azure_locations_westeurope.json
+++ b/selftests/azure/azure_locations_westeurope.json
@@ -55,7 +55,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -223,7 +227,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -402,6 +410,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },

--- a/selftests/azure/azure_locations_westus3.json
+++ b/selftests/azure/azure_locations_westus3.json
@@ -58,6 +58,9 @@
                         },
                         {
                             "type": "SerialConsole"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },
@@ -205,7 +208,11 @@
                 "gpu_count": 0,
                 "features": {
                     "is_allow_set": true,
-                    "items": []
+                    "items": [
+                        {
+                            "type": "IaaS"
+                        }
+                    ]
                 },
                 "excluded_features": {
                     "is_allow_set": false
@@ -385,6 +392,9 @@
                     "items": [
                         {
                             "type": "StartStop"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },
@@ -570,6 +580,9 @@
                         },
                         {
                             "type": "SerialConsole"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },
@@ -751,6 +764,9 @@
                         },
                         {
                             "type": "SerialConsole"
+                        },
+                        {
+                            "type": "IaaS"
                         }
                     ]
                 },


### PR DESCRIPTION
before fix, when test ran against the VM sizes which don't support IaaS, the result is like below
```
deployment failed. LisaException: BadRequest: Requested operation cannot be performed because VM size Standard_D5_v2_Internal does not support IaaS deployments.
```

after fix, the test case results are skipped.