### PR TITLE
Ultra Disk Support

### DIFF
--- a/lisa/features/disks.py
+++ b/lisa/features/disks.py
@@ -70,19 +70,19 @@ DiskEphemeral = partial(
 )
 DiskPremiumSSDLRS = partial(
     schema.DiskOptionSettings,
-    disk_type=schema.DiskType.PremiumSSDLRS,
+    data_disk_type=schema.DiskType.PremiumSSDLRS,
     os_disk_type=schema.DiskType.PremiumSSDLRS,
 )
 DiskStandardHDDLRS = partial(
     schema.DiskOptionSettings,
-    disk_type=schema.DiskType.StandardHDDLRS,
+    data_disk_type=schema.DiskType.StandardHDDLRS,
     os_disk_type=schema.DiskType.StandardHDDLRS,
 )
 DiskStandardSSDLRS = partial(
     schema.DiskOptionSettings,
-    disk_type=schema.DiskType.StandardSSDLRS,
+    data_disk_type=schema.DiskType.StandardSSDLRS,
     os_disk_type=schema.DiskType.StandardSSDLRS,
 )
 DiskUltraSSDLRS = partial(
-    schema.DiskOptionSettings, disk_type=schema.DiskType.UltraSSDLRS
+    schema.DiskOptionSettings, data_disk_type=schema.DiskType.UltraSSDLRS
 )

--- a/lisa/features/disks.py
+++ b/lisa/features/disks.py
@@ -65,13 +65,24 @@ class Disk(Feature):
         raise NotImplementedError
 
 
-DiskEphemeral = partial(schema.DiskOptionSettings, disk_type=schema.DiskType.Ephemeral)
+DiskEphemeral = partial(
+    schema.DiskOptionSettings, os_disk_type=schema.DiskType.Ephemeral
+)
 DiskPremiumSSDLRS = partial(
-    schema.DiskOptionSettings, disk_type=schema.DiskType.PremiumSSDLRS
+    schema.DiskOptionSettings,
+    disk_type=schema.DiskType.PremiumSSDLRS,
+    os_disk_type=schema.DiskType.PremiumSSDLRS,
 )
 DiskStandardHDDLRS = partial(
-    schema.DiskOptionSettings, disk_type=schema.DiskType.StandardHDDLRS
+    schema.DiskOptionSettings,
+    disk_type=schema.DiskType.StandardHDDLRS,
+    os_disk_type=schema.DiskType.StandardHDDLRS,
 )
 DiskStandardSSDLRS = partial(
-    schema.DiskOptionSettings, disk_type=schema.DiskType.StandardSSDLRS
+    schema.DiskOptionSettings,
+    disk_type=schema.DiskType.StandardSSDLRS,
+    os_disk_type=schema.DiskType.StandardSSDLRS,
+)
+DiskUltraSSDLRS = partial(
+    schema.DiskOptionSettings, disk_type=schema.DiskType.UltraSSDLRS
 )

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -453,7 +453,7 @@ class DiskOptionSettings(FeatureSettings):
             decoder=partial(search_space.decode_set_space_by_type, base_type=DiskType)
         ),
     )
