### PR TITLE
DPDK: Make test nic choice consistent

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -188,6 +188,14 @@ class Nics(InitializableMixin):
     def get_nic(self, nic_name: str) -> NicInfo:
         return self.nics[nic_name]
 
+    def get_primary_nic(self) -> NicInfo:
+        return self.get_nic_by_index(0)
+
+    def get_secondary_nic(self) -> NicInfo:
+        # get a nic which isn't servicing the SSH connection with lisa.
+        # will assert if none is present.
+        return self.get_nic_by_index(1)
+
     def get_nic_by_index(self, index: int = -1) -> NicInfo:
         # get nic by index, default is -1 to give a non-primary nic
         # when there are more than one nic on the system

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -787,7 +787,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         if reset_connections:
             self._node.close()
         self._node.nics.reload()
-        default_nic = self._node.nics.get_nic_by_index(0)
+        default_nic = self._node.nics.get_primary_nic()
 
         if enabled and not default_nic.lower:
             raise LisaException("SRIOV is enabled, but VF is not found.")

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -138,7 +138,7 @@ class Dpdk(TestSuite):
 
         try:
             # run OVS tests, providing OVS with the NIC info needed for DPDK init
-            ovs.setup_ovs(node.nics.get_nic_by_index().pci_slot)
+            ovs.setup_ovs(node.nics.get_nic_by_index(1).pci_slot)
 
             # validate if OVS was able to initialize DPDK
             node.execute(
@@ -331,7 +331,7 @@ class Dpdk(TestSuite):
     ) -> None:
         test_kit = initialize_node_resources(node, log, variables, "failsafe")
         testpmd = test_kit.testpmd
-        test_nic = node.nics.get_nic_by_index()
+        test_nic = node.nics.get_nic_by_index(1)
         testpmd_cmd = testpmd.generate_testpmd_command(
             test_nic, 0, "txonly", "failsafe"
         )
@@ -392,7 +392,7 @@ class Dpdk(TestSuite):
         vpp.install()
 
         net = node.nics
-        nic = net.get_nic_by_index()
+        nic = net.get_nic_by_index(1)
 
         # set devices to down and restart vpp service
         ip = node.tools[Ip]

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -138,7 +138,7 @@ class Dpdk(TestSuite):
 
         try:
             # run OVS tests, providing OVS with the NIC info needed for DPDK init
