### PR TITLE
add_cloud_init_test

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -925,13 +925,12 @@ class AzureImageStandard(TestSuite):
                         log_output, self._ERROR_WARNING_pattern
                     )
                     for x in sublist
-                    if x and x not in ignored_candidates
+                    if x 
                 ]
                 assert_that(found_results).described_as(
                     "unexpected ERROR/WARNING shown up in cloud-init.log"
                     f" {node.os.name} {node.os.information.version}"
                 ).is_empty()
-
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
                     raise LisaException(f"cloud-init status failed with exit_code {cmd_result.exit_code}")
@@ -939,7 +938,6 @@ class AzureImageStandard(TestSuite):
                 raise LisaException(f"cloud-init.log not exists")
         else:
             return
-
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -941,7 +941,7 @@ class AzureImageStandard(TestSuite):
                         f" {cmd_result.exit_code}."
                     )
             else:
-                raise LisaException(f"cloud-init.log not exists")
+                raise LisaException("cloud-init.log not exists")
         else:
             return
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -935,9 +935,9 @@ class AzureImageStandard(TestSuite):
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
                     raise LisaException(f"cloud-init status failed with exit_code {cmd_result.exit_code}")
-            else
+            else:
                 raise LisaException(f"cloud-init.log not exists")
-        else
+        else:
             return
 
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -83,9 +83,9 @@ class AzureImageStandard(TestSuite):
     # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
     # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
-        re.compile(r"^(.*[ERROR]*)$", re.MULTILINE),
+        re.compile(r"^(.*\[ERROR\]*)$", re.MULTILINE),
         re.compile(r"^(.*ERROR:*)$", re.MULTILINE),
-        re.compile(r"^(.*[WARNING]*)$", re.MULTILINE),
+        re.compile(r"^(.*\[WARNING\]*)$", re.MULTILINE),
         re.compile(r"^(.*WARNING:*)$", re.MULTILINE),
     ]
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -83,9 +83,9 @@ class AzureImageStandard(TestSuite):
     # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
     # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
-        re.compile(r"^(.*[ERROR].*)$", re.MULTILINE),
+        re.compile(r"^(.*[ERROR]*)$", re.MULTILINE),
         re.compile(r"^(.*ERROR:*)$", re.MULTILINE),
-        re.compile(r"^(.*[WARNING].*)$", re.MULTILINE),
+        re.compile(r"^(.*[WARNING]*)$", re.MULTILINE),
         re.compile(r"^(.*WARNING:*)$", re.MULTILINE),
     ]
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -945,9 +945,7 @@ class AzureImageStandard(TestSuite):
                 raise LisaException("cloud-init.log not exists")
         else:
             raise SkippedException(
-                UnsupportedDistroException(
-                    node.os, "unsupported distro to run verify_cloud_init_error_status test."
-                    )
+                UnsupportedDistroException(node.os, "unsupported distro to run verify_cloud_init_error_status test.")
                 )
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -945,9 +945,10 @@ class AzureImageStandard(TestSuite):
                 raise LisaException("cloud-init.log not exists")
         else:
             raise SkippedException(
-                f"Distro {node.os.name} ver: {node.os.information.version}"
-                " not supported to run verify_cloud_init_error_status test."
-            )
+                UnsupportedDistroException(
+                    node.os, "unsupported distro to run verify_cloud_init_error_status test."
+                    )
+                )
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -922,8 +922,7 @@ class AzureImageStandard(TestSuite):
         cat = node.tools[Cat]
         if isinstance(node.os, CBLMariner):
             if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
