### PR TITLE
Update libvirt-python package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ legacy = [
 ]
 
 libvirt = [
-    "libvirt-python ~= 8.9.0; platform_system != 'Windows'",
+    "libvirt-python ~= 9.3.0; platform_system != 'Windows'",
     "pycdlib ~= 1.12.0; platform_system != 'Windows'",
 ]
 


### PR DESCRIPTION
A newer version of libvirt-python is needed for compatibility with the latest version of libvirt.

Note that libvirt-python versions are backwards-compatibility with older versions of libvirt. But they aren't always forwards compatible.