### PR TITLE
Nic: cleanup node nic info gathering

### DIFF
--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -37,7 +37,7 @@ _max_settings_pattern = re.compile(
 _current_settings_pattern = re.compile(
     r"Current hardware settings:[\s+](?P<settings>.*?)$", re.DOTALL
 )
-
+_bus_info_pattern = re.compile(r"bus-info:[\s+](?P<bus_info>.*?)$", re.DOTALL)
 # Some device settings are retrieved like below -
 #
 # ~$ ethtool eth0
@@ -562,6 +562,14 @@ class Ethtool(Tool):
 
         device.device_channel = device_channel_info
         return device_channel_info
+
+    def get_device_bus_info(self, interface: str) -> str:
+        output = self.run(f"-i {interface}").stdout
+        for line in output.splitlines():
+            match = _bus_info_pattern.search(line)
+            if match:
+                return match.group("bus_info").strip()
+        return ""
 
     def change_device_channels_info(
         self,


### PR DESCRIPTION
Move to using ethtool, ip, and lspci tools (now that they exist) to gather nic info. This avoids some issues when gathering nic info on systems like MANA where there are many interfaces with the same bus info.
- directly call `ip` to get master/slave pairs rather than inferring from sysfs. Each master interface is identified by having a child interface, rather than inferring it the other way around.
- use ethtool to fetch bus-info (aka 'pci address' in LISA).

This cleans up a lot of the logic, rather than making one large call and regex parsing the output of `ip`. These calls are run in parallel where possible.