### PR TITLE
tools: qemu_img: allow sudo to be used by convert

### DIFF
--- a/lisa/tools/qemu_img.py
+++ b/lisa/tools/qemu_img.py
@@ -47,11 +47,17 @@ class QemuImg(Tool):
         )
 
     def convert(
-        self, src_format: str, src_path: str, dest_format: str, dest_path: str
+        self,
+        src_format: str,
+        src_path: str,
+        dest_format: str,
+        dest_path: str,
+        sudo: bool = False,
     ) -> None:
         self.run(
             f"convert -f {src_format} -O {dest_format} {src_path} {dest_path}",
             force_run=True,
+            sudo=sudo,
             expected_exit_code=0,
             expected_exit_code_failure_message="Failed to convert disk image",
         )


### PR DESCRIPTION
Currently, QemuImg tool cannot use sudo with the convert() function. Add a new parameter to allow sudo to be specified with this command.

Other functions in QemuImg also don't have sudo. They can be added when needed.