### PR TITLE
MANA: enable rdma-core source installation

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -2,6 +2,8 @@ import re
 from typing import TYPE_CHECKING, Optional, Tuple, Type
 from urllib.parse import urlparse
 
+from retry import retry
+
 from lisa.executable import Tool
 from lisa.tools.ls import Ls
 from lisa.tools.mkdir import Mkdir
@@ -31,6 +33,7 @@ class Wget(Tool):
         posix_os.install_packages([self])
         return self._check_exists()
 
+    @retry(LisaException, tries=5, delay=2, backoff=1.5)
     def get(
         self,
         url: str,

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import re
-import time
 from pathlib import PurePosixPath
 from typing import Any, List, Tuple, Type, Union
 
@@ -547,7 +546,10 @@ class DpdkTestpmd(Tool):
             return
 
         tar_path = wget.get(
-            url="https://github.com/linux-rdma/rdma-core/releases/download/v46.0/rdma-core-46.0.tar.gz",
+            url=(
+                "https://github.com/linux-rdma/rdma-core/"
+                "releases/download/v46.0/rdma-core-46.0.tar.gz"
+            ),
             file_path=str(node.working_path),
         )
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -265,12 +265,29 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
     # enable if it is not already enabled
     if not lsmod.module_exists("uio_hv_generic", force_run=True):
         modprobe.load("uio_hv_generic")
-        # vmbus magic to enable uio_hv_generic
-        echo.write_to_file(
-            hv_uio_generic_uuid,
-            node.get_pure_path("/sys/bus/vmbus/drivers/uio_hv_generic/new_id"),
-            sudo=True,
-        )
+    # vmbus magic to enable uio_hv_generic
+    echo.write_to_file(
+        hv_uio_generic_uuid,
+        node.get_pure_path("/sys/bus/vmbus/drivers/uio_hv_generic/new_id"),
+        sudo=True,
+    )
+
+
+def do_pmd_driver_setup(
+    node: Node, test_nic: NicInfo, testpmd: DpdkTestpmd, pmd: str = "failsafe"
+) -> None:
+    if pmd == "netvsc":
+        # setup system for netvsc pmd
+        # https://doc.dpdk.org/guides/nics/netvsc.html
+        enable_uio_hv_generic_for_nic(node, test_nic)
+        node.nics.unbind(test_nic)
+        node.nics.bind(test_nic, UIO_HV_GENERIC_SYSFS_PATH)
+
+    # if mana is present, set VF interface down.
+    # FIXME: add mana dpdk docs link when it's available.
+    if testpmd.is_mana:
+        if test_nic.lower:
+            node.tools[Ip].down(test_nic.lower)
 
 
 def initialize_node_resources(
@@ -341,18 +358,7 @@ def initialize_node_resources(
     ).is_equal_to("hv_netvsc")
 
     # netvsc pmd requires uio_hv_generic to be loaded before use
-    if pmd == "netvsc":
-        # setup system for netvsc pmd
-        # https://doc.dpdk.org/guides/nics/netvsc.html
-        enable_uio_hv_generic_for_nic(node, test_nic)
-        node.nics.unbind(test_nic)
-        node.nics.bind(test_nic, UIO_HV_GENERIC_SYSFS_PATH)
-
-    # if mana is present, set VF interface down.
-    # FIXME: add mana dpdk docs link when it's available.
-    if testpmd.is_mana:
-        if test_nic.lower:
-            node.tools[Ip].down(test_nic.lower)
+    do_pmd_driver_setup(node=node, test_nic=test_nic, testpmd=testpmd, pmd=pmd)
 
     return DpdkTestResources(node, testpmd)
 
@@ -440,6 +446,7 @@ def init_nodes_concurrent(
     variables: Dict[str, Any],
     pmd: str,
     enable_gibibyte_hugepages: bool = False,
+    sample_apps: Union[List[str], None] = None,
 ) -> List[DpdkTestResources]:
     # quick check when initializing, have each node ping the other nodes.
     # When binding DPDK directly to the VF this helps ensure l2/l3 routes
@@ -456,6 +463,7 @@ def init_nodes_concurrent(
                 variables,
                 pmd,
                 enable_gibibyte_hugepages=enable_gibibyte_hugepages,
+                sample_apps=sample_apps,
             )
             for node in environment.nodes.list()
         ],


### PR DESCRIPTION
First commit:
- Enable a source build of rdma-core; useful for MANA testing where backported kernel patches are available but backported rdma-core and dpdk are not available in the package manager.
- small refactors: 
  - move pmd setup to it's own exposed function, used in upcoming commit for l3fwd
  - fix some variable names for clarity
  - allow sample_apps to be used in init_nodes_concurrent

Wget commit:
- add 5 retries to wget tool.

