### PR TITLE
DiskControllerType - Allow blank

### DIFF
--- a/lisa/features/security_profile.py
+++ b/lisa/features/security_profile.py
@@ -47,7 +47,7 @@ class SecurityProfileSettings(schema.FeatureSettings):
                 search_space.decode_set_space_by_type(
                     data=input, base_type=SecurityProfileType
                 )
-                if input
+                if str(input).strip()
                 else search_space.SetSpace(
                     items=[
                         SecurityProfileType.Standard,

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -492,8 +492,14 @@ class DiskOptionSettings(FeatureSettings):
             items=[DiskControllerType.SCSI, DiskControllerType.NVME],
         ),
         metadata=field_metadata(
-            decoder=partial(
-                search_space.decode_set_space_by_type, base_type=DiskControllerType
+            decoder=lambda input: (
+                search_space.decode_set_space_by_type(
+                    data=input, base_type=DiskControllerType
+                )
+                if str(input).strip()
+                else search_space.SetSpace(
+                    items=[DiskControllerType.SCSI, DiskControllerType.NVME]
+                )
             )
         ),
     )


### PR DESCRIPTION
If you set disk_controller_type to "" or " ", it should use the default value.