### PR TITLE
Set USE_MS_GUEST_KERNEL for CLH testcase only if YES

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -202,7 +202,8 @@ class CloudHypervisorTestSuite(TestSuite):
         CloudHypervisorTests.ms_clh_repo = ms_clh_repo
         CloudHypervisorTests.ms_igvm_parser_repo = ms_igvm_parser_repo
         CloudHypervisorTests.clh_guest_vm_type = clh_guest_vm_type
-        CloudHypervisorTests.use_ms_guest_kernel = use_ms_guest_kernel
+        if use_ms_guest_kernel == "YES":
+            CloudHypervisorTests.use_ms_guest_kernel = use_ms_guest_kernel
 
 
 def get_test_list(variables: Dict[str, Any], var1: str, var2: str) -> Any:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -230,7 +230,8 @@ class CloudHypervisorTests(Tool):
                 auth_token=self.ms_access_token,
             )
             self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
-            self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
+            if self.use_ms_guest_kernel:
+                self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
         else:
             git.clone(self.upstream_repo, clone_path)
 


### PR DESCRIPTION
We will set the env var USR_MS_GUEST_KERNEL only
if it is set to YES as new CLH dev_cli script had some changes which expect this env var to be set only
when required. Setting default value to NO would not work with it anymore.