### PR TITLE
Add support for PATCH and UPDATE commands on job templates in AITL wrapper

### DIFF
--- a/microsoft/utils/aitl/template.json
+++ b/microsoft/utils/aitl/template.json
@@ -1,0 +1,25 @@
+{
+    "location": "westus3",
+    "properties": {
+        "vmSize": [
+            "Standard_D4_v4"
+        ],
+        "selections": [
+            {
+                "caseName": [],
+                "caseArea": [],
+                "caseCategory": [],
+                "casePriority": [
+                    0
+                ],
+                "caseTags": [],
+                "action": "include",
+                "testIterations": 1,
+                "retryCount": 0,
+                "useNewEnvironment": false,
+                "ignoreFailure": false
+            }
+        ],
+        "concurrency": 4
+    }
+}


### PR DESCRIPTION
This PR extends support for the jobTemplates resource type in the AITL wrapper. The following changes are made:

- For job templates, PATCH and PUT (updates) commands are accepted. PATCH commands will modify only the specific property listed in the request body, while PUT commands either create a new job template or replace the existing one. 
- The help menu will now show job template examples if it is requested for job templates.
- A new "jobTemplates" template has been added. It includes to Selections object to demonstrate how to add different test cases, priorities, or areas in a single template. This has come up in the past and the goal is that the example will help provide clarity.   