### PR TITLE
Use apt-get to install mock

### DIFF
--- a/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
+++ b/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
@@ -19,6 +19,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
+from lisa.operating_system import Debian
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
     AzureNodeSchema,
@@ -144,10 +145,16 @@ class VmSnapsotLinuxBVTExtension(TestSuite):
                     break
 
         # installing all the required packages
-        # install python3 and pip
+        # install python3
         python = node.tools[Python]
-        pip = node.tools[Pip]
-        pip.install_packages("mock")
+        if isinstance(node.os, Debian):
+            package_name = "python3-mock"
+            node.os.install_packages(package_name)
+        else:
+            # install pip
+            pip = node.tools[Pip]
+            pip.install_packages("mock")
+
         # copy the file into the vm
         self._copy_to_node(node, "handle.txt")
         assert extension_dir, "Unable to find the extension directory."


### PR DESCRIPTION
This PR has fix for the test bug: 
Bug 49422312: [Quality][Guest] ubuntu 23_10 verify_exclude_disk_support_restore_point test fails with error "fail to install mock"

This change has been tested with the following list of images:
canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 20.04.202401291
canonical 0001-com-ubuntu-server-mantic 23_10-gen2 23.10.202402060
canonical ubuntuserver 18_04-lts-gen2 18.04.202401161
debian debian-12 12 0.20240102.1614
suse sles-12-sp5 gen1 2024.01.25