### PR TITLE
Add password extension feature

### DIFF
--- a/lisa/features/__init__.py
+++ b/lisa/features/__init__.py
@@ -18,6 +18,7 @@ from .nested_virtualization import NestedVirtualization
 from .network_interface import NetworkInterface, Sriov, Synthetic
 from .nfs import Nfs
 from .nvme import Nvme, NvmeSettings
+from .password_extension import PasswordExtension
 from .resize import Resize, ResizeAction
 from .security_profile import (
     SecureBootEnabled,
@@ -50,6 +51,7 @@ __all__ = [
     "NvmeSettings",
     "SerialConsole",
     "NetworkInterface",
+    "PasswordExtension",
     "Resize",
     "ResizeAction",
     "SecureBootEnabled",

--- a/lisa/features/password_extension.py
+++ b/lisa/features/password_extension.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from lisa.feature import Feature
+
+FEATURE_NAME_PASSWORD_EXTENSION = "PasswordExtension"
+
+
+class PasswordExtension(Feature):
+    @classmethod
+    def name(cls) -> str:
+        return FEATURE_NAME_PASSWORD_EXTENSION
+
+    @classmethod
+    def can_disable(cls) -> bool:
+        raise NotImplementedError()
+
+    def enabled(self) -> bool:
+        raise NotImplementedError()
+
+    def is_supported(self) -> bool:
+        raise NotImplementedError()
+
+    def reset_password(self, username: str, password: str) -> None:
+        raise NotImplementedError()

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -22,6 +22,7 @@ from lisa.util import (
     RequireUserPasswordException,
     constants,
     fields_to_dict,
+    generate_strong_password,
     get_datetime_path,
     hookimpl,
     hookspec,
@@ -683,6 +684,8 @@ class RemoteNode(Node):
         password_extension = self.features[PasswordExtension]
         username = self._connection_info.username
         password = self._connection_info.password
+        if not password:
+            password = generate_strong_password()
         try:
             password_extension.reset_password(username, str(password))
         except Exception as identifier:

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1500,10 +1500,14 @@ class ConnectionInfo:
             # use password
             # spurplus doesn't process empty string correctly, use None
             self.private_key_file = None
+        elif not self.password:
+            self.password = None
         else:
+            # Password and private_key_file all exist
+            # Private key is attempted with high priority for authentication when
+            # connecting to a remote node using paramiko
             if not Path(self.private_key_file).exists():
                 raise FileNotFoundError(self.private_key_file)
-            self.password = None
 
         if not self.username:
             raise LisaException("username must be set")

--- a/lisa/sut_orchestrator/azure/arm_template.json
+++ b/lisa/sut_orchestrator/azure/arm_template.json
@@ -376,7 +376,7 @@
                 "hardwareProfile": {
                     "vmSize": "[parameters('nodes')[copyIndex('vmCopy')]['vm_size']]"
                 },
-                "osProfile": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), lisa.getOsProfile( parameters('nodes')[copyIndex('vmCopy')]['short_name'], parameters('admin_username'), or(empty(parameters('admin_key_data')), not(parameters('nodes')[copyIndex('vmCopy')]['is_linux'])), parameters('admin_password'), and(not(empty(parameters('admin_key_data'))), parameters('nodes')[copyIndex('vmCopy')]['is_linux']), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data')) ))]",
+                "osProfile": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), lisa.getOsProfile( parameters('nodes')[copyIndex('vmCopy')]['short_name'], parameters('admin_username'), not(empty(parameters('admin_password'))), parameters('admin_password'), and(not(empty(parameters('admin_key_data'))), parameters('nodes')[copyIndex('vmCopy')]['is_linux']), lisa.getLinuxConfiguration(concat('/home/', parameters('admin_username'), '/.ssh/authorized_keys'), parameters('admin_key_data'), empty(parameters('admin_password'))) ))]",
                 "storageProfile": {
                     "imageReference": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))), json('null'), if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vhd_path']))), lisa.getOsDiskVhd(parameters('nodes')[copyIndex('vmCopy')]['name']), if(not(empty(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery'])), lisa.getOsDiskSharedGallery(parameters('nodes')[copyIndex('vmCopy')]['shared_gallery']), lisa.getOsDiskMarketplace(parameters('nodes')[copyIndex('vmCopy')]))))]",
                     "osDisk": "[if(and(not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd'])),not(empty(parameters('nodes')[copyIndex('vmCopy')]['vhd']['vmgs_path']))),  lisa.getOsDisk(concat(parameters('nodes')[copyIndex('vmCopy')]['name'], '-disk')),  if(equals(parameters('nodes')[copyIndex('vmCopy')]['os_disk_type'], 'Ephemeral'), lisa.getEphemeralOSImage(parameters('nodes')[copyIndex('vmCopy')]), lisa.getOSImage(parameters('nodes')[copyIndex('vmCopy')])) )]",
