### PR TITLE
Run CLH testcases with MS Guest Kernel

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -195,6 +195,11 @@ class CloudHypervisorTestSuite(TestSuite):
         # Get GUEST VM type, set default to NON-CVM
         clh_guest_vm_type = variables.get("clh_guest_vm_type", "NON-CVM")
 
+        # Check if MS Guest kernel need to be used
+        # Dom0 VHD is shipped with it now
+        # Default, we will use upstream guest kernel only
+        use_ms_guest_kernel = variables.get("use_ms_guest_kernel", "NO")
+
         if not ms_access_token:
             raise SkippedException("Access Token is needed while using MS-CLH")
         if not ms_clh_repo:
@@ -207,6 +212,7 @@ class CloudHypervisorTestSuite(TestSuite):
         CloudHypervisorTests.ms_clh_repo = ms_clh_repo
         CloudHypervisorTests.ms_igvm_parser_repo = ms_igvm_parser_repo
         CloudHypervisorTests.clh_guest_vm_type = clh_guest_vm_type
+        CloudHypervisorTests.use_ms_guest_kernel = use_ms_guest_kernel
 
 
 def get_test_list(variables: Dict[str, Any], var1: str, var2: str) -> Any:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -42,6 +42,7 @@ class CloudHypervisorTests(Tool):
     use_ms_clh_repo = False
     ms_access_token = ""
     clh_guest_vm_type = ""
+    use_ms_guest_kernel = ""
 
     cmd_path: PurePath
     repo_root: PurePath
@@ -234,6 +235,7 @@ class CloudHypervisorTests(Tool):
                 auth_token=self.ms_access_token,
             )
             self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
+            self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
         else:
             git.clone(self.upstream_repo, clone_path)
 


### PR DESCRIPTION
We have made corresponding changes in MS CLH to use MS Guest kernel. We need to set env var USE_MS_GUEST_KERNEL=YES in order to run integration/perf test with MS Guest kernel instead of upstream guest kernel.

This change will pass the env var if set so from testing infra while running the integration/perf testcase.