### PR TITLE
DPDK: Remove IsolatedResource for send/receive

### DIFF
--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -501,7 +501,6 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             min_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
@@ -528,7 +527,6 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             min_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_netvsc(
@@ -555,7 +553,6 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             min_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def verify_dpdk_send_receive_failsafe(
@@ -580,7 +577,6 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             min_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def verify_dpdk_send_receive_netvsc(


### PR DESCRIPTION
DPDK has been refactored such that shorter runs are possible. Since send time in the send/receive is now minimized to ~10 seconds in the default case, remove the IsolatedResource requirement for simple send/receive. SRIOV rescind tests must run longer, so should remain gated behind that feature.