### PR TITLE
Fix issue that marketplace, shared_gallery, vhd is not None when parameter is empty

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -464,7 +464,7 @@ class AzureNodeSchema:
             # this step makes vhd_raw is validated, and
             # filter out any unwanted content.
             self.vhd_raw = vhd.to_dict()  # type: ignore
-        elif self.vhd_raw is not None:
+        elif self.vhd_raw:
             assert isinstance(self.vhd_raw, str), f"actual: {type(self.vhd_raw)}"
             vhd = VhdSchema(vhd_path=self.vhd_raw)
             add_secret(vhd.vhd_path, PATTERN_URL)


### PR DESCRIPTION
Before fixing, if the runbook is like below, the azure_runbook,marketplace is not None though its each parameter is empty, this marketplace is invalid, so azure_runbook,marketplace should be None.
    requirement:
      azure:
        marketplace:
          publisher: ""
          offer: ""
          sku: ""
          version: ""
      vhd: ""https://vxxtralus.blob.core.windows.net/vhds/bvtpublisher1/bxxxT_Linux_Genxx_Success/27082023/blob-02.26.20.893.vhd"
      
This PR is to fix this issue in this situation.