### PR TITLE
Consume bindigs.rs for MSHV ioctl/bindings test

### DIFF
--- a/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
+++ b/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import re
-from pathlib import Path
-from typing import Any
+from pathlib import Path, PurePath
+from typing import Any, Dict
 
 from assertpy.assertpy import assert_that
 
@@ -10,7 +10,7 @@ from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.operating_system import BSD, Windows
 from lisa.testsuite import TestResult
-from lisa.tools import Cargo, Git, Ls
+from lisa.tools import Cargo, Git, Ls, RemoteCopy
 from lisa.util import SkippedException
 from lisa.util.process import ExecutableResult
 
@@ -46,10 +46,19 @@ class RustVmmTestSuite(TestSuite):
         node: Node,
         log_path: Path,
         result: TestResult,
+        variables: Dict[str, Any],
     ) -> None:
         repo = "https://github.com/rust-vmm/mshv.git"
         git = node.tools[Git]
         repo_root = git.clone(repo, node.get_working_path())
+        mshv_bindings_path = variables.get("mshv_bindings_path", "")
+        if mshv_bindings_path:
+            git_bindings_path = repo_root / "mshv-bindings" / "src"
+            rcp = node.tools[RemoteCopy]
+            rcp.copy_to_remote(
+                src=PurePath(mshv_bindings_path),
+                dest=git_bindings_path,
+            )
         testcase_log = log_path / "rust_vmm_mshv.log"
         cargo = node.tools[Cargo]
         test_result: ExecutableResult = cargo.test(cwd=repo_root, sudo=True)


### PR DESCRIPTION
This will consume bindings.rs file if provided
before running the test, otherwise it will run
with upstream bindings.rs file.