### PR TITLE
Increase sleep time in stress_mshv_vm_create test

### DIFF
--- a/microsoft/testsuites/mshv/mshv_root_stress_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_stress_tests.py
@@ -186,7 +186,8 @@ class MshvHostStressTestSuite(TestSuite):
             sleep_time = 10
             if guest_vm_type == "CVM":
                 # CVM guest take little more time to boot
-                sleep_time = 100
+                # 20 seconds per VM (with default 1024M)
+                sleep_time = 20 * vm_count
             time.sleep(sleep_time)
 
             for i in range(len(procs)):
@@ -197,6 +198,11 @@ class MshvHostStressTestSuite(TestSuite):
                     continue
                 log.info(f"Killing VM {i}")
                 p.kill()
+
+            if guest_vm_type == "CVM":
+                # CVM guest killing takes sometime
+                sleep_time = 20
+                time.sleep(sleep_time)
 
             node.tools[Free].log_memory_stats_mb()
 


### PR DESCRIPTION
CVM guest takes longer time to boot. 20 seconds is the empirical boot time for a guest with 1G memory. Also, CVM guest process killing takes slightly longer time. Hence, increase the sleep timeout accordingly.