### PR TITLE
Fix docs for shared gallery image

### DIFF
--- a/docs/run_test/platform.rst
+++ b/docs/run_test/platform.rst
@@ -94,7 +94,7 @@ the shared image gallery.
          ...
          azure:
             ...
-            shared_gallery: "<subscription_id>/<image_gallery>/<image_definition>/<image_version>"
+            shared_gallery: "<subscription_id>/<resource_group>/<image_gallery>/<image_definition>/<image_version>"
 
 The remaining steps are same as outlined in
 :doc:`Getting started with Azure <quick_run>`.


### PR DESCRIPTION
Shared gallery docs leave out that you need an RG to use a subscription level shared gallery image. Update docs.