### PR TITLE
update message when vm in bad status caused by kernel panic

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -173,16 +173,20 @@ class TestResult:
     def set_status(
         self, new_status: TestStatus, message: Union[str, List[str]]
     ) -> None:
+        send_result = False
         if message:
             if isinstance(message, str):
                 message = [message]
             if self.message:
                 message.insert(0, self.message)
             self.message = "\n".join(message)
+            send_result = True
         if self.status != new_status:
             self.status = new_status
             if new_status == TestStatus.RUNNING:
                 self._timer = create_timer()
+            send_result = True
+        if send_result:
             self._send_result_message(self.stacktrace)
 
     def check_environment(


### PR DESCRIPTION
per previous code logic, when vm in bad state + kernel panic detected, we will set state as FAILED + panic message here https://github.com/microsoft/lisa/blob/main/lisa/runners/lisa_runner.py#L364
since the state is FAILED which is equal with the previous state of current test result, so the _send_result_message not invoked.
before this change
```
cannot connect to TCP port: [IP:PORT], error code: 10060
```
after this change
```
cannot connect to TCP port: [IP:PORT], error code: 10060 after_case found panic in serial log: ['[   18.054362][  T630] RIP: 0010:hv_irq_unmask+0xaf/0x390 [pci_hyperv]\r', '[   18.322878][  T630] RIP: 0010:hv_irq_unmask+0xaf/0x390 [pci_hyperv]\r']
```
not sure the impact of current change, maybe add one more parameter in set_status to indicate send result or not? @squirrelsc 