### PR TITLE
azure platform: throw exception when image is deprecated

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2104,6 +2104,9 @@ class AzurePlatform(Platform):
                     version=marketplace.version,
                 )
             except HttpResponseError as e:
+                # Code: ImageVersionDeprecated
+                if "ImageVersionDeprecated" in str(e):
+                    raise e
                 self._log.error(f"Could not find image info:\n {e}")
         return image_info
 


### PR DESCRIPTION
test will continue running against the deprecated images, when the images os disk size > 30 gb, then provision will failed.

e.g. image *redhat rhel 9-lvm-gen2 9.0.2022062014*

```
 deployment failed. LisaException: OperationNotAllowed: The specified disk size 30 GB is smaller than the size of the corresponding disk in the VM image: 64 GB. This is not allowed. Please choose equal or greater size or do not specify an explicit size.
```