### PR TITLE
util: introduce a special exception for SSH spawn process timeout

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -296,6 +296,13 @@ class RequireUserPasswordException(LisaException):
     """
 
 
+class SshSpawnTimeoutException(LisaException):
+    """
+    This exception is used to indicate a timeout while spawning a process
+    using SshShell.
+    """
+
+
 class ContextMixin:
     def get_context(self, context_type: Type[T]) -> T:
         if not hasattr(self, "_context"):

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -20,7 +20,12 @@ from func_timeout import FunctionTimedOut, func_set_timeout  # type: ignore
 from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 
 from lisa import development, schema
-from lisa.util import InitializableMixin, LisaException, TcpConnectionException
+from lisa.util import (
+    InitializableMixin,
+    LisaException,
+    SshSpawnTimeoutException,
+    TcpConnectionException,
+)
 
 from .logger import Logger, get_logger
 from .perf_timer import create_timer
@@ -337,7 +342,7 @@ class SshShell(InitializableMixin):
                 )
                 break
             except FunctionTimedOut:
-                raise LisaException(
+                raise SshSpawnTimeoutException(
                     f"The remote node is timeout on execute {command}. "
                     f"It may be caused by paramiko/spur not support the shell of node."
                 )


### PR DESCRIPTION
For transient failures with the following message:

"The remote node is timeout on execute [...]. It may be caused by paramiko/spur not support the shell of node."

When we are sure that the shell of the node is supported, the only thing to do in this case is to retry. But since it raises a LisaException it is impossible to differentiate it from other errors.

So, introduce a new exception type SshSpawnTimeoutException so that test cases and/or tools can catch this exception and retry the command (if they wish to).