### PR TITLE
DPDK L3Fwd test (stacked PR)

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -112,6 +112,8 @@ from .common import (
 )
 from .tools import Waagent
 
+HTTP_TOO_MANY_REQUESTS = 429
+
 
 class AzureFeatureMixin:
     def _initialize_information(self, node: Node) -> None:
@@ -993,7 +995,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         virtual_network_name: str,
         subnet_name: str,
         subnet_mask: str,
-        route_table: Any,
+        route_table: RouteTable,
     ) -> bool:
         platform: AzurePlatform = self._platform  # type: ignore
         network_client = get_network_client(platform)
@@ -1125,6 +1127,18 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                         for x in interface.ip_configurations
                         if x.primary
                     ][0],
+                )
+            )
+        return interfaces_info_list
+
+    def get_all_nics_ip_info(self) -> List[IpInfo]:
+        interfaces_info_list: List[IpInfo] = []
+        for interface in self._get_all_nics():
+            interfaces_info_list.append(
+                IpInfo(
+                    interface.name,
+                    ":".join(interface.mac_address.lower().split("-")),
+                    [x.private_ip_address for x in interface.ip_configurations][0],
                 )
             )
         return interfaces_info_list

--- a/lisa/util/constants.py
+++ b/lisa/util/constants.py
@@ -163,7 +163,3 @@ LISA_TEST_FOR_SUDO = "lisa test for sudo"
 SIGINT = 2
 SIGTERM = 15
 SIGKILL = 9
-
-# azure routing table magic subnet prefix
-# signals 'route all traffic on this subnet'
-AZ_ROUTE_ALL_TRAFFIC = "0.0.0.0/0"

--- a/lisa/util/constants.py
+++ b/lisa/util/constants.py
@@ -159,6 +159,11 @@ NETWORK_PERFORMANCE_TOOL_DPDK_TESTPMD = "dpdk-testpmd"
 # Test for command with sudo
 LISA_TEST_FOR_SUDO = "lisa test for sudo"
 
+# linux signals
 SIGINT = 2
 SIGTERM = 15
 SIGKILL = 9
+
+# azure routing table magic subnet prefix
+# signals 'route all traffic on this subnet'
+AZ_ROUTE_ALL_TRAFFIC = "0.0.0.0/0"

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from typing import Any, Dict
+
 from lisa import Node
 from lisa.operating_system import Debian, Oracle, Redhat, Suse, Ubuntu
 from lisa.util import UnsupportedDistroException
@@ -10,6 +12,11 @@ DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
 # azure routing table magic subnet prefix
 # signals 'route all traffic on this subnet'
 AZ_ROUTE_ALL_TRAFFIC = "0.0.0.0/0"
+
+
+def force_dpdk_default_source(variables: Dict[str, Any]) -> None:
+    if not variables.get("dpdk_source", None):
+        variables["dpdk_source"] = DPDK_STABLE_GIT_REPO
 
 
 def check_dpdk_support(node: Node) -> None:

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -7,6 +7,10 @@ from lisa.util import UnsupportedDistroException
 
 DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
 
