### PR TITLE
add logic to assert truncation logic

### DIFF
--- a/microsoft/testsuites/vm_extensions/linux_patch_extension.py
+++ b/microsoft/testsuites/vm_extensions/linux_patch_extension.py
@@ -55,7 +55,10 @@ def _verify_vm_agent_running(node: Node, log: Logger) -> None:
 
 
 def _assert_status_file_result(status_file: Any) -> None:
-    if status_file["error"]["code"] == "PACKAGE_LIST_TRUNCATED":
+    if (
+        len(status_file["error"]["details"]) > 0
+        and status_file["error"]["details"][0]["code"] == "PACKAGE_LIST_TRUNCATED"
+    ):
         assert_that(status_file["status"]).described_as(
             "Expected the status file patches to CompletedWithWarnings"
         ).is_equal_to("CompletedWithWarnings")

--- a/microsoft/testsuites/vm_extensions/linux_patch_extension.py
+++ b/microsoft/testsuites/vm_extensions/linux_patch_extension.py
@@ -142,7 +142,7 @@ class LinuxPatchExtensionBVT(TestSuite):
             vm_name=vm_name,
             install_patches_input=install_patches_input,
         )
-        # set wait operation max duration 3H30M timeout, status file should be
+        # set wait operation max duration 4H timeout, status file should be
         # generated before timeout
         install_result = wait_operation(operation, self.TIMEOUT)
 

--- a/microsoft/testsuites/vm_extensions/linux_patch_extension.py
+++ b/microsoft/testsuites/vm_extensions/linux_patch_extension.py
@@ -54,6 +54,21 @@ def _verify_vm_agent_running(node: Node, log: Logger) -> None:
     ).is_true()
 
 
+def _assert_status_file_result(status_file: Any) -> None:
+    if status_file["error"]["code"] == "PACKAGE_LIST_TRUNCATED":
+        assert_that(status_file["status"]).described_as(
+            "Expected the status file patches to CompletedWithWarnings"
+        ).is_equal_to("CompletedWithWarnings")
+    else:
+        assert_that(status_file["status"]).described_as(
+            "Expected the status file patches to succeed"
+        ).is_equal_to("Succeeded")
+
+        assert_that(status_file["error"]["code"]).described_as(
+            "Expected no error in status file patches operation"
+        ).is_equal_to("0")
+
+
 @TestSuiteMetadata(
     area="vm_extension",
     category="functional",
@@ -90,13 +105,8 @@ class LinuxPatchExtensionBVT(TestSuite):
 
         assert assess_result, "assess_result shouldn't be None"
         log.debug(f"assess_result:{assess_result}")
-        assert_that(assess_result["status"]).described_as(
-            "Expected the assess patches to succeed"
-        ).is_equal_to("Succeeded")
 
-        assert_that(assess_result["error"]["code"]).described_as(
-            "Expected no error in assess patches operation"
-        ).is_equal_to("0")
+        _assert_status_file_result(assess_result)
 
     @TestCaseMetadata(
         description="""
@@ -135,10 +145,5 @@ class LinuxPatchExtensionBVT(TestSuite):
 
         assert install_result, "install_result shouldn't be None"
         log.debug(f"install_result:{install_result}")
-        assert_that(install_result["status"]).described_as(
-            "Expected the install patches to succeed"
-        ).is_equal_to("Succeeded")
 
-        assert_that(install_result["error"]["code"]).described_as(
-            "Expected no error in install patches operation"
-        ).is_equal_to("0")
+        _assert_status_file_result(install_result)


### PR DESCRIPTION
[x] add logic to assert truncation_logic in some images, this allowed lisa to pass the below example images. the truncation logic is recent lpe change we deployed to handle vm agent json deserialization error. 
<img width="743" alt="image" src="https://github.com/microsoft/lisa/assets/127874208/827c3dcc-e329-43bb-b85f-1499bd78c5f8">

running bvt on image: marketplace_image:redhat rhel 8-lvm 8.5.2022031405
![image](https://github.com/microsoft/lisa/assets/127874208/86c1d7a4-9439-4944-917b-1ff56c935136)

