### PR TITLE
feat: Implement mshv_install test to verify Linux Dom0 boot against fresh Hyper-V bins

### DIFF
--- a/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
+++ b/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
@@ -45,3 +45,9 @@ class CloudHypervisor(Tool):
             shell=True,
             sudo=sudo,
         )
+
+    def save_dmesg_logs(self, node: Node, log_path: Path) -> None:
+        dmesg_str = node.tools[Dmesg].get_output()
+        dmesg_path = log_path / "dmesg"
+        with open(str(dmesg_path), "w", encoding="utf-8") as f:
+            f.write(dmesg_str)

--- a/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
+++ b/microsoft/testsuites/mshv/cloud_hypervisor_tool.py
@@ -2,8 +2,11 @@
 # Licensed under the MIT license.
 
 import secrets
+from pathlib import Path
 
+from lisa import Node
 from lisa.executable import Tool
+from lisa.tools import Dmesg
 from lisa.util.process import Process
 
 

--- a/microsoft/testsuites/mshv/mshv_install.py
+++ b/microsoft/testsuites/mshv/mshv_install.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
-from lisa.testsuite import TestResult
 from lisa.tools import Cp, Ls, Reboot
 from lisa.util import SkippedException
 from microsoft.testsuites.mshv.cloud_hypervisor_tool import CloudHypervisor

--- a/microsoft/testsuites/mshv/mshv_install.py
+++ b/microsoft/testsuites/mshv/mshv_install.py
@@ -1,68 +1,58 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import os
-import re
 from pathlib import Path
 from typing import Any, Dict
 
-import time
-
-from assertpy import assert_that
-
-from lisa import (
-    Environment,
-    Logger,
-    Node,
-    TestCaseMetadata,
-    TestSuite,
-    TestSuiteMetadata
-)
-# from lisa.features import SerialConsole
+from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.testsuite import TestResult
-from lisa.tools import Cp, Dmesg, Ls, Reboot
+from lisa.tools import Cp, Ls, Reboot
+from lisa.util import SkippedException
+
 
 @TestSuiteMetadata(
     area="mshv",
     category="functional",
     description="""
-    This test suite is to test VM working well after updating MSHV on VM and rebooting.
+    This test suite is to test VM working well after updating MSHV on VM
+    and rebooting.
     """,
 )
 class MshvHostInstallSuite(TestSuite):
     CONFIG_BINPATH = "mshv_binpath"
 
     _test_path_init_hvix = (
-        Path("/home/cloud") / f"hvix64.exe"
+        Path("/home/cloud") / "hvix64.exe"
     )
 
     _init_path_init_kdstub = (
-        Path("/home/cloud") / f"kdstub.dll"
+        Path("/home/cloud") / "kdstub.dll"
     )
 
     _init_path_init_lxhvloader = (
-        Path("/home/cloud") / f"lxhvloader.dll"
+        Path("/home/cloud") / "lxhvloader.dll"
     )
 
     _test_path_dst_hvix = (
-        Path("/boot/efi/Windows/System32") / f"hvix64.exe"
+        Path("/boot/efi/Windows/System32") / "hvix64.exe"
     )
 
     _test_path_dst_kdstub = (
-        Path("/boot/efi/Windows/System32") / f"kdstub.dll"
+        Path("/boot/efi/Windows/System32") / "kdstub.dll"
     )
 
     _test_path_dst_lxhvloader = (
-        Path("/boot/efi") / f"lxhvloader.dll"
+        Path("/boot/efi") / "lxhvloader.dll"
     )
 
     @TestCaseMetadata(
         description="""
         This test case will
-        1. Update to new MSHV components over old ones in a pre-configured MSHV image
+        1. Update to new MSHV components over old ones in a
+            pre-configured MSHV image
         2. Reboot VM, check that mshv comes up
 
-        The test expects the MSHV binaries to be installed to be placed under lisa/microsoft/testsuites/mshv/test_data
-        before lisa is executed.
+        The test expects the directory containing MSHV binaries to be passed in
+        the mshv_binpath variable.
         """,
         timeout=120,
     )
@@ -75,25 +65,33 @@ class MshvHostInstallSuite(TestSuite):
         result: TestResult,
     ) -> None:
         binpath = variables.get(self.CONFIG_BINPATH, "")
