### PR TITLE
Use runbook variable instead host_stress config

### DIFF
--- a/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -90,6 +90,7 @@ class MshvHostTestSuite(TestSuite):
     ) -> None:
         configs = variables.get(self.CONFIG_VARIABLE, [{}])
         igvm_path = variables.get(self.IGVM_PATH_VARIABLE, "")
+        guest_vm_type = variables.get("clh_guest_vm_type", self.DEFAULT_GUEST_VM_TYPE)
 
         # This test can end up creating and a lot of ssh sessions and these kept active
         # at the same time.
@@ -102,7 +103,6 @@ class MshvHostTestSuite(TestSuite):
             times = config.get("iterations", self.DEFAULT_ITERS)
             cpus_per_vm = config.get("cpus_per_vm", self.DEFAULT_CPUS_PER_VM)
             mem_per_vm_mb = config.get("mem_per_vm_mb", self.DEFAULT_MEM_PER_VM_MB)
-            guest_vm_type = config.get("clh_guest_vm_type", self.DEFAULT_GUEST_VM_TYPE)
             test_name = f"mshv_stress_vm_create_{times}times_{cpus_per_vm}cpu_{mem_per_vm_mb}MB"  # noqa: E501
             try:
                 self._mshv_stress_vm_create(


### PR DESCRIPTION
Used runbook variable instead host_stress config to get guest_vm_type for mshv host stress test