### PR TITLE
Fix conflict with AMA installed by AzSecPack

### DIFF
--- a/microsoft/testsuites/vm_extensions/AzureMonitorAgentLinux.py
+++ b/microsoft/testsuites/vm_extensions/AzureMonitorAgentLinux.py
@@ -56,7 +56,7 @@ class AzureMonitorAgentLinuxExtension(TestSuite):
             name="AzureMonitorLinuxAgent",
             publisher="Microsoft.Azure.Monitor",
             type_="AzureMonitorLinuxAgent",
-            type_handler_version="1.28",
+            type_handler_version="1.0",
             auto_upgrade_minor_version=True,
         )
 


### PR DESCRIPTION
Fix this error:

Cannot update handlerVersion or autoUpgradeMinorVersion for VM extension 'AzureMonitorLinuxAgent'. Change is in conflict with other extensions under handler 'Microsoft.Azure.Monitor.AzureMonitorLinuxAgent', with typeHandler version '1.0' and autoUpgradeMinorVersion 'True'.