### PR TITLE
Fix gallery has no attribute 'name' issue

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1793,6 +1793,7 @@ class CBLMariner(RPMDistro):
     def add_azure_core_repo(
         self, repo_name: Optional[AzureCoreRepo] = None, code_name: Optional[str] = None
     ) -> None:
+        super().add_azure_core_repo(repo_name, code_name)
         release = self.information.release
         from lisa.tools import Curl
 

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -533,7 +533,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_location,
             self._log,
         )
-        gallery = check_or_create_gallery(
+        check_or_create_gallery(
             platform,
             runbook.gallery_resource_group_name,
             runbook.gallery_name,
@@ -573,7 +573,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_image_location,
         )
 
-        sig_url = f"{gallery.name}/{runbook.gallery_image_name}/{gallery_image_version}"
+        sig_url = f"{runbook.gallery_name}/{runbook.gallery_image_name}/{gallery_image_version}"
 
         self._log.info(f"SIG Url: {sig_url}")
         return {self.__sig_name: sig_url}


### PR DESCRIPTION
When new creates a gallery, the return value of "check_or_create_gallery" is a dict. "gallery.name" has error "AttributeError: 'dict' object has no attribute 'name'" .