### PR TITLE
increase pytorch/CUDA space from 8GB to 16GB

### DIFF
--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -262,8 +262,8 @@ class GpuTestSuite(TestSuite):
         _install_driver(node, log_path, log)
         _check_driver_installed(node, log)
 
-        # Step 1, pytorch and CUDA needs 8GB space to download and install
-        torch_required_space = 8
+        # Step 1, pytorch/CUDA needs 8GB to download & install, increase to 16GB
+        torch_required_space = 16
         work_path = node.get_working_path_with_required_space(torch_required_space)
         use_new_path = work_path != str(node.working_path)
 


### PR DESCRIPTION
Old Ubuntu 18.04.2023031501 version has issue with 8GB disk space installation. It has been solved in 18.04.2023063001. To be safe, increase to 16GB.
