### PR TITLE
libvirt_tck_tool: Increase timeout for Reboot

### DIFF
--- a/microsoft/testsuites/libvirt/libvirt_tck_tool.py
+++ b/microsoft/testsuites/libvirt/libvirt_tck_tool.py
@@ -156,7 +156,7 @@ class LibvirtTck(Tool):
                 sudo=True,
             )
 
-            self.node.reboot()
+            self.node.reboot(time_out=900)
 
             # After reboot, libvirtd service is in failed state and needs to
             # be restarted manually. Doing it immediately after restarts


### PR DESCRIPTION
These tests are usually run on server grade machines and it might take longer time for the machine to reboot. Hence, increase the reboot timeout