### PR TITLE
Add cd-rom 'empty tray' regression test

### DIFF
--- a/microsoft/testsuites/cdrom/cdrom.py
+++ b/microsoft/testsuites/cdrom/cdrom.py
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import pathlib
+
+from assertpy import assert_that
+
+from lisa import Node, SkippedException, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.operating_system import Linux
+from lisa.sut_orchestrator import AZURE
+from lisa.testsuite import simple_requirement
+from lisa.tools import Gcc
+
+
+@TestSuiteMetadata(
+    area="cdrom",
+    category="functional",
+    description="""
+        Tests to check the behavior of the virtual cdrom device in VMs.
+    """,
+)
+class CdromSuite(TestSuite):
+    # CD drive status constants from linux uapi
+    # see https://github.com/torvalds/linux/blob/master/include/uapi/linux/cdrom.h#L417
+    _expected_device_status = (
+        "CDS_NO_DISC"  # drive tray is closed, no disk in the drive
+    )
+
+    @TestCaseMetadata(
+        description="""
+            Test to check the installation ISO is unloaded
+            after provisioning and rebooting a new VM.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_os=[Linux], supported_platform_type=[AZURE]
+        ),
+    )
+    def verify_cdrom_device_status_code(self, node: Node) -> None:
+        # check there's a device to test
+        if not node.shell.exists(pathlib.PurePosixPath("/dev/cdrom")):
+            raise SkippedException(
+                "No /dev/cdrom device was present in this distro/image/vm."
+            )
+        # reboot to ensure there is no iso in the cd/dvd 'drive'
+        node.reboot()
+
+        # collect some paths before we start compiling...
+        local_path = pathlib.PurePath(__file__).parent.joinpath("cdstat.c")
+        working_path = node.get_working_path()
+        node_source_path = working_path.joinpath("cdstat.c")
+        node_exec_path = working_path.joinpath("cdstat")
+
+        # copy the tiny c program to the node (cdstat.c)
+        node.shell.copy(local_path=local_path, node_path=node_source_path)
+
+        # compile it
+        node.tools[Gcc].compile(
+            filename=str(node_source_path), output_name=str(node_exec_path)
+        )
+
+        # and run the test if the device is present.
+        result = node.execute(
+            cmd=str(node_exec_path),
+            shell=True,
+            sudo=True,
+        )
+        output = result.stdout.strip()
+
+        # first check for failure to open the cdrom device
+        assert_that(result.exit_code).described_as(
+            "Needs Triage: calling "
+            "open('/dev/cdrom', O_RDONLY|O_NONBLOCK) failed on this VM."
+        ).is_not_equal_to(-1)
+
+        # then check if the exit code was expected and
+        # log the output code on failure
+        assert_that(result.exit_code).described_as(
+            "Bug! /dev/cdrom device status should be "
+            f"{self._expected_device_status} after reboot, found {output}."
+        ).is_zero()

--- a/microsoft/testsuites/cdrom/cdstat.c
+++ b/microsoft/testsuites/cdrom/cdstat.c
@@ -1,0 +1,54 @@
+#include <fcntl.h>
+#include <linux/cdrom.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+// A small program to check the status code of the CD-ROM device.
+// Expected value is CDS_NO_DISK, assuming the VM has been rebooted 
+// after provisioning.
+// authors: mamcgove@microsoft.com, rahugupta@microsoft.com
+
+int
+main (int argc, char *argv[])
+{
+
+  int slot, result, fd;
+
+  fd = open ("/dev/cdrom", O_RDONLY | O_NONBLOCK);
+  if (fd < 0)
+    {
+      printf ("Error: could not open /dev/cdrom\n");
+      exit (-1);
+    }
+  slot = 0;
+  result = ioctl (fd, CDROM_DRIVE_STATUS, slot);
+  switch (result)
+    {
+    case CDS_NO_DISC:
+      // This is our expected value after reboot,
+      // There should be no disk (or iso) in the drive.
+      printf ("CDS_NO_DISC\n");
+      exit (0);
+    
+    // otherwise something is off.
+    // log the disk drive status code and return 1
+    case CDS_NO_INFO:
+      printf ("CDS_NO_INFO\n");
+      break;
+    case CDS_TRAY_OPEN:
+      printf ("CDS_TRAY_OPEN\n");
+      break;
+    case CDS_DRIVE_NOT_READY:
+      printf ("CDS_DRIVE_NOT_READY\n");
+      break;
+    case CDS_DISC_OK:
+      printf ("CDS_DISC_OK\n");
+      break;
+    default:
+      printf ("UNKNOWN_STATUS_CODE!\n");
+    }
+
+  exit (1);
+}


### PR DESCRIPTION
Adding a regression test to check virtual cd/dvd tray reports 'empty' after initial provisioning is complete.
A recent bug would cause the tray to report CDS_DISK_OK which means 'the drive has a disk inside and it's ready to use' even though there is no ISO/CD/DVD in the 'tray'. 
This test uses a small portable C program to check that the behavior is fixed after the initial provisioning process; all linux distros will support these commands; they've been around as long as CD-ROM support has. 