### PR TITLE
throw the detailed exception when VM can't be connected after VM reboot

### DIFF
--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -32,6 +32,7 @@ from lisa.tools import (
     Ssh,
 )
 from lisa.tools.ntttcp import NTTTCP_TCP_CONCURRENCY, NTTTCP_UDP_CONCURRENCY
+from lisa.util import LisaException
 from lisa.util.process import ExecutableResult, Process
 
 
@@ -363,6 +364,15 @@ def perf_ntttcp(
 
             perf_ntttcp_message_list.append(ntttcp_message)
     finally:
+        error_msg = ""
+        throw_error = False
+        for node in [client, server]:
+            if not node.is_connected:
+                error_msg += f" VM {node.name} can't be connected, "
+                throw_error = True
+        if throw_error:
+            error_msg += "probably due to VM stuck on reboot stage."
+            raise LisaException(error_msg)
         for ntttcp in [client_ntttcp, server_ntttcp]:
             ntttcp.restore_system(udp_mode)
         for lagscope in [client_lagscope, server_lagscope]:


### PR DESCRIPTION
previous it failed for `NetworkPerformace.perf_tcp_ntttcp_synthetic: FAILED   failed. AssertionError:`

call trace
```
  File "D:\a\_work\1\s\lisa\lisa\testsuite.py", line 64, in _call_with_retry_and_timeout
    retry_call(
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\retry\api.py", line 101, in retry_call
    return __retry_internal(partial(f, *args, **kwargs), exceptions, tries, delay, max_delay, backoff, jitter, logger)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\retry\api.py", line 33, in __retry_internal
    return f()
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\func_timeout\dafunc.py", line 108, in func_timeout
    raise_exception(exception)
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\func_timeout\py3_raise.py", line 7, in raise_exception
    raise exception[0] from None
  File "D:\a\_work\1\s\lisa\microsoft\testsuites\performance\networkperf.py", line 284, in after_case
    cleanup_process(environment, process)
  File "D:\a\_work\1\s\lisa\microsoft\testsuites\performance\common.py", line 114, in cleanup_process
    kill = node.tools[Kill]
  File "D:\a\_work\1\s\lisa\lisa\executable.py", line 543, in __getitem__
    return self.get(tool_type=tool_type)
  File "D:\a\_work\1\s\lisa\lisa\executable.py", line 598, in get
    if not tool.exists:
  File "D:\a\_work\1\s\lisa\lisa\executable.py", line 153, in exists
    self._exists = self._check_exists()
  File "D:\a\_work\1\s\lisa\lisa\executable.py", line 341, in _check_exists
    exists, self._use_sudo = self.command_exists(self.command)
  File "D:\a\_work\1\s\lisa\lisa\executable.py", line 195, in command_exists
    result = self.node.execute(where_command, shell=True, no_info_log=True)
  File "D:\a\_work\1\s\lisa\lisa\node.py", line 213, in execute
    process = self.execute_async(
  File "D:\a\_work\1\s\lisa\lisa\node.py", line 244, in execute_async
    return self._execute(
  File "D:\a\_work\1\s\lisa\lisa\node.py", line 421, in _execute
    process.start(
  File "D:\a\_work\1\s\lisa\lisa\util\process.py", line 162, in start
    self._process = self._shell.spawn(
  File "D:\a\_work\1\s\lisa\lisa\util\shell.py", line 301, in spawn
    assert self._inner_shell
AssertionError
2023-04-19 15:04:38.314[5676][DEBUG] lisa.suite[NetworkPerformace].case[perf_tcp_ntttcp_synthetic] after_case end in 0.248 sec
```