### PR TITLE
fix ssh key id_rsa.pub not found

### DIFF
--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -26,7 +26,7 @@ class Ssh(Tool):
             if self.node.shell.exists(file_path):
                 self.node.shell.remove(file_path)
         self.node.execute(
-            "echo | ssh-keygen -N ''",
+            "echo | ssh-keygen -t rsa -N ''",
             shell=True,
             expected_exit_code=0,
             expected_exit_code_failure_message="error on generate key files.",


### PR DESCRIPTION
In mariner 3.0, by default `ssh-keygen` command uses ed25519 algorithm to generate ssh key files. This fixes the issue by specifying the algorithm used during keygen command, as some lisa tests expects rsa key files (e.g id_rsa.pub) to be present in the `~/.ssh` directory. 