-    disk_type: Optional[
+    data_disk_type: Optional[
         Union[search_space.SetSpace[DiskType], DiskType]
     ] = field(  # type:ignore
         default_factory=partial(
@@ -531,7 +531,7 @@ class DiskOptionSettings(FeatureSettings):
         return (
             self.type == o.type
             and self.os_disk_type == o.os_disk_type
-            and self.disk_type == o.disk_type
+            and self.data_disk_type == o.data_disk_type
             and self.data_disk_count == o.data_disk_count
             and self.data_disk_caching_type == o.data_disk_caching_type
             and self.data_disk_iops == o.data_disk_iops
@@ -543,7 +543,7 @@ class DiskOptionSettings(FeatureSettings):
     def __repr__(self) -> str:
         return (
             f"os_disk_type: {self.os_disk_type},"
-            f"disk_type: {self.disk_type},"
+            f"data_disk_type: {self.data_disk_type},"
             f"count: {self.data_disk_count},"
             f"caching: {self.data_disk_caching_type},"
             f"iops: {self.data_disk_iops},"
@@ -583,7 +583,7 @@ class DiskOptionSettings(FeatureSettings):
 
     def _get_key(self) -> str:
         return (
-            f"{super()._get_key()}/{self.os_disk_type}/{self.disk_type}/"
+            f"{super()._get_key()}/{self.os_disk_type}/{self.data_disk_type}/"
             f"{self.data_disk_count}/{self.data_disk_caching_type}/"
             f"{self.data_disk_iops}/{self.data_disk_size}/"
             f"{self.disk_controller_type}"
@@ -606,10 +606,10 @@ class DiskOptionSettings(FeatureSettings):
             value.os_disk_type = getattr(
                 search_space, f"{method.value}_setspace_by_priority"
             )(self.os_disk_type, capability.os_disk_type, disk_type_priority)
-        if self.disk_type or capability.disk_type:
-            value.disk_type = getattr(
+        if self.data_disk_type or capability.data_disk_type:
+            value.data_disk_type = getattr(
                 search_space, f"{method.value}_setspace_by_priority"
-            )(self.disk_type, capability.disk_type, disk_type_priority)
+            )(self.data_disk_type, capability.data_disk_type, disk_type_priority)
         if self.data_disk_count or capability.data_disk_count:
             value.data_disk_count = search_space_countspace_method(
                 self.data_disk_count, capability.data_disk_count

--- a/lisa/sut_orchestrator/aws/features.py
+++ b/lisa/sut_orchestrator/aws/features.py
@@ -367,7 +367,7 @@ class AwsDiskOptionSettings(schema.DiskOptionSettings):
         result = super().check(capability)
 
         result.merge(
-            search_space.check_setspace(self.disk_type, capability.disk_type),
+            search_space.check_setspace(self.data_disk_type, capability.data_disk_type),
             "disk_type",
         )
         result.merge(
@@ -405,7 +405,7 @@ class AwsDiskOptionSettings(schema.DiskOptionSettings):
         ), f"actual: {type(capability)}"
 
         assert (
-            capability.disk_type
+            capability.data_disk_type
         ), "capability should have at least one disk type, but it's None"
         value = AwsDiskOptionSettings()
         super_value = schema.DiskOptionSettings._call_requirement_method(
@@ -413,7 +413,7 @@ class AwsDiskOptionSettings(schema.DiskOptionSettings):
         )
         set_filtered_fields(super_value, value, ["data_disk_count"])
 
-        cap_disk_type = capability.disk_type
+        cap_disk_type = capability.data_disk_type
         if isinstance(cap_disk_type, search_space.SetSpace):
             assert (
                 len(cap_disk_type) > 0
@@ -427,9 +427,9 @@ class AwsDiskOptionSettings(schema.DiskOptionSettings):
                 f"unknown disk type on capability, type: {cap_disk_type}"
             )
 
-        value.disk_type = getattr(search_space, f"{method.value}_setspace_by_priority")(
-            self.disk_type, capability.disk_type, schema.disk_type_priority
-        )
+        value.data_disk_type = getattr(
+            search_space, f"{method.value}_setspace_by_priority"
+        )(self.data_disk_type, capability.data_disk_type, schema.disk_type_priority)
 
         # below values affect data disk only.
         if self.data_disk_count is not None or capability.data_disk_count is not None:
@@ -452,9 +452,9 @@ class AwsDiskOptionSettings(schema.DiskOptionSettings):
 
         if method == RequirementMethod.generate_min_capability:
             assert isinstance(
-                value.disk_type, schema.DiskType
-            ), f"actual: {type(value.disk_type)}"
-            disk_type_iops = _disk_size_iops_map.get(value.disk_type, None)
+                value.data_disk_type, schema.DiskType
+            ), f"actual: {type(value.data_disk_type)}"
+            disk_type_iops = _disk_size_iops_map.get(value.data_disk_type, None)
             # ignore unsupported disk type like Ephemeral. It supports only os
             # disk. Calculate for iops, if it has value. If not, try disk size
             if disk_type_iops:

--- a/lisa/sut_orchestrator/aws/platform_.py
+++ b/lisa/sut_orchestrator/aws/platform_.py
@@ -614,9 +614,9 @@ class AwsPlatform(Platform):
 
         # Set disk type
         assert node_space.disk, "node space must have disk defined."
-        assert isinstance(node_space.disk.disk_type, schema.DiskType)
+        assert isinstance(node_space.disk.data_disk_type, schema.DiskType)
         aws_node_runbook.disk_type = features.get_aws_disk_type(
-            node_space.disk.disk_type
+            node_space.disk.data_disk_type
         )
         aws_node_runbook.data_disk_caching_type = node_space.disk.data_disk_caching_type
         assert isinstance(
@@ -1021,7 +1021,7 @@ class AwsPlatform(Platform):
             is_allow_set=True
         )
         node_space.disk = features.AwsDiskOptionSettings()
-        node_space.disk.disk_type = search_space.SetSpace[schema.DiskType](
+        node_space.disk.data_disk_type = search_space.SetSpace[schema.DiskType](
             is_allow_set=True, items=[]
         )
         node_space.disk.data_disk_iops = search_space.IntRange(min=0)
@@ -1060,9 +1060,9 @@ class AwsPlatform(Platform):
                 schema.FeatureSettings.create(features.SerialConsole.name()),
             ]
         )
-        node_space.disk.disk_type.add(schema.DiskType.StandardHDDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.StandardSSDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.PremiumSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardHDDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.PremiumSSDLRS)
         node_space.network_interface.data_path.add(schema.NetworkDataPath.Synthetic)
 
         return node_space

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -356,7 +356,7 @@
                 "osProfile": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), lisa.getOsProfile( parameters('nodes')[copyIndex('vmCopy')]['short_name'], parameters('admin_username'), or(empty(parameters('admin_key_data')), not(parameters('nodes')[copyIndex('vmCopy')]['is_linux'])), parameters('admin_password'), and(not(empty(parameters('admin_key_data'))), parameters('nodes')[copyIndex('vmCopy')]['is_linux']), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')) ))]",
                 "storageProfile": {
                     "imageReference": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vhd_path']))), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')]))))]",
