### PR TITLE
verify_timesync_ptp: Read chrony config as sudo

### DIFF
--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -115,7 +115,9 @@ class TimeSync(TestSuite):
         #  instead of /dev/ptp0 or /dev/ptp1.
         for chrony_config in self.chrony_path:
             if node.shell.exists(PurePosixPath(chrony_config)):
-                chrony_results = cat.run(f"{chrony_config}")
+                chrony_results = cat.run(
+                    f"{chrony_config}", sudo=True, shell=True, force_run=True
+                )
                 assert_that(chrony_results.stdout).described_as(
                     "Chrony config file should use the symlink /dev/ptp_hyperv."
                 ).contains(self.hyperv_ptp_udev_rule)

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -113,14 +113,16 @@ class TimeSync(TestSuite):
 
         # 4. Chrony should be configured to use the symlink /dev/ptp_hyperv
         #  instead of /dev/ptp0 or /dev/ptp1.
+        all_chrony_configs: str = ""
         for chrony_config in self.chrony_path:
             if node.shell.exists(PurePosixPath(chrony_config)):
-                chrony_results = cat.run(
+                config_data = cat.run(
                     f"{chrony_config}", sudo=True, shell=True, force_run=True
                 )
-                assert_that(chrony_results.stdout).described_as(
-                    "Chrony config file should use the symlink /dev/ptp_hyperv."
-                ).contains(self.hyperv_ptp_udev_rule)
+                all_chrony_configs = all_chrony_configs + config_data.stdout + "\n"
+        assert_that(all_chrony_configs).described_as(
+            "Chrony config file should use the symlink /dev/ptp_hyperv."
+        ).contains(self.hyperv_ptp_udev_rule)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Fix for "Failed. AssertionError: [Chrony config file should use the symlink /dev/ptp_hyperv.] Expected **<cat: /etc/chrony.conf: Permission denied**> to contain item <ptp_hyperv>, but did not"