### PR TITLE
Add some actions for AITL role definition

### DIFF
--- a/microsoft/utils/setup_aitl.py
+++ b/microsoft/utils/setup_aitl.py
@@ -258,6 +258,10 @@ def _set_target_role_parameters(
         "Microsoft.Storage/storageAccounts/read",
         "Microsoft.Storage/storageAccounts/write",
         "Microsoft.Storage/storageAccounts/listKeys/action",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+        "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action",  # noqa: E501
     ]
 
     data_action_perms_list = [


### PR DESCRIPTION
 One change of storage ([PR](https://github.com/microsoft/lisa/pull/3293)) requires the AITL service principle to have these storage blob actions.