### PR TITLE
Iperf TCP Messages: Include number of connections

### DIFF
--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -317,6 +317,7 @@ class Iperf3(Tool):
         server_result: str,
         client_result: str,
         buffer_length: int,
+        connections_num: int,
         test_case_name: str,
         test_result: "TestResult",
     ) -> NetworkTCPPerformanceMessage:
@@ -338,6 +339,7 @@ class Iperf3(Tool):
         other_fields["congestion_windowsize_kb"] = (
             congestion_windowsize_kb_total / len(client_json["intervals"]) / 1024
         )
+        other_fields["connections_num"] = connections_num
         for client_stream in client_json["end"]["streams"]:
             other_fields["retransmitted_segments"] = client_stream["sender"][
                 "retransmits"

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -510,6 +510,7 @@ def perf_iperf(
                         server_result_list[0].stdout,
                         client_result_list[0].stdout,
                         buffer_length,
+                        connection,
                         test_case_name,
                         test_result,
                     )


### PR DESCRIPTION
The number of connections used in the test is 1, but it is currently not included in the perf message.