### PR TITLE
perf tool installation fix for bookworm

### DIFF
--- a/lisa/tools/perf.py
+++ b/lisa/tools/perf.py
@@ -37,10 +37,16 @@ class Perf(Tool):
                 self.node.os.install_packages("perf")
             elif isinstance(
                 self.node.os, Debian
-            ) and self.node.os.information.codename in ["buster", "bullseye"]:
+            ) and self.node.os.information.codename in {"buster", "bullseye"}:
                 # Similar issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=983314 # noqa: E501
                 self.node.os.install_packages("linux-perf-5.10")
                 self._command = "perf_5.10"
+            elif (
+                isinstance(self.node.os, Debian)
+                and self.node.os.information.codename == "bookworm"
+            ):
+                # bookworm, where command "perf" works
+                self.node.os.install_packages("linux-perf")
             else:
                 self.node.os.install_packages(
                     [


### PR DESCRIPTION
This change is to take care of all the failures of tests PerfToolSuite.perf_epoll for Debian-12 images.
This change is tested with:
debian debian-12 12-gen2 0.20240415.1718
debian debian-11 11-backports-arm64 0.20230910.1499
debian debian-12 12 0.20240415.1718