### PR TITLE
Disable Cloud Components: install_packages

### DIFF
--- a/lisa/mixin_modules.py
+++ b/lisa/mixin_modules.py
@@ -68,6 +68,7 @@ import lisa.transformers.dump_variables  # noqa: F401
 import lisa.transformers.file_uploader  # noqa: F401
 import lisa.transformers.kernel_source_installer  # noqa: F401
 import lisa.transformers.package_installer  # noqa: F401
+import lisa.transformers.repo_package_installer  # noqa: F401
 import lisa.transformers.rpm_kernel_installer  # noqa: F401
 import lisa.transformers.script_transformer  # noqa: F401
 import lisa.transformers.to_list  # noqa: F401

--- a/lisa/transformers/repo_package_installer.py
+++ b/lisa/transformers/repo_package_installer.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Type
+
+from dataclasses_json import dataclass_json
+
+from lisa import schema
+from lisa.operating_system import Posix
+from lisa.transformers.deployment_transformer import (
+    DeploymentTransformer,
+    DeploymentTransformerSchema,
+)
+
+
+@dataclass_json()
+@dataclass
+class RepoPackageInstallerTransformerSchema(DeploymentTransformerSchema):
+    install_packages: List[str] = field(default_factory=list)
+
+
+class RepoPackageInstallerTransformer(DeploymentTransformer):
+    """
+    This Transformer installs packages from a repository.
+    """
+
+    @classmethod
+    def type_name(cls) -> str:
+        return "install_repo_packages"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return RepoPackageInstallerTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: RepoPackageInstallerTransformerSchema = self.runbook
+        assert isinstance(runbook, RepoPackageInstallerTransformerSchema)
+        node = self._node
+
+        # Only Posix has install_packages method
+        if not isinstance(node.os, Posix):
+            raise NotImplementedError(
+                "RepoPackageInstallerTransformer is not "
+                f"supported on {node.os.__class__.__name__}"
+            )
+
+        if runbook.install_packages and any(runbook.install_packages):
+            node.os.install_packages(runbook.install_packages)
+        else:
+            self._log.debug(
+                "No packages are specified in the runbook, nothing to install."
+            )
+
+        return {}


### PR DESCRIPTION
Different lab testing environments have different package dependencies for the OS. This will allow packages to be installed as part of the process to prepare the OS for lab environment.