### PR TITLE
Tools: Modprobe, Lsmod

### DIFF
--- a/lisa/tools/modprobe.py
+++ b/lisa/tools/modprobe.py
@@ -3,6 +3,7 @@
 from typing import Any, List, Union
 
 from lisa.executable import Tool
+from lisa.tools import Lsmod
 
 
 class Modprobe(Tool):
@@ -80,7 +81,14 @@ class Modprobe(Tool):
         self,
         modules: Union[str, List[str]],
         dry_run: bool = False,
+        skip_loaded: bool = False,
     ) -> bool:
+        if skip_loaded:
+            minimized = self.node.tools[Lsmod].get_unloaded_modules(modules)
+            if not minimized:
+                self.node.log.debug(f"Modules {modules} were already loaded")
+                return True
+            modules = minimized
         if isinstance(modules, list):
             modules_str = "-a " + " ".join(modules)
         else:
@@ -88,6 +96,7 @@ class Modprobe(Tool):
         command = f"{modules_str}"
         if dry_run:
             command = f"--dry-run {command}"
+
         result = self.run(
             command,
             force_run=True,

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -711,8 +711,8 @@ class DpdkTestpmd(Tool):
             if modprobe.module_exists(module):
                 rmda_drivers.append(module)
 
-        modprobe.load(rmda_drivers)
-        modprobe.load(mellanox_drivers)
+        modprobe.load(rmda_drivers, skip_loaded=True)
+        modprobe.load(mellanox_drivers, skip_loaded=True)
 
     def _install_dependencies(self) -> None:
         node = self.node


### PR DESCRIPTION
Two commits fine-tuning behavior and capabilities on a few tools:

- Lsmod: 
Add a function to check for unloaded modules
If modules are compiled in, attempting to modprobe without checking if they're present can raise an error code. 
Add a function to minimize a list of drivers, removing any that are already loaded.

-Modprobe: 
add an option to use Lsmod to only load missing modules.