-                    "osDisk": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))),  lisa.getOsDisk(concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk')),  if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'Ephemeral'), lisa.getEphemeralOSImage(parameters('nodes')[copyIndex('vmCopy')]), lisa.getOSImage(parameters('nodes')[copyIndex('vmCopy')])) )]",
+                    "osDisk": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))),  lisa.getOsDisk(concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk')),  if(equals(parameters('nodes')[copyIndex('vmCopy')]['os_disk_type'], 'Ephemeral'), lisa.getEphemeralOSImage(parameters('nodes')[copyIndex('vmCopy')]), lisa.getOSImage(parameters('nodes')[copyIndex('vmCopy')])) )]",
                     "diskControllerType": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_controller_type'], 'SCSI'), json('null'), parameters('nodes')[copyIndex('vmCopy')]['disk_controller_type'])]",
                     "copy": [
                         {
@@ -395,6 +395,7 @@
                         "storageUri": "[reference(resourceId(parameters('shared_resource_group_name'), 'Microsoft.Storage/storageAccounts', parameters('storage_name')), '2015-06-15').primaryEndpoints['blob']]"
                     }
                 },
+                "additionalCapabilities": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'UltraSSD_LRS'), json('{\"ultraSSDEnabled\": true}'), json('null'))]",
                 "securityProfile": "[if(empty(parameters('nodes')[copyIndex('vmCopy')]['security_profile']), json('null'), lisa.getSecurityProfile(parameters('nodes')[copyIndex('vmCopy')]['security_profile']))]"
             }
         }
@@ -537,10 +538,10 @@
                         "value": {
                             "name": "[concat(parameters('node')['name'], '-osDisk')]",
                             "managedDisk": {
-                                "storageAccountType": "[parameters('node')['disk_type']]",
+                                "storageAccountType": "[parameters('node')['os_disk_type']]",
                                 "securityProfile": "[if(or(empty(parameters('node')['security_profile']), not(equals(parameters('node')['security_profile']['security_type'], 'ConfidentialVM'))), json('null'), json(concat('{\"securityEncryptionType\": \"', parameters('node')['security_profile']['encryption_type'], '\"', if(empty(parameters('node')['security_profile']['disk_encryption_set_id']), '', concat(', \"diskEncryptionSet\": {\"id\": \"', parameters('node')['security_profile']['disk_encryption_set_id'], '\"}')), '}')))]"
                             },
-                            "caching": "[if(equals(parameters('node')['disk_type'], 'Ephemeral'), 'ReadOnly', 'ReadWrite')]",
+                            "caching": "[if(equals(parameters('node')['os_disk_type'], 'Ephemeral'), 'ReadOnly', 'ReadWrite')]",
                             "createOption": "FromImage",
                             "diskSizeGB": "[parameters('node')['osdisk_size_in_gb']]"
                         }

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -395,7 +395,7 @@
                         "storageUri": "[reference(resourceId(parameters('shared_resource_group_name'), 'Microsoft.Storage/storageAccounts', parameters('storage_name')), '2015-06-15').primaryEndpoints['blob']]"
                     }
                 },
