### PR TITLE
Bamuir/ade minor version checks

### DIFF
--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -241,6 +241,7 @@ class AzureDiskEncryption(TestSuite):
     def _is_unsupported_version(self, node: Node, image: str) -> bool:
         # List of known bad images that should be skipped
         known_bad_images = [
+            # Minimal not supported
             "canonical 0001-com-ubuntu-minimal-kinetic minimal-22_10 22.10.202307010",
             # Missing packages
             "canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202007080",
@@ -264,14 +265,6 @@ class AzureDiskEncryption(TestSuite):
             "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20230126.01",
             "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20230303.02",
             "microsoftcblmariner cbl-mariner cbl-mariner-2-arm64 2.20230126.01",
-            # unknown images
-            "/KAMERONCARR-ASAP/kameroncarr_asap_sig/"
-            + "ubuntu2204-unified-image-20230906.vhd/1.0.0",
-            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/"
-            + "2023.09.07_14.37.46-bionic-linux-image-azure-lts-"
-            + "18.04-4.15.0.1169.137-gen1.vhd",
-            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/"
-            + "2023.09.08_10.25.55-lunar-proposed-azure-6.2.0.1012.12-gen1.vhd",
         ]
 
         if image in known_bad_images:

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -213,9 +213,21 @@ class AzureDiskEncryption(TestSuite):
             CBLMariner: 2,
         }
 
+        if self._is_unsupported_version(node):
+            return False
+
         for distro, min_supported_version in minimum_supported_major_versions.items():
             if isinstance(node.os, distro):
                 if node.os.information.version.major >= min_supported_version:
                     return True
 
+        return False
+
+    def _is_unsupported_version(self, node: Node) -> bool:
+        if isinstance(node.os, Oracle):
+            version_info = node.os.information.version
+            major_version = version_info.major
+            minor_version = version_info.minor
+            if major_version == 8 and minor_version < 5:
+                return True
         return False

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -256,12 +256,11 @@ class AzureDiskEncryption(TestSuite):
         known_bad_images = [
             # Minimal not supported
             "canonical 0001-com-ubuntu-minimal-kinetic minimal-22_10 22.10.202307010",
-            # Missing packages
+            # Some older Ubuntu images are missing critical ADE packages
             "canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202007080",
             "canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 20.04.202308310",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202303220",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202306190",
-            # Some older UB18 images are missing critical ADE packages
             "canonical ubuntuserver 18.04-lts 18.04.202001210",
             "canonical ubuntuserver 18.04-lts 18.04.202006101",
             "canonical ubuntuserver 18.04-lts 18.04.202306070",

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -230,7 +230,7 @@ class AzureDiskEncryption(TestSuite):
         unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
             Oracle: [{"major": 8, "minor": 5}],
             CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
-            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 3}],
+            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
         }
 
         version_info = node.os.information.version

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -241,28 +241,37 @@ class AzureDiskEncryption(TestSuite):
     def _is_unsupported_version(self, node: Node, image: str) -> bool:
         # List of known bad images that should be skipped
         known_bad_images = [
-            "/KAMERONCARR-ASAP/kameroncarr_asap_sig/ubuntu2204-unified-image-20230906.vhd/1.0.0",
             "canonical 0001-com-ubuntu-minimal-kinetic minimal-22_10 22.10.202307010",
-            "canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202007080",  # Missing packages
+            # Missing packages
+            "canonical 0001-com-ubuntu-server-focal 20_04-lts 20.04.202007080",
             "canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 20.04.202308310",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202303220",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202306190",
-            "canonical 0001-com-ubuntu-server-lunar 23_04 23.04.202309050",  # Ubuntu 23 is not yet supported
+            # Ubuntu 23 is not yet supported
+            "canonical 0001-com-ubuntu-server-lunar 23_04 23.04.202309050",
             "canonical 0001-com-ubuntu-server-lunar 23_04-arm64 23.04.202309050",
             "canonical 0001-com-ubuntu-server-lunar 23_04-gen2 23.04.202307120",
             "canonical 0001-com-ubuntu-server-lunar 23_04-gen2 23.04.202309050",
-            "canonical ubuntuserver 18.04-lts 18.04.202001210",  # Some older UB18 images are missing critical ADE packages
+            # Some older UB18 images are missing critical ADE packages
+            "canonical ubuntuserver 18.04-lts 18.04.202001210",
             "canonical ubuntuserver 18.04-lts 18.04.202006101",
             "canonical ubuntuserver 18.04-lts 18.04.202306070",
             "canonical ubuntuserver 18_04-lts-gen2 18.04.202001210",
             "canonical ubuntuserver 18_04-lts-gen2 18.04.202004290",
             "canonical ubuntuserver 18_04-lts-gen2 18.04.202009220",
-            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/2023.09.07_14.37.46-bionic-linux-image-azure-lts-18.04-4.15.0.1169.137-gen1.vhd",
-            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/2023.09.08_10.25.55-lunar-proposed-azure-6.2.0.1012.12-gen1.vhd",
-            "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20221122.01",  # Mariner is supported after may 2023
+            # Mariner is supported after may 2023
+            "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20221122.01",
             "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20230126.01",
             "microsoftcblmariner cbl-mariner cbl-mariner-2 2.20230303.02",
             "microsoftcblmariner cbl-mariner cbl-mariner-2-arm64 2.20230126.01",
+            # unknown images
+            "/KAMERONCARR-ASAP/kameroncarr_asap_sig/"
+            + "ubuntu2204-unified-image-20230906.vhd/1.0.0",
+            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/"
+            + "2023.09.07_14.37.46-bionic-linux-image-azure-lts-"
+            + "18.04-4.15.0.1169.137-gen1.vhd",
+            "https://lisatwestus26a28e896.blob.core.windows.net/lisa-vhd-exported/"
+            + "2023.09.08_10.25.55-lunar-proposed-azure-6.2.0.1012.12-gen1.vhd",
         ]
 
         if image in known_bad_images:

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -256,6 +256,11 @@ class AzureDiskEncryption(TestSuite):
         major_version = version_info.major
         minor_version = version_info.minor
 