-            ovs.setup_ovs(node.nics.get_nic_by_index(1).pci_slot)
+            ovs.setup_ovs(node.nics.get_secondary_nic().pci_slot)
 
             # validate if OVS was able to initialize DPDK
             node.execute(
@@ -232,7 +232,7 @@ class Dpdk(TestSuite):
         server_proc = node.execute_async(
             (
                 f"{server_app_path} -l 1-2 -n 4 "
-                f"-b {node.nics.get_nic_by_index(0).pci_slot} -- -p 3 -n 1"
+                f"-b {node.nics.get_primary_nic().pci_slot} -- -p 3 -n 1"
             ),
             sudo=True,
             shell=True,
@@ -247,7 +247,7 @@ class Dpdk(TestSuite):
         client_result = node.execute(
             (
                 f"timeout -s INT 2 {client_app_path} --proc-type=secondary -l 3 -n 4"
-                f" -b {node.nics.get_nic_by_index(0).pci_slot} -- -n 0"
+                f" -b {node.nics.get_primary_nic().pci_slot} -- -n 0"
             ),
             sudo=True,
             shell=True,
@@ -331,7 +331,7 @@ class Dpdk(TestSuite):
     ) -> None:
         test_kit = initialize_node_resources(node, log, variables, "failsafe")
         testpmd = test_kit.testpmd
-        test_nic = node.nics.get_nic_by_index(1)
+        test_nic = node.nics.get_secondary_nic()
         testpmd_cmd = testpmd.generate_testpmd_command(
             test_nic, 0, "txonly", "failsafe"
         )
@@ -392,7 +392,7 @@ class Dpdk(TestSuite):
         vpp.install()
 
         net = node.nics
-        nic = net.get_nic_by_index(1)
+        nic = net.get_secondary_nic()
 
         # set devices to down and restart vpp service
         ip = node.tools[Ip]
@@ -605,7 +605,7 @@ class Dpdk(TestSuite):
     ) -> None:
         lsmod = node.tools[Lsmod]
         modprobe = node.tools[Modprobe]
-        nic = node.nics.get_nic_by_index()
+        nic = node.nics.get_secondary_nic()
         node.nics.get_nic_driver(nic.upper)
         if nic.bound_driver == "hv_netvsc":
             enable_uio_hv_generic_for_nic(node, nic)

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1,4 +1,3 @@
-import random
 import time
 from collections import deque
 from functools import partial
@@ -159,18 +158,7 @@ def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
 
 
-def get_random_nic_with_ip(test_kit: DpdkTestResources) -> NicInfo:
-    nics = [
-        test_kit.node.nics.get_nic(nic)
-        for nic in test_kit.node.nics.get_upper_nics()
-        if nic != test_kit.node.nics.get_nic_by_index(0).upper
-        and test_kit.node.nics.get_nic(nic).ip_addr
-    ]
-    if not nics:
-        raise LisaException(
-            f"Node has no secondary nics with ip addresses! {test_kit.node.name}"
-        )
-    return random.choice(nics)
+
 
 
 def generate_send_receive_run_info(
@@ -182,7 +170,7 @@ def generate_send_receive_run_info(
     use_max_nics: bool = False,
     use_service_cores: int = 1,
 ) -> Dict[DpdkTestResources, str]:
-    snd_nic, rcv_nic = [get_random_nic_with_ip(x) for x in [sender, receiver]]
+    snd_nic, rcv_nic = [x.node.nics.get_nic_by_index(1) for x in [sender, receiver]]
 
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
@@ -309,7 +297,7 @@ def initialize_node_resources(
         "Test needs at least 1 NIC on the test node."
     ).is_greater_than_or_equal_to(1)
 
-    test_nic = node.nics.get_nic_by_index()
+    test_nic = node.nics.get_nic_by_index(1)
 
     # check an assumption that our nics are bound to hv_netvsc
     # at test start.
@@ -435,7 +423,7 @@ def verify_dpdk_build(
     testpmd = test_kit.testpmd
 
     # grab a nic and run testpmd
-    test_nic = node.nics.get_nic_by_index()
+    test_nic = node.nics.get_nic_by_index(1)
 
     testpmd_cmd = testpmd.generate_testpmd_command(
         test_nic,

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -158,9 +158,6 @@ def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
 
 
-
-
-
 def generate_send_receive_run_info(
     pmd: str,
     sender: DpdkTestResources,
@@ -170,7 +167,7 @@ def generate_send_receive_run_info(
     use_max_nics: bool = False,
     use_service_cores: int = 1,
 ) -> Dict[DpdkTestResources, str]:
-    snd_nic, rcv_nic = [x.node.nics.get_nic_by_index(1) for x in [sender, receiver]]
+    snd_nic, rcv_nic = [x.node.nics.get_secondary_nic() for x in [sender, receiver]]
 
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
@@ -297,7 +294,7 @@ def initialize_node_resources(
         "Test needs at least 1 NIC on the test node."
     ).is_greater_than_or_equal_to(1)
 
-    test_nic = node.nics.get_nic_by_index(1)
+    test_nic = node.nics.get_secondary_nic()
 
     # check an assumption that our nics are bound to hv_netvsc
     # at test start.
@@ -423,7 +420,7 @@ def verify_dpdk_build(
     testpmd = test_kit.testpmd
 
     # grab a nic and run testpmd
-    test_nic = node.nics.get_nic_by_index(1)
+    test_nic = node.nics.get_secondary_nic()
 
     testpmd_cmd = testpmd.generate_testpmd_command(
         test_nic,

--- a/microsoft/testsuites/xdp/functional.py
+++ b/microsoft/testsuites/xdp/functional.py
@@ -154,7 +154,7 @@ class XdpFunctional(TestSuite):
     ) -> None:
         # expect no response from the ping source side.
         captured_node = environment.nodes[0]
-        default_nic = captured_node.nics.get_nic_by_index(0)
+        default_nic = captured_node.nics.get_primary_nic()
         original_count = get_dropped_count(
             node=captured_node,
             nic=default_nic,
@@ -183,7 +183,7 @@ class XdpFunctional(TestSuite):
 
         # expect no packet from the ping target side
         captured_node = environment.nodes[1]
-        default_nic = captured_node.nics.get_nic_by_index(0)
+        default_nic = captured_node.nics.get_primary_nic()
         original_count = get_dropped_count(
             node=captured_node,
             nic=default_nic,
@@ -341,7 +341,7 @@ class XdpFunctional(TestSuite):
 
         nic_name = node.nics.default_nic
         nic_feature = node.features[NetworkInterface]
-        default_nic = node.nics.get_nic_by_index(0)
+        default_nic = node.nics.get_primary_nic()
 
         try:
             # validate xdp works with VF
@@ -371,7 +371,7 @@ class XdpFunctional(TestSuite):
             # disable VF
             nic_feature.switch_sriov(False)
 
-            default_nic = node.nics.get_nic_by_index(0)
+            default_nic = node.nics.get_primary_nic()
             # validate xdp works with synthetic
             original_count = get_dropped_count(
                 node=node,
@@ -399,7 +399,7 @@ class XdpFunctional(TestSuite):
             # enable VF and validate xdp works with VF again
             nic_feature.switch_sriov(True)
 
-            default_nic = node.nics.get_nic_by_index(0)
+            default_nic = node.nics.get_primary_nic()
             original_count = get_dropped_count(
                 node=node,
                 nic=default_nic,


### PR DESCRIPTION
DPDK is sensitive to numa/core/hugepage/nic association settings. Since tests do not make use of more than one NIC at a time, make NIC choice consistent (choose second nic).

This should reduce weird test failures on larger sizes, on environments with more than two nics, etc.