-        test_hvix_file_path = Path(binpath) / f"hvix64.exe"
-        test_kdstub_file_path = Path(binpath) / f"kdstub.dll"
-        test_lxhvloader_file_path = Path(binpath) / f"lxhvloader.dll"
+        if not binpath:
+            raise SkippedException(
+                "Requires a path to MSHV binaries to be passed via mshv_binpath"
+            )
+
+        test_hvix_file_path = Path(binpath) / "hvix64.exe"
+        test_kdstub_file_path = Path(binpath) / "kdstub.dll"
+        test_lxhvloader_file_path = Path(binpath) / "lxhvloader.dll"
 
         log.info(f"binpath: {binpath}")
 
         # Copy Hvix64.exe, kdstub.dll, lxhvloader.dll into test machine
         node.shell.copy(test_hvix_file_path, self._test_path_init_hvix)
-        node.tools[Cp].copy(self._test_path_init_hvix.as_posix(), self._test_path_dst_hvix.as_posix(), sudo=True)
+        node.tools[Cp].copy(self._test_path_init_hvix,
+                            self._test_path_dst_hvix, sudo=True)
 
         node.shell.copy(test_kdstub_file_path, self._init_path_init_kdstub)
-        node.tools[Cp].copy(self._init_path_init_kdstub.as_posix(), self._test_path_dst_kdstub.as_posix(), sudo=True)
-        
+        node.tools[Cp].copy(self._init_path_init_kdstub,
+                            self._test_path_dst_kdstub, sudo=True)
+
         node.shell.copy(test_lxhvloader_file_path, self._init_path_init_lxhvloader)
-        node.tools[Cp].copy(self._init_path_init_lxhvloader.as_posix(), self._test_path_dst_lxhvloader.as_posix(), sudo=True)
+        node.tools[Cp].copy(self._init_path_init_lxhvloader,
+                            self._test_path_dst_lxhvloader, sudo=True)
 
         reboot_tool = node.tools[Reboot]
         reboot_tool.reboot_and_check_panic(log_path)
 
         # 2. check that mshv comes up
-        mshvUp = node.tools[Ls].path_exists("/dev/mshv", sudo=True)
-        assert mshvUp
+        mshv = node.tools[Ls].path_exists("/dev/mshv", sudo=True)
+        assert mshv

--- a/microsoft/testsuites/mshv/mshv_install.py
+++ b/microsoft/testsuites/mshv/mshv_install.py
@@ -63,24 +63,21 @@ class MshvHostInstallSuite(TestSuite):
         log.info(f"binpath: {binpath}")
 
         # Copy Hvix64.exe, kdstub.dll, lxhvloader.dll into test machine
+        copy_tool = node.tools[Cp]
         node.shell.copy(test_hvix_file_path, self._test_path_init_hvix)
-        node.tools[Cp].copy(
-            self._test_path_init_hvix, self._test_path_dst_hvix, sudo=True
-        )
+        copy_tool.copy(self._test_path_init_hvix, self._test_path_dst_hvix, sudo=True)
 
         node.shell.copy(test_kdstub_file_path, self._init_path_init_kdstub)
