### PR TITLE
vmbus_devices_channels: fix count for MANA

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -437,6 +437,9 @@ class Nics(InitializableMixin):
                     self.nics[nic].pci_slot = pci_device.slot
                 break
 
+    def is_mana_present(self) -> bool:
+        return self._is_mana_device_discovered()
+
     def _is_mana_device_discovered(self) -> bool:
         lspci = self._node.tools[Lspci]
         pci_devices = lspci.get_devices_by_type(

--- a/microsoft/testsuites/core/lsvmbus.py
+++ b/microsoft/testsuites/core/lsvmbus.py
@@ -122,7 +122,10 @@ class LsVmBus(TestSuite):
         expected_network_channel_count = min(core_count, 8)
         # Each storvsc SCSI device should have "the_number_of_vCPUs / 4" channel(s)
         #  with a cap value of 64.
-        expected_scsi_channel_count = math.ceil(min(core_count, 256) / 4)
+        if node.nics.is_mana_present():
+            expected_scsi_channel_count = min(core_count, 64)
+        else:
+            expected_scsi_channel_count = math.ceil(min(core_count, 256) / 4)
         for vmbus_device in vmbus_devices_list:
             if vmbus_device.name == "Synthetic network adapter":
                 assert_that(vmbus_device.channel_vp_map).is_length(


### PR DESCRIPTION
MANA has a 1:1 channel to core ratio up to 64.
Fix test to account for this change.