### PR TITLE
Add no_redundancy_vm_tags to Azure Platform

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -695,6 +695,7 @@ class AvailabilityArmParameter:
     availability_set_tags: Dict[str, str] = field(default_factory=dict)
     availability_set_properties: Dict[str, Any] = field(default_factory=dict)
     availability_zones: List[int] = field(default_factory=list)
+    no_redundancy_vm_tags: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass_json()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2408,10 +2408,13 @@ class Availability(AzureFeatureMixin, features.Availability):
                 else AvailabilityType.NoRedundancy
             )
 
+        if params.availability_type == AvailabilityType.NoRedundancy:
+            arm_parameters.vm_tags.update(params.no_redundancy_vm_tags)
         # Once the availability type has been determined, clear the unecessary
         # fields for clarity
         if params.availability_type == AvailabilityType.AvailabilitySet:
             params.availability_zones.clear()
+            params.no_redundancy_vm_tags.clear()
         elif params.availability_type == AvailabilityType.AvailabilityZone:
             assert (
                 params.availability_zones
@@ -2419,6 +2422,7 @@ class Availability(AzureFeatureMixin, features.Availability):
             params.availability_zones = [params.availability_zones[0]]
             params.availability_set_tags.clear()
             params.availability_set_properties.clear()
+            params.no_redundancy_vm_tags.clear()
         else:
             params.availability_set_tags.clear()
             params.availability_set_properties.clear()

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -289,6 +289,7 @@ class AzurePlatformSchema:
         default=None
     )
     availability_set_tags: Optional[Dict[str, str]] = field(default=None)
+    no_redundancy_vm_tags: Optional[Dict[str, str]] = field(default=None)
     availability_set_properties: Optional[Dict[str, Any]] = field(default=None)
     availability_zones: Optional[List[int]] = field(default=None)
     availability_type: str = field(
@@ -1165,6 +1166,7 @@ class AzurePlatform(Platform):
             "availability_set_properties",
             "availability_zones",
             "availability_type",
+            "no_redundancy_vm_tags",
         ]
         set_filtered_fields(self._azure_runbook, arm_parameters, copied_fields)
         set_filtered_fields(


### PR DESCRIPTION
Add no_redundancy_vm_tags to add VM tags when availability_type is set as none in Azure platform