### PR TITLE
Upgrade paramiko

### DIFF
--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, c
 
 import paramiko
 import spur  # type: ignore
-import spurplus  # type: ignore
+import spurplus
 from func_timeout import FunctionTimedOut, func_set_timeout  # type: ignore
 from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "assertpy ~= 1.1",
     "func-timeout ~= 4.3.5",
     "dataclasses-json ~= 0.5.2",
-    "paramiko ~= 2.12.0",
+    "paramiko ~= 3.4.0",
     "pluggy ~= 0.13.1",
     "python-dateutil ~= 2.8.1",
     "pytest-html ~= 3.2.0",
@@ -24,7 +24,7 @@ dependencies = [
     "retry ~= 0.9.2",
     "semver ~= 2.13.0",
     "simpleeval ~= 0.9.12",
-    "spurplus ~= 2.3.4",
+    "spurplus ~= 2.3.5",
     "websockets ~= 10.3",
     "charset_normalizer ~= 2.1.1",
 ]


### PR DESCRIPTION
The new version paramiko is not supported by latest spurplus on versions, but the functionality works. So force install spurplus to work around the version conflicts.