### PR TITLE
Use MS CLH fork for CLH testcases

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -71,6 +71,15 @@ class CloudHypervisorTestSuite(TestSuite):
         include_list, exclude_list = get_test_list(
             variables, "ch_integration_tests_included", "ch_integration_tests_excluded"
         )
+
+        use_ms_clh_repo = variables.get("use_ms_clh_repo", None)
+        ms_access_token = variables.get("ms_access_token", None)
+        if use_ms_clh_repo == "yes":
+            if not ms_access_token:
+                raise SkippedException("Access Token is needed while using MS-CLH")
+            CloudHypervisorTests.use_ms_clh_repo = True
+            CloudHypervisorTests.ms_access_token = ms_access_token
+
         node.tools[CloudHypervisorTests].run_tests(
             result,
             environment,
@@ -112,6 +121,15 @@ class CloudHypervisorTestSuite(TestSuite):
             "ch_live_migration_tests_included",
             "ch_live_migration_tests_excluded",
         )
+
+        use_ms_clh_repo = variables.get("use_ms_clh_repo", None)
+        ms_access_token = variables.get("ms_access_token", None)
+        if use_ms_clh_repo == "yes":
+            if not ms_access_token:
+                raise SkippedException("Access Token is needed while using MS-CLH")
+            CloudHypervisorTests.use_ms_clh_repo = True
+            CloudHypervisorTests.ms_access_token = ms_access_token
+
         node.tools[CloudHypervisorTests].run_tests(
             result,
             environment,
@@ -148,6 +166,15 @@ class CloudHypervisorTestSuite(TestSuite):
             "ch_perf_tests_excluded",
         )
         subtest_timeout = variables.get("ch_perf_subtest_timeout", None)
+
+        use_ms_clh_repo = variables.get("use_ms_clh_repo", None)
+        ms_access_token = variables.get("ms_access_token", None)
+        if use_ms_clh_repo == "yes":
+            if not ms_access_token:
+                raise SkippedException("Access Token is needed while using MS-CLH")
+            CloudHypervisorTests.use_ms_clh_repo = True
+            CloudHypervisorTests.ms_access_token = ms_access_token
+
         node.tools[CloudHypervisorTests].run_metrics_tests(
             result,
             environment,

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -32,7 +32,13 @@ class CloudHypervisorTests(Tool):
     CASE_TIME_OUT = CMD_TIME_OUT + 1200
     PERF_CMD_TIME_OUT = 900
 
-    repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
+    upstream_repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
+
+    ms_org_repo = "https://microsoft.visualstudio.com/DefaultCollection/LSG/_git"
+    ms_clh_repo = f"{ms_org_repo}/cloud-hypervisor"
+    ms_igvm_parser_repo = f"{ms_org_repo}/igvm-parser"
+    use_ms_clh_repo = False
+    ms_access_token = ""
 
     cmd_path: PurePath
     repo_root: PurePath
@@ -208,7 +214,21 @@ class CloudHypervisorTests(Tool):
 
     def _install(self) -> bool:
         git = self.node.tools[Git]
-        git.clone(self.repo, self.get_tool_path(use_global=True))
+        clone_path = self.get_tool_path(use_global=True)
+        if self.use_ms_clh_repo:
+            git.clone(
+                self.ms_clh_repo,
+                clone_path,
+                auth_token=self.ms_access_token,
+            )
+            git.clone(
+                self.ms_igvm_parser_repo,
+                clone_path,
+                auth_token=self.ms_access_token,
+            )
+        else:
+            git.clone(self.upstream_repo, clone_path)
+
         if isinstance(self.node.os, CBLMariner):
             daemon_json_file = PurePath("/etc/docker/daemon.json")
             daemon_json = '{"default-ulimits":{"nofile":{"Hard":65535,"Name":"nofile","Soft":65535}}}'  # noqa: E501


### PR DESCRIPTION
This PR will extend CLH test functionality to use MS CLH to run the testcase. If we dont pass variable **use_ms_clh_repo** it will use the existing flow of using upstream cloud-hypervisor 