-                log_output = cat.read(
-                    "/var/log/cloud-init.log",
+                log_output = cat.read("/var/log/cloud-init.log",
                     force_run=True, sudo=True
                 )
                 found_results = [

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -80,8 +80,8 @@ class AzureImageStandard(TestSuite):
 
     # pattern to get failure, error, warnings from cloud-init.log
     # examples from cloud-init.log:
-    # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output: Nothing to do. 
-    # cloud-init[958]: 2024-01-23 17:21:19,844 - photon.py[ERROR]: Error while installing packages: Nothing to do.
+    # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
+    # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
         re.compile(r"^(.*ERROR.*)$", re.MULTILINE),
         re.compile(r"^(.*WARNING.*)$", re.MULTILINE),

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -939,8 +939,7 @@ class AzureImageStandard(TestSuite):
                 ).is_empty()
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 cmd_result.assert_exit_code(
-                    0,
-                    f"cloud-init exit status failed with {cmd_result.exit_code}"
+                    0, f"cloud-init exit status failed with {cmd_result.exit_code}"
                 )
             else:
                 raise LisaException("cloud-init.log not exists")

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -900,7 +900,7 @@ class AzureImageStandard(TestSuite):
             f" {node.os.name} {node.os.information.version}"
         ).is_empty()
 
