### PR TITLE
Added unsupported OS requirement to verify_ringbuffer_settings_change

### DIFF
--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -91,6 +91,9 @@ class NetworkSettings(TestSuite):
 
         """,
         priority=1,
+        requirement=simple_requirement(
+            unsupported_os=[BSD],
+        ),
     )
     def verify_ringbuffer_settings_change(self, node: Node) -> None:
         ethtool = node.tools[Ethtool]

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -92,7 +92,7 @@ class NetworkSettings(TestSuite):
         """,
         priority=1,
         requirement=simple_requirement(
-            unsupported_os=[BSD],
+            unsupported_os=[BSD, Windows],
         ),
     )
     def verify_ringbuffer_settings_change(self, node: Node) -> None:


### PR DESCRIPTION
This test case should be skipped as FreeBSD does not support modifying ringbuffer sizes like in this test.