### PR TITLE
No need to check the authorized_keys file if it is empty

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -990,11 +990,13 @@ class AzureImageStandard(TestSuite):
                 # then it is harmless, otherwise fail the case
                 # command="echo 'Please login as the user \"USERNAME\" rather than the user \"root\".';echo;sleep 10;exit 142"  # noqa: E501
                 key_content = node.tools[Cat].read(file_path, sudo=True)
-                key_match = key_pattern.findall(key_content)
-                if not (key_match and key_match[0]):
-                    assert_that(
-                        file_exists, f"{file_path} is detected. It should be deleted."
-                    ).is_false()
+                if key_content:
+                    key_match = key_pattern.findall(key_content)
+                    if not (key_match and key_match[0]):
+                        assert_that(
+                            file_exists,
+                            f"{file_path} is detected. It should be deleted.",
+                        ).is_false()
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Cloud-init installs an empty authorized_keys file under the users' folder if the VM is deployed with the "Password" authentication type. If the authorized_keys file is empty, we don't need to report it.