### PR TITLE
Include templog in LisaException message for Wget

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -79,6 +79,7 @@ class Wget(Tool):
                 f"cannot find file path in stdout of '{command}', it may be caused "
                 " due to failed download or pattern mismatch."
                 f" stdout: {command_result.stdout}"
+                f" templog: {temp_log}"
             )
         actual_file_path = self.node.execute(
             f"ls {download_file_path}",


### PR DESCRIPTION
The testcase verify_hpc_over_sriov calls Infiniband's method install_ofed() which in turn calls Wget's method get().

install_ofed() looks for "404: Not Found." error and if that string is present in the Exception message, it goes ahead and skips the testcase by raising UnsupportedDistroException. However the "404: Not Found." string is captured in the temp_log variable which was not being passed when LisaException was raised in the get() method of Wget and that's why the testcase got failed instead of getting skipped

As part of this PR, I have included temp_log as well, because install_ofed() is designed to look for that error which is in temp_log variable

This change is tested with:
redhat rhel 9_3 9.3.2024022812
redhat rhel 90-gen2 9.0.2024021412
oracle oracle-linux ol93-lvm 9.3.2
suse sles-15-sp5 gen1 2024.02.07
