### PR TITLE
Use shipped hypervisor-fw/OVMF-fw for Cloud-Hypervisor Tests

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -182,10 +182,12 @@ class CloudHypervisorTestSuite(TestSuite):
         # Get GUEST VM type, set default to NON-CVM
         clh_guest_vm_type = variables.get("clh_guest_vm_type", "NON-CVM")
 
-        # Check if MS Guest kernel need to be used
-        # Dom0 VHD is shipped with it now
-        # Default, we will use upstream guest kernel only
+        # Check if MS Guest kernel/hypervisor-fw/OVMF-fw need to be used
+        # Dom0 VHD is shipped with those binaries now
+        # Default, we will use upstream CLH binaries only
         use_ms_guest_kernel = variables.get("use_ms_guest_kernel", "NO")
+        use_ms_hypervisor_fw = variables.get("use_ms_hypervisor_fw", "NO")
+        use_ms_ovmf_fw = variables.get("use_ms_ovmf_fw", "NO")
 
         if not ms_access_token:
             raise SkippedException("Access Token is needed while using MS-CLH")
@@ -198,6 +200,10 @@ class CloudHypervisorTestSuite(TestSuite):
         CloudHypervisorTests.clh_guest_vm_type = clh_guest_vm_type
         if use_ms_guest_kernel == "YES":
             CloudHypervisorTests.use_ms_guest_kernel = use_ms_guest_kernel
+        if use_ms_hypervisor_fw == "YES":
+            CloudHypervisorTests.use_ms_hypervisor_fw = use_ms_hypervisor_fw
+        if use_ms_ovmf_fw == "YES":
+            CloudHypervisorTests.use_ms_ovmf_fw = use_ms_ovmf_fw
 
 
 def get_test_list(variables: Dict[str, Any], var1: str, var2: str) -> Any:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -43,6 +43,8 @@ class CloudHypervisorTests(Tool):
     ms_access_token = ""
     clh_guest_vm_type = ""
     use_ms_guest_kernel = ""
+    use_ms_hypervisor_fw = ""
+    use_ms_ovmf_fw = ""
 
     cmd_path: PurePath
     repo_root: PurePath
@@ -228,6 +230,10 @@ class CloudHypervisorTests(Tool):
             self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
             if self.use_ms_guest_kernel:
                 self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
+            if self.use_ms_hypervisor_fw:
+                self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
+            if self.use_ms_ovmf_fw:
+                self.env_vars["USE_MS_OVMF_FW"] = self.use_ms_ovmf_fw
         else:
             git.clone(self.upstream_repo, clone_path)
 


### PR DESCRIPTION
This commit contains changes to use custom binaries for cloud-hypervisor tests when needed.

We will set appropriate env vars for it and cloud-hypervisor will decide which binaries (upstream/custom) need to be uses.