### PR TITLE
Add MSHV check for VDPA device config for CLH Integration Test

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -96,7 +96,7 @@ class CloudHypervisorTests(Tool):
             skip_args = ""
         self._log.debug(f"Final Subtests list to run: {subtests}")
 
-        if isinstance(self.node.os, CBLMariner):
+        if isinstance(self.node.os, CBLMariner) and hypervisor == "mshv":
             # Install dependency to create VDPA Devices
             self.node.os.install_packages(["iproute", "iproute-devel"])
             # Load VDPA kernel module and create devices


### PR DESCRIPTION
Create VDPA Device only when /dev/mshv exists.