### PR TITLE
Raise exception in wget when timeout and increase timeout for wget in mshv stress test

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -10,7 +10,7 @@ from lisa.tools.ls import Ls
 from lisa.tools.mkdir import Mkdir
 from lisa.tools.powershell import PowerShell
 from lisa.tools.rm import Rm
-from lisa.util import LisaException, is_valid_url
+from lisa.util import LisaException, LisaTimeoutException, is_valid_url
 
 if TYPE_CHECKING:
     from lisa.operating_system import Posix
@@ -80,6 +80,10 @@ class Wget(Tool):
                 " due to failed download or pattern mismatch."
                 f" stdout: {command_result.stdout}"
                 f" templog: {temp_log}"
+            )
+        if command_result.is_timeout:
+            raise LisaTimeoutException(
+                f"wget command is timed out after {timeout} seconds."
             )
         actual_file_path = self.node.execute(
             f"ls {download_file_path}",

--- a/microsoft/testsuites/mshv/mshv_root_stress_tests.py
+++ b/microsoft/testsuites/mshv/mshv_root_stress_tests.py
@@ -51,6 +51,7 @@ class MshvHostStressTestSuite(TestSuite):
             "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img",  # noqa: E501
             file_path=str(working_path),
             filename=f"{self.DISK_IMG_NAME}.img",
+            timeout=1200,
         )
         node.tools[QemuImg].convert(
             "qcow2",


### PR DESCRIPTION

    wget: raise exception if wget times out

    When wget times out, the downloaded file will be in corrupted state.
    Lisa should raise exception in this case, instead of returning the
    corrupted downloaded path.


    mshv: Increase timeout when downloading guest image

    The ubuntu cloud image is usually of 2GB size and sometimes, due to
    network delays, it might take more than the default 600s time to
    download it. So, increase it to 1200.