-                "additionalCapabilities": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['disk_type'], 'UltraSSD_LRS'), json('{\"ultraSSDEnabled\": true}'), json('null'))]",
+                "additionalCapabilities": "[if(equals(parameters('nodes')[copyIndex('vmCopy')]['data_disk_type'], 'UltraSSD_LRS'), json('{\"ultraSSDEnabled\": true}'), json('null'))]",
                 "securityProfile": "[if(empty(parameters('nodes')[copyIndex('vmCopy')]['security_profile']), json('null'), lisa.getSecurityProfile(parameters('nodes')[copyIndex('vmCopy')]['security_profile']))]"
             }
         }

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -333,6 +333,28 @@
             }
         },
         {
+            "name": "[concat(parameters('nodes')[div(copyIndex(), length(parameters('data_disks')))]['name'], '-data-disk-', mod(copyIndex(), length(parameters('data_disks'))))]",
+            "type": "Microsoft.Compute/disks",
+            "apiVersion": "2022-03-02",
+            "location": "[parameters('location')]",
+            "condition": "[equals(parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].type, 'UltraSSD_LRS')]",
+            "properties": {
+                "diskSizeGB": "[parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].size]",
+                "creationData": {
+                    "createOption": "[parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].create_option]"
+                },
+                "diskIOPSReadWrite": "[parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].iops]",
+                "diskMBpsReadWrite": "[parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].throughput]"
+            },
+            "sku": {
+                "name": "[parameters('data_disks')[mod(copyIndex(), length(parameters('data_disks')))].type]"
+            },
+            "copy": {
+                "name": "ultraDisks",
+                "count": "[mul(length(parameters('data_disks')), variables('node_count'))]"
+            }
+        },
+        {
             "apiVersion": "2022-08-01",
             "type": "Microsoft.Compute/virtualMachines",
             "copy": {
@@ -344,6 +366,7 @@
             "tags": "[parameters('vm_tags')]",
             "plan": "[parameters('nodes')[copyIndex('vmCopy')]['purchase_plan']]",
             "dependsOn": [
+                "ultraDisks",
                 "[resourceId('Microsoft.Compute/availabilitySets', variables('availability_set_name'))]",
                 "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk'), resourceId('Microsoft.Compute/images',concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-image')))]",
                 "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'],'-nics')]"
@@ -362,16 +385,7 @@
                         {
                             "name": "dataDisks",
                             "count": "[length(parameters('data_disks'))]",
-                            "input": {
-                                "name": "[concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-data-disk-', copyIndex('dataDisks'))]",
-                                "createOption": "[parameters('data_disks')[copyIndex('dataDisks')].create_option]",
-                                "caching": "[parameters('data_disks')[copyIndex('dataDisks')].caching_type]",
-                                "diskSizeGB": "[parameters('data_disks')[copyIndex('dataDisks')].size]",
-                                "lun": "[copyIndex('dataDisks')]",
-                                "managedDisk": {
-                                    "storageAccountType": "[parameters('data_disks')[copyIndex('dataDisks')].type]"
-                                }
-                            }
+                            "input": "[if(equals(parameters('data_disks')[copyIndex('dataDisks')].type, 'UltraSSD_LRS'), lisa.getAttachDisk(parameters('data_disks')[copyIndex('dataDisks')],concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-data-disk-', copyIndex('dataDisks')),copyIndex('dataDisks')), lisa.getCreateDisk(parameters('data_disks')[copyIndex('dataDisks')],concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-data-disk-', copyIndex('dataDisks')),copyIndex('dataDisks')))]"
                         }
                     ]
                 },
@@ -580,6 +594,62 @@
                         "value": {
                             "createOption": "Attach",
                             "osType": "Linux",
+                            "managedDisk": {
+                                "id": "[resourceId('Microsoft.Compute/disks', parameters('diskName'))]"
+                            }
+                        }
+                    }
+                },
+                "getCreateDisk": {
+                    "parameters": [
+                        {
+                            "name": "disk",
+                            "type": "object"
+                        },
+                        {
+                            "name": "diskName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "index",
+                            "type": "int"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": {
+                            "name": "[parameters('diskName')]",
+                            "createOption": "[parameters('disk').create_option]",
+                            "caching": "[parameters('disk').caching_type]",
+                            "diskSizeGB": "[parameters('disk').size]",
+                            "lun": "[parameters('index')]",
+                            "managedDisk": {
+                                "storageAccountType": "[parameters('disk').type]"
+                            }
+                        }
+                    }
+                },
+                "getAttachDisk": {
+                    "parameters": [
+                        {
+                            "name": "disk",
+                            "type": "object"
+                        },
+                        {
+                            "name": "diskName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "index",
+                            "type": "int"
+                        }
+                    ],
+                    "output": {
+                        "type": "object",
+                        "value": {
+                            "lun": "[parameters('index')]",
+                            "createOption": "attach",
+                            "caching": "[parameters('disk').caching_type]",
                             "managedDisk": {
                                 "id": "[resourceId('Microsoft.Compute/disks', parameters('diskName'))]"
                             }

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -253,7 +253,7 @@ class AzureNodeSchema:
                 "vhd_raw",
                 "data_disk_caching_type",
                 "os_disk_type",
-                "disk_type",
+                "data_disk_type",
             ],
         )
         # If vhd contains sas token, need add mask
@@ -450,7 +450,7 @@ class AzureNodeArmParameter(AzureNodeSchema):
     nic_count: int = 1
     enable_sriov: bool = False
     os_disk_type: str = ""
-    disk_type: str = ""
+    data_disk_type: str = ""
     disk_controller_type: str = ""
     security_profile: Dict[str, Any] = field(default_factory=dict)
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -502,6 +502,8 @@ class DataDiskSchema:
         ),
     )
     size: int = 32
