### PR TITLE
mariner 3.0: fix compile issue for xdpdump

### DIFF
--- a/microsoft/testsuites/xdp/xdpdump.py
+++ b/microsoft/testsuites/xdp/xdpdump.py
@@ -89,6 +89,18 @@ class XdpDump(Tool):
         ).is_equal_to(self._code_path.parent)
         git.init_submodules(cwd=self._code_path)
 
+        # This workaround addresses a discrepancy in the bpf_perf_event_read_simple
+        # function declaration and definition detected by the latest version of
+        # the clang C compiler. Specifically, the return value is incorrectly specified
+        # as an int in the .h file but as an enum in the C file.
+        sed = self.node.tools[Sed]
+        sed.substitute(
+            "LIBBPF_API int bpf_perf_event_read_simple",
+            "LIBBPF_API enum bpf_perf_event_ret bpf_perf_event_read_simple",
+            f"{self._code_path.parent}/libbpf/src/libbpf.h",
+            sudo=True,
+        )
+
         # create a default version for exists checking.
         make = self.node.tools[Make]
         make.make(


### PR DESCRIPTION
I have tested on mariner 2.0, 3.0 and ubuntu 20.04. no regression issue.