### PR TITLE
mdatp: Add noexec workaround

### DIFF
--- a/lisa/tools/df.py
+++ b/lisa/tools/df.py
@@ -33,7 +33,7 @@ class Df(Tool):
         ).stdout
         df_entries = find_patterns_groups_in_lines(out, [self._DF_ENTRY_REGEX])[0]
         if len(df_entries) == 0:
-            self._log.warn(f"Path: {directory} not exist!")
+            self._log.info(f"Path: {directory} not exist!")
             return None
         df_entry = df_entries[0]
         return PartitionInfo(

--- a/lisa/tools/df.py
+++ b/lisa/tools/df.py
@@ -25,7 +25,7 @@ class Df(Tool):
     def can_install(self) -> bool:
         return True
 
-    def get_mount_info_for_dir(
+    def get_partition_by_path(
         self, directory: str, force_run: bool = False
     ) -> Optional[PartitionInfo]:
         out = self.run(

--- a/lisa/tools/df.py
+++ b/lisa/tools/df.py
@@ -25,6 +25,26 @@ class Df(Tool):
     def can_install(self) -> bool:
         return True
 
+    def get_mount_info_for_dir(
+        self, directory: str, force_run: bool = False
+    ) -> Optional[PartitionInfo]:
+        out = self.run(
+            parameters=f"{directory}", force_run=force_run, shell=True, sudo=True
+        ).stdout
+        df_entries = find_patterns_groups_in_lines(out, [self._DF_ENTRY_REGEX])[0]
+        if len(df_entries) == 0:
+            self._log.warn(f"Path: {directory} not exist!")
+            return None
+        df_entry = df_entries[0]
+        return PartitionInfo(
+            name=df_entry["name"],
+            mountpoint=df_entry["mountpoint"],
+            available_blocks=int(df_entry["available"]),
+            used_blocks=int(df_entry["used"]),
+            total_blocks=int(df_entry["total"]),
+            percentage_blocks_used=int(df_entry["percentage_use"]),
+        )
+
     def get_partitions(self, force_run: bool = False) -> List[PartitionInfo]:
         # run df and parse the output
         # The output is in the following format:

--- a/lisa/tools/mount.py
+++ b/lisa/tools/mount.py
@@ -74,7 +74,7 @@ class Mount(Tool):
     # /dev/da1p1 on /mnt/resource (ufs, local, soft-updates)
     _partition_info_regex_bsd = re.compile(
         r"\s*/dev/(?P<name>.*)\s+on\s+(?P<mount_point>.*)\s+"
-        r"(\((?P<type>.*),(?P<options>.*,.*)\))"
+        r"(\((?P<type>.*),(?P<options>.*)\))"
     )
 
     @property

--- a/microsoft/testsuites/mdatp/mdatp.py
+++ b/microsoft/testsuites/mdatp/mdatp.py
@@ -37,11 +37,11 @@ def apply_working_path_noexec_workaround(node: Node) -> None:
         node.log.info(f"Working path in {mount_info.mountpoint} is mounted noexec!!")
         remount_without_noexec(node, mount_info)
     elif not mount_info:
-        # warn only, since nearly all (99.99%) of images do not
+        # info only, since nearly all (99.99%) of images do not
         # require this workaround. An image with weird DF or Mount
         # output should still be able to run the script, so we
-        # will warn and allow the test to continue.
-        node.log.warn(
+        # will info and allow the test to continue.
+        node.log.info(
             f"Could not locate mount info for directory "
             f"{working_path.as_posix()}. "
             "Test may fail due to noexec permissions error. "
@@ -63,7 +63,7 @@ def check_noexec_partition(node: Node, partition: PartitionInfo) -> bool:
     # This path would mean that df and mount are returning different
     # info about the mount points on the VM.
     # There should be no way for this to happen, assert if it does
-    node.log.warn(
+    node.log.info(
         f"Could not find partition info for {partition.mountpoint}! "
         "This indicates that LISA could not properly parse the output "
         "of 'mount' and 'df'. It's possible this image does not have "

--- a/microsoft/testsuites/mdatp/mdatp.py
+++ b/microsoft/testsuites/mdatp/mdatp.py
@@ -30,12 +30,10 @@ def apply_working_path_noexec_workaround(node: Node) -> None:
     # - Check if the mount point is mounted noexec.
     # - if yes, remount with exec flag
     working_path = node.get_working_path()
-    mount_info = node.tools[Df].get_mount_info_for_dir(
-        directory=working_path.as_posix()
-    )
+    mount_info = node.tools[Df].get_partition_by_path(directory=working_path.as_posix())
     if mount_info and check_noexec_partition(node, mount_info):
         node.log.info(f"Working path in {mount_info.mountpoint} is mounted noexec!!")
-        remount_without_noexec(node, mount_info)
+        remount_with_exec(node, mount_info)
     elif not mount_info:
         # info only, since nearly all (99.99%) of images do not
         # require this workaround. An image with weird DF or Mount
@@ -75,7 +73,7 @@ def check_noexec_partition(node: Node, partition: PartitionInfo) -> bool:
     return False
 
 
-def remount_without_noexec(node: Node, partition: PartitionInfo) -> None:
+def remount_with_exec(node: Node, partition: PartitionInfo) -> None:
     # Fix issue where working path is created in a partition marked
     # 'noexec' meaning file permissions for x are ignored.
     # Attempt to remount the parition to allow executables.

--- a/microsoft/testsuites/mdatp/mdatp.py
+++ b/microsoft/testsuites/mdatp/mdatp.py
@@ -59,7 +59,14 @@ def check_noexec_partition(node: Node, partition: PartitionInfo) -> bool:
     # This path would mean that df and mount are returning different
     # info about the mount points on the VM.
     # There should be no way for this to happen, assert if it does
-    assert f"Could not find partition info for {partition.mountpoint}!"
+    node.log.warn(
+        f"Could not find partition info for {partition.mountpoint}! "
+        "This indicates that LISA could not properly parse the output "
+        "of 'mount' and 'df'. It's possible this image does not have "
+        "these tools available. "
+        "Note: This is a non-fatal error for the mdatp test. "
+        "Resuming text execution..."
+    )
     # appease pylint by returning after assert
     return False
 


### PR DESCRIPTION
LISA ~~has a bug where it~~ (edited) won't consider mount permissions before placing the working path. This means you'll end with a path where you can maybe read and write but not execute anything regardless of the file permissions.

This example workaround demonstrates how to detect the issue and a possible workaround, remounting the partition with the executable permission.