### PR TITLE
Add is_accelerated_network_supported in VhdSchema

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -427,7 +427,12 @@
                     ],
                     "output": {
                         "type": "object",
-                        "value": "[parameters('node')['marketplace']]"
+                        "value": {
+                            "publisher": "[parameters('node')['marketplace']['publisher']]",
+                            "offer": "[parameters('node')['marketplace']['offer']]",
+                            "sku": "[parameters('node')['marketplace']['sku']]",
+                            "version": "[parameters('node')['marketplace']['version']]"
+                        }
                     }
                 },
                 "getOsDiskSharedGallery": {

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -488,7 +488,7 @@ class AzurePlatform(Platform):
 
         # covert to azure node space, so the azure extensions can be loaded.
         for req in nodes_requirement:
-            self._load_image_features(req)
+            self._set_image_features(req)
 
         is_success: bool = False
 
@@ -2592,12 +2592,24 @@ class AzurePlatform(Platform):
         else:
             ...
 
-    def _load_image_features(self, node_space: schema.NodeSpace) -> None:
+    def _check_image_capability(self, node_space: schema.NodeSpace) -> None:
+        azure_runbook = node_space.get_extended_runbook(AzureNodeSchema, AZURE)
+        if azure_runbook.vhd:
+            if node_space.network_interface:
+                data_path = search_space.intersect_setspace_by_priority(  # type: ignore
+                    node_space.network_interface.data_path,
+                    azure_runbook.vhd.network_data_path,
+                    [],
+                )
+                node_space.network_interface.data_path = data_path
+
+    def _set_image_features(self, node_space: schema.NodeSpace) -> None:
         # This method does the same thing as _convert_to_azure_node_space
         # method, and attach the additional features. The additional features
         # need Azure platform, so it needs to be in Azure Platform.
         _convert_to_azure_node_space(node_space)
         self._add_image_features(node_space)
+        self._check_image_capability(node_space)
 
 
 def _convert_to_azure_node_space(node_space: schema.NodeSpace) -> None:


### PR DESCRIPTION
Some VHDs don't support accelerated network. Add is_accelerated_network_supported in VhdSchema, so users can define the accelerated network capability for the VHD.

Add _check_image_capability to check if the image can support AN. If not, and test cases require an SRIOV data path, then raise NotMeetRequirementException.

If the VHD doesn't support AN, then set the network interface data path as Synthetic, Lisa will deploy VM without AN enabled.