### PR TITLE
Enable NVIDIA persistence mode by default for GPU test 

### DIFF
--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -415,6 +415,14 @@ def _install_driver(node: Node, log_path: Path, log: Logger) -> None:
 
     __install_driver_using_sdk(node, log, log_path)
 
+    # Enabling nvidia persistence mode which is recommended by NVIDIA
+    node.execute(
+        "nvidia-persistenced --persistence-mode",
+        sudo=True,
+        expected_exit_code=0,
+        expected_exit_code_failure_message="fail to enable nvidia persistence mode",
+    )
+
 
 def _gpu_provision_check(min_pci_count: int, node: Node, log: Logger) -> None:
     lspci = node.tools[Lspci]


### PR DESCRIPTION
Enable nvidia-persistence mode after installing the NVIDIA GPU driver by default. Fixed this [bug](https://microsoft.visualstudio.com/OS/_workitems/edit/49246027/)