### PR TITLE
libvirt: add ignition support for Flatcar

### DIFF
--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -28,11 +28,18 @@ class EnvironmentContext:
 
 
 @dataclass
+class InitSystem:
+    CLOUD_INIT: str = "cloud-init"
+    IGNITION: str = "ignition"
+
+
+@dataclass
 class NodeContext:
     vm_name: str = ""
     firmware_source_path: str = ""
     firmware_path: str = ""
     cloud_init_file_path: str = ""
+    ignition_file_path: str = ""
     os_disk_source_file_path: Optional[str] = None
     os_disk_base_file_path: str = ""
     os_disk_base_file_fmt: DiskImageFormat = DiskImageFormat.QCOW2
@@ -45,6 +52,7 @@ class NodeContext:
     next_disk_index: int = 0
     machine_type: Optional[str] = None
     enable_secure_boot: bool = False
+    init_system: str = InitSystem.CLOUD_INIT
 
     console_logger: Optional[QemuConsoleLogger] = None
     domain: Optional[libvirt.virDomain] = None

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Union
 
 from dataclasses_json import dataclass_json
 
+from lisa.util import LisaException
+
 FIRMWARE_TYPE_BIOS = "bios"
 FIRMWARE_TYPE_UEFI = "uefi"
 
@@ -68,6 +70,9 @@ class BaseLibvirtNodeSchema:
     disk_img_resize_gib: Optional[int] = None
     # Configuration options for cloud-init.
     cloud_init: Optional[CloudInitSchema] = None
+
+    # Configuration options for ignition.
+    ignition: Optional[bool] = False
     # Whether to use UEFI or BIOS firmware.
     # Defaults to UEFI.
     firmware_type: str = ""
@@ -93,6 +98,10 @@ class QemuNodeSchema(BaseLibvirtNodeSchema):
     qcow2: str = ""
 
     def __post_init__(self) -> None:
+        if self.ignition and self.cloud_init:
+            raise LisaException(
+                "Can't use Ignition and cloud-init provisioning at the same time"
+            )
         if not self.disk_img:
             self.disk_img = self.qcow2
             self.disk_img_format = DiskImageFormat.QCOW2.value

--- a/microsoft/runbook/qemu/flatcar.yml
+++ b/microsoft/runbook/qemu/flatcar.yml
@@ -1,0 +1,19 @@
+name: flatcar default
+include:
+  - path: ../tiers/tier.yml
+variable:
+  - name: keep_environment
+    value: "no"
+  - name: qcow2
+    value: ""
+notifier:
+  - type: html
+platform:
+  - type: qemu
+    admin_private_key_file: $(admin_private_key_file)
+    keep_environment: $(keep_environment)
+    admin_username: core
+    requirement:
+      qemu:
+        qcow2: $(qcow2)
+        ignition: true


### PR DESCRIPTION
Hello,

In this PR, we add the Ignition support to LISA. It allows to provide Ignition configuration instead of cloud-init for initial provisioning on the QEMU platform.

There is base config that is merged with an extra user-data (like for Mariner) and set as fw_cfg on the domain definition. 

```
$ lisa run -r ./microsoft/runbook/qemu/flatcar.yml -v "qcow2:/flatcar/stable/flatcar_production_qemu_image.img" -v "admin_private_key_file:/id_rsa"
 ----------------------------------information----------------------------------- 
area: provisioning
category: functional
tags: []
description: 
        This case verifies whether a node is operating normally.

        Steps,
        1. Connect to TCP port 22. If it's not connectable, failed and check whether
            there is kernel panic.
        2. Connect to SSH port 22, and reboot the node. If there is an error and kernel
            panic, fail the case. If it's not connectable, also fail the case.
        3. If there is another error, but not kernel panic or tcp connection, pass with
            warning.
        4. Otherwise, fully passed.
        
priority: 0
owner: Microsoft
platform: qemu
host_distro: Gentoo Linux
host_kernel_version: 6.1.31-gentoo-dist
libvirt_version: libvirtd (libvirt) 9.3.0
vmm_version: 7.2.0
environment: generated_0
hardware_platform: x86_64
distro_version: Flatcar Container Linux by Kinvolk 3510.2.2 (Oklo)
kernel_version: 5.15.111-flatcar
```
