### PR TITLE
virtstack: Add parameter for cache to run CLH block per test

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -189,6 +189,15 @@ class CloudHypervisorTestSuite(TestSuite):
         use_ms_hypervisor_fw = variables.get("use_ms_hypervisor_fw", "NO")
         use_ms_ovmf_fw = variables.get("use_ms_ovmf_fw", "NO")
 
+        # Below three params are for running block_* clh perf test
+        # with no disk caching and with direct mode. By Default, we
+        # will not run it with data-disk and it would not add direct=on
+        # if run_without_cache is not set to YES
+        use_datadisk = variables.get("use_datadisk", "")
+        datadisk_name = variables.get("datadisk_name", "")
+        disable_datadisk_cache = variables.get("disable_datadisk_cache", "")
+        block_size_kb = variables.get("block_size_kb", "")
+
         if not ms_access_token:
             raise SkippedException("Access Token is needed while using MS-CLH")
         if not ms_clh_repo:
@@ -204,6 +213,15 @@ class CloudHypervisorTestSuite(TestSuite):
             CloudHypervisorTests.use_ms_hypervisor_fw = use_ms_hypervisor_fw
         if use_ms_ovmf_fw == "YES":
             CloudHypervisorTests.use_ms_ovmf_fw = use_ms_ovmf_fw
+
+        if block_size_kb:
+            CloudHypervisorTests.block_size_kb = block_size_kb
+        if use_datadisk:
+            CloudHypervisorTests.use_datadisk = use_datadisk
+        if datadisk_name:
+            CloudHypervisorTests.datadisk_name = datadisk_name
+        if disable_datadisk_cache:
+            CloudHypervisorTests.disable_datadisk_cache = disable_datadisk_cache
 
 
 def get_test_list(variables: Dict[str, Any], var1: str, var2: str) -> Any:

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -48,6 +48,12 @@ class CloudHypervisorTests(Tool):
     use_ms_hypervisor_fw = ""
     use_ms_ovmf_fw = ""
 
+    # Block perf related env var
+    use_datadisk = ""
+    datadisk_name = ""
+    disable_datadisk_cache = ""
+    block_size_kb = ""
+
     cmd_path: PurePath
     repo_root: PurePath
 
@@ -241,6 +247,15 @@ class CloudHypervisorTests(Tool):
                 self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
             if self.use_ms_ovmf_fw:
                 self.env_vars["USE_MS_OVMF_FW"] = self.use_ms_ovmf_fw
+
+            if self.use_datadisk:
+                self.env_vars["USE_DATADISK"] = self.use_datadisk
+            if self.datadisk_name:
+                self.env_vars["DATADISK_NAME"] = self.datadisk_name
+            if self.disable_datadisk_cache:
+                self.env_vars["DISABLE_DATADISK_CACHING"] = self.disable_datadisk_cache
+            if self.block_size_kb:
+                self.env_vars["PERF_BLOCK_SIZE_KB"] = self.block_size_kb
         else:
             git.clone(self.upstream_repo, clone_path)
 


### PR DESCRIPTION
This will add 3 parameters related to CLH block perf test to be run with data disk and can configure the caching strategy

- Disk name and cache setting
- If we have to use data disk for block perf tests of CLH
- Block size for FIO command