### PR TITLE
Add cached_disk_size in Azure disk settings for Ephemeral os disk type

### DIFF
--- a/lisa/search_space.py
+++ b/lisa/search_space.py
@@ -328,6 +328,9 @@ class SetSpace(RequirementMixin, Set[T]):
         super().remove(element)
         self.items.remove(element)
 
+    def isunique(self, element: T) -> bool:
+        return len(self.items) == 1 and self.items[0] == element
+
     def update(self, *s: Iterable[T]) -> None:
         super().update(*s)
         self.items.extend(*s)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1235,6 +1235,10 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
             "os_disk_type",
         )
         result.merge(
+            search_space.check_countspace(self.os_disk_size, capability.os_disk_size),
+            "os_disk_size",
+        )
+        result.merge(
             search_space.check_setspace(self.data_disk_type, capability.data_disk_type),
             "disk_type",
         )
@@ -1335,6 +1339,11 @@ class AzureDiskOptionSettings(schema.DiskOptionSettings):
         else:
             raise LisaException(
                 f"unknown disk type on capability, type: {cap_disk_type}"
+            )
+
+        if self.os_disk_size is not None or capability.os_disk_size is not None:
+            value.os_disk_size = getattr(search_space, f"{method.value}_countspace")(
+                self.os_disk_size, capability.os_disk_size
             )
 
         value.data_disk_type = getattr(


### PR DESCRIPTION
Ephemeral disk type requires the image OS disk’s size to be less than or equal to the temp/cache size of the VM size chosen.
https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks#size-requirements

Add cached_disk_size in the Azure disk setting so Lisa can choose the right VM size for verify_deployment_provision_ephemeral_managed_disk test case.