+    iops: int = 0
+    throughput: int = 0  # MB/s
     type: str = field(
         default=schema.DiskType.StandardHDDLRS,
         metadata=field_metadata(

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -252,6 +252,7 @@ class AzureNodeSchema:
                 "shared_gallery_raw",
                 "vhd_raw",
                 "data_disk_caching_type",
+                "os_disk_type",
                 "disk_type",
             ],
         )
@@ -448,6 +449,7 @@ class AzureNodeSchema:
 class AzureNodeArmParameter(AzureNodeSchema):
     nic_count: int = 1
     enable_sriov: bool = False
+    os_disk_type: str = ""
     disk_type: str = ""
     disk_controller_type: str = ""
     security_profile: Dict[str, Any] = field(default_factory=dict)
@@ -508,6 +510,7 @@ class DataDiskSchema:
                     schema.DiskType.StandardHDDLRS,
                     schema.DiskType.StandardSSDLRS,
                     schema.DiskType.PremiumSSDLRS,
+                    schema.DiskType.UltraSSDLRS,
                     schema.DiskType.Ephemeral,
                 ]
             )

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -938,7 +938,7 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
             "os_disk_type",
         )
         result.merge(
-            search_space.check_setspace(self.disk_type, capability.disk_type),
+            search_space.check_setspace(self.data_disk_type, capability.data_disk_type),
             "disk_type",
         )
         result.merge(
@@ -991,7 +991,7 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
             capability.os_disk_type
         ), "capability should have at least one OS disk type, but it's None"
         assert (
-            capability.disk_type
+            capability.data_disk_type
         ), "capability should have at least one disk type, but it's None"
         assert (
             capability.disk_controller_type
@@ -1020,7 +1020,7 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
             search_space, f"{method.value}_setspace_by_priority"
         )(self.os_disk_type, capability.os_disk_type, schema.disk_type_priority)
 
-        cap_disk_type = capability.disk_type
+        cap_disk_type = capability.data_disk_type
         if isinstance(cap_disk_type, search_space.SetSpace):
             assert (
                 len(cap_disk_type) > 0
@@ -1034,9 +1034,9 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
                 f"unknown disk type on capability, type: {cap_disk_type}"
             )
 
-        value.disk_type = getattr(search_space, f"{method.value}_setspace_by_priority")(
-            self.disk_type, capability.disk_type, schema.disk_type_priority
-        )
+        value.data_disk_type = getattr(
+            search_space, f"{method.value}_setspace_by_priority"
+        )(self.data_disk_type, capability.data_disk_type, schema.disk_type_priority)
 
         cap_disk_controller_type = capability.disk_controller_type
         if isinstance(cap_disk_controller_type, search_space.SetSpace):
@@ -1083,9 +1083,9 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
 
         if method == RequirementMethod.generate_min_capability:
             assert isinstance(
-                value.disk_type, schema.DiskType
-            ), f"actual: {type(value.disk_type)}"
-            disk_type_iops = _disk_size_iops_map.get(value.disk_type, None)
+                value.data_disk_type, schema.DiskType
+            ), f"actual: {type(value.data_disk_type)}"
+            disk_type_iops = _disk_size_iops_map.get(value.data_disk_type, None)
             # ignore unsupported disk type like Ephemeral. It supports only os
             # disk. Calculate for iops, if it has value. If not, try disk size
             if disk_type_iops:
@@ -1140,7 +1140,7 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
                     value.data_disk_size = self._get_disk_size_from_iops(
                         value.data_disk_iops, disk_type_iops
                     )
-            elif value.disk_type == schema.DiskType.UltraSSDLRS:
+            elif value.data_disk_type == schema.DiskType.UltraSSDLRS:
                 req_disk_size = search_space.count_space_to_int_range(
                     self.data_disk_size
                 )

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1644,6 +1644,7 @@ class AzurePlatform(Platform):
             schema.DiskControllerType
         ](is_allow_set=True, items=[])
         node_space.disk.data_disk_iops = search_space.IntRange(min=0)
