### PR TITLE
DPDK: Refactor rdma-core source build, allow arbitrary package build

### DIFF
--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -343,14 +343,16 @@ class Git(Tool):
             expected_exit_code_failure_message="Failed to fetch author email.",
         ).stdout
 
-        describe = self.run(
+        describe_result = self.run(
             "describe",
             shell=True,
             cwd=cwd,
             force_run=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message="Failed to run git describe",
-        ).stdout
+        )
+        if describe_result.exit_code == 0:
+            describe = describe_result.stdout
+        else:
+            describe = ""
 
         result = {
             "full_commit_id": filter_ansi_escape(latest_commit_id),

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -48,7 +48,7 @@ global_ssh_key_access_lock = Lock()
 # source -
 # https://github.com/django/django/blob/stable/1.3.x/django/core/validators.py#L45
 __url_pattern = re.compile(
-    r"^(?:http|s?ftp)s?://"  # http:// or https://
+    r"^(?:http|https|sftp|ftp)://"  # http:// or https://
     r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)"
     r"+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # ...domain
     r"localhost|"  # localhost...
@@ -564,9 +564,7 @@ def find_group_in_lines(
     return result
 
 
-def deep_update_dict(
-    src: Dict[str, Any], dest: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
+def deep_update_dict(src: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
     if (
         dest is None
         or isinstance(dest, int)
@@ -580,7 +578,7 @@ def deep_update_dict(
 
     if isinstance(result, dict):
         for key, value in src.items():
-            if dest and isinstance(value, dict) and key in dest:
+            if isinstance(value, dict) and key in dest:
                 value = deep_update_dict(value, dest[key])
             result[key] = value
     elif isinstance(src, dict):
@@ -601,31 +599,57 @@ def is_valid_url(url: str, raise_error: bool = True) -> bool:
     return is_url
 
 
-def is_valid_source_code_package(
+def _raise_or_log_failure(log: "Logger", raise_error: bool, failure_msg: str) -> bool:
+    if raise_error:
+        raise LisaException(failure_msg)
+    else:
+        log.debug(failure_msg)
+        return False
+
+
+# big function to check the parts of a url
+# allow raising exceptions or log and return a bool
+# allows checks for:
+#   expected domains
+#   protocols (require https, sftp, etc)
+#   filenames (pattern matching)
+def check_url(
+    log: "Logger",
     source_url: str,
-    expected_package_name_pattern: Pattern[str],
     allowed_protocols: Optional[List[str]] = None,
-    expected_domains: Optional[List[str]] = None,
+    expected_domains_pattern: Optional[Pattern[str]] = None,
+    expected_filename_pattern: Optional[Pattern[str]] = None,
+    raise_error: bool = False,
 ) -> bool:
     # avoid using a mutable default parameter
     if not allowed_protocols:
         allowed_protocols = [
             "https",
-            "sftp",
         ]
+    # pylinter doesn't like returning too many times in a function
+    # instead we'll assign to a boolean and check it repeatedly.
+    # thanks, linter.
+    result = True
     # first, check if it's a url.
-    if not is_valid_url(url=source_url, raise_error=False):
+    failure_msg = f"{source_url} is not a valid URL, check your arguments."
+    if not (
+        is_valid_url(url=source_url, raise_error=False)
+        or _raise_or_log_failure(log, raise_error, failure_msg)
+    ):
+        # fast return false, other checks depend on this one
         return False
 
     # NOTE: urllib might not work as you'd expect.
     # It doesn't throw on lots of things you wouldn't expect to be urls.
     # You must verify the parts on your own, some of them may be empty, some null.
     # check: https://docs.python.org/3/library/urllib.parse.html#url-parsing
-
+    failure_msg = f"urlparse failed to parse url {source_url}, check your arguments."
     try:
         parts = urlparse(source_url)
     except ValueError:
-        return False
+        if not _raise_or_log_failure(log, raise_error, failure_msg):
+            # another fast return, other checks depend on this one
+            return False
 
     # ex: from https://www.com/path/to/file.tar
     # scheme : https
@@ -634,23 +658,51 @@ def is_valid_source_code_package(
 
     # get the filename from the path portion of the url
     file_path = parts.path.split("/")[-1]
-    full_match = expected_package_name_pattern.match(file_path)
-    if not full_match:
-        return False
+    full_match = None
+    # check we can match against the filename
+    if expected_filename_pattern:
+        full_match = expected_filename_pattern.match(file_path)
+        failure_msg = (
+            f"File at {source_url} did not match pattern "
+            f"{expected_filename_pattern.pattern}."
+        )
+        if not full_match:
+            result &= _raise_or_log_failure(log, raise_error, failure_msg)
 
     # check the expected domain is correct if present
-    valid_netloc = not expected_domains or any(
-        [domain.endswith(parts.netloc) for domain in expected_domains]
-    )
+    if (
+        result
+        and expected_domains_pattern
+        and not expected_domains_pattern.match(parts.netloc)
+    ):
+        # logging domains requires check that expected_domains != None
+        failure_msg = (
+            f"net location of url {source_url} did not match "
+            f"expected domains { expected_domains_pattern.pattern } "
+        )
+        result &= _raise_or_log_failure(log, raise_error, failure_msg)
 
-    # optional but default is check access is via sftp/https
-    valid_scheme = any([parts.scheme == x for x in allowed_protocols])
-    return (
-        valid_scheme
-        and parts.netloc != ""
-        and valid_netloc
-        and (full_match.group(0) == file_path)
+    # Check the protocol (aka scheme) in the url
+    # default is check access is via https
+    failure_msg = (
+        f"URL {source_url} uses an invalid protocol "
+        "or net location! Check url argument."
     )
+    valid_scheme = any([parts.scheme == x for x in allowed_protocols])
+    if result and not valid_scheme:
+        result &= _raise_or_log_failure(log, raise_error, failure_msg)
+    # finally verify the full match we found matches the actual filename
+    # avoids an accidental partial match
+    if result and expected_filename_pattern and full_match:
+        path_matches = full_match.group(0) == file_path
+        failure_msg = (
+            f"File at url {source_url} failed to match"
+            f" pattern {expected_filename_pattern.pattern}."
+        )
+        if not path_matches:
+            result &= _raise_or_log_failure(log, raise_error, failure_msg)
+
+    return result
 
 
 def filter_ansi_escape(content: str) -> str:

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -24,6 +24,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urlparse
 
 import paramiko
 import pluggy
@@ -47,7 +48,7 @@ global_ssh_key_access_lock = Lock()
 # source -
 # https://github.com/django/django/blob/stable/1.3.x/django/core/validators.py#L45
 __url_pattern = re.compile(
-    r"^(?:http|ftp)s?://"  # http:// or https://
+    r"^(?:http|s?ftp)s?://"  # http:// or https://
     r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)"
     r"+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # ...domain
     r"localhost|"  # localhost...
@@ -563,7 +564,9 @@ def find_group_in_lines(
     return result
 
 
-def deep_update_dict(src: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any]:
+def deep_update_dict(
+    src: Dict[str, Any], dest: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
     if (
         dest is None
         or isinstance(dest, int)
@@ -577,7 +580,7 @@ def deep_update_dict(src: Dict[str, Any], dest: Dict[str, Any]) -> Dict[str, Any
 
     if isinstance(result, dict):
         for key, value in src.items():
-            if isinstance(value, dict) and key in dest:
+            if dest and isinstance(value, dict) and key in dest:
                 value = deep_update_dict(value, dest[key])
             result[key] = value
     elif isinstance(src, dict):
@@ -596,6 +599,58 @@ def is_valid_url(url: str, raise_error: bool = True) -> bool:
         else:
             is_url = False
     return is_url
+
+
+def is_valid_source_code_package(
+    source_url: str,
+    expected_package_name_pattern: Pattern[str],
+    allowed_protocols: Optional[List[str]] = None,
+    expected_domains: Optional[List[str]] = None,
+) -> bool:
+    # avoid using a mutable default parameter
+    if not allowed_protocols:
+        allowed_protocols = [
+            "https",
+            "sftp",
+        ]
+    # first, check if it's a url.
+    if not is_valid_url(url=source_url, raise_error=False):
+        return False
+
+    # NOTE: urllib might not work as you'd expect.
+    # It doesn't throw on lots of things you wouldn't expect to be urls.
+    # You must verify the parts on your own, some of them may be empty, some null.
+    # check: https://docs.python.org/3/library/urllib.parse.html#url-parsing
+
+    try:
+        parts = urlparse(source_url)
+    except ValueError:
+        return False
+
+    # ex: from https://www.com/path/to/file.tar
+    # scheme : https
+    # netloc : www.com
+    # path   : path/to/file.tar
+
+    # get the filename from the path portion of the url
+    file_path = parts.path.split("/")[-1]
+    full_match = expected_package_name_pattern.match(file_path)
+    if not full_match:
+        return False
+
+    # check the expected domain is correct if present
+    valid_netloc = not expected_domains or any(
+        [domain.endswith(parts.netloc) for domain in expected_domains]
+    )
+
+    # optional but default is check access is via sftp/https
+    valid_scheme = any([parts.scheme == x for x in allowed_protocols])
+    return (
+        valid_scheme
+        and parts.netloc != ""
+        and valid_netloc
+        and (full_match.group(0) == file_path)
+    )
 
 
 def filter_ansi_escape(content: str) -> str:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -887,10 +887,9 @@ class DpdkTestpmd(Tool):
             rhel.install_packages(["libmnl-devel", "libbpf-devel"])
 
         try:
-            rhel.install_packages("kernel-devel-$(uname -r)")
-        except MissingPackagesException:
-            node.log.debug("kernel-devel-$(uname -r) not found. Trying kernel-devel")
             rhel.install_packages("kernel-devel")
+        except MissingPackagesException:
+            node.log.debug("Fedora: kernel-devel not found, attempting to continue")
 
         # RHEL 8 doesn't require special cases for installed packages.
         # TODO: RHEL9 may require updates upon release

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -312,6 +312,8 @@ def initialize_node_resources(
     _set_forced_source_by_distro(node, variables)
     dpdk_source = variables.get("dpdk_source", PACKAGE_MANAGER_SOURCE)
     dpdk_branch = variables.get("dpdk_branch", "")
+    rdma_core_source = variables.get("rdma_core_source", "")
+    rdma_core_ref = variables.get("rdma_core_git_ref", "")
     force_net_failsafe_pmd = variables.get("dpdk_force_net_failsafe_pmd", False)
     log.info(
         "Dpdk initialize_node_resources running"
@@ -348,6 +350,8 @@ def initialize_node_resources(
         dpdk_branch=dpdk_branch,
         sample_apps=sample_apps,
         force_net_failsafe_pmd=force_net_failsafe_pmd,
+        rdma_core_source=rdma_core_source,
+        rdma_core_ref=rdma_core_ref,
     )
 
     # init and enable hugepages (required by dpdk)

--- a/microsoft/testsuites/dpdk/rdma_core.py
+++ b/microsoft/testsuites/dpdk/rdma_core.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+from urllib.parse import urlparse
+
+from assertpy import fail
+
+from lisa import Node
+from lisa.operating_system import Debian, Fedora, Suse
+from lisa.tools import Git, Make, Pkgconfig, Tar, Wget
+from lisa.util import LisaException, SkippedException, is_valid_source_code_package
+
+
+class RdmaCoreManager:
+    def __init__(self, node: Node, rdma_core_source: str, rdma_core_ref: str) -> None:
+        self.is_installed_from_source = False
+        self.node = node
+        self._rdma_core_source = rdma_core_source
+        self._rdma_core_ref = rdma_core_ref
+
+    def get_missing_distro_packages(self) -> str:
+        distro = self.node.os
+        package = ""
+        # check if rdma-core is installed already...
+        if self.node.tools[Pkgconfig].package_info_exists("libibuverbs"):
+            return package
+        if isinstance(distro, Debian):
+            package = "rdma-core ibverbs-providers libibverbs-dev"
+        elif isinstance(distro, Suse):
+            package = "rdma-core-devel librdmacm1"
+        elif isinstance(distro, Fedora):
+            package = "librdmacm-devel"
+        else:
+            fail("Invalid OS for rdma-core source installation.")
+        return package
+
+    def _check_source_name(self) -> bool:
+        source = self._rdma_core_source
+        try:
+            parts = urlparse(self._rdma_core_source)
+        except ValueError:
+            raise LisaException(f"Invalid rdma-core source build url: {source}")
+        file_path = parts.path.split("/")[-1]
+        return (
+            any([parts.scheme == x for x in ["https", "ssh"]])
+            and parts.netloc != ""
+            and (
+                file_path == "rdma-core.git"
+                or (file_path.startswith("rdma-core") and file_path.endswith(".tar.gz"))
+            )
+        )
+
+    _source_pattern = re.compile(r"rdma-core(.v?[0-9]+)*.(git|tar(\.gz)?)")
+
+    def _check_source_install(self) -> None:
+        if self._rdma_core_source:
+            # accept either a tar.gz or a git tree
+            if self.is_from_tarball():
+                self._rdma_core_ref = ""
+            elif self.is_from_git():
+                # will check ref later
+                pass
+            else:
+                raise SkippedException(
+                    "rdma-core source must be rdma-core.*tar.gz "
+                    f"or https://.../rdma-core.git. found {self._rdma_core_source}"
+                )
+        elif self._rdma_core_ref:
+            # if there's a ref but no tree, use a default tree
+            self._rdma_core_source = "https://github.com/linux-rdma/rdma-core.git"
+        else:
+            # no ref, no tree, use a default tar.gz
+            self._rdma_core_source = (
+                "https://github.com/linux-rdma/rdma-core/"
+                "releases/download/v46.0/rdma-core-46.0.tar.gz"
+            )
+
+        # finally, validate what we have looks reasonable and cool
+        is_valid_package = is_valid_source_code_package(
+            source_url=self._rdma_core_source,
+            expected_package_name_pattern=self._source_pattern,
+            allowed_protocols=["https"],
+            expected_domains=[
+                "visualstudio.com",
+                "gitlab.com",
+                "github.com",
+                "git.launchpad.net",
+            ],
+        )
+        if not is_valid_package:
+            raise SkippedException(self._get_source_pkg_error_message())
+
+        self.is_installed_from_source = True
+
+    def _get_source_pkg_error_message(self) -> str:
+        return (
+            "rdma-source package provided did not validate. "
+            "Use https for a git named rdma-core.git or "
+            "https/sftp to fetch a tar.gz package named rdma-core(.xx).tar.gz. "
+            "Source site must be at visualstudio, gitlab, github, or git.launchpad.net."
+            f"Found: {self._rdma_core_source}"
+        )
+
+    def is_from_git(self) -> bool:
+        return bool(
+            self._rdma_core_source and self._rdma_core_source.endswith("rdma-core.git")
+        )
+
+    def is_from_tarball(self) -> bool:
+        return bool(
+            self._rdma_core_source and self._rdma_core_source.endswith(".tar.gz")
+        )
+
+    def can_install_from_source(self) -> bool:
+        return bool(self._rdma_core_source or self._rdma_core_ref)
+
+    def do_source_install(self) -> None:
+        node = self.node
+        wget = node.tools[Wget]
+        make = node.tools[Make]
+        tar = node.tools[Tar]
+        distro = node.os
+
+        # setup looks at options and selects some reasonable defaults
+        # allow a tar.gz or git
+        # if ref and no tree, use the default tree at github
+        # if tree and no ref, checkout latest tag
+        # if tree and ref... you get the idea
+        self._check_source_install()
+
+        # for dependencies, see https://github.com/linux-rdma/rdma-core#building
+        if isinstance(distro, Debian):
+            distro.install_packages(
+                "cmake libudev-dev "
+                "libnl-3-dev libnl-route-3-dev ninja-build pkg-config "
+                "valgrind python3-dev cython3 python3-docutils pandoc "
+                "libssl-dev libelf-dev python3-pip libnuma-dev"
+            )
+        elif isinstance(distro, Fedora):
+            distro.group_install_packages("Development Tools")
+            distro.install_packages(
+                "cmake gcc libudev-devel "
+                "libnl3-devel pkg-config "
+                "valgrind python3-devel python3-docutils  "
+                "openssl-devel unzip "
+                "elfutils-devel python3-pip libpcap-devel  "
+                "tar wget dos2unix psmisc kernel-devel-$(uname -r)  "
+                "librdmacm-devel libmnl-devel kernel-modules-extra numactl-devel  "
+                "kernel-headers elfutils-libelf-devel meson ninja-build libbpf-devel "
+            )
+        else:
+            # no-op, throw for invalid distro is before this function
+            return
+
+        if self.is_from_git():
+            git = node.tools[Git]
+            source_path = git.clone(
+                self._rdma_core_source, cwd=node.working_path, ref=self._rdma_core_ref
+            )
+            # if there wasn't a ref provided, check out the latest tag
+            if not self._rdma_core_ref:
+                git_ref = git.get_tag(cwd=source_path)
+            git.checkout(git_ref, cwd=source_path)
+        elif self.is_from_tarball():
+            tar_path = wget.get(
+                url=(self._rdma_core_source),
+                file_path=str(node.working_path),
+            )
+
+            tar.extract(tar_path, dest_dir=str(node.working_path), gzip=True, sudo=True)
+            source_folder = tar_path.replace(".tar.gz", "")
+            source_path = node.get_pure_path(source_folder)
+        else:
+            raise SkippedException(self._get_source_pkg_error_message())
+
+        node.execute(
+            "cmake -DIN_PLACE=0 -DNO_MAN_PAGES=1 -DCMAKE_INSTALL_PREFIX=/usr",
+            shell=True,
+            cwd=source_path,
+            sudo=True,
+        )
+        make.make_install(source_path)

--- a/microsoft/testsuites/dpdk/rdma_core.py
+++ b/microsoft/testsuites/dpdk/rdma_core.py
@@ -9,7 +9,7 @@ from assertpy import fail
 from lisa import Node
 from lisa.operating_system import Debian, Fedora, Suse
 from lisa.tools import Git, Make, Pkgconfig, Tar, Wget
-from lisa.util import LisaException, SkippedException, is_valid_source_code_package
+from lisa.util import LisaException, SkippedException, check_url
 
 
 class RdmaCoreManager:
@@ -51,6 +51,12 @@ class RdmaCoreManager:
             )
         )
 
+    _rdma_core_domain_pattern = re.compile(
+        (
+            r"^((?:www\.)?(?:(?:(?:microsoft|msazure)\.)"
+            r"?(?:visualstudio|gitlab|github)\.com)|git\.launchpad\.net)"
+        )
+    )
     _source_pattern = re.compile(r"rdma-core(.v?[0-9]+)*.(git|tar(\.gz)?)")
 
     def _check_source_install(self) -> None:
@@ -77,16 +83,12 @@ class RdmaCoreManager:
             )
 
         # finally, validate what we have looks reasonable and cool
-        is_valid_package = is_valid_source_code_package(
+        is_valid_package = check_url(
+            self.node.log,
             source_url=self._rdma_core_source,
-            expected_package_name_pattern=self._source_pattern,
             allowed_protocols=["https"],
-            expected_domains=[
-                "visualstudio.com",
-                "gitlab.com",
-                "github.com",
-                "git.launchpad.net",
-            ],
+            expected_domains_pattern=self._rdma_core_domain_pattern,
+            expected_filename_pattern=self._source_pattern,
         )
         if not is_valid_package:
             raise SkippedException(self._get_source_pkg_error_message())


### PR DESCRIPTION
Fulfilling an ask to be able to test multiple rdma-core versions to allow development and regression tests. Refactors the rdma-core bits into their own own class.

Setting rdma_core_source to either a git or tar.gz link allows you to build from source. For git either set rdma_core_ref or it will pick the latest version sorted tag.