### PR TITLE
fix nics count is not enough issue

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -416,6 +416,7 @@ class Dpdk(TestSuite):
         priority=4,
         requirement=simple_requirement(
             min_core_count=8,
+            min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             supported_features=[IsolatedResource],


### PR DESCRIPTION
before fix
```
failed. LisaException: Attempted get_upper_nics()[1], only 1 nics are registered in node.nics. Had upper interfaces: ['eth0']
```

after fix, test pass