### PR TITLE
close node to set up reconnection

### DIFF
--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -175,6 +175,7 @@ class Ntttcp(Tool):
         original_settings = self._original_settings_tcp
         if udp_mode:
             original_settings = self._original_settings_udp
+        self.node.close()
         sysctl = self.node.tools[Sysctl]
         for variable_list in original_settings:
             # restore back to the original value after testing


### PR DESCRIPTION
this is to fix perf_nested_kvm_ntttcp_private_bridge, it throws `failed. SSHException: SSH session not active` during clean up stage, because the previous operations happened on L2 vms, the connections to L1 VM are idle for a long time.