### PR TITLE
Fixing nic initialization for freebsd nodes

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -22,7 +22,7 @@ from lisa import schema
 from lisa.executable import Tools
 from lisa.feature import Features
 from lisa.nic import Nics, NicsBSD
-from lisa.operating_system import BSD, OperatingSystem
+from lisa.operating_system import OperatingSystem
 from lisa.secret import add_secret
 from lisa.tools import Chmod, Df, Echo, Lsblk, Mkfs, Mount, Reboot, Uname, Wsl
 from lisa.tools.mkfs import FileSystem

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -1215,8 +1215,10 @@ def create_nics(node: Node) -> Nics:
     """
     Returns a Nics object for the node based on the OS type.
     """
+    # Uses uname instead of the node.os because sometimes node.os has not been
+    # populated when this is called.
     os = node.execute(cmd="uname", no_error_log=True).stdout
-    if os.__contains__("FreeBSD"):
+    if "FreeBSD" in os:
         return NicsBSD(node)
 
     return Nics(node)

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -1215,7 +1215,8 @@ def create_nics(node: Node) -> Nics:
     """
     Returns a Nics object for the node based on the OS type.
     """
-    if isinstance(node.os, BSD):
+    os = node.execute(cmd="uname", no_error_log=True).stdout
+    if os.__contains__("FreeBSD"):
         return NicsBSD(node)
 
     return Nics(node)

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -31,7 +31,6 @@ from lisa.features import (
     StartStop,
     Synthetic,
 )
-from lisa.nic import Nics
 from lisa.tools import Lspci
 from lisa.util import constants
 from lisa.util.shell import wait_tcp_port_ready

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -342,7 +342,7 @@ class Provisioning(TestSuite):
         return all_mana_devices
 
     def check_sriov(self, log: Logger, node: RemoteNode) -> None:
-        node_nic_info = Nics(node)
+        node_nic_info = node.nics
         node_nic_info.initialize()
 
         network_interface_feature = node.features[NetworkInterface]


### PR DESCRIPTION
Added a different check to the nic initialization code to check for a freebsd operating system and updated the nic provisioning test case to use the built in method instead of call the Nic class directly.