### PR TITLE
Sleep & Timeout: add coreutils Sleep tool and first use

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -93,6 +93,7 @@ from .reboot import Reboot
 from .remote_copy import RemoteCopy
 from .rm import Rm
 from .sar import Sar
+from .sleep import Sleep
 from .ssh import Ssh
 from .sshpass import Sshpass
 from .start_configuration import StartConfiguration
@@ -208,6 +209,7 @@ __all__ = [
     "Rpm",
     "Rm",
     "Sar",
+    "Sleep",
     "Sed",
     "Service",
     "ServiceInternal",

--- a/lisa/tools/sleep.py
+++ b/lisa/tools/sleep.py
@@ -1,0 +1,28 @@
+from typing import cast
+
+from lisa.executable import Tool
+from lisa.operating_system import Posix
+
+
+class Sleep(Tool):
+    @property
+    def command(self) -> str:
+        return "sleep"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def install(self) -> bool:
+        posix_os: Posix = cast(Posix, self.node.os)
+        package_name = "coreutils"
+        posix_os.install_packages(package_name)
+        return self._check_exists()
+
+    # Pause for NUMBER seconds.  SUFFIX may be 's' for seconds (the
+    # default), 'm' for minutes, 'h' for hours or 'd' for days.  NUMBER
+    # need not be an integer.  Given two or more arguments, pause for
+    # the amount of time specified by the sum of their values.
+
+    def sleep_seconds(self, delay: int = 5) -> None:
+        self.run(parameters=f"{delay}", shell=True, force_run=True)

--- a/lisa/tools/timeout.py
+++ b/lisa/tools/timeout.py
@@ -1,5 +1,6 @@
 from lisa.executable import ExecutableResult, Tool
 from lisa.util.constants import SIGTERM
+from lisa.tools import Sleep
 
 
 class Timeout(Tool):
@@ -12,7 +13,12 @@ class Timeout(Tool):
         return False
 
     def run_with_timeout(
-        self, command: str, timeout: int, signal: int = SIGTERM, kill_timeout: int = 0
+        self,
+        command: str,
+        timeout: int,
+        signal: int = SIGTERM,
+        kill_timeout: int = 0,
+        delay_start: int = 0,
     ) -> ExecutableResult:
         # timeout [OPTION] DURATION COMMAND [ARG]...
         params = f"-s {signal} --preserve-status {timeout} {command}"
@@ -21,7 +27,8 @@ class Timeout(Tool):
         command_timeout = timeout
         if kill_timeout:
             command_timeout = kill_timeout + 10
-
+        if delay_start:
+            self.node.tools[Sleep].sleep_seconds(delay_start)
         return self.run(
             parameters=params,
             force_run=True,

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -347,9 +347,14 @@ class DpdkTestpmd(Tool):
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:
         self._last_run_timeout = timeout
         self.node.log.info(f"{self.node.name} running: {cmd}")
-
+        # add delays such that receiver will always start first and end last
+        delay_start = 0
+        if "rxonly" in cmd:
+            timeout *= 2
+        if "txonly" in cmd:
+            delay_start = 5
         proc_result = self.node.tools[Timeout].run_with_timeout(
-            cmd, timeout, SIGINT, kill_timeout=timeout + 10
+            cmd, timeout, SIGINT, kill_timeout=timeout + 10, delay_start=delay_start
         )
         self._last_run_output = proc_result.stdout
         self.populate_performance_data()


### PR DESCRIPTION
Add a tool for coreutils sleep.
- Add use in Timeout for adding a delay before start.
- Add use of both in dpdk for delaying sender to start after receiver