### PR TITLE
DPDK: performance test cleanup

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -338,9 +338,7 @@ class Dpdk(TestSuite):
         test_kit = initialize_node_resources(node, log, variables, "failsafe")
         testpmd = test_kit.testpmd
         test_nic = node.nics.get_secondary_nic()
-        testpmd_cmd = testpmd.generate_testpmd_command(
-            test_nic, 0, "txonly", "failsafe"
-        )
+        testpmd_cmd = testpmd.generate_testpmd_command(test_nic, 0, "txonly")
         kit_cmd_pairs = {
             test_kit: testpmd_cmd,
         }

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -445,7 +445,8 @@ def verify_dpdk_build(
     log: Logger,
     variables: Dict[str, Any],
     pmd: str,
-) -> None:
+    multiple_queues: bool = False,
+) -> DpdkTestResources:
     # setup and unwrap the resources for this test
     test_kit = initialize_node_resources(node, log, variables, pmd)
     testpmd = test_kit.testpmd
@@ -454,9 +455,7 @@ def verify_dpdk_build(
     test_nic = node.nics.get_secondary_nic()
 
     testpmd_cmd = testpmd.generate_testpmd_command(
-        test_nic,
-        0,
-        "txonly",
+        test_nic, 0, "txonly", multiple_queues=multiple_queues
     )
     testpmd.run_for_n_seconds(testpmd_cmd, 10)
     tx_pps = testpmd.get_mean_tx_pps()
@@ -467,6 +466,7 @@ def verify_dpdk_build(
     assert_that(tx_pps).described_as(
         f"TX-PPS ({tx_pps}) should have been greater than 2^20 (~1m) PPS."
     ).is_greater_than(2**20)
+    return DpdkTestResources(node, testpmd)
 
 
 def verify_dpdk_send_receive(


### PR DESCRIPTION
- Rename performance tests with clearer names.
- Remove unused tests and add send-only perf tests
- Refactor and remove unused arugments.