### PR TITLE
Increase kernel installer reboot timeout

### DIFF
--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -194,7 +194,7 @@ class KernelInstallerTransformer(Transformer):
                 )
 
             self._log.info("rebooting")
-            node.reboot()
+            node.reboot(time_out=900)
             boot_success = True
             new_kernel_version = uname.get_linux_information(force_run=True)
             message.new_kernel_version = new_kernel_version.kernel_version_raw


### PR DESCRIPTION
Bare metal servers take much longer than 300s to boot. Reboot timeout of 300s causes the kernel installer to consistently timeout.

Empirically, 900s has been successful.