- @TestCaseMetadata(
+    @TestCaseMetadata(
         description="""
         This test will check ERROR, WARNING messages from /var/log/cloud-init.log
         and also check cloud-init exit status.

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -910,7 +910,7 @@ class AzureImageStandard(TestSuite):
 
         Steps:
         1. Get ERROR, WARNING messages from /var/log/cloud-init.log.
-        2. If any unexpected ERROR, WARNING messages or non-zero cloud-init status 
+        2. If any unexpected ERROR, WARNING messages or non-zero cloud-init status
          fail the case.
         """,
         priority=1,
@@ -928,7 +928,7 @@ class AzureImageStandard(TestSuite):
                         log_output, self._ERROR_WARNING_pattern
                     )
                     for x in sublist
-                    if x 
+                    if x
                 ]
                 assert_that(found_results).described_as(
                     "unexpected ERROR/WARNING shown up in cloud-init.log"
@@ -937,7 +937,7 @@ class AzureImageStandard(TestSuite):
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
                     raise LisaException(
-                        "cloud-init status failed with exit_code" 
+                        "cloud-init status failed with exit_code"
                         f" {cmd_result.exit_code}."
                     )
             else:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -907,6 +907,7 @@ class AzureImageStandard(TestSuite):
         description="""
         This test will check ERROR, WARNING messages from /var/log/cloud-init.log
         and also check cloud-init exit status.
+
         Steps:
         1. Get ERROR, WARNING messages from /var/log/cloud-init.log.
         2. If any unexpected ERROR, WARNING messages or non-zero cloud-init status 
@@ -917,7 +918,7 @@ class AzureImageStandard(TestSuite):
     )
     def verify_cloud_init_error_status(self, node: Node) -> None:
         cat = node.tools[Cat]
-        if isinstance(self.node.os, CBLMariner):
+        if isinstance(node.os, CBLMariner):
             if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
                 log_output = cat.read("/var/log/syslog", force_run=True, sudo=True)
 
@@ -936,8 +937,7 @@ class AzureImageStandard(TestSuite):
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
                     raise LisaException(
-                        f"cloud-init status failed"
-                        "with exit_code {cmd_result.exit_code}."
+                        f"cloud-init status failed with exit_code {cmd_result.exit_code}."
                     )
             else:
                 raise LisaException(f"cloud-init.log not exists")

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -918,32 +918,29 @@ class AzureImageStandard(TestSuite):
     )
     def verify_cloud_init_error_status(self, node: Node) -> None:
         cat = node.tools[Cat]
-        if isinstance(node.os, CBLMariner):
-            if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
-                log_output = cat.read("/var/log/syslog", force_run=True, sudo=True)
+        if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
+            log_output = cat.read("/var/log/syslog", force_run=True, sudo=True)
 
-                found_results = [
-                    x
-                    for sublist in find_patterns_in_lines(
-                        log_output, self._ERROR_WARNING_pattern
-                    )
-                    for x in sublist
-                    if x
-                ]
-                assert_that(found_results).described_as(
-                    "unexpected ERROR/WARNING shown up in cloud-init.log"
-                    f" {node.os.name} {node.os.information.version}"
-                ).is_empty()
-                cmd_result = node.execute("cloud-init status --wait", sudo=True)
-                if 0 != cmd_result.exit_code:
-                    raise LisaException(
-                        "cloud-init status failed with exit_code"
-                        f" {cmd_result.exit_code}."
-                    )
-            else:
-                raise LisaException("cloud-init.log not exists")
+            found_results = [
+                x
+                for sublist in find_patterns_in_lines(
+                    log_output, self._ERROR_WARNING_pattern
+                )
+                for x in sublist
+                if x
+            ]
+            assert_that(found_results).described_as(
+                "unexpected ERROR/WARNING shown up in cloud-init.log"
+                f" {node.os.name} {node.os.information.version}"
+            ).is_empty()
+            cmd_result = node.execute("cloud-init status --wait", sudo=True)
+            if 0 != cmd_result.exit_code:
+                raise LisaException(
+                    "cloud-init status failed with exit_code"
+                    f" {cmd_result.exit_code}."
+                )
         else:
-            return
+            raise LisaException("cloud-init.log not exists")
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -923,7 +923,7 @@ class AzureImageStandard(TestSuite):
         if isinstance(node.os, CBLMariner):
             if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
                 log_output = cat.read(
-                    "/var/log/cloud-init.log", 
+                    "/var/log/cloud-init.log",
                     force_run=True, sudo=True
                 )
                 found_results = [
@@ -941,7 +941,7 @@ class AzureImageStandard(TestSuite):
                 ).is_empty()
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 cmd_result.assert_exit_code(
-                    0, 
+                    0,
                     f"cloud-init exit status failed with {cmd_result.exit_code}"
                 )
             else:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -921,12 +921,9 @@ class AzureImageStandard(TestSuite):
     def verify_cloud_init_error_status(self, node: Node) -> None:
         cat = node.tools[Cat]
         if isinstance(node.os, CBLMariner):
-            if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
-                log_output = cat.read(
-                    "/var/log/cloud-init.log",
-                    force_run=True, 
-                    sudo=True
-                )
+            cloud_init_log = "/var/log/cloud-init.log"
+            if node.shell.exists(node.get_pure_path(cloud_init_log)):
+                log_output = cat.read(cloud_init_log, force_run=True, sudo=True)
                 found_results = [
                     x
                     for sublist in find_patterns_in_lines(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -922,8 +922,10 @@ class AzureImageStandard(TestSuite):
         cat = node.tools[Cat]
         if isinstance(node.os, CBLMariner):
             if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
-                log_output = cat.read("/var/log/cloud-init.log",
-                    force_run=True, sudo=True
+                log_output = cat.read(
+                    "/var/log/cloud-init.log",
+                    force_run=True, 
+                    sudo=True
                 )
                 found_results = [
                     x

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -946,8 +946,7 @@ class AzureImageStandard(TestSuite):
         else:
             raise SkippedException(
                 UnsupportedDistroException(
-                    node.os,
-                    "unsupported distro to run verify_cloud_init_error_status test."
+                    node.os, "unsupported distro to run verify_cloud_init test."
                 )
             )
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -911,7 +911,7 @@ class AzureImageStandard(TestSuite):
         Steps:
         1. Get ERROR, WARNING messages from /var/log/cloud-init.log.
         2. If any unexpected ERROR, WARNING messages or non-zero cloud-init status 
-        fail the case.
+         fail the case.
         """,
         priority=1,
         requirement=simple_requirement(supported_platform_type=[AZURE, READY]),
@@ -937,7 +937,8 @@ class AzureImageStandard(TestSuite):
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
                     raise LisaException(
-                        f"cloud-init status failed with exit_code {cmd_result.exit_code}."
+                        "cloud-init status failed with exit_code" 
+                        f" {cmd_result.exit_code}."
                     )
             else:
                 raise LisaException(f"cloud-init.log not exists")

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -79,6 +79,9 @@ class AzureImageStandard(TestSuite):
     ]
 
     # pattern to get failure, error, warnings from cloud-init.log
