### PR TITLE
DPDK: add is_mana, handle driver load, use pkg-config for version check

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -85,6 +85,7 @@ from .perf import Perf
 from .pgrep import Pgrep, ProcessInfo
 from .pidof import Pidof
 from .ping import Ping
+from .pkgconfig import Pkgconfig
 from .powershell import PowerShell
 from .python import Pip, Python
 from .qemu import Qemu
@@ -200,6 +201,7 @@ __all__ = [
     "Pgrep",
     "Ping",
     "Pip",
+    "Pkgconfig",
     "PowerShell",
     "ProcessInfo",
     "Python",

--- a/lisa/tools/pkgconfig.py
+++ b/lisa/tools/pkgconfig.py
@@ -50,10 +50,15 @@ class Pkgconfig(Tool):
         coerced_version = ".".join([str(int(x)) for x in [major, minor, patch]])
         return VersionInfo.parse(coerced_version)
 
-    def _get_package_info(self, package_name: str, update_cached: bool = False) -> str:
+    def get_package_info(
+        self, package_name: str, check_exists: bool = False, update_cached: bool = False
+    ) -> str:
         package_info_result = self.run(
             f"--modversion {package_name}", force_run=update_cached
         )
+        if check_exists and package_info_result.exit_code != 0:
+            return ""
+
         assert_that(package_info_result.exit_code).described_as(
             (
                 f"pkg-config information was not available for {package_name}. "
@@ -66,5 +71,5 @@ class Pkgconfig(Tool):
     def get_package_version(
         self, package_name: str, update_cached: bool = False
     ) -> VersionInfo:
-        version_info = self._get_package_info(package_name, update_cached=update_cached)
+        version_info = self.get_package_info(package_name, update_cached=update_cached)
         return self._coerce_version_info_string(version_info)

--- a/lisa/tools/pkgconfig.py
+++ b/lisa/tools/pkgconfig.py
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import re
+
+from assertpy import assert_that
+from semver import VersionInfo
+
+from lisa.executable import Tool
+from lisa.operating_system import Posix
+
+coerce_version_info_regex = re.compile(
+    r"v?(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(\.(?P<patch>[0-9]+))?"
+)
+
+
+class Pkgconfig(Tool):
+    @property
+    def command(self) -> str:
+        return "pkg-config"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def install(self) -> bool:
+        assert isinstance(self.node.os, Posix)
+        self.node.os.install_packages("pkg-config")
+        return True
+
+    def _coerce_version_info_string(self, version_string: str) -> VersionInfo:
+        if VersionInfo.isvalid(version_string):
+            return VersionInfo.parse(version_string)
+        # else, attempt to coerce
+        matches = coerce_version_info_regex.search(version_string)
+        assert (
+            matches
+        ), f"Could not coalesce version string {version_string} into a package version"
+
+        major = matches.group("major")
+        minor = matches.group("minor")
+        patch = matches.group("patch")
+
+        assert_that(major).described_as(
+            f"Could not identify major version in version string {version_string}"
+        ).is_not_none()
+        assert_that(minor).described_as(
+            f"Could not identify minor version in version string {version_string}"
+        ).is_not_none()
+
+        coerced_version = ".".join([str(int(x)) for x in [major, minor, patch]])
+        return VersionInfo.parse(coerced_version)
+
+    def _get_package_info(self, package_name: str, update_cached: bool = False) -> str:
+        package_info_result = self.run(
+            f"--modversion {package_name}", force_run=update_cached
+        )
+        assert_that(package_info_result.exit_code).described_as(
+            (
+                f"pkg-config information was not available for {package_name}. "
+                "This indicates an installation or package detection bug. "
+                f"ensure .pc file is available for {package_name} on this OS."
+            )
+        ).is_zero()
+        return package_info_result.stdout
+
+    def get_package_version(
+        self, package_name: str, update_cached: bool = False
+    ) -> VersionInfo:
+        version_info = self._get_package_info(package_name, update_cached=update_cached)
+        return self._coerce_version_info_string(version_info)

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -32,7 +32,7 @@ from lisa.util import (
     SkippedException,
     UnsupportedDistroException,
 )
-from lisa.util.constants import SIGINT
+from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 
 PACKAGE_MANAGER_SOURCE = "package_manager"
 
@@ -189,24 +189,27 @@ class DpdkTestpmd(Tool):
 
         # identify which nics to inlude in test, exclude others
         include_nics = [node_nic]
-        exclude_nics = [
-            self.node.nics.get_nic(nic)
-            for nic in self.node.nics.get_nic_names()
-            if nic != node_nic.name
-        ]
+        if self._dpdk_version_info and self._dpdk_version_info < "20.11.0":
+            include_flag = "-w"
+        else:
+            include_flag = "-a"
 
         # build list of vdev info flags for each nic
         vdev_info = ""
         self.node.log.info(f"Running test with {len(include_nics)} nics.")
         for nic in include_nics:
-            if self._dpdk_version_info and self._dpdk_version_info >= "18.11.0":
-                vdev_name = "net_vdev_netvsc"
-                vdev_flags = f"iface={nic.name},force=1"
-            else:
+            if self._dpdk_version_info < "18.11.0":
                 vdev_name = "net_failsafe"
                 vdev_flags = (
                     f"dev({nic.pci_slot}),dev(net_tap0,iface={nic.name},force=1)"
                 )
+            elif self.is_mana:
+                vdev_name = "net_vdev_netvsc"
+                vdev_flags = f"mac={nic.mac_addr}"
+            else:
+                vdev_name = "net_vdev_netvsc"
+                vdev_flags = f"iface={nic.name},force=1"
+
             if nic.module_name == "hv_netvsc":
                 vdev_info += f'--vdev="{vdev_name}{vdev_id},{vdev_flags}" '
             elif nic.module_name == "uio_hv_generic":
@@ -221,11 +224,11 @@ class DpdkTestpmd(Tool):
                 )
 
         # exclude pci slots not associated with the test nic
-        exclude_flags = ""
-        for nic in exclude_nics:
-            exclude_flags += f' -b "{nic.pci_slot}"'
+        include_flags = ""
+        for nic in include_nics:
+            include_flags += f' {include_flag} "{nic.pci_slot}"'
 
-        return vdev_info + exclude_flags
+        return vdev_info + include_flags
 
     def generate_testpmd_command(
         self,
@@ -439,10 +442,11 @@ class DpdkTestpmd(Tool):
 
     def _determine_network_hardware(self) -> None:
         lspci = self.node.tools[Lspci]
-        device_list = lspci.get_devices()
+        device_list = lspci.get_devices_by_type(DEVICE_TYPE_SRIOV)
         self.is_connect_x3 = any(
             ["ConnectX-3" in dev.device_info for dev in device_list]
         )
+        self.is_mana = any(["Microsoft" in dev.vendor for dev in device_list])
 
     def _check_pps_data_exists(self, rx_or_tx: str) -> None:
         data_attr_name = f"{rx_or_tx.lower()}_pps_data"
@@ -632,9 +636,13 @@ class DpdkTestpmd(Tool):
     def _load_drivers_for_dpdk(self) -> None:
         self.node.log.info("Loading drivers for infiniband, rdma, and mellanox hw...")
         if self.is_connect_x3:
-            mellanox_drivers = ["mlx4_core", "mlx4_ib"]
+            nic_drivers = ["mlx4_core", "mlx4_ib"]
+        elif self.is_mana:
+            nic_drivers = ["mana"]
+            if self.node.tools[Modprobe].load("mana_ib", dry_run=True):
+                nic_drivers.append("mana_ib")
         else:
-            mellanox_drivers = ["mlx5_core", "mlx5_ib"]
+            nic_drivers = ["mlx5_core", "mlx5_ib"]
         modprobe = self.node.tools[Modprobe]
         if isinstance(self.node.os, (Ubuntu, Suse)):
             # Ubuntu shouldn't need any special casing, skip to loading rdma/ib
@@ -661,7 +669,7 @@ class DpdkTestpmd(Tool):
         elif isinstance(self.node.os, Fedora):
             if not self.is_connect_x3:
                 self.node.execute(
-                    f"dracut --add-drivers '{' '.join(mellanox_drivers)} ib_uverbs' -f",
+                    f"dracut --add-drivers '{' '.join(nic_drivers)} ib_uverbs' -f",
                     expected_exit_code=0,
                     expected_exit_code_failure_message=(
                         "Issue loading mlx and ib_uverb drivers into ramdisk."
@@ -679,7 +687,7 @@ class DpdkTestpmd(Tool):
                 rmda_drivers.append(module)
 
         modprobe.load(rmda_drivers)
-        modprobe.load(mellanox_drivers)
+        modprobe.load(nic_drivers)
 
     def _install_dependencies(self) -> None:
         node = self.node

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -448,9 +448,9 @@ class DpdkTestpmd(Tool):
         self._determine_network_hardware()
         # if dpdk is already installed, find the binary and check the version
         if self.find_testpmd_binary(assert_on_fail=False):
-            self._dpdk_version_info = self.node.tools[Pkgconfig].get_package_version(
-                "libdpdk"
-            )
+            pkgconfig = self.node.tools[Pkgconfig]
+            if pkgconfig.get_package_info("libdpdk", check_exists=True):
+                self._dpdk_version_info = pkgconfig.get_package_version("libdpdk")
 
     def _determine_network_hardware(self) -> None:
         lspci = self.node.tools[Lspci]


### PR DESCRIPTION
Two commits of a larger set refactoring DPDK.

MANA: add is_mana and handle driver loading & testpmd arugments.

pkg-config:
Parsing git tags and tar file names was a dumb choice on my part, moving to pkg-config to get libdpdk information. This has the benefit of allowing for shared gallery images with pre-build versions of DPDK to speed up testing.

- Add Pkg-Config tool, allows coercing of nonstandard version strings for semver
- Use pkg-config tool to get DPDK version info instead of parsing tags and filenames.