### PR TITLE
tools/ls: remove extraneous back tick in WindowsLs

### DIFF
--- a/lisa/tools/ls.py
+++ b/lisa/tools/ls.py
@@ -99,7 +99,7 @@ class WindowsLs(Ls):
         return output.strip() == "True"
 
     def list(self, path: str, sudo: bool = False) -> List[str]:
-        command = f'Get-ChildItem -Path "{path}" `| Select-Object -ExpandProperty Name'
+        command = f'Get-ChildItem -Path "{path}" | Select-Object -ExpandProperty Name'
         output = self.node.tools[PowerShell].run_cmdlet(
             cmdlet=command,
             force_run=True,


### PR DESCRIPTION
Extraneous \` (back tick) causes error while using this tool.
Error: `Get-ChildItem: A positional parameter cannot be found that accepts argument 'Select-Object'.`