### PR TITLE
Deploy VM in TiP with Availability_Type None

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1184,6 +1184,13 @@ class AzurePlatform(Platform):
             )
         arm_parameters.admin_password = self.runbook.admin_password
 
+        # TipNode.SessionId is defined under vm_tags for availability_type none
+        # but it conflicts with the tags defined under availability_set_tags
+        if (
+            arm_parameters.availability_options.availability_type
+            != constants.AVAILABILITY_NONE
+        ):
+            arm_parameters.vm_tags.pop("TipNode.SessionId", None)
         environment_context = get_environment_context(environment=environment)
         arm_parameters.vm_tags["RG"] = environment_context.resource_group_name
 


### PR DESCRIPTION
To Deploy VM in TiP with Availability_type None requires TipNode.SessionId to be defined in vm_tags.
This tag however has to be removed in case of availability set deployment.