### PR TITLE
Correct file name from mariner.cfg to mariner-mshv.cfg as per new change in VHD

### DIFF
--- a/lisa/transformers/dom0_kernel_installer.py
+++ b/lisa/transformers/dom0_kernel_installer.py
@@ -178,10 +178,10 @@ def _update_mariner_config(
     current_kernel: str,
     new_kernel: str,
 ) -> None:
-    ll_conf_file: str = "/boot/mariner.cfg"
+    ll_conf_file: str = "/boot/mariner-mshv.cfg"
     sed = node.tools[Sed]
 
-    # Modify the mariner.cfg to point new kernel binary
+    # Modify the /boot/mariner-mshv.cfg to point new kernel binary
     sed.substitute(
         regexp=f"mariner_linux=vmlinuz-{current_kernel}",
         replacement=f"mariner_linux=vmlinuz-{new_kernel}",
@@ -190,7 +190,7 @@ def _update_mariner_config(
     )
 
     if is_initrd:
-        # Modify the mariner.cfg to point new initrd binary
+        # Modify the /boot/mariner-mshv.cfg to point new initrd binary
         sed.substitute(
             regexp=f"mariner_initrd=initrd.img-{current_kernel}",
             replacement=f"mariner_initrd=initrd.img-{new_kernel}",


### PR DESCRIPTION
There is a filename change in new VHD for mariner config file. Changing it as per need for dom0 kernel installer transformer.