### PR TITLE
VMAccess Fix - Add user to wheel group in Mariner 2.0 before running 'su'

### DIFF
--- a/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
+++ b/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
@@ -13,11 +13,14 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import BSD
+from lisa.operating_system import BSD, CBLMariner
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.features import AzureExtension
 from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
     create_and_verify_vmaccess_extension_run,
+)
+from lisa.tools import (
+    Usermod,
 )
 
 
@@ -77,9 +80,16 @@ def _validate_password(
     node: Node, username: str, password: str, valid: bool = True
 ) -> None:
     message = f"Password not set as intended for user {username}."
+
+    if isinstance(node.os, CBLMariner):
+        if node.os.information.version >= "2.0.0":
+            # In Mariner 2.0, there is a security restriction that only allows wheel group users to use 'su' command
+            # Add current user (specified during VM creation) to wheel group in Mariner
+            node.tools[Usermod].add_user_to_group("wheel", sudo=True)
+
     # simple command to determine if username password combination is valid/invalid
     node.execute(
-        cmd=f'echo "{password}" | su --command true - {username}',
+        cmd=f'echo "{password}" | su --command true {username}',
         shell=True,
         expected_exit_code=0 if valid else 1,
         expected_exit_code_failure_message=message,

--- a/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
+++ b/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
@@ -89,8 +89,9 @@ def _validate_password(
 
     if isinstance(node.os, CBLMariner):
         if node.os.information.version >= "2.0.0":
-            # In Mariner 2.0, there is a security restriction that only allows wheel group users to use 'su' command
-            # Add current user (specified during VM creation) to wheel group in Mariner
+            # In Mariner 2.0, there is a security restriction that only allows wheel
+            # group users to use 'su' command. Add current user
+            # (specified during VM creation) to wheel group in Mariner
             node.tools[Usermod].add_user_to_group("wheel", sudo=True)
 
     # simple command to determine if username password combination is valid/invalid

--- a/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
+++ b/microsoft/testsuites/vm_extensions/runtime_extensions/vmaccess.py
@@ -14,13 +14,13 @@ from lisa import (
     simple_requirement,
 )
 from lisa.operating_system import BSD, CBLMariner
+from lisa.secret import add_secret
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.features import AzureExtension
+from lisa.tools import Usermod
+from lisa.util import generate_random_chars
 from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
     create_and_verify_vmaccess_extension_run,
-)
-from lisa.tools import (
-    Usermod,
 )
 
 
@@ -42,6 +42,12 @@ def _generate_and_retrieve_openssh_key(node: Node, filename: str) -> str:
         expected_exit_code_failure_message="Failed to open OpenSSH key file.",
     )
     return result.stdout
+
+
+def _generate_password() -> str:
+    password = generate_random_chars()
+    add_secret(password)
+    return password
 
 
 def _generate_and_retrieve_ssh2_key(node: Node, filename: str) -> str:
@@ -161,8 +167,8 @@ class VMAccessTests(TestSuite):
     )
     def verify_valid_password_run(self, log: Logger, node: Node) -> None:
         username = "vmaccessuser"
-        password = str(uuid.uuid4())
-        incorrect_password = str(uuid.uuid4())
+        password = _generate_password()
+        incorrect_password = _generate_password()
         protected_settings = {
             "username": username,
             "password": password,
@@ -204,7 +210,7 @@ class VMAccessTests(TestSuite):
     )
     def verify_password_and_ssh_key_run(self, log: Logger, node: Node) -> None:
         username = "vmaccessuser-both"
-        password = str(uuid.uuid4())
+        password = _generate_password()
         ssh_filename = f"/tmp/{str(uuid.uuid4())}"
         openssh_key = _generate_and_retrieve_openssh_key(
             node=node, filename=ssh_filename
@@ -233,7 +239,7 @@ class VMAccessTests(TestSuite):
         self, log: Logger, node: Node
     ) -> None:
         username = "vmaccessuser-none"
-        password = str(uuid.uuid4())
+        password = _generate_password()
         protected_settings = {"username": username}
 
         create_and_verify_vmaccess_extension_run(
@@ -286,7 +292,7 @@ class VMAccessTests(TestSuite):
     )
     def verify_remove_username_run(self, log: Logger, node: Node) -> None:
         username = "vmaccessuser-remove"
-        password = str(uuid.uuid4())
+        password = _generate_password()
         protected_settings = {"username": username, "password": password}
 
         create_and_verify_vmaccess_extension_run(


### PR DESCRIPTION
VMAccess tests have been failing on Mariner 2.0 because the non-root user is executing a 'su' command to determine the validity of the username-password combination for an account, without having permissions to do so.

In Mariner, the user has to be added to wheel group before running a 'su' command. This PR introduces a fix to add the user to wheel group first.