-        node.tools[Cp].copy(
+        copy_tool.copy(
             self._init_path_init_kdstub, self._test_path_dst_kdstub, sudo=True
         )
 
         node.shell.copy(test_lxhvloader_file_path, self._init_path_init_lxhvloader)
-        node.tools[Cp].copy(
+        copy_tool.copy(
             self._init_path_init_lxhvloader, self._test_path_dst_lxhvloader, sudo=True
         )
 
-        reboot_tool = node.tools[Reboot]
-        reboot_tool.reboot_and_check_panic(log_path)
-
+        node.tools[Reboot].reboot_and_check_panic(log_path)
         node.tools[CloudHypervisor].save_dmesg_logs(node, log_path)
 
         # 2. check that mshv comes up

--- a/microsoft/testsuites/mshv/mshv_install.py
+++ b/microsoft/testsuites/mshv/mshv_install.py
@@ -1,0 +1,129 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+from assertpy import assert_that
+
+from lisa import (
+    Environment,
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+# from lisa.features import SerialConsole
+from lisa.testsuite import TestResult
+from lisa.tools import Dmesg, Ls, Service, Reboot
+from lisa.util import SkippedException, TcpConnectionException, constants
+from lisa.util.shell import wait_tcp_port_ready
+
+
+@TestSuiteMetadata(
+    area="mshv",
+    category="functional",
+    description="""
+    This test suite is to test VM working well after updating MSHV on VM and rebooting.
+    """,
+)
+class MshvHostInstallSuite(TestSuite):
+
+    _test_hvix_file_path = (
+        Path(os.path.dirname(__file__)) / "test_data" / f"hvix64.exe"
+    )
+
+    _test_hvix_file_path_dst = (
+        Path("/boot/efi/Windows/System32") / f"hvix64.exe"
+    )
+
+    _test_kdstub_file_path = (
+        Path(os.path.dirname(__file__)) / "test_data" / f"kdstub.dll"
+    )
+
+    _test_kdstub_file_path_dst = (
+        Path("/boot/efi/Windows/System32") / f"kdstub.dll"
+    )
+
+    _test_lxhvloader_file_path = (
+        Path(os.path.dirname(__file__)) / "test_data" / f"lxhvloader.dll"
+    )
+
+    _test_lxhvloader_file_path_dst = (
+        Path("/boot/efi") / f"lxhvloader.dll"
+    )
+
+    _init_path_dst = (
+        Path("/home/cloud")
+    )
+
+    @TestCaseMetadata(
+        description="""
+        This test case will
+        1. Update to new MSHV components over old ones in a pre-configured MSHV image
+        2. Reboot VM, check that mshv comes up
+
+        The test expects the MSHV binaries to be installed to be placed under lisa/microsoft/testsuites/mshv/test_data
+        before lisa is executed.
+        """,
+        priority=0,
+        timeout=60,  # 60 seconds
+    )
+    def verify_mshv_install_succeeds(
+        self,
+        log: Logger,
+        node: Node,
+        log_path: Path,
+        result: TestResult,
+    ) -> None:
+        # Copy Hvix64.exe, kdstub.dll, lxhvloader.dll into test machine
+        hvix_path = self._init_path_dst / f"hvix64.exe"
+        node.shell.copy(self._test_hvix_file_path, hvix_path)
+        res = node.shell.spawn(
+            command=['sudo', 'cp', hvix_path.as_posix(), self._test_hvix_file_path_dst.as_posix()],
+            allow_error=False,
+        ).wait_for_result()
+        log.info(f"sudo cp result {res.return_code}")
+
+        assert res.return_code == 0
+
+        # kdstub_path = self._init_path_dst / f"kdstub.dll"
+        # node.shell.copy(self._test_kdstub_file_path, kdstub_path)
+        # res = node.shell.spawn(
+        #     command=['sudo', 'cp', kdstub_path.as_posix(), self._test_hvix_file_path_dst.as_posix()],
+        #     allow_error=False,
+        # ).wait_for_result()
+        # assert res.return_code == 0
+        
+        lxhvloader_path = self._init_path_dst / f"lxhvloader.dll"
+        node.shell.copy(self._test_lxhvloader_file_path, lxhvloader_path)
+        res = node.shell.spawn(
+            command=['sudo', 'cp', lxhvloader_path.as_posix(), self._test_lxhvloader_file_path_dst.as_posix()],
+            allow_error=False,
+        ).wait_for_result()
+        assert res.return_code == 0
+
+        reboot_tool = node.tools[Reboot]
+        reboot_tool.reboot_and_check_panic(log_path)
+
+        is_ready, tcp_error_code = wait_tcp_port_ready(
+            node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS],
+            node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_PORT],
+            log=log,
+        )
+
+        if is_ready:
+            # 2. check that mshv comes up
+            mshvUp = node.tools[Ls].path_exists("/dev/mshv", sudo=True)
+            assert mshvUp
+        else:
+            raise TcpConnectionException(
+                node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS],
+                node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_PORT],
+                tcp_error_code,
+                "no panic found in serial log",
+            )
+        return

--- a/microsoft/testsuites/mshv/mshv_install.py
+++ b/microsoft/testsuites/mshv/mshv_install.py
@@ -20,29 +20,17 @@ from lisa.util import SkippedException
 class MshvHostInstallSuite(TestSuite):
     CONFIG_BINPATH = "mshv_binpath"
 
-    _test_path_init_hvix = (
-        Path("/home/cloud") / "hvix64.exe"
-    )
+    _test_path_init_hvix = Path("/home/cloud") / "hvix64.exe"
 
-    _init_path_init_kdstub = (
-        Path("/home/cloud") / "kdstub.dll"
-    )
+    _init_path_init_kdstub = Path("/home/cloud") / "kdstub.dll"
 
-    _init_path_init_lxhvloader = (
-        Path("/home/cloud") / "lxhvloader.dll"
-    )
+    _init_path_init_lxhvloader = Path("/home/cloud") / "lxhvloader.dll"
 
-    _test_path_dst_hvix = (
-        Path("/boot/efi/Windows/System32") / "hvix64.exe"
-    )
+    _test_path_dst_hvix = Path("/boot/efi/Windows/System32") / "hvix64.exe"
 