+    # examples from cloud-init.log:
+    # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output: Nothing to do. 
+    # cloud-init[958]: 2024-01-23 17:21:19,844 - photon.py[ERROR]: Error while installing packages: Nothing to do.
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
         re.compile(r"^(.*ERROR.*)$", re.MULTILINE),
         re.compile(r"^(.*WARNING.*)$", re.MULTILINE),
@@ -904,7 +907,6 @@ class AzureImageStandard(TestSuite):
         description="""
         This test will check ERROR, WARNING messages from /var/log/cloud-init.log
         and also check cloud-init exit status.
-
         Steps:
         1. Get ERROR, WARNING messages from /var/log/cloud-init.log.
         2. If any unexpected ERROR, WARNING messages or non-zero cloud-init status 
@@ -933,7 +935,10 @@ class AzureImageStandard(TestSuite):
                 ).is_empty()
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
                 if 0 != cmd_result.exit_code:
-                    raise LisaException(f"cloud-init status failed with exit_code {cmd_result.exit_code}")
+                    raise LisaException(
+                        f"cloud-init status failed"
+                        "with exit_code {cmd_result.exit_code}."
+                    )
             else:
                 raise LisaException(f"cloud-init.log not exists")
         else:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -943,6 +943,11 @@ class AzureImageStandard(TestSuite):
                 )
             else:
                 raise LisaException("cloud-init.log not exists")
+        else:
+            raise SkippedException(
+                f"Distro {node.os.name} ver: {node.os.information.version}"
+                " not supported to run verify_cloud_init_error_status test."
+            )
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -945,8 +945,11 @@ class AzureImageStandard(TestSuite):
                 raise LisaException("cloud-init.log not exists")
         else:
             raise SkippedException(
-                UnsupportedDistroException(node.os, "unsupported distro to run verify_cloud_init_error_status test.")
+                UnsupportedDistroException(
+                    node.os, 
+                    "unsupported distro to run verify_cloud_init_error_status test."
                 )
+            )
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -922,7 +922,10 @@ class AzureImageStandard(TestSuite):
         cat = node.tools[Cat]
         if isinstance(node.os, CBLMariner):
             if node.shell.exists(node.get_pure_path("/var/log/cloud-init.log")):
-                log_output = cat.read("/var/log/cloud-init.log", force_run=True, sudo=True)
+                log_output = cat.read(
+                    "/var/log/cloud-init.log", 
+                    force_run=True, sudo=True
+                )
                 found_results = [
                     x
                     for sublist in find_patterns_in_lines(
@@ -933,12 +936,13 @@ class AzureImageStandard(TestSuite):
                 ]
                 assert_that(found_results).described_as(
                     "unexpected ERROR/WARNING shown up in cloud-init.log"
-                    f" {x}"
+                    f" {found_results}"
                     f" {node.os.name} {node.os.information.version}"
                 ).is_empty()
                 cmd_result = node.execute("cloud-init status --wait", sudo=True)
-                cmd_result.assert_exit_code(0, 
-                f"cloud-init exit status failed with {cmd_result.exit_code}"
+                cmd_result.assert_exit_code(
+                    0, 
+                    f"cloud-init exit status failed with {cmd_result.exit_code}"
                 )
             else:
                 raise LisaException("cloud-init.log not exists")

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -946,7 +946,7 @@ class AzureImageStandard(TestSuite):
         else:
             raise SkippedException(
                 UnsupportedDistroException(
-                    node.os, 
+                    node.os,
                     "unsupported distro to run verify_cloud_init_error_status test."
                 )
             )


### PR DESCRIPTION
Add test case for cloud-init to catch any "ERROR" or "WARNING" message in /var/log/cloud-init.log and also check if command "cloud-init status" return 0. 

Limit the test only to CBLMariner.