### PR TITLE
Remove mlx_compat

### DIFF
--- a/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/microsoft/testsuites/hpc/infinibandsuite.py
@@ -100,7 +100,6 @@ class InfinibandSuite(TestSuite):
             "ib_uverbs",
             "ib_core",
             "mlx5_core",
-            "mlx_compat",
             "rdma_cm",
             "iw_cm",
             "ib_cm",


### PR DESCRIPTION
No longer have mlx_compat as a required module. It is not always required depending on how HPC support was installed.