+        node_space.disk.data_disk_throughput = search_space.IntRange(min=0)
         node_space.disk.data_disk_size = search_space.IntRange(min=0)
         node_space.network_interface = schema.NetworkInterfaceOptionSettings()
         node_space.network_interface.data_path = search_space.SetSpace[
@@ -2092,6 +2093,8 @@ class AzurePlatform(Platform):
                             _get_disk_size_in_gb(
                                 default_data_disk.additional_properties
                             ),
+                            0,
+                            0,
                             azure_node_runbook.data_disk_type,
                             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
                         )
@@ -2100,11 +2103,21 @@ class AzurePlatform(Platform):
             node.capability.disk.data_disk_count, int
         ), f"actual: {type(node.capability.disk.data_disk_count)}"
         for _ in range(node.capability.disk.data_disk_count):
-            assert isinstance(node.capability.disk.data_disk_size, int)
+            assert isinstance(
+                node.capability.disk.data_disk_size, int
+            ), f"actual: {type(node.capability.disk.data_disk_size)}"
+            assert isinstance(
+                node.capability.disk.data_disk_iops, int
+            ), f"actual: {type(node.capability.disk.data_disk_iops)}"
+            assert isinstance(
+                node.capability.disk.data_disk_throughput, int
+            ), f"actual: {type(node.capability.disk.data_disk_throughput)}"
             data_disks.append(
                 DataDiskSchema(
                     node.capability.disk.data_disk_caching_type,
                     node.capability.disk.data_disk_size,
+                    node.capability.disk.data_disk_iops,
+                    node.capability.disk.data_disk_throughput,
                     azure_node_runbook.data_disk_type,
                     DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_EMPTY,
                 )

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1401,9 +1401,9 @@ class AzurePlatform(Platform):
         arm_parameters.os_disk_type = features.get_azure_disk_type(
             capability.disk.os_disk_type
         )
-        assert isinstance(capability.disk.disk_type, schema.DiskType)
-        arm_parameters.disk_type = features.get_azure_disk_type(
-            capability.disk.disk_type
+        assert isinstance(capability.disk.data_disk_type, schema.DiskType)
+        arm_parameters.data_disk_type = features.get_azure_disk_type(
+            capability.disk.data_disk_type
         )
         assert isinstance(
             capability.disk.disk_controller_type, schema.DiskControllerType
@@ -1637,7 +1637,7 @@ class AzurePlatform(Platform):
         node_space.disk.os_disk_type = search_space.SetSpace[schema.DiskType](
             is_allow_set=True, items=[]
         )
-        node_space.disk.disk_type = search_space.SetSpace[schema.DiskType](
+        node_space.disk.data_disk_type = search_space.SetSpace[schema.DiskType](
             is_allow_set=True, items=[]
         )
         node_space.disk.disk_controller_type = search_space.SetSpace[
@@ -1696,10 +1696,10 @@ class AzurePlatform(Platform):
 
         if azure_raw_capabilities.get("PremiumIO", None) == "True":
             node_space.disk.os_disk_type.add(schema.DiskType.PremiumSSDLRS)
-            node_space.disk.disk_type.add(schema.DiskType.PremiumSSDLRS)
+            node_space.disk.data_disk_type.add(schema.DiskType.PremiumSSDLRS)
 
         if azure_raw_capabilities.get("UltraSSDAvailable", None) == "True":
-            node_space.disk.disk_type.add(schema.DiskType.UltraSSDLRS)
+            node_space.disk.data_disk_type.add(schema.DiskType.UltraSSDLRS)
 
         disk_controller_types = azure_raw_capabilities.get("DiskControllerTypes", None)
         if disk_controller_types:
@@ -1823,8 +1823,8 @@ class AzurePlatform(Platform):
 
         node_space.disk.os_disk_type.add(schema.DiskType.StandardHDDLRS)
         node_space.disk.os_disk_type.add(schema.DiskType.StandardSSDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.StandardHDDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.StandardSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardHDDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardSSDLRS)
         node_space.network_interface.data_path.add(schema.NetworkDataPath.Synthetic)
 
         return node_space
@@ -1999,13 +1999,13 @@ class AzurePlatform(Platform):
         node_space.disk.os_disk_type.add(schema.DiskType.Ephemeral)
         node_space.disk.os_disk_type.add(schema.DiskType.StandardHDDLRS)
         node_space.disk.os_disk_type.add(schema.DiskType.StandardSSDLRS)
-        node_space.disk.disk_type = search_space.SetSpace[schema.DiskType](
+        node_space.disk.data_disk_type = search_space.SetSpace[schema.DiskType](
             is_allow_set=True, items=[]
         )
-        node_space.disk.disk_type.add(schema.DiskType.UltraSSDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.PremiumSSDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.StandardHDDLRS)
-        node_space.disk.disk_type.add(schema.DiskType.StandardSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.UltraSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.PremiumSSDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardHDDLRS)
+        node_space.disk.data_disk_type.add(schema.DiskType.StandardSSDLRS)
         node_space.disk.disk_controller_type = search_space.SetSpace[
             schema.DiskControllerType
         ](is_allow_set=True, items=[])
@@ -2092,7 +2092,7 @@ class AzurePlatform(Platform):
                             _get_disk_size_in_gb(
                                 default_data_disk.additional_properties
                             ),
-                            azure_node_runbook.disk_type,
+                            azure_node_runbook.data_disk_type,
                             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
                         )
                     )
@@ -2105,7 +2105,7 @@ class AzurePlatform(Platform):
                 DataDiskSchema(
                     node.capability.disk.data_disk_caching_type,
                     node.capability.disk.data_disk_size,
-                    azure_node_runbook.disk_type,
+                    azure_node_runbook.data_disk_type,
                     DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_EMPTY,
                 )
             )

--- a/microsoft/testsuites/performance/nestedperf.py
+++ b/microsoft/testsuites/performance/nestedperf.py
@@ -85,7 +85,8 @@ class KVMPerformance(TestSuite):  # noqa
         timeout=_TIME_OUT,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=2),
             ),
@@ -111,7 +112,8 @@ class KVMPerformance(TestSuite):  # noqa
         timeout=_TIME_OUT,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=7),
             ),
