### PR TITLE
A couple fixes for SSH access onto 'minimal' nodes

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -55,6 +55,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         is_test_target: bool = True,
         base_part_path: Optional[Path] = None,
         parent_logger: Optional[Logger] = None,
+        encoding: str = "utf-8",
     ) -> None:
         super().__init__(runbook=runbook)
         self.is_default = runbook.is_default
@@ -65,6 +66,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         self.provision_time: float
         self._shell: Optional[Shell] = None
         self._first_initialize: bool = False
+        self._encoding = encoding
 
         # will be initialized by platform
         self.features: Features
@@ -499,6 +501,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
             no_error_log=no_error_log,
             no_info_log=no_info_log,
             no_debug_log=no_debug_log,
+            encoding=self._encoding,
             cwd=cwd,
             update_envs=update_envs,
         )

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -429,10 +429,11 @@ class Process:
             isinstance(self._shell, SshShell)
             and self._shell.spawn_initialization_error_string
         ):
-            raw_input = re.sub(
-                re.compile(rf"{self._shell.spawn_initialization_error_string}\r\n"),
-                "",
-                raw_input,
+            raw_input = raw_input.replace(
+                rf"{self._shell.spawn_initialization_error_string}\n", ""
+            )
+            raw_input = raw_input.replace(
+                rf"{self._shell.spawn_initialization_error_string}\r\n", ""
             )
             self._log.debug(
                 "filter the profile error string: "

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -327,6 +327,13 @@ class Process:
         return self._result
 
     def kill(self) -> None:
+        if (
+            isinstance(self._shell, SshShell)
+            and self._shell._inner_shell
+            and self._shell._inner_shell._spur._shell_type
+            == spur.ssh.ShellTypes.minimal
+        ):
+            return
         if self._process:
             self._log.debug(f"Killing process : {self._id_}")
             try:

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -108,6 +108,7 @@ class Process:
         no_error_log: bool = False,
         no_info_log: bool = False,
         no_debug_log: bool = False,
+        encoding: str = "utf-8",
     ) -> None:
         """
         command include all parameters also.
@@ -169,7 +170,7 @@ class Process:
                 update_env=update_envs,
                 allow_error=True,
                 store_pid=self._is_posix,
-                encoding="utf-8",
+                encoding=encoding,
                 use_pty=self._is_posix,
             )
             # save for logging.


### PR DESCRIPTION
In one LISA derivative we have, the nodes at the other side of the SSH channel will be of the 'minimal' type, for real.
We mean non-POSIX, very barebones. These are fixes to make that setup work, while not harming the general case.