### PR TITLE
Improve Systemctl and Journalctl tools

### DIFF
--- a/lisa/base_tools/service.py
+++ b/lisa/base_tools/service.py
@@ -148,6 +148,15 @@ class Systemctl(Tool):
         )
         return group["state"]
 
+    def mask(self, unit_name: str) -> None:
+        self.run(
+            f"mask {unit_name}",
+            shell=True,
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
     def is_service_running(self, name: str) -> bool:
         cmd_result = self.run(
             f"--full --no-pager status {name}", shell=True, sudo=True, force_run=True

--- a/lisa/tools/journalctl.py
+++ b/lisa/tools/journalctl.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from pathlib import PurePosixPath
+from typing import Optional
+
 from lisa.executable import Tool
 
 
@@ -24,13 +27,29 @@ class Journalctl(Tool):
         return result.stdout
 
     def first_n_logs_from_boot(
-        self, boot_id: str = "", no_of_lines: int = 1000, sudo: bool = True
+        self,
+        boot_id: str = "",
+        no_of_lines: int = 1000,
+        out_file: Optional[PurePosixPath] = None,
+        sudo: bool = True,
     ) -> str:
+        cmd = f"-b {boot_id} --no-pager"
+
+        if no_of_lines > 0:
+            cmd = cmd + f" | head -n {no_of_lines}"
+
+        if out_file is not None:
+            cmd = cmd + f" > {out_file}"
+
+        # if an output file is given, don't flood lisa logs
+        no_debug_log = True if out_file is not None else False
+
         result = self.run(
-            f"-b {boot_id} | head -n {no_of_lines} ",
+            cmd,
             force_run=True,
             shell=True,
             sudo=sudo,
+            no_debug_log=no_debug_log,
             expected_exit_code=0,
         )
         return result.stdout


### PR DESCRIPTION
- Add mask method to Systemctl tool - same as `systemctl mask xyz`.
- Allow capturing all boot logs instead of 1st n lines and redirect them to a file.