@@ -139,7 +141,8 @@ class KVMPerformance(TestSuite):  # noqa
             supported_os=[Windows],
             supported_platform_type=[AZURE, READY],
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardSSDLRS,
+                data_disk_type=schema.DiskType.StandardSSDLRS,
+                os_disk_type=schema.DiskType.StandardSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=1),
             ),
@@ -166,7 +169,8 @@ class KVMPerformance(TestSuite):  # noqa
             supported_os=[Windows],
             supported_platform_type=[AZURE, READY],
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardSSDLRS,
+                data_disk_type=schema.DiskType.StandardSSDLRS,
+                os_disk_type=schema.DiskType.StandardSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=6),
             ),

--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -54,7 +54,8 @@ class StoragePerformance(TestSuite):
         timeout=TIME_OUT,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=16),
             ),
@@ -71,7 +72,8 @@ class StoragePerformance(TestSuite):
         timeout=TIME_OUT,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=16),
             ),
@@ -88,7 +90,8 @@ class StoragePerformance(TestSuite):
         timeout=TIME_OUT,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=24),
             ),
@@ -107,7 +110,8 @@ class StoragePerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=12),
                 data_disk_size=search_space.IntRange(min=10),
@@ -128,7 +132,8 @@ class StoragePerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=12),
                 data_disk_size=search_space.IntRange(min=10),
@@ -149,7 +154,8 @@ class StoragePerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=12),
                 data_disk_size=search_space.IntRange(min=10),
@@ -170,7 +176,8 @@ class StoragePerformance(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.PremiumSSDLRS,
+                data_disk_type=schema.DiskType.PremiumSSDLRS,
+                os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
                 data_disk_count=search_space.IntRange(min=12),
                 data_disk_size=search_space.IntRange(min=10),

--- a/microsoft/testsuites/storage/storagesuite.py
+++ b/microsoft/testsuites/storage/storagesuite.py
@@ -62,7 +62,8 @@ class StorageTest(TestSuite):
         priority=3,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
                 data_disk_iops=search_space.IntRange(min=500),
                 data_disk_count=search_space.IntRange(min=64),
             ),

--- a/microsoft/testsuites/xfstests/xfstesting.py
+++ b/microsoft/testsuites/xfstests/xfstesting.py
@@ -146,7 +146,8 @@ class Xfstesting(TestSuite):
         """,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
                 data_disk_iops=500,
                 data_disk_count=search_space.IntRange(min=1),
             ),
@@ -181,7 +182,8 @@ class Xfstesting(TestSuite):
         """,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
                 data_disk_iops=500,
                 data_disk_count=search_space.IntRange(min=1),
             ),
