### PR TITLE
Fix gallery has no attribute 'name' issue

### DIFF
--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -533,7 +533,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_location,
             self._log,
         )
-        gallery = check_or_create_gallery(
+        check_or_create_gallery(
             platform,
             runbook.gallery_resource_group_name,
             runbook.gallery_name,
@@ -573,7 +573,11 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_image_location,
         )
 
-        sig_url = f"{gallery.name}/{runbook.gallery_image_name}/{gallery_image_version}"
+        sig_url = (
+            f"{runbook.gallery_name}/"
+            f"{runbook.gallery_image_name}/"
+            f"{gallery_image_version}"
+        )
 
         self._log.info(f"SIG Url: {sig_url}")
         return {self.__sig_name: sig_url}


### PR DESCRIPTION
When new creates a gallery, the return value of "check_or_create_gallery" is a dict. "gallery.name" has error "AttributeError: 'dict' object has no attribute 'name'" .