### PR TITLE
Remove Infiniband on_before_deploy

### DIFF
--- a/lisa/features/__init__.py
+++ b/lisa/features/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from .acc import ACC
-from .availability import Availability, AvailabilitySettings
+from .availability import Availability, AvailabilitySetEnabled, AvailabilitySettings
 from .cvm_nested_virtualization import CVMNestedVirtualization
 from .disks import (
     Disk,
@@ -33,6 +33,7 @@ from .startstop import StartStop, StopState, VMStatus
 __all__ = [
     "ACC",
     "Availability",
+    "AvailabilitySetEnabled",
     "AvailabilitySettings",
     "CVMNestedVirtualization",
     "Disk",

--- a/lisa/features/availability.py
+++ b/lisa/features/availability.py
@@ -127,3 +127,9 @@ class Availability(Feature):
 
     def enabled(self) -> bool:
         return True
+
+
+AvailabilitySetEnabled = partial(
+    AvailabilitySettings,
+    availability_type=search_space.SetSpace(True, [AvailabilityType.AvailabilitySet]),
+)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2474,6 +2474,10 @@ class Availability(AzureFeatureMixin, features.Availability):
         # fields for clarity
         if params.availability_type == AvailabilityType.AvailabilitySet:
             params.availability_zones.clear()
+            if "platformFaultDomainCount" not in params.availability_set_properties:
+                params.availability_set_properties["platformFaultDomainCount"] = 1
+            if "platformUpdateDomainCount" not in params.availability_set_properties:
+                params.availability_set_properties["platformUpdateDomainCount"] = 1
         elif params.availability_type == AvailabilityType.AvailabilityZone:
             assert (
                 params.availability_zones

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -656,20 +656,6 @@ class Gpu(AzureFeatureMixin, features.Gpu):
 
 class Infiniband(AzureFeatureMixin, features.Infiniband):
     @classmethod
-    def on_before_deployment(cls, *args: Any, **kwargs: Any) -> None:
-        arm_parameters: AzureArmParameter = kwargs.pop("arm_parameters")
-
-        arm_parameters.availability_options.availability_set_properties[
-            "platformFaultDomainCount"
-        ] = 1
-        arm_parameters.availability_options.availability_set_properties[
-            "platformUpdateDomainCount"
-        ] = 1
-        arm_parameters.availability_options.availability_type = (
-            AvailabilityType.AvailabilitySet.value
-        )
-
-    @classmethod
     def create_setting(
         cls, *args: Any, **kwargs: Any
     ) -> Optional[schema.FeatureSettings]:

--- a/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/microsoft/testsuites/hpc/infinibandsuite.py
@@ -11,7 +11,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.features import Infiniband, Sriov
+from lisa.features import AvailabilitySetEnabled, Infiniband, Sriov
 from lisa.operating_system import BSD, Windows
 from lisa.sut_orchestrator.azure.tools import Waagent
 from lisa.tools import Find, KernelConfig, Ls, Modprobe, Ssh
@@ -169,7 +169,7 @@ class InfinibandSuite(TestSuite):
         """,
         priority=1,
         requirement=simple_requirement(
-            supported_features=[Infiniband],
+            supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
             unsupported_os=[BSD, Windows],
         ),
@@ -238,7 +238,7 @@ class InfinibandSuite(TestSuite):
             """,
         priority=4,
         requirement=simple_requirement(
-            supported_features=[Infiniband],
+            supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
             unsupported_os=[BSD, Windows],
         ),
@@ -332,7 +332,7 @@ class InfinibandSuite(TestSuite):
             """,
         priority=4,
         requirement=simple_requirement(
-            supported_features=[Infiniband],
+            supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
             unsupported_os=[BSD, Windows],
         ),
@@ -432,7 +432,7 @@ class InfinibandSuite(TestSuite):
             """,
         priority=4,
         requirement=simple_requirement(
-            supported_features=[Infiniband],
+            supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
             unsupported_os=[BSD, Windows],
         ),
@@ -531,7 +531,7 @@ class InfinibandSuite(TestSuite):
             """,
         priority=4,
         requirement=simple_requirement(
-            supported_features=[Infiniband],
+            supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
             unsupported_os=[BSD, Windows],
         ),


### PR DESCRIPTION
Availability sets are an optimization not a requirement and it is causing problems for Ultra Disk and Availability Feature.