### PR TITLE
Fix dpdk version format check regex pattern

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -736,9 +736,11 @@ class Debian(Linux):
     _debian_version_splitter_regex = re.compile(
         r"([0-9]+:)?"  # some examples have a mystery number followed by a ':' (git)
         r"(?P<major>[0-9]+)\."  # major
-        r"(?P<minor>[0-9]+)\."  # minor
+        r"(?P<minor>[0-9]+)[\-\.]"  # minor
         r"(?P<patch>[0-9]+)"  # patch
-        r"-(?P<build>[a-zA-Z0-9-_\.~+]+)"  # build
+        r"(?:-)?(?P<build>[a-zA-Z0-9-_\.~+]+)"  # build
+        # '-' is added after minor and made optional before build
+        # due to the formats like 23.11-1build3
     )
     # apt-cache policy git
     # git:


### PR DESCRIPTION
New DPDK version has a different format which is being installed to the os as part of the test:
https://launchpad.net/ubuntu/+source/dpdk/23.11-1build3 for ubuntu

and the version format check is failing the tests:
verify_dpdk_build_failsafe
verify_dpdk_send_receive_multi_txrx_queue_failsafe

This change is tested with both the above tests.

Also the change with tested with the older dpdk version formats too:
22.11.3-1, 22.11.4-0ubuntu0.23.10.1, 21.11-1build1