### PR TITLE
DPDK: reboot in between tests

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Tuple
 from assertpy import assert_that
 
 from lisa import (
+    Environment,
     Logger,
     Node,
     TestCaseMetadata,
@@ -24,6 +25,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     DpdkTestResources,
     SkippedException,
     UnsupportedPackageVersionException,
+    do_parallel_cleanup,
     verify_dpdk_build,
     verify_dpdk_send_receive,
     verify_dpdk_send_receive_multi_txrx_queue,
@@ -324,3 +326,7 @@ class DpdkPerformance(TestSuite):
             "Nodes contain different core counts, DPDK Suite expects sender "
             "and receiver to have same core count."
         ).contains_only(core_counts[0])
+
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        environment: Environment = kwargs.pop("environment")
+        do_parallel_cleanup(environment)

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -342,9 +342,6 @@ def initialize_node_resources(
 
     # netvsc pmd requires uio_hv_generic to be loaded before use
     if pmd == "netvsc":
-        # this code makes changes to interfaces that will cause later tests to fail.
-        # Therefore we mark the node dirty to prevent future testing on this environment
-        node.mark_dirty()
         # setup system for netvsc pmd
         # https://doc.dpdk.org/guides/nics/netvsc.html
         enable_uio_hv_generic_for_nic(node, test_nic)

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -591,3 +591,16 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     return verify_dpdk_send_receive(
         environment, log, variables, pmd, use_service_cores=1, multiple_queues=True
     )
+
+
+def do_parallel_cleanup(environment: Environment) -> None:
+    def _parallel_cleanup(node: Node) -> None:
+        interface = node.features[NetworkInterface]
+        if not interface.is_enabled_sriov():
+            interface.switch_sriov(enable=True, wait=False, reset_connections=True)
+            # cleanup temporary hugepage and driver changes
+        node.reboot()
+
+    run_in_parallel(
+        [partial(_parallel_cleanup, node) for node in environment.nodes.list()]
+    )


### PR DESCRIPTION
With the addition of hugepages cleanup we now have a bunch of things to clean up before running a new test. This commit simplifies this process since none of the changes we make are persistent: just reboot rather than try and handle all of these individually.