### PR TITLE
tests: Add docker/dmesg logs in after_case for CLH test

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -15,7 +15,7 @@ from lisa import (
 )
 from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.testsuite import TestResult
-from lisa.tools import Ls, Lscpu, Modprobe, Usermod
+from lisa.tools import Dmesg, Journalctl, Ls, Lscpu, Modprobe, Usermod
 from lisa.util import SkippedException
 from microsoft.testsuites.cloud_hypervisor.ch_tests_tool import CloudHypervisorTests
 
@@ -46,6 +46,17 @@ class CloudHypervisorTestSuite(TestSuite):
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
         node.tools[Modprobe].remove(["openvswitch"])
+
+        journalctl = node.tools[Journalctl]
+        docker_log = journalctl.logs_for_unit(
+            unit_name="docker",
+            sudo=True,
+        )
+        log.debug(f"Journalctl Docker Logs: {docker_log}")
+
+        dmesg = node.tools[Dmesg]
+        dmesg_log = dmesg.get_output(force_run=True)
+        log.debug(f"Dmesg Logs: {dmesg_log}")
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Collect journalctl docker logs and dmesg log for CLH test under after_case

Sometime, we miss the dmesg logs because of serial console as we collect dmesg only if serial console is not there. For baremetal run, serail console logs are not whole and we miss the logs.