### PR TITLE
Skip cases where there is no initrd

### DIFF
--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -19,7 +19,7 @@ from lisa.operating_system import BSD, Redhat
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.sut_orchestrator.azure.tools import LisDriver
 from lisa.tools import KernelConfig, Lsinitrd, Lsmod, Modinfo, Modprobe
-from lisa.util import SkippedException
+from lisa.util import LisaException, SkippedException
 
 
 @TestSuiteMetadata(
@@ -102,9 +102,15 @@ class HvModule(TestSuite):
         #    is missing.
         lsinitrd = node.tools[Lsinitrd]
         missing_modules = []
-        for module in hv_modules_file_names:
-            if not lsinitrd.has_module(module_file_name=hv_modules_file_names[module]):
-                missing_modules.append(module)
+        try:
+            for module in hv_modules_file_names:
+                if not lsinitrd.has_module(
+                    module_file_name=hv_modules_file_names[module]
+                ):
+                    missing_modules.append(module)
+        except (LisaException, AssertionError) as e:
+            # Skip CVM images and other images with initrdless boot
+            raise SkippedException(e)
 
         if (
             isinstance(environment.platform, AzurePlatform)


### PR DESCRIPTION
Initrd is a dependency, not a failure condition, so we can skip the test case if the dependency is not met.

CVM does not have initrd so it will fail with "Could not find initrd file path". This does not mean that the modules are missing.

Ubuntu Mantic fails with "modules.dep" could not be found". The initrd might be structured differently in the new version of Ubuntu.