### PR TITLE
Use dpdk22 and dpdk22-devel for SUSE

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -631,6 +631,10 @@ class DpdkTestpmd(Tool):
                     ["dpdk", "dpdk-dev"],
                     extra_args=self._backport_repo_args,
                 )
+            elif (
+                isinstance(node.os, Suse) and float(node.os.information.release) >= 15.5
+            ):
+                node.os.install_packages(["dpdk22", "dpdk22-devel"])
             elif isinstance(node.os, (Fedora, Suse)):
                 node.os.install_packages(["dpdk", "dpdk-devel"])
             else:
@@ -642,8 +646,10 @@ class DpdkTestpmd(Tool):
                 f"Installed DPDK version {str(self._dpdk_version_info)} "
                 "from package manager"
             )
-
-            self._dpdk_version_info = node.os.get_package_information("dpdk")
+            if isinstance(node.os, Suse) and float(node.os.information.release) >= 15.5:
+                self._dpdk_version_info = node.os.get_package_information("dpdk22")
+            else:
+                self._dpdk_version_info = node.os.get_package_information("dpdk")
             self.find_testpmd_binary()
             self._load_drivers_for_dpdk()
             return True


### PR DESCRIPTION
This is to take care of the Task 50164592 [DPDK] failure on suse sles-15-sp5 gen2 2024.02.07

The change is tested with each of the following tests:
verify_dpdk_build_failsafe,
verify_dpdk_build_gb_hugepages_failsafe,
verify_dpdk_send_receive_failsafe,
verify_dpdk_send_receive_gb_hugepages_failsafe,
verify_dpdk_send_receive_multi_txrx_queue_failsafe,
perf_dpdk_minimal_failsafe_pmd


with each of the follow images:
suse sles-15-sp5 gen2 2024.02.07,
suse sles-15-sp5 gen2 2023.12.14,
suse sles-15-sp5 gen2 2023.09.21,
suse sles-15-sp5 gen2 2023.06.20,
suse sles-15-sp5 gen1 2024.02.07,
suse sles-15-sp5 gen1 2023.12.14,
suse sles-15-sp5 gen1 2023.09.21,
suse sles-15-sp5 gen1 2023.06.20,
suse sles-15-sp4 gen2 latest