### PR TITLE
ch_tests: Use different timeouts for perf and other suites

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -126,7 +126,7 @@ class CloudHypervisorTestSuite(TestSuite):
             Runs cloud-hypervisor performance metrics tests.
         """,
         priority=3,
-        timeout=CloudHypervisorTests.CASE_TIME_OUT,
+        timeout=CloudHypervisorTests.PERF_CASE_TIME_OUT,
     )
     def verify_cloud_hypervisor_performance_metrics_tests(
         self,

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -24,11 +24,13 @@ class CloudHypervisorTestResult:
 
 
 class CloudHypervisorTests(Tool):
-    CMD_TIME_OUT = 7200
+    CMD_TIME_OUT = 3600
     # Slightly higher case timeout to give the case a window to
     # - list subtests before running the tests.
     # - extract sub test results from stdout and report them.
-    CASE_TIME_OUT = CMD_TIME_OUT + 2400
+    CASE_TIME_OUT = CMD_TIME_OUT + 1200
+    # 2 Hrs of timeout for perf tests and 2400 seconds for other operations
+    PERF_CASE_TIME_OUT = 7200 + 2400
     PERF_CMD_TIME_OUT = 1200
 
     upstream_repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"


### PR DESCRIPTION
The testsuite runtime for CH Perf Metrics is different from CH Integration, LiveMigration. Hence, use separate timeout variables. Also, reduce Integration/LiveMigration testsuite timeout to 3600.