### PR TITLE
XDPdump change llvm version change to 18

### DIFF
--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -57,7 +57,7 @@ class XdpDump(Tool):
             if self.node.os.information.version < "18.4.0":
                 raise UnsupportedDistroException(self.node.os)
             else:
-                toolchain = f"llvm-toolchain-{self.node.os.information.codename}-15"
+                toolchain = f"llvm-toolchain-{self.node.os.information.codename}-18"
 
             self.node.os.add_repository(
                 repo=(


### PR DESCRIPTION
llvm-toolchain-mantic-15 no more exists.
18 exists for bionic and upwards.

This change is tested with:
canonical 0001-com-ubuntu-server-mantic 23_10-gen2 23.10.202403010
Canonical 0001-com-ubuntu-server-lunar 23_04-gen2 23.04.202401160
Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 22.04.202403010
Canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 20.04.202402290
Canonical 0001-com-ubuntu-pro-bionic pro-18_04-lts-gen2 18.04.202403010