### PR TITLE
Replace the blob name as the original vhd path in the error message

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -78,7 +78,9 @@ hookimpl = pluggy.HookimplMarker(_NAME_LISA)
 
 
 class LisaException(Exception):
-    ...
+    def __init__(self, *args: object) -> None:
+        args = tuple(secret.mask(arg) if isinstance(arg, str) else arg for arg in args)
+        super().__init__(*args)
 
 
 class UnsupportedOperationException(LisaException):

--- a/selftests/test_secret.py
+++ b/selftests/test_secret.py
@@ -12,6 +12,9 @@ class SecretTestCase(TestCase):
     def setUp(self) -> None:
         reset()
 
+    def tearDown(self) -> None:
+        reset()
+
     def test_happen_twice(self) -> None:
         add_secret("test1", sub="*")
         result = mask("test1 test1 test3")


### PR DESCRIPTION
When the vhd has the wrong format or dynamic type, the error message prints the normalized vhd name but not the original one. The normalized vhd name will confuse users. This PR replaces the normalized vhd name as the original vhd name in the error message.

Before fix:
The error message like:
deployment failed. LisaException: InvalidParameter: The specified cookie value in VHD footer indicates that disk '**99990101/https---vcertsasouthcentralus-blob-core-windows-net-vhds-fortinet-fortinet-fortisiem-vm-fortinet-fortisiem-byol-blob-6-7-4-vhd-sv-2019-07-07-sr-b-sig-UYEGActDShEhn3ojE-2BCIIgrz8plT0-3D-st-2023-05-04T14-3A11-3A07Z-se-2023-05-19T14-3A11-3A07Z-sp-r.vhd**' with blob **https://lisatwestus36a28e896.blob.core.windows.net:8443/lisa-sas-copied/99990101/https---vcertsasouthcentralus-blob-core-windows-net-vhds-fortinet-fortinet-fortisiem-vm-fortinet-fortisiem-byol-blob-6-7-4-vhd-sv-2019-07-07-sr-b-sig-UYEG3ojE-2BCIIgrz8plT0-3D-st-2023-05-04T14-3A11-3A07Z-se-2023-05-19T14-3A11-3A07Z-sp-r.vhd** is not a supported VHD. Disk is expected to have cookie value 'conectix'.

After fix:
The error message like:
deployment failed. LisaException: InvalidParameter: The specified cookie value in VHD footer indicates that disk **fortinet-byol-blob-6-7-4.vhd?**** with blob **https://userstorageaccount.blob.core.windows.net/vhds/fortinet-byol-blob-6-7-4.vhd?**** is not a supported VHD. Disk is expected to have cookie value 'conectix'.