+# azure routing table magic subnet prefix
+# signals 'route all traffic on this subnet'
+AZ_ROUTE_ALL_TRAFFIC = "0.0.0.0/0"
+
 
 def check_dpdk_support(node: Node) -> None:
     # check requirements according to:

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -21,12 +21,14 @@ from lisa.messages import (
 from lisa.testsuite import TestResult
 from lisa.tools import Lscpu
 from lisa.util import constants
+from microsoft.testsuites.dpdk.common import force_dpdk_default_source
 from microsoft.testsuites.dpdk.dpdkutil import (
     DpdkTestResources,
     SkippedException,
     UnsupportedPackageVersionException,
     do_parallel_cleanup,
     verify_dpdk_build,
+    verify_dpdk_l3fwd_ntttcp_tcp,
     verify_dpdk_send_receive,
     verify_dpdk_send_receive_multi_txrx_queue,
 )
@@ -223,6 +225,35 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             use_queues=True,
+        )
+
+    @TestCaseMetadata(
+        description=(
+            """
+                Run the L3 forwarding perf test for DPDK.
+                This test creates a DPDK port forwarding setup between
+                two NICs on the same VM. It forwards packets from a sender on
+                subnet_a to a receiver on subnet_b. Without l3fwd,
+                packets will not be able to jump the subnets.  This imitates
+                a network virtual appliance setup, firewall, or other data plane
+                tool for managing network traffic with DPDK.
+        """
+        ),
+        priority=3,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_count=3,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+    )
+    def perf_dpdk_l3fwd_ntttcp_tcp(
+        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+    ) -> None:
+        force_dpdk_default_source(variables)
+        verify_dpdk_l3fwd_ntttcp_tcp(
+            environment, log, variables, pmd="netvsc", is_perf_test=True
         )
 
     def _run_dpdk_perf_test(

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -19,7 +19,7 @@ from lisa import (
     search_space,
 )
 from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
-from lisa.operating_system import BSD, CBLMariner, Windows
+from lisa.operating_system import BSD, CBLMariner, Ubuntu, Windows
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe
 from lisa.util.constants import SIGINT
@@ -709,10 +709,12 @@ class Dpdk(TestSuite):
         ),
         priority=3,
         requirement=simple_requirement(
+            supported_os=[Ubuntu],
             min_core_count=8,
             min_count=3,
             min_nic_count=3,
             network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
         ),
     )
     def verify_dpdk_l3fwd_ntttcp_tcp(
@@ -734,6 +736,7 @@ class Dpdk(TestSuite):
             """,
         priority=3,
         requirement=simple_requirement(
+            supported_os=[Ubuntu],
             min_core_count=8,
             min_count=3,
             min_nic_count=3,

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -698,10 +698,16 @@ class Dpdk(TestSuite):
     @TestCaseMetadata(
         description=(
             """
-                Run the L3 forwarding test for DPDK
+                Run the L3 forwarding test for DPDK.
+                This test creates a DPDK port forwarding setup between
+                two NICs on the same VM. It forwards packets from a sender on
+                subnet_a to a receiver on subnet_b. Without l3fwd,
+                packets will not be able to jump the subnets.  This imitates
+                a network virtual appliance setup, firewall, or other data plane
+                tool for managing network traffic with DPDK.
         """
         ),
-        priority=4,
+        priority=3,
         requirement=simple_requirement(
             min_core_count=8,
             min_count=3,
@@ -718,9 +724,15 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-          Run the L3 forwarding test for DPDK
-        """,
-        priority=4,
+                Run the l3fwd test using GiB hugepages.
+                This test creates a DPDK port forwarding setup between
+                two NICs on the same VM. It forwards packets from a sender on
+                subnet_a to a receiver on subnet_b. Without l3fwd,
+                packets will not be able to jump the subnets. This imitates
+                a network virtual appliance setup, firewall, or other data plane
+                tool for managing network traffic with DPDK.
+            """,
+        priority=3,
         requirement=simple_requirement(
             min_core_count=8,
             min_count=3,

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -23,7 +23,10 @@ from lisa.operating_system import BSD, CBLMariner, Ubuntu, Windows
 from lisa.testsuite import simple_requirement
 from lisa.tools import Echo, Git, Ip, Kill, Lsmod, Make, Modprobe
 from lisa.util.constants import SIGINT
-from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO
+from microsoft.testsuites.dpdk.common import (
+    DPDK_STABLE_GIT_REPO,
+    force_dpdk_default_source,
+)
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
 from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
@@ -175,7 +178,7 @@ class Dpdk(TestSuite):
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         # initialize DPDK first, OVS requires it built from source before configuring.
-        self._force_dpdk_default_source(variables)
+        force_dpdk_default_source(variables)
         test_kit = initialize_node_resources(node, log, variables, "netvsc")
 
         # checkout OpenVirtualSwitch
@@ -248,7 +251,7 @@ class Dpdk(TestSuite):
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         # multiprocess test requires dpdk source.
-        self._force_dpdk_default_source(variables)
+        force_dpdk_default_source(variables)
         kill = node.tools[Kill]
         pmd = "failsafe"
         server_app_name = "dpdk-mp_server"
@@ -488,7 +491,7 @@ class Dpdk(TestSuite):
     ) -> None:
         # ring ping requires dpdk source to run, since default is package_manager
         # we special case here to use to dpdk-stable as the default.
-        self._force_dpdk_default_source(variables)
+        force_dpdk_default_source(variables)
         # setup and unwrap the resources for this test
         test_kit = initialize_node_resources(node, log, variables, "failsafe")
         testpmd = test_kit.testpmd
@@ -720,7 +723,7 @@ class Dpdk(TestSuite):
     def verify_dpdk_l3fwd_ntttcp_tcp(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        self._force_dpdk_default_source(variables)
+        force_dpdk_default_source(variables)
         pmd = "netvsc"
         verify_dpdk_l3fwd_ntttcp_tcp(environment, log, variables, pmd=pmd)
 
@@ -747,7 +750,7 @@ class Dpdk(TestSuite):
     def verify_dpdk_l3fwd_ntttcp_tcp_gb_hugepages(
         self, environment: Environment, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        self._force_dpdk_default_source(variables)
+        force_dpdk_default_source(variables)
         pmd = "netvsc"
         verify_dpdk_l3fwd_ntttcp_tcp(
             environment, log, variables, pmd=pmd, enable_gibibyte_hugepages=True

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -38,6 +38,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     initialize_node_resources,
     run_testpmd_concurrent,
     verify_dpdk_build,
+    verify_dpdk_l3fwd_ntttcp_tcp,
     verify_dpdk_send_receive,
     verify_dpdk_send_receive_multi_txrx_queue,
 )
@@ -335,8 +336,8 @@ class Dpdk(TestSuite):
             min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
-            min_count=2,
             unsupported_features=[Gpu, Infiniband],
+            min_count=2,
             supported_features=[IsolatedResource],
         ),
     )
@@ -432,7 +433,6 @@ class Dpdk(TestSuite):
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
         ),
     )
     def verify_dpdk_vpp(
@@ -444,6 +444,8 @@ class Dpdk(TestSuite):
                     node.os, "VPP test does not support Mariner installation."
                 )
             )
+        initialize_node_resources(node, log, variables, "failsafe")
+
         vpp = node.tools[DpdkVpp]
         vpp.install()
 
@@ -543,16 +545,16 @@ class Dpdk(TestSuite):
         description="""
             Tests a basic sender/receiver setup for default failsafe driver setup.
             Sender sends the packets, receiver receives them.
-            We check both to make sure the received traffic is within the expected
-            order-of-magnitude.
+            We check both to make sure the received traffic is within the
+            expected order-of-magnitude.
         """,
         priority=2,
         requirement=simple_requirement(
             min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
-            min_count=2,
             unsupported_features=[Gpu, Infiniband],
+            min_count=2,
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
@@ -577,8 +579,8 @@ class Dpdk(TestSuite):
             min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
-            min_count=2,
             unsupported_features=[Gpu, Infiniband],
+            min_count=2,
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_netvsc(
@@ -603,8 +605,8 @@ class Dpdk(TestSuite):
             min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
-            min_count=2,
             unsupported_features=[Gpu, Infiniband],
+            min_count=2,
         ),
     )
     def verify_dpdk_send_receive_failsafe(
@@ -654,8 +656,8 @@ class Dpdk(TestSuite):
             min_core_count=8,
             min_nic_count=2,
             network_interface=Sriov(),
-            min_count=2,
             unsupported_features=[Gpu, Infiniband],
+            min_count=2,
         ),
     )
     def verify_dpdk_send_receive_netvsc(
@@ -692,6 +694,49 @@ class Dpdk(TestSuite):
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
+
+    @TestCaseMetadata(
+        description=(
+            """
+                Run the L3 forwarding test for DPDK
+        """
+        ),
+        priority=4,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_count=3,
+            min_nic_count=3,
+            network_interface=Sriov(),
+        ),
+    )
+    def verify_dpdk_l3fwd_ntttcp_tcp(
+        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+    ) -> None:
+        self._force_dpdk_default_source(variables)
+        pmd = "netvsc"
+        verify_dpdk_l3fwd_ntttcp_tcp(environment, log, variables, pmd=pmd)
+
+    @TestCaseMetadata(
+        description="""
+          Run the L3 forwarding test for DPDK
+        """,
+        priority=4,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_count=3,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+    )
+    def verify_dpdk_l3fwd_ntttcp_tcp_gb_hugepages(
+        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+    ) -> None:
+        self._force_dpdk_default_source(variables)
+        pmd = "netvsc"
+        verify_dpdk_l3fwd_ntttcp_tcp(
+            environment, log, variables, pmd=pmd, enable_gibibyte_hugepages=True
+        )
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -42,9 +42,13 @@ from lisa.tools import (
     Timeout,
 )
 from lisa.tools.mkfs import FileSystem
-from lisa.util.constants import AZ_ROUTE_ALL_TRAFFIC, SIGINT
+from lisa.util.constants import SIGINT
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
-from microsoft.testsuites.dpdk.common import DPDK_STABLE_GIT_REPO, check_dpdk_support
+from microsoft.testsuites.dpdk.common import (
+    AZ_ROUTE_ALL_TRAFFIC,
+    DPDK_STABLE_GIT_REPO,
+    check_dpdk_support,
+)
 from microsoft.testsuites.dpdk.dpdktestpmd import PACKAGE_MANAGER_SOURCE, DpdkTestpmd
 
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -719,6 +719,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     pmd: str = "netvsc",
     enable_gibibyte_hugepages: bool = False,
     force_single_queue: bool = False,
+    is_perf_test: bool = False,
 ) -> None:
     # This is currently the most complicated DPDK test. There is a lot that can
     # go wrong, so we restrict the test to netvsc and only a few distros.
@@ -1000,7 +1001,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         sender: ntttcp[sender].create_ntttcp_result(sender_result, "client"),
     }
     # send result to notifier if we found a test result to report with
-    if test_result:
+    if test_result and is_perf_test:
         msg = ntttcp[sender].create_ntttcp_tcp_performance_message(
             server_result=ntttcp_results[receiver],
             client_result=ntttcp_results[sender],


### PR DESCRIPTION
This PR adds the l3fwd test to dpdkutil.py, dpdksuite.py, and dpdkperf.py

It is a stacked PR, building on the content from:
[Routing tables: az route and linux kernel routing with ip route by mcgov · Pull Request #3020 · microsoft/lisa (github.com)](https://github.com/microsoft/lisa/pull/3020)
[MANA: enable rdma-core source installation by mcgov · Pull Request #2981 · microsoft/lisa (github.com)](https://github.com/microsoft/lisa/pull/2981)