### PR TITLE
use lower case of location

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -303,6 +303,7 @@ class AzureNodeSchema:
                 "data_disk_type",
             ],
         )
+        self.location = self.location.lower()
         # If vhd contains sas token, need add mask
         if isinstance(self.vhd_raw, str):
             add_secret(self.vhd_raw, PATTERN_URL)


### PR DESCRIPTION
If the user inputs a location such as "WestUS," and the specified subscription does not have a storage account for this location, the code initiates the creation of a storage account with a name containing uppercase letters. In the event of such a scenario, the code raises an exception.