### PR TITLE
Consolidated MANA testing changes:

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -437,6 +437,16 @@ class Nics(InitializableMixin):
                     self.nics[nic].pci_slot = pci_device.slot
                 break
 
+    def get_mac_address(self, nic_name: str) -> str:
+        return self._node.execute(
+            f"cat /sys/class/net/{nic_name}/address",
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"No sysfs entry for mac address for {nic_name}"
+            ),
+            shell=True,
+        ).stdout.strip()
+
     def _is_mana_device_discovered(self) -> bool:
         lspci = self._node.tools[Lspci]
         pci_devices = lspci.get_devices_by_type(

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -32,7 +32,7 @@ from lisa.util import (
     SkippedException,
     UnsupportedDistroException,
 )
-from lisa.util.constants import SIGINT
+from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 
 PACKAGE_MANAGER_SOURCE = "package_manager"
 
@@ -187,45 +187,60 @@ class DpdkTestpmd(Tool):
     def generate_testpmd_include(self, node_nic: NicInfo, vdev_id: int) -> str:
         # handle generating different flags for pmds/device combos for testpmd
 
-        # identify which nics to inlude in test, exclude others
-        include_nics = [node_nic]
-        exclude_nics = [
-            self.node.nics.get_nic(nic)
-            for nic in self.node.nics.get_nic_names()
-            if nic != node_nic.name
-        ]
+        # flag changed to 'allowlist' in 20.11
+        # use 'allow' instead of 'deny' for envionments where
+        # there is 1 bus address due to v-ports
+        if self._dpdk_version_info and self._dpdk_version_info < "20.11.0":
+            include_flag = "-w"
+        else:
+            include_flag = "-a"
 
         # build list of vdev info flags for each nic
         vdev_info = ""
-        self.node.log.info(f"Running test with {len(include_nics)} nics.")
-        for nic in include_nics:
-            if self._dpdk_version_info and self._dpdk_version_info >= "18.11.0":
-                vdev_name = "net_vdev_netvsc"
-                vdev_flags = f"iface={nic.name},force=1"
-            else:
-                vdev_name = "net_failsafe"
-                vdev_flags = (
-                    f"dev({nic.pci_slot}),dev(net_tap0,iface={nic.name},force=1)"
-                )
-            if nic.module_name == "hv_netvsc":
-                vdev_info += f'--vdev="{vdev_name}{vdev_id},{vdev_flags}" '
-            elif nic.module_name == "uio_hv_generic":
-                pass
-            else:
-                fail(
-                    (
-                        f"Unknown driver({nic.module_name}) bound to "
-                        f"{nic.name}/{nic.lower}."
-                        "Cannot generate testpmd include arguments."
-                    )
-                )
 
-        # exclude pci slots not associated with the test nic
-        exclude_flags = ""
-        for nic in exclude_nics:
-            exclude_flags += f' -b "{nic.pci_slot}"'
+        if self._dpdk_version_info < "18.11.0":
+            vdev_name = "net_failsafe"
+            vdev_flags = f"dev({node_nic.pci_slot}),dev(iface={node_nic.name},force=1)"
+        elif self.is_mana:
+            # mana will not need include flag since it can select by mac
+            # return the vdev info directly
+            if node_nic.module_name == "uio_hv_generic":
+                return f' --vdev="{node_nic.pci_slot},mac={node_nic.mac_addr}" '
+            # if mana_ib is present, use mana friendly args
+            elif self.node.tools[Modprobe].module_exists("mana_ib"):
+                return f' --vdev="net_vdev_netvsc0,mac={node_nic.mac_addr}" '
+            else:
+                # use eth interface for failsafe otherwise
+                return f' --vdev="net_vdev_netvsc0,iface={node_nic.name}" '
+        # allow force failsafe to test old pmd in newer dpdk releases
+        elif self._force_net_failsafe_pmd:
+            vdev_name = "net_failsafe"
+            vdev_flags = (
+                f'--vdev="net_failsafe0,mac={node_nic.mac_addr},'
+                f'dev(net_tap0,iface={node_nic.name},force=1)"'
+            )
+        else:
+            vdev_name = "net_vdev_netvsc"
+            vdev_flags = f"iface={node_nic.name},force=1"
 
-        return vdev_info + exclude_flags
+        if node_nic.module_name == "hv_netvsc":
+            vdev_info += f'--vdev="{vdev_name}{vdev_id},{vdev_flags}" '
+        elif node_nic.module_name == "uio_hv_generic":
+            pass
+        else:
+            fail(
+                (
+                    f"Unknown driver({node_nic.module_name}) bound to "
+                    f"{node_nic.name}/{node_nic.lower}."
+                    "Cannot generate testpmd include arguments."
+                )
+            )
+
+        # include bus address info for the test nic only
+
+        include_flag = f' {include_flag} "{node_nic.pci_slot}"'
+
+        return vdev_info + include_flag
 
     def generate_testpmd_command(
         self,
@@ -247,12 +262,16 @@ class DpdkTestpmd(Tool):
         #   --eth-peer=<port id>,<receiver peer MAC address> \
         #   --stats-period <display interval in seconds>
 
+        # txq and rxq will always be equal in our testing
         if multiple_queues:
-            txq = 4
-            rxq = 4
+            if self.is_mana:
+                queues = 8
+            else:
+                queues = 4
         else:
-            txq = 1
-            rxq = 1
+            queues = 1
+
+        txd = 128
 
         nic_include_info = self.generate_testpmd_include(nic_to_include, vdev_id)
 
@@ -262,16 +281,20 @@ class DpdkTestpmd(Tool):
             "DPDK tests need more than 4 cores, recommended more than 8 cores"
         ).is_greater_than(4)
 
-        # EAL core model is logical cores, so one thread per EAL 'core'
-        threads_per_core = max(1, self.node.tools[Lscpu].get_thread_per_core_count())
-        logical_cores_available = cores_available * threads_per_core
-        queues_and_servicing_core = txq + rxq + service_cores
+        queues_and_servicing_core = (queues * 2) + service_cores
 
-        # use enough cores for (queues + service core) or max available
-        max_core_index = min(
-            logical_cores_available - threads_per_core,  # leave one physical for system
-            queues_and_servicing_core,
-        )
+        # use less than max queues if not enough cores are available
+        while queues_and_servicing_core > (cores_available - 2):
+            # if less, split the number of queues
+            queues_and_servicing_core = queues + service_cores
+            queues = queues // 2
+            txd = txd // 2
+            assert_that(queues).described_as(
+                "txq value must be greater than 1"
+            ).is_greater_than_or_equal_to(1)
+
+        # label core index for future use
+        max_core_index = queues_and_servicing_core
 
         # service cores excluded from forwarding cores count
         forwarding_cores = max_core_index - service_cores
@@ -282,6 +305,11 @@ class DpdkTestpmd(Tool):
             extra_args = extra_args.strip()
         else:
             extra_args = ""
+        # mana pmd needs tx/rx descriptors declared.
+        if self.is_mana:
+            extra_args += f" --txd={txd} --rxd={txd}  --stats 2"
+        if queues > 1:
+            extra_args += f" --txq={queues} --rxq={queues}"
 
         assert_that(forwarding_cores).described_as(
             ("DPDK tests need at least one forwading core. ")
@@ -425,6 +453,7 @@ class DpdkTestpmd(Tool):
         super().__init__(*args, **kwargs)
         self._dpdk_source = kwargs.pop("dpdk_source", PACKAGE_MANAGER_SOURCE)
         self._dpdk_branch = kwargs.pop("dpdk_branch", "main")
+        self._force_net_failsafe_pmd = kwargs.pop("force_net_failsafe_pmd", False)
         self._sample_apps_to_build = kwargs.pop("sample_apps", [])
         self._dpdk_version_info = VersionInfo(0, 0)
         self._testpmd_install_path: str = ""
@@ -435,14 +464,16 @@ class DpdkTestpmd(Tool):
             self.dpdk_path = self.node.get_pure_path(work_path).joinpath(
                 self._dpdk_repo_path_name
             )
+        self._determine_network_hardware()
         self.find_testpmd_binary(assert_on_fail=False)
 
     def _determine_network_hardware(self) -> None:
         lspci = self.node.tools[Lspci]
-        device_list = lspci.get_devices()
+        device_list = lspci.get_devices_by_type(DEVICE_TYPE_SRIOV)
         self.is_connect_x3 = any(
             ["ConnectX-3" in dev.device_info for dev in device_list]
         )
+        self.is_mana = any(["Microsoft" in dev.vendor for dev in device_list])
 
     def _check_pps_data_exists(self, rx_or_tx: str) -> None:
         data_attr_name = f"{rx_or_tx.lower()}_pps_data"
@@ -477,7 +508,6 @@ class DpdkTestpmd(Tool):
         self._testpmd_output_before_rescind = ""
         self._testpmd_output_during_rescind = ""
         self._last_run_output = ""
-        self._determine_network_hardware()
         node = self.node
         if isinstance(node.os, Debian):
             repos = node.os.get_repositories()
@@ -633,6 +663,10 @@ class DpdkTestpmd(Tool):
         self.node.log.info("Loading drivers for infiniband, rdma, and mellanox hw...")
         if self.is_connect_x3:
             mellanox_drivers = ["mlx4_core", "mlx4_ib"]
+        elif self.is_mana:
+            mellanox_drivers = ["mana"]
+            if self.node.tools[Modprobe].load("mana_ib", dry_run=True):
+                mellanox_drivers.append("mana_ib")
         else:
             mellanox_drivers = ["mlx5_core", "mlx5_ib"]
         modprobe = self.node.tools[Modprobe]

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -27,6 +27,7 @@ from lisa.tools import (
     Echo,
     Firewall,
     Free,
+    Ip,
     KernelConfig,
     Lscpu,
     Lsmod,
@@ -276,6 +277,7 @@ def initialize_node_resources(
     _set_forced_source_by_distro(node, variables)
     dpdk_source = variables.get("dpdk_source", PACKAGE_MANAGER_SOURCE)
     dpdk_branch = variables.get("dpdk_branch", "")
+    force_net_failsafe_pmd = variables.get("dpdk_force_net_failsafe_pmd", False)
     log.info(
         "Dpdk initialize_node_resources running"
         f"found dpdk_source '{dpdk_source}' and dpdk_branch '{dpdk_branch}'"
@@ -311,6 +313,7 @@ def initialize_node_resources(
         dpdk_source=dpdk_source,
         dpdk_branch=dpdk_branch,
         sample_apps=sample_apps,
+        force_net_failsafe_pmd=force_net_failsafe_pmd,
     )
 
     # init and enable hugepages (required by dpdk)
@@ -337,9 +340,21 @@ def initialize_node_resources(
         node.mark_dirty()
         enable_uio_hv_generic_for_nic(node, test_nic)
         # if this device is paired, set the upper device 'down'
+
+        node.nics.unbind(test_nic)
+        node.nics.bind(test_nic, UIO_HV_GENERIC_SYSFS_PATH)
+
+    # check for other nics with the same mac address, set them down for netvsc or mana
+    if testpmd.is_mana:
         if test_nic.lower:
-            node.nics.unbind(test_nic)
-            node.nics.bind(test_nic, UIO_HV_GENERIC_SYSFS_PATH)
+            node.tools[Ip].down(test_nic.lower)
+        else:
+            test_mac = test_nic.mac_addr
+            for nic in node.nics._get_nic_names():
+                if nic != test_nic.name and (
+                    node.nics.get_mac_address(nic) == test_mac
+                ):
+                    node.tools[Ip].down(nic)
 
     return DpdkTestResources(node, testpmd)
 


### PR DESCRIPTION
Consolidated MANA testing changes:
- Adds better MANA pmd arguments handling
- Adds option to force use of net_failsafe on newer platforms for failure mode testing
- Swaps from exclusion to inclusion of test nics for handling scenarios where all dpdk interfaces share a pci bus address
- Adds handling of MANA idiosyncracy of setting devices down before testing.
- Adds get_mac_address function for nic class to handle setting shared MAC devices down. 

Acknowledging this last point is a hack, but the addition of that function will lead to a larger fix soon. The get_mac_address function covers an issue in the NIC class where slave devices can go undetected, refactoring is needed to fix this. This get_mac_address function will be used in the eventual refactoring, so this backup check will eventually be moved into the parent class.