### PR TITLE
Capture and log exceptions when there is an error reading serial console logs

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -667,7 +667,12 @@ class TestSuite:
             )
 
             if case_result.status == TestStatus.FAILED:
-                self.__save_serial_log(environment, case_log_path)
+                try:
+                    self.__save_serial_log(environment, case_log_path)
+                except Exception as e:
+                    suite_log.debug(
+                        f"exception thrown during serial console log read. [{e}]"
+                    )
 
             case_log.info(
                 f"result: {case_result.status.name}, " f"elapsed: {total_timer}"


### PR DESCRIPTION
This PR adds a try/except when reading serial console logs and logs the exception, so that the LISA tasks are not cancelled. 