### PR TITLE
Add more roles related with gallery image for AITL

### DIFF
--- a/microsoft/utils/setup_aitl.py
+++ b/microsoft/utils/setup_aitl.py
@@ -220,8 +220,13 @@ def _set_target_role_parameters(
         "Microsoft.Compute/disks/delete",
         "Microsoft.Compute/images/read",
         "Microsoft.Compute/images/write",
+        # for testing ARM64 VHD and gallery image
         "Microsoft.Compute/galleries/images/read",
         "Microsoft.Compute/galleries/images/write",
+        "Microsoft.Compute/galleries/images/versions/read",
+        "Microsoft.Compute/galleries/images/versions/write",
+        "Microsoft.Compute/galleries/read",
+        "Microsoft.Compute/galleries/write",
         # for test VM extension running
         "Microsoft.Compute/virtualMachines/extensions/read",
         "Microsoft.Compute/virtualMachines/extensions/write",


### PR DESCRIPTION
I met the following errors when testing SIG transformer in AITL. Adding these roles in setup_aitl.py, and rerun setup_aitl.py. The errors have disappeared.

lisa.util.LisaException: (AuthorizationFailed) The client '' with object id '' does not have authorization to perform action '**Microsoft.Compute/galleries/read**' over scope '/subscriptions//resourceGroups/lisa_shared_resource/providers/Microsoft.Compute/galleries/aitl_gallery' or the scope is invalid. If access was recently granted, please refresh your credentials.



Message: The client '' with object id '' does not have authorization to perform action '**Microsoft.Compute/galleries/images/versions/read**' over scope '/subscriptions//resourceGroups/lisa_shared_resource/providers/Microsoft.Compute/galleries/aitl_gallery/images/aitl_test_balu_20240314003/