### PR TITLE
Update LTP to the newest 20230929 version

### DIFF
--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -50,7 +50,7 @@ class Ltp(Tool):
     _RESULT_LTP_ARCH_REGEX = re.compile(r"Machine Architecture: (.*)\s+")
 
     LTP_DIR_NAME = "ltp"
-    DEFAULT_LTP_TESTS_GIT_TAG = "20200930"
+    DEFAULT_LTP_TESTS_GIT_TAG = "20230929"
     LTP_GIT_URL = "https://github.com/linux-test-project/ltp.git"
     BUILD_REQUIRED_DISK_SIZE_IN_GB = 2
     LTP_RESULT_PATH = "/opt/ltp/ltp-results.log"


### PR DESCRIPTION
Fix test bug 47596061:
LTP oom test cases will consume lots of memory, which makes SSH be terminated when out of memory.
https://microsoft.visualstudio.com/OS/_workitems/edit/47596061