### PR TITLE
DPDK: Remove perf isolatedresource

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -11,7 +11,7 @@ from lisa import (
     notifier,
     simple_requirement,
 )
-from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
+from lisa.features import Gpu, Infiniband, Sriov
 from lisa.messages import (
     NetworkPPSPerformanceMessage,
     TransportProtocol,
@@ -38,8 +38,6 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     """,
 )
 class DpdkPerformance(TestSuite):
-    TIMEOUT = 12000
-
     @TestCaseMetadata(
         description="""
         DPDK Performance: failsafe mode, minimal core count
@@ -51,7 +49,6 @@ class DpdkPerformance(TestSuite):
             network_interface=Sriov(),
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_send_only_failsafe_pmd(
@@ -96,7 +93,6 @@ class DpdkPerformance(TestSuite):
             network_interface=Sriov(),
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_send_only_netvsc_pmd(
@@ -141,7 +137,6 @@ class DpdkPerformance(TestSuite):
             network_interface=Sriov(),
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_minimal_failsafe_pmd(
@@ -163,7 +158,6 @@ class DpdkPerformance(TestSuite):
             network_interface=Sriov(),
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_minimal_netvsc_pmd(
@@ -186,7 +180,6 @@ class DpdkPerformance(TestSuite):
             network_interface=Sriov(),
             min_nic_count=2,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_multi_queue_failsafe_pmd(
@@ -214,7 +207,6 @@ class DpdkPerformance(TestSuite):
             min_nic_count=2,
             min_core_count=16,
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def perf_dpdk_multi_queue_netvsc_pmd(


### PR DESCRIPTION
Many new large SKUs don't guarantee isolation, now that DPDK perf tests are stable (and don't run for longer than 30 seconds) remove the iso requirement.

The only test which should retain this is the sriov rescind test, which has an unbound run time and large timeout. Perf has no such issue, so it's safe to remove.