@@ -472,12 +472,16 @@
                         {
                             "name": "publicKeyData",
                             "type": "string"
+                        },
+                        {
+                            "name": "disable_password_authentication",
+                            "type": "bool"
                         }
                     ],
                     "output": {
                         "type": "object",
                         "value": {
-                            "disablePasswordAuthentication": true,
+                            "disablePasswordAuthentication": "[parameters('disable_password_authentication')]",
                             "ssh": {
                                 "publicKeys": [
                                     {

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2469,3 +2469,29 @@ class IaaS(AzureFeatureMixin, Feature):
             return schema.FeatureSettings.create(cls.name())
 
         return None
+
+
+class PasswordExtension(AzureFeatureMixin, features.PasswordExtension):
+    @classmethod
+    def create_setting(
+        cls, *args: Any, **kwargs: Any
+    ) -> Optional[schema.FeatureSettings]:
+        return schema.FeatureSettings.create(cls.name())
+
+    def reset_password(self, username: str, password: str) -> None:
+        # This uses the VMAccessForLinux extension to reset the credentials for an
+        # existing user or create a new user with sudo privileges.
+        # https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/vmaccess
+        reset_user_password = {"username": username, "password": password}
+        extension = self._node.features[AzureExtension]
+        result = extension.create_or_update(
+            name="VMAccessForLinux",
+            publisher="Microsoft.OSTCExtensions",
+            type_="VMAccessForLinux",
+            type_handler_version="1.5",
+            auto_upgrade_minor_version=True,
+            protected_settings=reset_user_password,
+        )
+        assert_that(result["provisioning_state"]).described_as(
+            "Expected the extension to succeed"
+        ).is_equal_to("Succeeded")

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -454,6 +454,7 @@ class AzurePlatform(Platform):
             features.CVMNestedVirtualization,
             features.SerialConsole,
             features.NetworkInterface,
+            features.PasswordExtension,
             features.Resize,
             features.StartStop,
             features.IaaS,

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1116,8 +1116,7 @@ class AzurePlatform(Platform):
             arm_parameters.admin_key_data = get_public_key_data(
                 self.runbook.admin_private_key_file
             )
-        else:
-            arm_parameters.admin_password = self.runbook.admin_password
+        arm_parameters.admin_password = self.runbook.admin_password
 
         environment_context = get_environment_context(environment=environment)
         arm_parameters.vm_tags["RG"] = environment_context.resource_group_name

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -271,6 +271,9 @@ class SshShell(InitializableMixin):
             port=self.connection_info.port,
         )
 
+        # According to paramiko\client.py connect() function,
+        # when password and private_key_file all exist, private key is attempted
+        # with high priority for authentication when connecting to a remote node
         spur_kwargs = {
             "hostname": self.connection_info.address,
             "port": self.connection_info.port,


### PR DESCRIPTION
This PR is to resolve the scenario that some images need to input a password when running the sudo command. Like primekey, vmware-inc images, they have a service to change the sudoers. The password and username which is set in the arm template and configured in the image by Cloud-init might be invalid. So need to reset a password if encounter this situation.