### PR TITLE
Add CLH guest vm type for internal MS CLH use case

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -183,19 +183,30 @@ class CloudHypervisorTestSuite(TestSuite):
         return ""
 
     def _set_ms_clh_param(self, variables: Dict[str, Any]) -> None:
+        # Get access token from testing infra to clone the repo
         ms_access_token = variables.get("ms_access_token", None)
+
+        # Get URL for MS CLH repo
         ms_clh_repo = variables.get("ms_clh_repo", None)
+
+        # Get URL for igvm-parser repo
         ms_igvm_parser_repo = variables.get("ms_igvm_parser_repo", None)
+
+        # Get GUEST VM type, set default to NON-CVM
+        clh_guest_vm_type = variables.get("clh_guest_vm_type", "NON-CVM")
+
         if not ms_access_token:
             raise SkippedException("Access Token is needed while using MS-CLH")
         if not ms_clh_repo:
             raise SkippedException("CLH URL is needed while using MS-CLH")
         if not ms_igvm_parser_repo:
             raise SkippedException("IGVM-Parser URL is needed while using MS-CLH")
+
         CloudHypervisorTests.use_ms_clh_repo = True
         CloudHypervisorTests.ms_access_token = ms_access_token
         CloudHypervisorTests.ms_clh_repo = ms_clh_repo
         CloudHypervisorTests.ms_igvm_parser_repo = ms_igvm_parser_repo
+        CloudHypervisorTests.clh_guest_vm_type = clh_guest_vm_type
 
 
 def get_test_list(variables: Dict[str, Any], var1: str, var2: str) -> Any:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -33,11 +33,15 @@ class CloudHypervisorTests(Tool):
     PERF_CMD_TIME_OUT = 900
 
     upstream_repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"
+    env_vars = {
+        "RUST_BACKTRACE": "full",
+    }
 
     ms_clh_repo = ""
     ms_igvm_parser_repo = ""
     use_ms_clh_repo = False
     ms_access_token = ""
+    clh_guest_vm_type = ""
 
     cmd_path: PurePath
     repo_root: PurePath
@@ -90,6 +94,7 @@ class CloudHypervisorTests(Tool):
             cwd=self.repo_root,
             no_info_log=False,  # print out result of each test
             shell=True,
+            update_envs=self.env_vars,
         )
 
         # Report subtest results and collect logs before doing any
@@ -163,14 +168,17 @@ class CloudHypervisorTests(Tool):
             if subtest_timeout:
                 cmd_args = f"{cmd_args} --timeout {subtest_timeout}"
             try:
+                cmd_timeout = self.PERF_CMD_TIME_OUT
+                if self.clh_guest_vm_type == "CVM":
+                    cmd_timeout = cmd_timeout + 300
                 result = self.run(
                     cmd_args,
-                    timeout=self.PERF_CMD_TIME_OUT,
+                    timeout=cmd_timeout,
                     force_run=True,
                     cwd=self.repo_root,
                     no_info_log=False,  # print out result of each test
                     shell=True,
-                    update_envs={"RUST_BACKTRACE": "full"},
+                    update_envs=self.env_vars,
                 )
 
                 if result.exit_code == 0:
@@ -225,6 +233,7 @@ class CloudHypervisorTests(Tool):
                 clone_path,
                 auth_token=self.ms_access_token,
             )
+            self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
         else:
             git.clone(self.upstream_repo, clone_path)
 


### PR DESCRIPTION
This change will pass env variable for guest vm type while using internal MS CLH which will decide the type of guest vm to be launched while running integration/perf tests. Our testing infra will pass this variable to testcase.