+        # ADE support only on Ubuntu LTS images
+        if isinstance(node.os, Ubuntu):
+            if minor_version != 4:
+                return True
+
         for distro, versions in min_supported_versions.items():
             if isinstance(node.os, distro):
                 for version in versions:

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -231,7 +231,7 @@ class AzureDiskEncryption(TestSuite):
         unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
             Oracle: {"major": 8, "minor": 5},
             CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
-            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
+            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 3}],
         }
 
         version_info = node.os.information.version

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -3,7 +3,7 @@
 import json
 import string
 import time
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from assertpy import assert_that
 from azure.mgmt.keyvault.models import AccessPolicyEntry, Permissions
@@ -33,8 +33,7 @@ TIME_LIMIT = 3600 * 2
 MIN_REQUIRED_MEMORY_MB = 8 * 1024
 
 # Define a type alias for readability
-# It will either be a single dictionary or a list of dictionaries.
-UnsupportedVersionInfo = Union[Dict[str, int], List[Dict[str, int]]]
+UnsupportedVersionInfo = List[Dict[str, int]]
 
 
 @TestSuiteMetadata(
@@ -229,7 +228,7 @@ class AzureDiskEncryption(TestSuite):
 
     def _is_unsupported_version(self, node: Node) -> bool:
         unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
-            Oracle: {"major": 8, "minor": 5},
+            Oracle: [{"major": 8, "minor": 5}],
             CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
             Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 3}],
         }
@@ -240,17 +239,11 @@ class AzureDiskEncryption(TestSuite):
 
         for distro, versions in unsupported_versions.items():
             if isinstance(node.os, distro):
-                if isinstance(versions, list):  # List[Dict[str, int]]
-                    for version in versions:
-                        if (
-                            major_version == version["major"]
-                            and minor_version < version["minor"]
-                        ):
-                            return True
-                else:  # Dict[str, int]
+                for version in versions:
                     if (
-                        major_version == versions["major"]
-                        and minor_version < versions["minor"]
+                        major_version == version["major"]
+                        and minor_version < version["minor"]
                     ):
                         return True
+
         return False

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -230,4 +230,20 @@ class AzureDiskEncryption(TestSuite):
             minor_version = version_info.minor
             if major_version == 8 and minor_version < 5:
                 return True
