### PR TITLE
Reduce ultradisk usage

### DIFF
--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -57,7 +57,7 @@ class StoragePerformance(TestSuite):
                 data_disk_type=schema.DiskType.UltraSSDLRS,
                 os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=160000),
-                data_disk_count=search_space.IntRange(min=8),
+                data_disk_count=search_space.IntRange(min=2),
             ),
         ),
     )
@@ -79,7 +79,7 @@ class StoragePerformance(TestSuite):
                 data_disk_type=schema.DiskType.UltraSSDLRS,
                 os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=160000),
-                data_disk_count=search_space.IntRange(min=8),
+                data_disk_count=search_space.IntRange(min=2),
             ),
         ),
     )


### PR DESCRIPTION
The fastest SKU right now can handle 260K IOPS. Each ultra disk can provide 160K IOPS so we should only need two.