### PR TITLE
shell: fix mkdir with parents for Windows nodes

### DIFF
--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -422,6 +422,16 @@ class SshShell(InitializableMixin):
             if "Channel closed." in str(identifier):
                 assert isinstance(path_str, str)
                 self.spawn(command=["mkdir", "-p", path_str])
+        except OSError as e:
+            if not self.is_posix and parents:
+                # spurplus doesn't handle Windows style paths properly. As a result,
+                # it is unable to create parent directories when parents=True is
+                # passed. So, mkdir ultimately fails. In such cases, use command
+                # instead. On Windows, mkdir creates parent directories by default;
+                # no additional parameter is needed.
+                self._inner_shell.run(command=["mkdir", path_str])
+            else:
+                raise e
 
     def exists(self, path: PurePath) -> bool:
         """Check if a target directory/file exist


### PR DESCRIPTION
`spurplus` is unable to create parent directories when the target node is a Windows node. This is because it expects only POSIX paths, and its parent creation logic doesn't work well with Windows paths. In these cases, `spurplus` throws `OSError`.

To fix this, catch the `OSError` exception and fallback to using the `mkdir` command to create the directory.