### PR TITLE
ch_tests_tool: Increase timeout for Reboot

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -222,7 +222,7 @@ class CloudHypervisorTests(Tool):
         if username not in res.stdout:  # if current user is not in docker group
             self.node.execute(f"usermod -a -G docker {username}", sudo=True)
             # reboot for group membership change to take effect
-            self.node.reboot()
+            self.node.reboot(time_out=900)
 
         self.node.tools[Docker].start()
 


### PR DESCRIPTION
These tests are usually run on server grade machines and it might take longer time for the machine to reboot. Hence, increase the reboot timeout