### PR TITLE
Remove CI exclusion for 3.12 tests on Windows

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -22,13 +22,6 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12-dev']
         nox-session: [test, example]
 
-        exclude:
-          # Azure installation (Win, 3.12) currently hangs due to excessive pip backtracking
-          # Disable unit tests and retry in 2Q23
-          - python-version: '3.12-dev'
-            os: windows-2019
-            nox-session: test
-
         include:
 
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ azure = [
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
     "requests",
-    "Pillow ~= 9.4.0",
+    "Pillow ~= 9.5.0",
     "PyGObject ~= 3.42.0; platform_system == 'Linux'",
 ]
 


### PR DESCRIPTION
Pywin32 released version 306 on March 25th adding tags for 3.12.
Pillow released version 9.5.0 on April 1st adding a pre-built binary for 3.12.

These were the only blockers previously identified for installing Azure dependencies so the unit tests would run with Python 3.12. This PR updates Pillow and removes the exclusion.
