### PR TITLE
Remove IGVM PARSER REPO for Cloud-Hypervisor testsuite

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -179,9 +179,6 @@ class CloudHypervisorTestSuite(TestSuite):
         # Get URL for MS CLH repo
         ms_clh_repo = variables.get("ms_clh_repo", None)
 
-        # Get URL for igvm-parser repo
-        ms_igvm_parser_repo = variables.get("ms_igvm_parser_repo", None)
-
         # Get GUEST VM type, set default to NON-CVM
         clh_guest_vm_type = variables.get("clh_guest_vm_type", "NON-CVM")
 
@@ -194,13 +191,10 @@ class CloudHypervisorTestSuite(TestSuite):
             raise SkippedException("Access Token is needed while using MS-CLH")
         if not ms_clh_repo:
             raise SkippedException("CLH URL is needed while using MS-CLH")
-        if not ms_igvm_parser_repo:
-            raise SkippedException("IGVM-Parser URL is needed while using MS-CLH")
 
         CloudHypervisorTests.use_ms_clh_repo = True
         CloudHypervisorTests.ms_access_token = ms_access_token
         CloudHypervisorTests.ms_clh_repo = ms_clh_repo
-        CloudHypervisorTests.ms_igvm_parser_repo = ms_igvm_parser_repo
         CloudHypervisorTests.clh_guest_vm_type = clh_guest_vm_type
         if use_ms_guest_kernel == "YES":
             CloudHypervisorTests.use_ms_guest_kernel = use_ms_guest_kernel

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -37,7 +37,6 @@ class CloudHypervisorTests(Tool):
     }
 
     ms_clh_repo = ""
-    ms_igvm_parser_repo = ""
     use_ms_clh_repo = False
     ms_access_token = ""
     clh_guest_vm_type = ""
@@ -221,11 +220,6 @@ class CloudHypervisorTests(Tool):
         if self.use_ms_clh_repo:
             git.clone(
                 self.ms_clh_repo,
-                clone_path,
-                auth_token=self.ms_access_token,
-            )
-            git.clone(
-                self.ms_igvm_parser_repo,
                 clone_path,
                 auth_token=self.ms_access_token,
             )


### PR DESCRIPTION
We dont need to clone the IGVM PARSER repo now for MS CLH as it is getting handled with crates dependencies within CLH.