+        if isinstance(node.os, CentOs):
+            version_info = node.os.information.version
+            major_version = version_info.major
+            minor_version = version_info.minor
+            if major_version == 8 and minor_version < 1:
+                return True
+            if major_version == 7 and minor_version < 4:
+                return True
+        if isinstance(node.os, Redhat):
+            version_info = node.os.information.version
+            major_version = version_info.major
+            minor_version = version_info.minor
+            if major_version == 8 and minor_version < 1:
+                return True
+            if major_version == 7 and minor_version < 4:
+                return True
         return False

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -234,7 +234,7 @@ class AzureDiskEncryption(TestSuite):
             CBLMariner: 2,
         }
 
-        if self._is_unsupported_version(node):
+        if self._is_unsupported_minor_version(node):
             return False
 
         for distro, max_supported_version in max_supported_major_versions.items():
@@ -249,7 +249,7 @@ class AzureDiskEncryption(TestSuite):
 
         return False
 
-    def _is_unsupported_version(self, node: Node) -> bool:
+    def _is_unsupported_minor_version(self, node: Node) -> bool:
         min_supported_versions: Dict[type, UnsupportedVersionInfo] = {
             Oracle: [{"major": 8, "minor": 5}],
             CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -152,10 +152,6 @@ class AzureDiskEncryption(TestSuite):
         location = node_capability.location
         shared_resource_group = runbook.shared_resource_group_name
 
-        log.debug(f"Node Version {node.os.information.version}\n\n")
-        log.debug(f"Node Full Version {node.os.information.full_version}\n\n")
-        log.debug(f"Node release {node.os.information.release}\n\n")
-
         # Create key vault if there is not available adelisa key vault for that region
         existing_vault = get_matching_key_vault_name(
             platform, location, shared_resource_group, r"adelisa-\w{5}"

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -227,9 +227,19 @@ class AzureDiskEncryption(TestSuite):
             Ubuntu: 18,
             CBLMariner: 2,
         }
+        # Remove after automatic major version support is released to ADE
+        max_supported_major_versions = {
+            Oracle: 8,
+            Ubuntu: 22,
+        }
 
         if self._is_unsupported_version(node, image):
             return False
+
+        for distro, max_supported_version in max_supported_major_versions.items():
+            if isinstance(node.os, distro):
+                if node.os.information.version.major > max_supported_version:
+                    return False
 
         for distro, min_supported_version in minimum_supported_major_versions.items():
             if isinstance(node.os, distro):
@@ -248,11 +258,6 @@ class AzureDiskEncryption(TestSuite):
             "canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 20.04.202308310",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202303220",
             "canonical 0001-com-ubuntu-server-kinetic 22_10 22.10.202306190",
-            # Ubuntu 23 is not yet supported
-            "canonical 0001-com-ubuntu-server-lunar 23_04 23.04.202309050",
-            "canonical 0001-com-ubuntu-server-lunar 23_04-arm64 23.04.202309050",
-            "canonical 0001-com-ubuntu-server-lunar 23_04-gen2 23.04.202307120",
-            "canonical 0001-com-ubuntu-server-lunar 23_04-gen2 23.04.202309050",
             # Some older UB18 images are missing critical ADE packages
             "canonical ubuntuserver 18.04-lts 18.04.202001210",
             "canonical ubuntuserver 18.04-lts 18.04.202006101",
@@ -270,7 +275,7 @@ class AzureDiskEncryption(TestSuite):
         if image in known_bad_images:
             return True
 
-        unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
+        min_supported_versions: Dict[type, UnsupportedVersionInfo] = {
             Oracle: [{"major": 8, "minor": 5}],
             CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
             Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
@@ -280,7 +285,7 @@ class AzureDiskEncryption(TestSuite):
         major_version = version_info.major
         minor_version = version_info.minor
 
-        for distro, versions in unsupported_versions.items():
+        for distro, versions in min_supported_versions.items():
             if isinstance(node.os, distro):
                 for version in versions:
                     if (

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -228,50 +228,29 @@ class AzureDiskEncryption(TestSuite):
         return False
 
     def _is_unsupported_version(self, node: Node) -> bool:
-        # Define unsupported versions for each distribution
         unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
-            Oracle: {"major": 8, "minor": 5, "patch": 0},
-            Ubuntu: {"major": 18, "minor": 4, "patch": 202101120},
-            CentOs: [
-                {"major": 8, "minor": 1, "patch": 0},
-                {"major": 7, "minor": 4, "patch": 0},
-            ],
-            Redhat: [
-                {"major": 8, "minor": 1, "patch": 0},
-                {"major": 7, "minor": 4, "patch": 0},
-            ],
+            Oracle: {"major": 8, "minor": 5},
+            CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
+            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
         }
 
-        # Extract version information from the node
         version_info = node.os.information.version
         major_version = version_info.major
         minor_version = version_info.minor
-        patch_version = version_info.patch
 
-        # Check each distribution in the unsupported_versions dict
         for distro, versions in unsupported_versions.items():
             if isinstance(node.os, distro):
-                # Handle multiple unsupported versions for the same distro
-                if isinstance(versions, list):
+                if isinstance(versions, list):  # List[Dict[str, int]]
                     for version in versions:
-                        if major_version < version["major"]:
+                        if (
+                            major_version == version["major"]
+                            and minor_version < version["minor"]
+                        ):
                             return True
-                        elif major_version == version["major"]:
-                            if minor_version < version["minor"]:
-                                return True
-                            elif minor_version == version["minor"]:
-                                if patch_version < version["patch"]:
-                                    return True
-                # Handle a single unsupported version for the distro
-                else:
-                    if major_version < versions["major"]:
+                else:  # Dict[str, int]
+                    if (
+                        major_version == versions["major"]
+                        and minor_version < versions["minor"]
+                    ):
                         return True
-                    elif major_version == versions["major"]:
-                        if minor_version < versions["minor"]:
-                            return True
-                        elif minor_version == versions["minor"]:
-                            if patch_version < versions["patch"]:
-                                return True
-
-        # Return False if no unsupported version is found
         return False

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -229,8 +229,11 @@ class AzureDiskEncryption(TestSuite):
         }
         # Remove after automatic major version support is released to ADE
         max_supported_major_versions = {
+            Redhat: 9,
+            CentOs: 8,
             Oracle: 8,
             Ubuntu: 22,
+            CBLMariner: 2,
         }
 
         if self._is_unsupported_version(node, image):

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -228,29 +228,50 @@ class AzureDiskEncryption(TestSuite):
         return False
 
     def _is_unsupported_version(self, node: Node) -> bool:
+        # Define unsupported versions for each distribution
         unsupported_versions: Dict[type, UnsupportedVersionInfo] = {
-            Oracle: {"major": 8, "minor": 5},
-            CentOs: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
-            Redhat: [{"major": 8, "minor": 1}, {"major": 7, "minor": 4}],
+            Oracle: {"major": 8, "minor": 5, "patch": 0},
+            Ubuntu: {"major": 18, "minor": 4, "patch": 202101120},
+            CentOs: [
+                {"major": 8, "minor": 1, "patch": 0},
+                {"major": 7, "minor": 4, "patch": 0},
+            ],
+            Redhat: [
+                {"major": 8, "minor": 1, "patch": 0},
+                {"major": 7, "minor": 4, "patch": 0},
+            ],
         }
 
+        # Extract version information from the node
         version_info = node.os.information.version
         major_version = version_info.major
         minor_version = version_info.minor
+        patch_version = version_info.patch
 
+        # Check each distribution in the unsupported_versions dict
         for distro, versions in unsupported_versions.items():
             if isinstance(node.os, distro):
-                if isinstance(versions, list):  # List[Dict[str, int]]
+                # Handle multiple unsupported versions for the same distro
+                if isinstance(versions, list):
                     for version in versions:
-                        if (
-                            major_version == version["major"]
-                            and minor_version < version["minor"]
-                        ):
+                        if major_version < version["major"]:
                             return True
-                else:  # Dict[str, int]
-                    if (
-                        major_version == versions["major"]
-                        and minor_version < versions["minor"]
-                    ):
+                        elif major_version == version["major"]:
+                            if minor_version < version["minor"]:
+                                return True
+                            elif minor_version == version["minor"]:
+                                if patch_version < version["patch"]:
+                                    return True
+                # Handle a single unsupported version for the distro
+                else:
+                    if major_version < versions["major"]:
                         return True
+                    elif major_version == versions["major"]:
+                        if minor_version < versions["minor"]:
+                            return True
+                        elif minor_version == versions["minor"]:
+                            if patch_version < versions["patch"]:
+                                return True
+
+        # Return False if no unsupported version is found
         return False


### PR DESCRIPTION
- Mandate 4 cores for full encryption test
- increase time allowed to check for fully encrypted OS
- Check for unsupported OS Major/Minor versions and skip tests