### PR TITLE
get kernel version from node if it is connected

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -628,6 +628,10 @@ class AzurePlatform(Platform):
     def _get_kernel_version(self, node: Node) -> str:
         result: str = ""
 
+        if node.is_connected and node.is_posix:
+            linux_information = node.tools[Uname].get_linux_information()
+            result = linux_information.kernel_version_raw
+
         if not result and hasattr(node, ATTRIBUTE_FEATURES):
             # try to get kernel version in Azure. use it, when uname doesn't work
             node.log.debug("detecting kernel version from serial log...")


### PR DESCRIPTION
this is to save time when send subtestresults

before fixing, it needs 8 mins to send total 616 subtestresults
```
2023-04-21T06:31:55.2524683Z 2023-04-21 06:31:55.237[1192][DEBUG] lisa.notifier[Console] received message [SubTestResult]: ...
2023-04-21T06:39:33.6933565Z 2023-04-21 06:39:33.688[1236][DEBUG] lisa.notifier[Console] received message [SubTestResult]: ...
```

after fixing, it needs 1 mins to send total 616 subtestresults
```
2023-04-21T05:08:02.5366873Z 2023-04-21 05:08:02.524[1720][DEBUG] lisa.notifier[Console] received message [SubTestResult]: ...
2023-04-21T05:09:15.1111084Z 2023-04-21 05:09:15.096[5140][DEBUG] lisa.notifier[Console] received message [SubTestResult]: ...
```