-    _test_path_dst_kdstub = (
-        Path("/boot/efi/Windows/System32") / "kdstub.dll"
-    )
+    _test_path_dst_kdstub = Path("/boot/efi/Windows/System32") / "kdstub.dll"
 
-    _test_path_dst_lxhvloader = (
-        Path("/boot/efi") / "lxhvloader.dll"
-    )
+    _test_path_dst_lxhvloader = Path("/boot/efi") / "lxhvloader.dll"
 
     @TestCaseMetadata(
         description="""
@@ -78,16 +66,19 @@ class MshvHostInstallSuite(TestSuite):
 
         # Copy Hvix64.exe, kdstub.dll, lxhvloader.dll into test machine
         node.shell.copy(test_hvix_file_path, self._test_path_init_hvix)
-        node.tools[Cp].copy(self._test_path_init_hvix,
-                            self._test_path_dst_hvix, sudo=True)
+        node.tools[Cp].copy(
+            self._test_path_init_hvix, self._test_path_dst_hvix, sudo=True
+        )
 
         node.shell.copy(test_kdstub_file_path, self._init_path_init_kdstub)
-        node.tools[Cp].copy(self._init_path_init_kdstub,
-                            self._test_path_dst_kdstub, sudo=True)
+        node.tools[Cp].copy(
+            self._init_path_init_kdstub, self._test_path_dst_kdstub, sudo=True
+        )
 
         node.shell.copy(test_lxhvloader_file_path, self._init_path_init_lxhvloader)
-        node.tools[Cp].copy(self._init_path_init_lxhvloader,
-                            self._test_path_dst_lxhvloader, sudo=True)
+        node.tools[Cp].copy(
+            self._init_path_init_lxhvloader, self._test_path_dst_lxhvloader, sudo=True
+        )
 
         reboot_tool = node.tools[Reboot]
         reboot_tool.reboot_and_check_panic(log_path)

--- a/microsoft/testsuites/mshv/mshv_root_stress_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_stress_tests.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.testsuite import TestResult
-from lisa.tools import Cp, Dmesg, Free, Ls, Lscpu, QemuImg, Rm, Ssh, Usermod, Wget
+from lisa.tools import Cp, Free, Ls, Lscpu, QemuImg, Rm, Ssh, Usermod, Wget
 from lisa.util import SkippedException
 from microsoft.testsuites.mshv.cloud_hypervisor_tool import CloudHypervisor
 

--- a/microsoft/testsuites/mshv/mshv_root_stress_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_stress_tests.py
@@ -120,7 +120,7 @@ class MshvHostStressTestSuite(TestSuite):
                     test_status=TestStatus.FAILED,
                     test_message=repr(e),
                 )
-        self._save_dmesg_logs(node, log_path)
+        node.tools[CloudHypervisor].save_dmesg_logs(node, log_path)
         assert_that(failures).is_equal_to(0)
         return
 
@@ -221,9 +221,3 @@ class MshvHostStressTestSuite(TestSuite):
             return PurePath("/mnt")
         else:
             return node.working_path
-
-    def _save_dmesg_logs(self, node: Node, log_path: Path) -> None:
-        dmesg_str = node.tools[Dmesg].get_output()
-        dmesg_path = log_path / "dmesg"
-        with open(str(dmesg_path), "w", encoding="utf-8") as f:
-            f.write(dmesg_str)

--- a/microsoft/testsuites/mshv/test_data/README.md
+++ b/microsoft/testsuites/mshv/test_data/README.md
@@ -1,0 +1,7 @@
+To execute this testsuite, one must provide the set of MSHV binaries to test. 
+
+The set of required binaries are:
+
+- hvix64.exe  --> maps to /boot/efi/Windows/System32/hvix64.exe on node
+- kdstub.dll  --> maps to /boot/efi/Windows/System32/kdstub.dll on node
+- lxhvloader.dll  --> maps to /boot/efi/lxhvloader.dll on node

--- a/microsoft/testsuites/mshv/test_data/README.md
+++ b/microsoft/testsuites/mshv/test_data/README.md
@@ -1,7 +1,0 @@
-To execute this testsuite, one must provide the set of MSHV binaries to test. 
-
-The set of required binaries are:
-
-- hvix64.exe  --> maps to /boot/efi/Windows/System32/hvix64.exe on node
-- kdstub.dll  --> maps to /boot/efi/Windows/System32/kdstub.dll on node
-- lxhvloader.dll  --> maps to /boot/efi/lxhvloader.dll on node


### PR DESCRIPTION
Add Linux Dom0 boot smoketest to verify a set of Hyper-V binaries against Linux, the linux-mshv driver. 