### PR TITLE
Reduce min data_disk_count to 4 in IO perf test.

### DIFF
--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -102,7 +102,7 @@ class StoragePerformance(TestSuite):
                 data_disk_type=schema.DiskType.PremiumSSDLRS,
                 os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
-                data_disk_count=search_space.IntRange(min=16),
+                data_disk_count=search_space.IntRange(min=4),
             ),
         ),
     )
@@ -120,7 +120,7 @@ class StoragePerformance(TestSuite):
                 data_disk_type=schema.DiskType.PremiumSSDLRS,
                 os_disk_type=schema.DiskType.PremiumSSDLRS,
                 data_disk_iops=search_space.IntRange(min=5000),
-                data_disk_count=search_space.IntRange(min=16),
+                data_disk_count=search_space.IntRange(min=4),
             ),
         ),
     )


### PR DESCRIPTION
Having min data_disk_count =16 in these testcases is blocking tests on smaller sizes.
