### PR TITLE
[Tools] Tee

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from assertpy import assert_that
 from retry import retry
 
-from lisa.tools import Echo, Ip, Lspci
+from lisa.tools import Ip, Lspci, Tee
 from lisa.util import InitializableMixin, LisaException, constants, find_groups_in_lines
 
 if TYPE_CHECKING:
@@ -166,7 +166,7 @@ class Nics(InitializableMixin):
 
     # update the current nic driver in the NicInfo instance
     # grabs the driver short name and the driver sysfs path
-    def get_nic_driver(self, nic_name: str) -> str:
+    def get_nic_driver(self, nic_name: str, store_driver: bool = True) -> str:
         # get the current driver for the nic from the node
         # sysfs provides a link to the driver entry at device/driver
         nic = self.get_nic(nic_name)
@@ -182,7 +182,8 @@ class Nics(InitializableMixin):
         assert_that(driver_name).described_as(
             f"sysfs entry contained no filename for device driver: {found_link}"
         ).is_not_equal_to("")
-        nic.bound_driver = driver_name
+        if store_driver:
+            nic.bound_driver = driver_name
         return driver_name
 
     def get_nic(self, nic_name: str) -> NicInfo:
@@ -216,22 +217,19 @@ class Nics(InitializableMixin):
 
     def unbind(self, nic: NicInfo) -> None:
         # unbind nic from current driver and return the old sysfs path
-        echo = self._node.tools[Echo]
+        tee = self._node.tools[Tee]
         # if sysfs path is not set, fetch the current driver
         if not nic.driver_sysfs_path:
             self.get_nic_driver(nic.upper)
+        self._node.tools[Ip].down(nic.upper)
         unbind_path = nic.driver_sysfs_path.joinpath("unbind")
-        echo.write_to_file(
-            nic.dev_uuid,
-            unbind_path,
-            sudo=True,
-        )
+        tee.write_to_file(nic.dev_uuid, unbind_path, sudo=True)
 
     def bind(self, nic: NicInfo, driver_module_path: str) -> None:
-        echo = self._node.tools[Echo]
+        tee = self._node.tools[Tee]
         nic.driver_sysfs_path = PurePosixPath(driver_module_path)
         bind_path = nic.driver_sysfs_path.joinpath("bind")
-        echo.write_to_file(
+        tee.write_to_file(
             nic.dev_uuid,
             self._node.get_pure_path(f"{str(bind_path)}"),
             sudo=True,

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -105,6 +105,7 @@ from .systemd_analyze import SystemdAnalyze
 from .tar import Tar
 from .taskset import TaskSet
 from .tcpdump import TcpDump
+from .tee import Tee
 from .texinfo import Texinfo
 from .timedatectl import Timedatectl
 from .timeout import Timeout
@@ -222,6 +223,7 @@ __all__ = [
     "SystemdAnalyze",
     "Tar",
     "TaskSet",
+    "Tee",
     "Texinfo",
     "TcpDump",
     "Timedatectl",

--- a/lisa/tools/tee.py
+++ b/lisa/tools/tee.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import PurePath
+from typing import cast
+
+from lisa.executable import Tool
+from lisa.operating_system import Posix
+
+
+class Tee(Tool):
+    @property
+    def command(self) -> str:
+        return "tee"
+
+    @property
+    def can_install(self) -> bool:
+        return self.node.os.is_posix
+
+    def install(self) -> bool:
+        posix_os: Posix = cast(Posix, self.node.os)
+        package_name = "coreutils"
+        posix_os.install_packages(package_name)
+        return self._check_exists()
+
+    def write_to_file(
+        self,
+        value: str,
+        file: PurePath,
+        append: bool = False,
+        sudo: bool = False,
+    ) -> None:
+        # tee breaks sudo ordering of tool.run()
+        # cwd, shell, etc will be passed through to execute
+        # sudo is the only one which needs special casing
+        cmd = "tee"
+        if append:
+            cmd = f"{cmd} -a"
+        if sudo:
+            cmd = f"sudo {cmd}"
+        cmd = f"{cmd} {str(file)}"
+        self.node.execute(f"echo '{value}' | {cmd}", shell=True)


### PR DESCRIPTION
nic bind/unbind can fail when using echo and bash append.
This results in strange behavior in dpdk tests when nics are not set up correctly.

- Add Tee tool for using echo 'value' | sudo tee filename to ensure writes are not lost due to file permissions on special files
- Add option to not store NIC driver when calling get_nic_driver