### PR TITLE
Mask SMB credentials

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3248,6 +3248,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         echo = node.tools[Echo]
         username = account_credential["account_name"]
         password = account_credential["account_key"]
+        add_secret(password)
         echo.write_to_file(f"username={username}", file_path, sudo=True, append=True)
         echo.write_to_file(f"password={password}", file_path, sudo=True, append=True)
         node.execute("cp -f /etc/fstab /etc/fstab_cifs", sudo=True)


### PR DESCRIPTION
This PR masks the credentials used to establish file sharing within Azure. The change has been tested and verified.

```
2024-04-24 18:50:18.275[31336][DEBUG] lisa.env[generated_0].node[0].cmd[6121] cmd: ['sudo', 'sh', '-c', "echo 'username=lisasczn3cvjeqlv' >> /etc/smbcredentials/lisa.cred"], cwd: None, shell: True, sudo: True, nohup: False, posix: True, remote: True, encoding: utf-8
2024-04-24 18:50:18.498[31336][DEBUG] lisa.env[generated_0].node[0].cmd[6121] execution time: 0.222 sec, exit code: 0
2024-04-24 18:50:18.499[31336][DEBUG] lisa.env[generated_0].node[0].cmd[1245] cmd: ['sudo', 'sh', '-c', "echo 'password=******' >> /etc/smbcredentials/lisa.cred"], cwd: None, shell: True, sudo: True, nohup: False, posix: True, remote: True, encoding: utf-8
``` 