### PR TITLE
Add Encoding while saving kernel log for CLH testcase

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -404,7 +404,7 @@ class CloudHypervisorTests(Tool):
         else:
             dmesg_str = self.node.tools[Dmesg].get_output(force_run=True)
             dmesg_path = log_path / "dmesg"
-            with open(str(dmesg_path), "w") as f:
+            with open(str(dmesg_path), "w", encoding="utf-8") as f:
                 f.write(dmesg_str)
 
 


### PR DESCRIPTION
This will add encoding while opening file to save kernel logs under Cloud-Hypervisor testcase.

This is needed while running LISA on windows to resolve UnicodeEncodeError.