### PR TITLE
Run `environment_connected` phase after deploy_environment

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -279,6 +279,11 @@ class LisaRunner(BaseRunner):
                     environment.status == EnvironmentStatus.Deployed
                 ), f"actual: {environment.status}"
                 self._reset_awaitable_timer("deploy")
+                transformer.run(
+                    self._runbook_builder,
+                    phase=constants.TRANSFORMER_PHASE_ENVIRONMENT_CONNECTED,
+                    environment=environment,
+                )
             except ResourceAwaitableException as identifier:
                 if self._is_awaitable_timeout("deploy"):
                     self._log.info(


### PR DESCRIPTION
This change will allow to run transformers with `environment_connected` phase after a new environment is deployed as well