### PR TITLE
add check_or_set_storage_account_blob_public_access

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -56,6 +56,7 @@ from azure.mgmt.storage import StorageManagementClient  # type: ignore
 from azure.mgmt.storage.models import (  # type: ignore
     Sku,
     StorageAccountCreateParameters,
+    StorageAccountUpdateParameters,
 )
 from azure.storage.blob import (
     AccountSasPermissions,
@@ -2353,3 +2354,23 @@ def is_cloud_init_enabled(node: Node) -> bool:
     ) and ls_tool.path_exists("/var/lib/cloud/instance", sudo=True):
         return True
     return False
+
+
+def check_or_set_storage_account_blob_public_access(
+    credential: Any,
+    subscription_id: str,
+    cloud: Cloud,
+    resource_group_name: str,
+    storage_account_name: str,
+) -> None:
+    storage_client = get_storage_client(credential, subscription_id, cloud)
+    sc_properties = storage_client.storage_accounts.get_properties(
+        resource_group_name=resource_group_name,
+        account_name=storage_account_name,
+    )
+    if not sc_properties.allow_blob_public_access:
+        storage_client.storage_accounts.update(
+            resource_group_name=resource_group_name,
+            account_name=storage_account_name,
+            parameters=StorageAccountUpdateParameters(allow_blob_public_access=True),
+        )

--- a/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
+++ b/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
@@ -12,6 +12,7 @@ from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
     AZURE_SHARED_RG_NAME,
     AzureNodeSchema,
+    check_or_set_storage_account_blob_public_access,
     generate_blob_sas_token,
     get_or_create_storage_container,
     get_storage_account_name,
@@ -92,6 +93,13 @@ def retrieve_storage_blob_url(
     location = node_context.location
     storage_account_name = get_storage_account_name(
         subscription_id=subscription_id, location=location
+    )
+    check_or_set_storage_account_blob_public_access(
+        credential=platform.credential,
+        subscription_id=subscription_id,
+        cloud=platform.cloud,
+        resource_group_name=AZURE_SHARED_RG_NAME,
+        storage_account_name=storage_account_name,
     )
     is_public_container = container_name.endswith("-public")
     blob_data = script or f"touch {test_file}"


### PR DESCRIPTION
Fix failed. ResourceExistsError: Public access is not permitted on this storage account. when run 
```
            container_client.set_container_access_policy(
                signed_identifiers={}, public_access="container"
            )
```