### PR TITLE
Log case name if case is timedout.

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -83,7 +83,12 @@ def _call_with_retry_and_timeout(
     except FunctionTimedOut:
         # FunctionTimedOut is a special exception. If it's not captured
         # explicitly, it will make the whole program exit.
-        raise TimeoutError(f"time out in {timeout} seconds.")
+        name = ""
+        # Display casename if it is timedout.
+        test_result: TestResult = test_kwargs.get("result", None)
+        if test_result:
+            name = test_result.name
+        raise TimeoutError(f"{name} time out in {timeout} seconds.")
 
 
 @dataclass


### PR DESCRIPTION
At present when case timeout, the logging is as below 
`TimeoutError: time out in 4500 seconds.
`
This change logs the failure as below
`TimeoutError: stress_sriov_disable_enable time out in 4500 seconds
`