### PR TITLE
Add name pattern for Alpine like images

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -637,7 +637,7 @@ class CoreOs(Linux):
 class Alpine(Linux):
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
-        return re.compile("^Alpine")
+        return re.compile("^Alpine|alpine|alpaquita")
 
 
 @dataclass


### PR DESCRIPTION
Alpine like images don't support -O option for the ping command. Add some name patterns that are Alpine-like images. Then when running ping command, it doesn't add -O option.
