### PR TITLE
Mana and NVMe enabled in the info field

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -426,9 +426,7 @@ class Nics(InitializableMixin):
         ).is_greater_than(0)
 
         # handle situation when there is no mana driver, but have mana pci devices
-        if self._is_mana_device_discovered() and not self._node.tools[
-            KernelConfig
-        ].is_enabled("CONFIG_MICROSOFT_MANA"):
+        if self.is_mana_device_present() and not self.is_mana_driver_enabled():
             pci_devices = lspci.get_devices_by_type(
                 constants.DEVICE_TYPE_SRIOV, force_run=True
             )
@@ -437,10 +435,7 @@ class Nics(InitializableMixin):
                     self.nics[nic].pci_slot = pci_device.slot
                 break
 
-    def is_mana_present(self) -> bool:
-        return self._is_mana_device_discovered()
-
-    def _is_mana_device_discovered(self) -> bool:
+    def is_mana_device_present(self) -> bool:
         lspci = self._node.tools[Lspci]
         pci_devices = lspci.get_devices_by_type(
             constants.DEVICE_TYPE_SRIOV, force_run=True
@@ -456,6 +451,9 @@ class Nics(InitializableMixin):
             else:
                 all_mana_devices = False
         return all_mana_devices
+
+    def is_mana_driver_enabled(self) -> bool:
+        return self._node.tools[KernelConfig].is_enabled("CONFIG_MICROSOFT_MANA")
 
     def _get_default_nic(self) -> None:
         self.default_nic: str = ""

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -53,7 +53,8 @@ from lisa.environment import Environment
 from lisa.node import Node, RemoteNode, local
 from lisa.platform_ import Platform
 from lisa.secret import PATTERN_GUID, add_secret
-from lisa.tools import Dmesg, Hostname, Modinfo, Whoami
+from lisa.tools import Dmesg, Hostname, KernelConfig, Modinfo, Whoami
+from lisa.tools.lsinitrd import Lsinitrd
 from lisa.util import (
     LisaException,
     LisaTimeoutException,
@@ -169,6 +170,8 @@ KEY_KERNEL_VERSION = "kernel_version"
 KEY_WALA_VERSION = "wala_version"
 KEY_WALA_DISTRO_VERSION = "wala_distro"
 KEY_HARDWARE_PLATFORM = "hardware_platform"
+KEY_MANA_DRIVER_ENABLED = "mana_driver_enabled"
+KEY_NVME_ENABLED = "nvme_enabled"
 ATTRIBUTE_FEATURES = "features"
 
 CLOUD: Dict[str, Dict[str, Any]] = {
@@ -733,6 +736,24 @@ class AzurePlatform(Platform):
             node.log.debug("detecting vm generation...")
             information[KEY_VM_GENERATION] = node.tools[VmGeneration].get_generation()
             node.log.debug(f"vm generation: {information[KEY_VM_GENERATION]}")
+            node.log.debug("detecting mana driver enabled...")
+            information[KEY_MANA_DRIVER_ENABLED] = node.nics.is_mana_driver_enabled()
+            node.log.debug(f"mana enabled: {information[KEY_MANA_DRIVER_ENABLED]}")
+
+            node.log.debug("detecting nvme driver enabled...")
+
+            _has_nvme_core = node.tools[KernelConfig].is_built_in(
+                "CONFIG_NVME_CORE"
+            ) or (
+                node.tools[KernelConfig].is_built_as_module("CONFIG_NVME_CORE")
+                and node.tools[Lsinitrd].has_module("nvme-core.ko")
+            )
+            _has_nvme = node.tools[KernelConfig].is_built_in("CONFIG_BLK_DEV_NVME") or (
+                node.tools[KernelConfig].is_built_as_module("CONFIG_BLK_DEV_NVME")
+                and node.tools[Lsinitrd].has_module("nvme.ko")
+            )
+            information[KEY_NVME_ENABLED] = _has_nvme_core and _has_nvme
+            node.log.debug(f"nvme enabled: {information[KEY_NVME_ENABLED]}")
 
         node_runbook = node.capability.get_extended_runbook(AzureNodeSchema, AZURE)
         if node_runbook:

--- a/lisa/tools/lsinitrd.py
+++ b/lisa/tools/lsinitrd.py
@@ -2,10 +2,12 @@
 # Licensed under the MIT license.
 
 import re
-from typing import cast
+from typing import Optional, cast
 
+from lisa.base_tools import Uname
 from lisa.executable import Tool
 from lisa.operating_system import Posix
+from lisa.tools import Find
 from lisa.util import LisaException, find_patterns_in_lines, get_matched_str
 
 
@@ -28,11 +30,18 @@ class Lsinitrd(Tool):
         posix_os.install_packages("dracut-core")
         return self._check_exists()
 
-    def has_module(self, module_file_name: str, initrd_file_path: str = "") -> bool:
+    def has_module(
+        self, module_file_name: str, initrd_file_path: Optional[str] = None
+    ) -> bool:
         """
         1) Finds path of modules.dep in initrd
         2) Searches modules.dep for the module file name
         """
+        if not initrd_file_path:
+            initrd_file_path = self.find_initrd_file_path()
+
+        assert initrd_file_path, "Could not find initrd file path"
+
         result = self.run(
             initrd_file_path,
             sudo=True,
@@ -64,3 +73,23 @@ class Lsinitrd(Tool):
         return any(
             module_file_name in requirement for requirement in modules_required[0]
         )
+
+    def find_initrd_file_path(self) -> str:
+        node = self.node
+        uname = node.tools[Uname]
+        kernel_version = uname.get_linux_information().kernel_version_raw
+        find = node.tools[Find]
+        initrd_possible_file_names = [
+            f"initrd-{kernel_version}",
+            f"initramfs-{kernel_version}.img",
+            f"initrd.img-{kernel_version}",
+        ]
+
+        for file_name in initrd_possible_file_names:
+            cmd_result = find.find_files(
+                node.get_pure_path("/boot"), file_name, sudo=True
+            )
+            if cmd_result and cmd_result[0]:
+                return cmd_result[0]
+
+        return ""

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -18,7 +18,7 @@ from lisa import (
 from lisa.operating_system import BSD, Redhat
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.sut_orchestrator.azure.tools import LisDriver
-from lisa.tools import Find, KernelConfig, Lsinitrd, Lsmod, Modinfo, Modprobe, Uname
+from lisa.tools import KernelConfig, Lsinitrd, Lsmod, Modinfo, Modprobe
 from lisa.util import SkippedException
 
 
@@ -73,8 +73,7 @@ class HvModule(TestSuite):
         This test case will ensure all necessary hv_modules are present in
         initrd. This is achieved by
         1. Skipping any modules that are loaded directly in the kernel
-        2. Find the path of initrd file
-        3. Use lsinitrd tool to check whether a necessary module is missing
+        2. Use lsinitrd tool to check whether a necessary module is missing
         """,
         priority=1,
         requirement=simple_requirement(
@@ -99,34 +98,12 @@ class HvModule(TestSuite):
             if k not in skip_modules
         }
 
-        # 2) Find the path of initrd
-        uname = node.tools[Uname]
-        kernel_version = uname.get_linux_information().kernel_version_raw
-        find = node.tools[Find]
-        initrd_possible_file_names = [
-            f"initrd-{kernel_version}",
-            f"initramfs-{kernel_version}.img",
-            f"initrd.img-{kernel_version}",
-        ]
-
-        initrd_file_path = ""
-        for file_name in initrd_possible_file_names:
-            cmd_result = find.find_files(
-                node.get_pure_path("/boot"), file_name, sudo=True
-            )
-            if cmd_result and cmd_result[0]:
-                initrd_file_path = cmd_result[0]
-                break
-
-        # 3) Use lsinitrd to check whether a necessary module
+        # 2) Use lsinitrd to check whether a necessary module
         #    is missing.
         lsinitrd = node.tools[Lsinitrd]
         missing_modules = []
         for module in hv_modules_file_names:
-            if not lsinitrd.has_module(
-                module_file_name=hv_modules_file_names[module],
-                initrd_file_path=initrd_file_path,
-            ):
+            if not lsinitrd.has_module(module_file_name=hv_modules_file_names[module]):
                 missing_modules.append(module)
 
         if (

--- a/microsoft/testsuites/core/lsvmbus.py
+++ b/microsoft/testsuites/core/lsvmbus.py
@@ -122,7 +122,7 @@ class LsVmBus(TestSuite):
         expected_network_channel_count = min(core_count, 8)
         # Each storvsc SCSI device should have "the_number_of_vCPUs / 4" channel(s)
         #  with a cap value of 64.
-        if node.nics.is_mana_present():
+        if node.nics.is_mana_device_present():
             expected_scsi_channel_count = min(core_count, 64)
         else:
             expected_scsi_channel_count = math.ceil(min(core_count, 256) / 4)

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+from assertpy import assert_that
+
 from lisa import (
     BadEnvironmentStateException,
     Logger,
@@ -21,11 +23,14 @@ from lisa.features import (
     DiskEphemeral,
     DiskPremiumSSDLRS,
     DiskStandardSSDLRS,
+    NetworkInterface,
     SerialConsole,
     Sriov,
     StartStop,
     Synthetic,
 )
+from lisa.nic import Nics
+from lisa.tools import Lspci
 from lisa.util import constants
 from lisa.util.shell import wait_tcp_port_ready
 
@@ -159,7 +164,9 @@ class Provisioning(TestSuite):
     def verify_deployment_provision_sriov(
         self, log: Logger, node: RemoteNode, log_path: Path
     ) -> None:
+        self.check_sriov(log, node)
         self._smoke_test(log, node, log_path, "verify_deployment_provision_sriov")
+        self.check_sriov(log, node)
 
     @TestCaseMetadata(
         description="""
@@ -284,3 +291,47 @@ class Provisioning(TestSuite):
             if isinstance(identifier, TcpConnectionException):
                 raise BadEnvironmentStateException(f"after reboot, {identifier}")
             raise PassedException(identifier)
+
+    def is_mana_device_discovered(self, node: RemoteNode) -> bool:
+        lspci = node.tools[Lspci]
+        pci_devices = lspci.get_devices_by_type(
+            constants.DEVICE_TYPE_SRIOV, force_run=True
+        )
+        assert_that(
+            len(pci_devices),
+            "One or more SRIOV devices are expected to be discovered.",
+        ).is_greater_than(0)
+
+        all_mana_devices = False
+        for pci_device in pci_devices:
+            if (
+                "Device 00ba" in pci_device.device_info
+                and pci_device.vendor == "Microsoft Corporation"
+            ):
+                all_mana_devices = True
+            else:
+                all_mana_devices = False
+                break
+        return all_mana_devices
+
+    def check_sriov(self, log: Logger, node: RemoteNode) -> None:
+        node_nic_info = Nics(node)
+        node_nic_info.initialize()
+
+        network_interface_feature = node.features[NetworkInterface]
+        sriov_count = network_interface_feature.get_nic_count()
+        log.info(f"check_sriov: sriov_count {sriov_count}")
+        pci_nic_check = True
+        if self.is_mana_device_discovered(node):
+            if not node.nics.is_mana_driver_enabled():
+                pci_nic_check = False
+            else:
+                pci_nic_check = True
+        if pci_nic_check:
+            log.info(
+                f"check_sriov: PCI nic count {len(node_nic_info.get_lower_nics())}"
+            )
+            assert_that(len(node_nic_info.get_lower_nics())).described_as(
+                f"VF count inside VM is {len(node_nic_info.get_lower_nics())},"
+                f"actual sriov nic count is {sriov_count}"
+            ).is_equal_to(sriov_count)


### PR DESCRIPTION
These changes were cherry picked from `checkpoint_v3_1`.

Adds information about MANA and NVMe capabilities to the info field of LISA test results.