### PR TITLE
Tool to check supported hugepagesize and fix in dpdk tests while mounting with 1G hugepage size

### DIFF
--- a/lisa/__init__.py
+++ b/lisa/__init__.py
@@ -16,6 +16,7 @@ from lisa.testsuite import (
 from lisa.util import (
     BadEnvironmentStateException,
     LisaException,
+    NotEnoughMemoryException,
     PassedException,
     ResourceAwaitableException,
     SkippedException,
@@ -38,6 +39,7 @@ __all__ = [
     "LisaException",
     "Logger",
     "Node",
+    "NotEnoughMemoryException",
     "PassedException",
     "RemoteNode",
     "ResourceAwaitableException",

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -44,6 +44,7 @@ from .gdb import Gdb
 from .git import Git
 from .hibernation_setup import HibernationSetup
 from .hostname import Hostname
+from .hugepages import Hugepages
 from .hwclock import Hwclock
 from .hyperv import HyperV
 from .interrupt_inspector import InterruptInspector
@@ -158,6 +159,7 @@ __all__ = [
     "Iperf3",
     "HibernationSetup",
     "Hostname",
+    "Hugepages",
     "Hwclock",
     "HyperV",
     "InterruptInspector",

--- a/lisa/tools/free.py
+++ b/lisa/tools/free.py
@@ -74,6 +74,9 @@ class Free(Tool):
         # Return total swap size in Mebibytes
         return self._get_field_bytes_kib("Swap", "total") >> 10
 
+    def get_free_memory_kb(self) -> int:
+        return self._get_field_bytes_kib("Mem", "free")
+
     def get_free_memory_mb(self) -> int:
         return self._get_field_bytes_kib("Mem", "free") >> 10
 

--- a/lisa/tools/hugepages.py
+++ b/lisa/tools/hugepages.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+import re
+from enum import Enum
+from typing import Any, Set
+
+from lisa.executable import Tool
+from lisa.tools.echo import Echo
+from lisa.tools.free import Free
+from lisa.tools.ls import Ls
+from lisa.tools.lscpu import Lscpu
+from lisa.tools.mkfs import FileSystem
+from lisa.tools.mount import Mount
+from lisa.util import NotEnoughMemoryException, UnsupportedOperationException
+
+PATTERN_HUGEPAGE = re.compile(
+    r"^.*hugepages-(?P<hugepage_size_in_kb>\d+)kB.*",
+)
+
+
+class HugePageSize(Enum):
+    HUGE_1GB = 1048576
+    HUGE_2MB = 2048
+    HUGE_512MB = 524288
+    HUGE_16GB = 16777216
+
+
+class Hugepages(Tool):
+    @property
+    def command(self) -> str:
+        return ""
+
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self._hugepages_dir_path = "/sys/devices/system/node/node*/hugepages"
+
+    def get_hugepage_sizes_in_kb(self) -> Set[int]:
+        """
+        This function get the hugepage sizes in kB available on the system.
+        This is done by listing the hugepages directory
+        and extracting the size from the directory name.
+        e.g. [
+        "'/sys/devices/system/node/node0/hugepages/hugepages-16777216kB/'",
+        "'/sys/devices/system/node/node0/hugepages/hugepages-2048kB/'",
+        "'/sys/devices/system/node/node0/hugepages/hugepages-524288kB/'"
+        ]
+        """
+        hugepage_sizes: Set[int] = set()
+        ls = self.node.tools[Ls]
+        # if not ls.path_exists(self._hugepages_dir_path, sudo=True):
+        #     raise SkippedException(f"path: {self._hugepages_dir_path} does not exist")
+        hugepage_size_dir_names = ls.list_dir(self._hugepages_dir_path, sudo=True)
+        for hugepage_size_dir_name in hugepage_size_dir_names:
+            matched_hugepage = PATTERN_HUGEPAGE.match(hugepage_size_dir_name)
+            if not matched_hugepage:
+                raise UnsupportedOperationException(
+                    "No supported hugepage size found in the"
+                    f"list: {hugepage_size_dir_name}"
+                )
+            hugepage_sizes.add(int(matched_hugepage.group("hugepage_size_in_kb")))
+        return hugepage_sizes
+
+    def _enable_hugepages(self, hugepage_size_kb: HugePageSize) -> None:
+        echo = self.node.tools[Echo]
+        meminfo = self.node.tools[Free]
+        nics_count = len(self.node.nics.get_nic_names())
+        numa_nodes = self.node.tools[Lscpu].get_numa_node_count()
+
+        request_space_kb = (nics_count - 1) * 1024 * 1024 * numa_nodes * 2
+        free_memory_kb = meminfo.get_free_memory_kb()
+
+        if free_memory_kb < request_space_kb:
+            raise NotEnoughMemoryException(
+                f"Not enough {hugepage_size_kb.value} KB pages "
+                "available for DPDK! "
+                f"Requesting {request_space_kb} KB found {free_memory_kb} "
+                "KB free."
+            )
+
+        request_pages = request_space_kb // hugepage_size_kb.value
+        for i in range(numa_nodes):
+            # nr_hugepages will be written with the number calculated
+            # based on 2MB hugepages if not specified, subject to change
+            # this based on further discussion
+            echo.write_to_file(
+                f"{request_pages}",
+                self.node.get_pure_path(
+                    f"/sys/devices/system/node/node{i}/hugepages/"
+                    f"hugepages-{hugepage_size_kb.value}kB/nr_hugepages"
+                ),
+                sudo=True,
+            )
+
+    def init_hugepages(self, hugepage_size: HugePageSize) -> None:
+        mount = self.node.tools[Mount]
+        hugepage_sizes = self.get_hugepage_sizes_in_kb()
+        if hugepage_size.value not in hugepage_sizes:
+            raise UnsupportedOperationException(
+                f"Supported hugepage sizes in kB are: {hugepage_sizes}."
+                f" {hugepage_size.value} kB size is not available"
+            )
+        if not mount.check_mount_point_exist(f"/mnt/huge-{hugepage_size.value}kb"):
+            mount.mount(
+                name="nodev",
+                point=f"/mnt/huge-{hugepage_size.value}kb",
+                fs_type=FileSystem.hugetlbfs,
+                options=f"pagesize={hugepage_size.value}KB",
+            )
+        self._enable_hugepages(hugepage_size_kb=hugepage_size)

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -207,6 +207,21 @@ class UnsupportedKernelException(LisaException):
         return message
 
 
+class NotEnoughMemoryException(LisaException):
+    """
+    This exception is used to indicate that that the system does not have enough memory.
+    """
+
+    def __init__(self, message: str = "") -> None:
+        self._extended_message = message
+
+    def __str__(self) -> str:
+        message = "Not enough memory"
+        if self._extended_message:
+            message = f"{message}. {self._extended_message}"
+        return message
+
+
 class UnsupportedCpuArchitectureException(LisaException):
     """
     This exception is used to indicate that a test case does not support the

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -20,6 +20,7 @@ from lisa.messages import (
 )
 from lisa.testsuite import TestResult
 from lisa.tools import Lscpu
+from lisa.tools.hugepages import HugePageSize
 from lisa.util import constants
 from microsoft.testsuites.dpdk.common import force_dpdk_default_source
 from microsoft.testsuites.dpdk.dpdkutil import (
@@ -62,7 +63,9 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        sender_kit = verify_dpdk_build(node, log, variables, "failsafe")
+        sender_kit = verify_dpdk_build(
+            node, log, variables, "failsafe", HugePageSize.HUGE_2MB
+        )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
         # shared results fields
@@ -106,7 +109,9 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        sender_kit = verify_dpdk_build(node, log, variables, "netvsc")
+        sender_kit = verify_dpdk_build(
+            node, log, variables, "netvsc", HugePageSize.HUGE_2MB
+        )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
         # shared results fields
@@ -253,7 +258,12 @@ class DpdkPerformance(TestSuite):
     ) -> None:
         force_dpdk_default_source(variables)
         verify_dpdk_l3fwd_ntttcp_tcp(
-            environment, log, variables, pmd="netvsc", is_perf_test=True
+            environment,
+            log,
+            variables,
+            HugePageSize.HUGE_2MB,
+            pmd="netvsc",
+            is_perf_test=True,
         )
 
     def _run_dpdk_perf_test(
@@ -285,6 +295,7 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
+                    HugePageSize.HUGE_2MB,
                     use_service_cores=service_cores,
                 )
         except UnsupportedPackageVersionException as err:


### PR DESCRIPTION
Some dpdk tests are failing during mounting as hugepage size of 1G is not supported all the time.
A tool has been written to check the hugepage sizes available. If 1G hugepage is not supported, it will skip the tests.

This change has been tested (both positive and negative scenario)