### PR TITLE
Skip OFED install failure

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -411,16 +411,19 @@ class Infiniband(Feature):
         if not self._is_legacy_device():
             extra_params += " --skip-unsupported-devices-check"
 
-        node.execute(
-            f"{self.resource_disk_path}/{ofed_folder}/mlnxofedinstall "
-            f"--add-kernel-support {extra_params} "
-            f"--tmpdir {self.resource_disk_path}/tmp",
-            expected_exit_code=0,
-            expected_exit_code_failure_message="SetupRDMA: failed to install "
-            "OFED Drivers",
-            sudo=True,
-            timeout=1200,
-        )
+        try:
+            node.execute(
+                f"{self.resource_disk_path}/{ofed_folder}/mlnxofedinstall "
+                f"--add-kernel-support {extra_params} "
+                f"--tmpdir {self.resource_disk_path}/tmp",
+                expected_exit_code=0,
+                expected_exit_code_failure_message="SetupRDMA: failed to install "
+                "OFED Drivers",
+                sudo=True,
+                timeout=1200,
+            )
+        except AssertionError as e:
+            raise MissingPackagesException(["OFED Drivers"]) from e
         node.execute(
             "/etc/init.d/openibd force-restart",
             expected_exit_code=0,

--- a/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/microsoft/testsuites/hpc/infinibandsuite.py
@@ -17,6 +17,7 @@ from lisa.sut_orchestrator.azure.tools import Waagent
 from lisa.tools import Find, KernelConfig, Ls, Modprobe, Ssh
 from lisa.util import (
     LisaException,
+    MissingPackagesException,
     SkippedException,
     UnsupportedDistroException,
     UnsupportedKernelException,
@@ -79,7 +80,11 @@ class InfinibandSuite(TestSuite):
     def verify_hpc_over_sriov(self, log: Logger, node: Node) -> None:
         try:
             infiniband = node.features[Infiniband]
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         assert_that(infiniband.is_over_sriov()).described_as(
@@ -131,7 +136,11 @@ class InfinibandSuite(TestSuite):
 
         try:
             infiniband = node.features[Infiniband]
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         if not infiniband.is_over_nd():
@@ -180,7 +189,11 @@ class InfinibandSuite(TestSuite):
                     lambda: server_node.features[Infiniband],
                 ]
             )
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         server_ib_interfaces = server_infiniband.get_ib_interfaces()
@@ -242,7 +255,11 @@ class InfinibandSuite(TestSuite):
                     lambda: server_node.features[Infiniband],
                 ]
             )
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         run_in_parallel([server_ib.install_intel_mpi, client_ib.install_intel_mpi])
@@ -332,7 +349,11 @@ class InfinibandSuite(TestSuite):
                     lambda: server_node.features[Infiniband],
                 ]
             )
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         run_in_parallel([server_ib.install_open_mpi, client_ib.install_open_mpi])
@@ -428,7 +449,11 @@ class InfinibandSuite(TestSuite):
                     lambda: server_node.features[Infiniband],
                 ]
             )
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         run_in_parallel([server_ib.install_ibm_mpi, client_ib.install_ibm_mpi])
@@ -523,7 +548,11 @@ class InfinibandSuite(TestSuite):
                     lambda: server_node.features[Infiniband],
                 ]
             )
-        except (UnsupportedDistroException, UnsupportedKernelException) as err:
+        except (
+            UnsupportedDistroException,
+            UnsupportedKernelException,
+            MissingPackagesException,
+        ) as err:
             raise SkippedException(err)
 
         run_in_parallel([server_ib.install_mvapich_mpi, client_ib.install_mvapich_mpi])


### PR DESCRIPTION
No not treat a failure to install the OFED drivers as a test case failure.