### PR TITLE
Added TDX case in verify_isolation_config, and fixed bit masking

### DIFF
--- a/microsoft/testsuites/acc/cvm.py
+++ b/microsoft/testsuites/acc/cvm.py
@@ -26,6 +26,21 @@ class CVMSuite(TestSuite):
         r"(?P<config_a>(0x[a-z,A-Z,0-9]+)), Group B.(?P<config_b>(0x[a-z,A-Z,0-9]+))"
     )
 
+    # HYPERV_CPUID_ISOLATION_CONFIG.EAX Structure
+    #     UINT32 ParavisorPresent : 1;
+    #     UINT32 Reserved0 : 31;
+    HV_PARAVISOR_PRESENT_MASK = 0b1
+
+    # HYPERV_CPUID_ISOLATION_CONFIG.EBX Structure
+    #     UINT32 IsolationType : 4;
+    #     UINT32 Reserved11 : 1;
+    #     UINT32 SharedGpaBoundaryActive : 1;
+    #     UINT32 SharedGpaBoundaryBits : 6;
+    #     UINT32 Reserved12 : 20;
+    HV_ISOLATION_TYPE_MASK = 0b1111
+    HV_SHARED_GPA_BOUNDARY_ACTIVE_MASK = 0b100000
+    HV_SHARED_GPA_BOUNDARY_BITS_MASK = 0b111111000000
+
     @TestCaseMetadata(
         description="""
         This case verifies that lsvmbus only shows devices
@@ -72,6 +87,7 @@ class CVMSuite(TestSuite):
     def verify_isolation_config(self, log: Logger, node: Node) -> None:
         valid_cvm_type = {
             "HV_ISOLATION_TYPE_SNP": 2,
+            "HV_ISOLATION_TYPE_TDX": 3,
         }
 
         dmesg_tool = node.tools[Dmesg]
@@ -79,7 +95,7 @@ class CVMSuite(TestSuite):
         isolation_config = re.search(self.__isolation_config_pattern, dmesg_output)
         if isolation_config is not None:
             isolation_config_a = int(isolation_config.group("config_a"), 16)
-            isolation_config_b = bin(int(isolation_config.group("config_b"), 16))
+            isolation_config_b = int(isolation_config.group("config_b"), 16)
             log.debug(
                 f"Isolation Config is Group A:{isolation_config_a}, "
                 f"Group B:{isolation_config_b}"
@@ -87,16 +103,40 @@ class CVMSuite(TestSuite):
         else:
             raise LisaException("No find matched Isolation Config in dmesg")
 
-        cvm_type = int(isolation_config_b[10:14], 2)
+        cvm_type = isolation_config_b & self.HV_ISOLATION_TYPE_MASK
         assert_that(list(valid_cvm_type.values())).contains(cvm_type)
         if cvm_type == valid_cvm_type["HV_ISOLATION_TYPE_SNP"]:
-            # config_a has 1 bit that indicates if paravisor is present
-            assert_that(isolation_config_a).is_equal_to(1)
-
-            # shared_gpa_boundary_active indicates that shared_gpa_boundary_bits is set
-            shared_gpa_boundary_active = int(isolation_config_b[8:9], 2)
-            assert_that(shared_gpa_boundary_active).is_equal_to(1)
-
-            # shared_gpa_boundary_bits indicates the bit that is used for vTOM
-            shared_gpa_boundary_bits = int(isolation_config_b[2:8], 2)
-            assert_that(shared_gpa_boundary_bits).is_equal_to(46)
+            if isolation_config_a & self.HV_PARAVISOR_PRESENT_MASK:
+                # SNP /w paravisor
+                # shared_gpa_boundary_active should be set
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_ACTIVE_MASK
+                ).is_equal_to(0b100000)
+                # shared_gpa_boundary_bits should be 101110
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_BITS_MASK
+                ).is_equal_to(0b101110000000)
+            else:
+                # Fully Enlightened SNP
+                # shared_gpa_boundary_active should be clear
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_ACTIVE_MASK
+                ).is_equal_to(0)
+                # shared_gpa_boundary_bits should be clear
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_BITS_MASK
+                ).is_equal_to(0)
+        elif cvm_type == valid_cvm_type["HV_ISOLATION_TYPE_TDX"]:
+            if isolation_config_a & self.HV_PARAVISOR_PRESENT_MASK:
+                # These fields are still not yet settled
+                pass
+            else:
+                # Fully Enlightened TDX
+                # shared_gpa_boundary_active should be clear
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_ACTIVE_MASK
+                ).is_equal_to(0)
+                # shared_gpa_boundary_bits should be clear
+                assert_that(
+                    isolation_config_b & self.HV_SHARED_GPA_BOUNDARY_BITS_MASK
+                ).is_equal_to(0)


### PR DESCRIPTION
TDX was added as a valid_cvm_type. An if case was added for it as well.

Currently for TDX /w paravisor HV_SHARED_GPA_BOUNDARY_ACTIVE and HV_SHARED_GPA_BOUNDARY_BITS are not settled so that case is left blank for now.

Also fixed bit selection logic, now using bit masks instead.