### PR TITLE
DPDK: update debian and ubuntu package selection criteria

### DIFF
--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from datetime import datetime
 from typing import Any, Dict
+
+from assertpy import assert_that
 
 from lisa import Node
 from lisa.operating_system import Debian, Oracle, Redhat, Suse, Ubuntu
@@ -19,15 +22,64 @@ def force_dpdk_default_source(variables: Dict[str, Any]) -> None:
         variables["dpdk_source"] = DPDK_STABLE_GIT_REPO
 
 
+# rough check for ubuntu supported versions.
+# assumes:
+# - canonical convention of YEAR.MONTH for major versions
+# - canoical release cycle of EVEN_YEAR.04 for lts versions.
+# - 4 year support cycle. 6 year for ESM
+# get the age of the distro, if negative or 0, release is new.
+# if > 6, distro is out of support
+def is_ubuntu_lts_version(distro: Ubuntu) -> bool:
+    # asserts if not ubuntu OS object
+    version_info = distro.information.version
+    distro_age = _get_ubuntu_distro_age(distro)
+    is_even_year = (version_info.major % 2) == 0
+    is_april_release = version_info.minor == 4
+    is_within_support_window = distro_age <= 6
+    return is_even_year and is_april_release and is_within_support_window
+
+
+def is_ubuntu_latest_or_prerelease(distro: Ubuntu) -> bool:
+    distro_age = _get_ubuntu_distro_age(distro)
+    return distro_age <= 2
+
+
+def _get_ubuntu_distro_age(distro: Ubuntu) -> int:
+    version_info = distro.information.version
+    # check release is within esm window
+    year_string = str(datetime.today().year)
+    assert_that(len(year_string)).described_as(
+        "Package bug: The year received from datetime module is an "
+        "unexpected size. This indicates a broken package or incorrect "
+        "date in this computer."
+    ).is_greater_than_or_equal_to(4)
+    # TODO: handle the century rollover edge case in 2099
+    current_year = int(year_string[-2:])
+    release_year = int(version_info.major)
+    # 23-18 == 5
+    # long term support and extended security updates for ~6 years
+    return current_year - release_year
+
+
 def check_dpdk_support(node: Node) -> None:
     # check requirements according to:
     # https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk
     supported = False
     if isinstance(node.os, Debian):
         if isinstance(node.os, Ubuntu):
-            supported = node.os.information.version >= "18.4.0"
+            node.log.debug(
+                "Checking Ubuntu release: "
+                f"is_latest_or_prerelease? ({is_ubuntu_latest_or_prerelease(node.os)})"
+                f" is_lts_version? ({is_ubuntu_lts_version(node.os)})"
+            )
+            # TODO: undo special casing for 18.04 when it's usage is less common
+            supported = (
+                node.os.information.version == "18.4.0"
+                or is_ubuntu_latest_or_prerelease(node.os)
+                or is_ubuntu_lts_version(node.os)
+            )
         else:
-            supported = node.os.information.version >= "10.0.0"
+            supported = node.os.information.version >= "11.0.0"
     elif isinstance(node.os, Redhat) and not isinstance(node.os, Oracle):
         supported = node.os.information.version >= "7.5.0"
     elif isinstance(node.os, Suse):


### PR DESCRIPTION
Fine-tune Ubuntu and Debian selection criteria:
- Deprecate debian 10 support
-  Deprecate non-lts ubuntu support after initial release year when support ends.
- Skip attempting to use backports on latest and pre-release Ubuntu

Fixes a recent bug on mantic where 'backports' repository is available but is not usable.