### PR TITLE
DPDK: Send receive refactoring

### DIFF
--- a/lisa/tools/timeout.py
+++ b/lisa/tools/timeout.py
@@ -1,5 +1,7 @@
-from lisa.executable import ExecutableResult, Tool
+from lisa.executable import ExecutableResult, Process, Tool
 from lisa.util.constants import SIGTERM
+
+TIMEOUT_SLACK_TIME_SECONDS = 10
 
 
 class Timeout(Tool):
@@ -12,20 +14,43 @@ class Timeout(Tool):
         return False
 
     def run_with_timeout(
-        self, command: str, timeout: int, signal: int = SIGTERM, kill_timeout: int = 0
+        self,
+        command: str,
+        timeout: int,
+        signal: int = SIGTERM,
+        kill_timeout: int = 0,
     ) -> ExecutableResult:
+        # timeout [OPTION] DURATION COMMAND [ARG]...
+
+        # timeout exposes an option for a second timeout to force kill if
+        # the initial signal fails to stop the process.
+        # Select which timeout to base our LISA timeout on, then add some slack time
+        # to allow the process to finish before LISA force kills.
+
+        command_timeout = timeout
+        if kill_timeout:
+            command_timeout = kill_timeout
+        command_timeout += TIMEOUT_SLACK_TIME_SECONDS
+
+        return self.start_with_timeout(
+            command=command,
+            timeout=timeout,
+            signal=signal,
+            kill_timeout=kill_timeout,
+        ).wait_result(timeout=command_timeout)
+
+    def start_with_timeout(
+        self,
+        command: str,
+        timeout: int,
+        signal: int = SIGTERM,
+        kill_timeout: int = 0,
+        delay_start: int = 0,
+    ) -> Process:
         # timeout [OPTION] DURATION COMMAND [ARG]...
         params = f"-s {signal} --preserve-status {timeout} {command}"
         if kill_timeout:
             params = f"--kill-after {kill_timeout} " + params
-        command_timeout = timeout
-        if kill_timeout:
-            command_timeout = kill_timeout + 10
-
-        return self.run(
-            parameters=params,
-            force_run=True,
-            shell=True,
-            sudo=True,
-            timeout=command_timeout,
+        return self.run_async(
+            parameters=params, force_run=True, shell=True, sudo=True
         )

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -102,9 +102,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "failsafe", result, log, variables, use_max_nics=True, service_cores=4
-        )
+        self._run_dpdk_perf_test("failsafe", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
@@ -149,9 +147,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "failsafe", result, log, variables, use_max_nics=True, use_queues=True
-        )
+        self._run_dpdk_perf_test("failsafe", result, log, variables, use_queues=True)
 
     @TestCaseMetadata(
         description="""
@@ -179,7 +175,6 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             service_cores=4,
-            use_max_nics=True,
             use_queues=True,
         )
 
@@ -249,9 +244,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test(
-            "netvsc", result, log, variables, service_cores=4, use_max_nics=True
-        )
+        self._run_dpdk_perf_test("netvsc", result, log, variables, service_cores=4)
 
     @TestCaseMetadata(
         description="""
@@ -296,7 +289,11 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self._run_dpdk_perf_test(
-            "netvsc", result, log, variables, use_queues=True, use_max_nics=True
+            "netvsc",
+            result,
+            log,
+            variables,
+            use_queues=True,
         )
 
     @TestCaseMetadata(
@@ -325,7 +322,6 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             service_cores=4,
-            use_max_nics=True,
             use_queues=True,
         )
 
@@ -335,7 +331,6 @@ class DpdkPerformance(TestSuite):
         test_result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
-        use_max_nics: bool = False,
         use_queues: bool = False,
         service_cores: int = 1,
     ) -> None:
@@ -351,7 +346,6 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
-                    use_max_nics=use_max_nics,
                     use_service_cores=service_cores,
                 )
             else:
@@ -360,7 +354,6 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
-                    use_max_nics=use_max_nics,
                     use_service_cores=service_cores,
                 )
         except UnsupportedPackageVersionException as err:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -346,9 +346,14 @@ class DpdkTestpmd(Tool):
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:
         self._last_run_timeout = timeout
         self.node.log.info(f"{self.node.name} running: {cmd}")
-
+        # add delays such that receiver will always start first and end last
+        delay_start = 0
+        if "rxonly" in cmd:
+            timeout *= 2
+        if "txonly" in cmd:
+            delay_start = 5
         proc_result = self.node.tools[Timeout].run_with_timeout(
-            cmd, timeout, SIGINT, kill_timeout=timeout + 10
+            cmd, timeout, SIGINT, kill_timeout=timeout + 10, delay_start=delay_start
         )
         self._last_run_output = proc_result.stdout
         self.populate_performance_data()

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -34,6 +34,7 @@ from lisa.tools import (
     Modprobe,
     Mount,
     Ping,
+    Timeout,
 )
 from lisa.tools.mkfs import FileSystem
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
@@ -195,9 +196,7 @@ def generate_send_receive_run_info(
     pmd: str,
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
-    txq: int = 0,
-    rxq: int = 0,
-    use_max_nics: bool = False,
+    multiple_queues: bool = False,
     use_service_cores: int = 1,
 ) -> Dict[DpdkTestResources, str]:
     snd_nic, rcv_nic = [x.node.nics.get_secondary_nic() for x in [sender, receiver]]
