### PR TITLE
Add bash prompt check when execute commands

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -112,6 +112,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         self.capture_boot_time: bool = False
         self.capture_azure_information: bool = False
         self.capture_kernel_config: bool = False
+        self.has_checked_bash_prompt: bool = False
 
     @property
     def shell(self) -> Shell:
@@ -288,6 +289,8 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         encoding: str = "",
     ) -> Process:
         self.initialize()
+        if isinstance(self, RemoteNode):
+            self._check_bash_prompt()
 
         return self._execute(
             cmd,
@@ -735,6 +738,26 @@ class RemoteNode(Node):
             self.log.debug(f"password prompt {i}: {password_prompt}")
         ssh_shell = cast(SshShell, self.shell)
         ssh_shell.password_prompts = password_prompts
+
+    def _check_bash_prompt(self) -> None:
+        # Check if there is bash prompt in stdout of command. If yes, the prompt
+        # should be filtered from the stdout. E.g. image yaseensmarket1645449809728
+        # wordpress-red-hat images.
+        if not self.has_checked_bash_prompt:
+            process = self._execute(f"echo {constants.LISA_TEST_FOR_BASH_PROMPT}")
+            result = process.wait_result(10)
+            if result.stdout.endswith(f"{constants.LISA_TEST_FOR_BASH_PROMPT}"):
+                bash_prompt = result.stdout.replace(
+                    constants.LISA_TEST_FOR_BASH_PROMPT, ""
+                )
+                if bash_prompt:
+                    self.log.debug(
+                        "detected bash prompt, it will be removed from every output: "
+                        f"{bash_prompt}"
+                    )
+                    ssh_shell = cast(SshShell, self.shell)
+                    ssh_shell.bash_prompt = bash_prompt
+                self.has_checked_bash_prompt = True
 
     def _reset_password(self) -> bool:
         from lisa.features import PasswordExtension

--- a/lisa/util/constants.py
+++ b/lisa/util/constants.py
@@ -163,6 +163,7 @@ NETWORK_PERFORMANCE_TOOL_DPDK_TESTPMD = "dpdk-testpmd"
 
 # Test for command with sudo
 LISA_TEST_FOR_SUDO = "lisa test for sudo"
+LISA_TEST_FOR_BASH_PROMPT = "lisa test for bash prompt"
 
 # linux signals
 SIGINT = 2

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -223,6 +223,7 @@ class SshShell(InitializableMixin):
         self._jump_box_sock: Any = None
         self.is_sudo_required_password: bool = False
         self.password_prompts: List[str] = []
+        self.bash_prompt: str = ""
         self.spawn_initialization_error_string = ""
 
         paramiko_logger = logging.getLogger("paramiko")


### PR DESCRIPTION
Some images have bash prompts in stdout, E.g. yaseensmarket1645449809728 wordpress-red-hat images. The bash prompt is like:
        # ----------------------------------------------------------------------
        # Use the this command 'sudo bash ~/getcert.sh' to install a certificate
        # ----------------------------------------------------------------------
 This PR adds a bash prompt check and filters the bash prompt.
