### PR TITLE
Mcgov/dpdk send receive refactor

### DIFF
--- a/lisa/tools/timeout.py
+++ b/lisa/tools/timeout.py
@@ -1,4 +1,4 @@
-from lisa.executable import ExecutableResult, Tool
+from lisa.executable import ExecutableResult, Process, Tool
 from lisa.util.constants import SIGTERM
 
 
@@ -12,20 +12,36 @@ class Timeout(Tool):
         return False
 
     def run_with_timeout(
-        self, command: str, timeout: int, signal: int = SIGTERM, kill_timeout: int = 0
+        self,
+        command: str,
+        timeout: int,
+        signal: int = SIGTERM,
+        kill_timeout: int = 0,
     ) -> ExecutableResult:
+        # timeout [OPTION] DURATION COMMAND [ARG]...
+
+        return self.start_with_timeout(
+            command=command,
+            timeout=timeout,
+            signal=signal,
+            kill_timeout=kill_timeout,
+        ).wait_result()
+
+    def start_with_timeout(
+        self,
+        command: str,
+        timeout: int,
+        signal: int = SIGTERM,
+        kill_timeout: int = 0,
+        delay_start: int = 0,
+    ) -> Process:
         # timeout [OPTION] DURATION COMMAND [ARG]...
         params = f"-s {signal} --preserve-status {timeout} {command}"
         if kill_timeout:
             params = f"--kill-after {kill_timeout} " + params
-        command_timeout = timeout
-        if kill_timeout:
-            command_timeout = kill_timeout + 10
-
-        return self.run(
+        return self.run_async(
             parameters=params,
             force_run=True,
             shell=True,
             sudo=True,
-            timeout=command_timeout,
         )

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -102,9 +102,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "failsafe", result, log, variables, use_max_nics=True, service_cores=4
-        )
+        self._run_dpdk_perf_test("failsafe", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
@@ -149,9 +147,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "failsafe", result, log, variables, use_max_nics=True, use_queues=True
-        )
+        self._run_dpdk_perf_test("failsafe", result, log, variables, use_queues=True)
 
     @TestCaseMetadata(
         description="""
@@ -179,7 +175,6 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             service_cores=4,
-            use_max_nics=True,
             use_queues=True,
         )
 
@@ -249,9 +244,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "netvsc", result, log, variables, service_cores=4, use_max_nics=True
-        )
+        self._run_dpdk_perf_test("netvsc", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
@@ -296,7 +289,11 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self._run_dpdk_perf_test(
-            "netvsc", result, log, variables, use_queues=True, use_max_nics=True
+            "netvsc",
+            result,
+            log,
+            variables,
+            use_queues=True,
         )
 
     @TestCaseMetadata(
@@ -325,7 +322,6 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             service_cores=4,
-            use_max_nics=True,
             use_queues=True,
         )
 
@@ -335,7 +331,6 @@ class DpdkPerformance(TestSuite):
         test_result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
-        use_max_nics: bool = False,
         use_queues: bool = False,
         service_cores: int = 1,
     ) -> None:
@@ -351,7 +346,6 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
-                    use_max_nics=use_max_nics,
                     use_service_cores=service_cores,
                 )
             else:
@@ -360,7 +354,6 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
-                    use_max_nics=use_max_nics,
                     use_service_cores=service_cores,
                 )
         except UnsupportedPackageVersionException as err:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -346,9 +346,14 @@ class DpdkTestpmd(Tool):
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:
         self._last_run_timeout = timeout
         self.node.log.info(f"{self.node.name} running: {cmd}")
-
+        # add delays such that receiver will always start first and end last
+        delay_start = 0
+        if "rxonly" in cmd:
+            timeout *= 2
+        if "txonly" in cmd:
+            delay_start = 5
         proc_result = self.node.tools[Timeout].run_with_timeout(
-            cmd, timeout, SIGINT, kill_timeout=timeout + 10
+            cmd, timeout, SIGINT, kill_timeout=timeout + 10, delay_start=delay_start
         )
         self._last_run_output = proc_result.stdout
         self.populate_performance_data()


### PR DESCRIPTION
Cleaning up some logic which has been tripping send/receive testing up.
- refactor send/receive
   - ensure receiver starts first
   - simplify multiple queue test logic to allow use of shared logic
   - simplify queue and core selection to fix issues across variable threads/core/numa configurations.
   - rename variables to make logical core vs physical core model in DPDK EAL explicit.
 