### PR TITLE
update pillow to 10.2.0 to fix vul

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ azure = [
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
     "requests",
-    "Pillow ~= 10.0.1",
+    "Pillow ~= 10.2.0",
     "PyGObject ~= 3.42.0; platform_system == 'Linux'",
 ]
 


### PR DESCRIPTION
This should be where the vulnerability from

```
#17 27.17 Collecting Pillow~=10.0.1 (from lisa==20240219.1)
#17 27.18   Downloading Pillow-10.0.1-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (9.5 kB)
```