@@ -208,20 +207,16 @@ def generate_send_receive_run_info(
         "txonly",
         pmd,
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
-        txq=txq,
-        rxq=rxq,
+        multiple_queues=multiple_queues,
         service_cores=use_service_cores,
-        use_max_nics=use_max_nics,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
         0,
         "rxonly",
         pmd,
-        txq=txq,
-        rxq=rxq,
+        multiple_queues=multiple_queues,
         service_cores=use_service_cores,
-        use_max_nics=use_max_nics,
     )
 
     kit_cmd_pairs = {
@@ -482,8 +477,8 @@ def verify_dpdk_send_receive(
     log: Logger,
     variables: Dict[str, Any],
     pmd: str,
-    use_max_nics: bool = False,
     use_service_cores: int = 1,
+    multiple_queues: bool = False,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # helpful to have the public ips labeled for debugging
     external_ips = []
@@ -499,7 +494,7 @@ def verify_dpdk_send_receive(
     # get test duration variable if set
     # enables long-running tests to shakeQoS and SLB issue
     test_duration: int = variables.get("dpdk_test_duration", 15)
-
+    kill_timeout = test_duration + 5
     test_kits = init_nodes_concurrent(environment, log, variables, pmd)
 
     check_send_receive_compatibility(test_kits)
@@ -510,11 +505,29 @@ def verify_dpdk_send_receive(
         pmd,
         sender,
         receiver,
-        use_max_nics=use_max_nics,
         use_service_cores=use_service_cores,
+        multiple_queues=multiple_queues,
+    )
+    receive_timeout = kill_timeout + 10
+    receive_result = receiver.node.tools[Timeout].start_with_timeout(
+        kit_cmd_pairs[receiver],
+        receive_timeout,
+        constants.SIGINT,
+        kill_timeout=receive_timeout,
+    )
+    receive_result.wait_output("start packet forwarding")
+    sender_result = sender.node.tools[Timeout].start_with_timeout(
+        kit_cmd_pairs[sender],
+        test_duration,
+        constants.SIGINT,
+        kill_timeout=kill_timeout,
     )
 
-    results = run_testpmd_concurrent(kit_cmd_pairs, test_duration, log)
+    results = dict()
+    results[sender] = sender.testpmd.process_testpmd_output(sender_result.wait_result())
+    results[receiver] = receiver.testpmd.process_testpmd_output(
+        receive_result.wait_result()
+    )
 
     # helpful to have the outputs labeled
     log.debug(f"\nSENDER:\n{results[sender]}")
@@ -541,47 +554,10 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     log: Logger,
     variables: Dict[str, Any],
     pmd: str,
-    use_max_nics: bool = False,
     use_service_cores: int = 1,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # get test duration variable if set
     # enables long-running tests to shakeQoS and SLB issue
-    test_duration: int = variables.get("dpdk_test_duration", 15)
-
-    test_kits = init_nodes_concurrent(environment, log, variables, pmd)
-
-    check_send_receive_compatibility(test_kits)
-
-    sender, receiver = test_kits
-
-    kit_cmd_pairs = generate_send_receive_run_info(
-        pmd,
-        sender,
-        receiver,
-        txq=4,
-        rxq=4,
-        use_max_nics=use_max_nics,
-        use_service_cores=use_service_cores,
+    return verify_dpdk_send_receive(
+        environment, log, variables, pmd, use_service_cores=1, multiple_queues=True
     )
-
-    results = run_testpmd_concurrent(kit_cmd_pairs, test_duration, log)
-
-    # helpful to have the outputs labeled
-    log.debug(f"\nSENDER:\n{results[sender]}")
-    log.debug(f"\nRECEIVER:\n{results[receiver]}")
-
-    rcv_rx_pps = receiver.testpmd.get_mean_rx_pps()
-    snd_tx_pps = sender.testpmd.get_mean_tx_pps()
-    log.info(f"receiver rx-pps: {rcv_rx_pps}")
-    log.info(f"sender tx-pps: {snd_tx_pps}")
-
-    # differences in NIC type throughput can lead to different snd/rcv counts
-    # check that throughput it greater than 1m pps as a baseline
-    assert_that(rcv_rx_pps).described_as(
-        "Throughput for RECEIVE was below the correct order-of-magnitude"
-    ).is_greater_than(2**20)
-    assert_that(snd_tx_pps).described_as(
-        "Throughput for SEND was below the correct order of magnitude"
-    ).is_greater_than(2**20)
-
-    return sender, receiver

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -205,7 +205,6 @@ def generate_send_receive_run_info(
         snd_nic,
         0,
         "txonly",
-        pmd,
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
@@ -214,7 +213,6 @@ def generate_send_receive_run_info(
         rcv_nic,
         0,
         "rxonly",
-        pmd,
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
     )
@@ -459,7 +457,6 @@ def verify_dpdk_build(
         test_nic,
         0,
         "txonly",
-        pmd,
     )
     testpmd.run_for_n_seconds(testpmd_cmd, 10)
     tx_pps = testpmd.get_mean_tx_pps()


### PR DESCRIPTION
Cleaning up some logic which has been tripping send/receive testing up.
Timeout refactor:
- Allow async execution to enable DPDK send/recv refactor

Refactor send/receive
- Ensure receiver starts first
- Simplify multiple queue test logic to allow use of shared logic
- Simplify queue and core selection to fix issues across variable threads/core/numa configurations.
- Rename variables to make logical core vs physical core model in DPDK EAL explicit.