@@ -215,7 +217,8 @@ class Xfstesting(TestSuite):
         """,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
                 data_disk_iops=500,
                 data_disk_count=search_space.IntRange(min=1),
             ),
@@ -250,7 +253,8 @@ class Xfstesting(TestSuite):
         """,
         requirement=simple_requirement(
             disk=schema.DiskOptionSettings(
-                disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
                 data_disk_iops=500,
                 data_disk_count=search_space.IntRange(min=1),
             ),

--- a/selftests/azure/test_disk_feature.py
+++ b/selftests/azure/test_disk_feature.py
@@ -23,7 +23,7 @@ class AzureDiskFeatureTestCase(TestCase):
     def test_disk_type_overlap(self) -> None:
         # req and cap both have DiskPremiumSSDLRS, so it's selected
         req = features.AzureDiskOptionSettings(
-            disk_type=search_space.SetSpace[schema.DiskType](
+            data_disk_type=search_space.SetSpace[schema.DiskType](
                 items=[schema.DiskType.PremiumSSDLRS, schema.DiskType.StandardSSDLRS]
             )
         )
@@ -40,7 +40,7 @@ class AzureDiskFeatureTestCase(TestCase):
     def test_disk_type_no_common(self) -> None:
         # req and cap has no common disk type
         req = features.AzureDiskOptionSettings(
-            disk_type=search_space.SetSpace[schema.DiskType](
+            data_disk_type=search_space.SetSpace[schema.DiskType](
                 items=[schema.DiskType.StandardSSDLRS]
             )
         )
@@ -90,7 +90,8 @@ class AzureDiskFeatureTestCase(TestCase):
         # given a range of iops, match min one in range
         req = features.AzureDiskOptionSettings(
             data_disk_count=1,
-            disk_type=schema.DiskType.PremiumSSDLRS,
+            data_disk_type=schema.DiskType.PremiumSSDLRS,
+            os_disk_type=schema.DiskType.PremiumSSDLRS,
             data_disk_iops=search_space.IntRange(min=1800, max=8000),
         )
         cap = self._get_default_cap()
@@ -106,7 +107,8 @@ class AzureDiskFeatureTestCase(TestCase):
         # given a range of iops on req and cap, match min one in range
         req = features.AzureDiskOptionSettings(
             data_disk_count=1,
-            disk_type=schema.DiskType.PremiumSSDLRS,
+            data_disk_type=schema.DiskType.PremiumSSDLRS,
+            os_disk_type=schema.DiskType.PremiumSSDLRS,
             data_disk_iops=search_space.IntRange(min=1800, max=8000),
         )
         cap = self._get_default_cap()
@@ -122,7 +124,7 @@ class AzureDiskFeatureTestCase(TestCase):
     def test_disk_specify_iops_use_premium(self) -> None:
         # given premium disk type
         req = features.AzureDiskOptionSettings(
-            disk_type=search_space.SetSpace[schema.DiskType](
+            data_disk_type=search_space.SetSpace[schema.DiskType](
                 items=[schema.DiskType.PremiumSSDLRS]
             ),
             data_disk_count=1,
@@ -154,7 +156,7 @@ class AzureDiskFeatureTestCase(TestCase):
     def test_disk_specify_disk_size_a_range(self) -> None:
         # given a range to disk size, match the min one in range
         req = features.AzureDiskOptionSettings(
-            disk_type=search_space.SetSpace[schema.DiskType](
+            data_disk_type=search_space.SetSpace[schema.DiskType](
                 items=[schema.DiskType.PremiumSSDLRS]
             ),
             data_disk_count=1,
@@ -182,7 +184,7 @@ class AzureDiskFeatureTestCase(TestCase):
         reason = req.check(cap)
         self.assertTrue(reason.result, f"check reasons: {reason.reasons}")
         min_value: features.AzureDiskOptionSettings = req.generate_min_capability(cap)
-        self.assertEqual(disk_type, min_value.disk_type)
+        self.assertEqual(disk_type, min_value.data_disk_type)
         self.assertEqual(data_disk_count, min_value.data_disk_count)
         self.assertEqual(data_disk_caching_type, min_value.data_disk_caching_type)
         self.assertEqual(data_disk_iops, min_value.data_disk_iops)
@@ -190,7 +192,7 @@ class AzureDiskFeatureTestCase(TestCase):
 
     def _get_default_cap(self) -> features.AzureDiskOptionSettings:
         return features.AzureDiskOptionSettings(
-            disk_type=search_space.SetSpace[schema.DiskType](
+            data_disk_type=search_space.SetSpace[schema.DiskType](
                 items=[schema.DiskType.PremiumSSDLRS, schema.DiskType.StandardHDDLRS]
             ),
             data_disk_iops=search_space.IntRange(max=sys.maxsize),


### PR DESCRIPTION
- Separates OS disk type from the data disk type
- Adds VM SKU feature check for Ultra disk
- Adds Ultra disk type
- Makes changes to ARM template to allow for Ultra disk to be deployed
- Set Ultra Disk IOPS and throughput in the ARM template. I implemented this by always setting to the max IOPS and throughput for a given disk size. Restricting IOPS / throughput on a larger disk size is not a current use case. 

NOT implemented (yet)
- Availability zones: many regions require ultra disks to be deployed in an availability zone
- Resolving availability set conflict gracefully: Ultra disks cannot be deployed in an availability set. This will necessarily conflict with any tip session parameters set in a runbook.
- Caching: caching type must be set to none
