### PR TITLE
modify cloud-init error pattern

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -83,8 +83,8 @@ class AzureImageStandard(TestSuite):
     # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
     # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
-        re.compile(r"^(.*\[ERROR\]:*)", re.MULTILINE),
-        re.compile(r"^(.*\[WARNING\]:*)", re.MULTILINE),
+        re.compile(r"^(.*\[ERROR\]:.*)", re.MULTILINE),
+        re.compile(r"^(.*\[WARNING\]:.*)", re.MULTILINE),
     ]
 
     # ignorable failure, error, warnings pattern which got confirmed

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -83,11 +83,10 @@ class AzureImageStandard(TestSuite):
     # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
     # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
-        re.compile(r"^(.*\[ERROR\]*)$", re.MULTILINE),
-        re.compile(r"^(.*ERROR:*)$", re.MULTILINE),
-        re.compile(r"^(.*\[WARNING\]*)$", re.MULTILINE),
-        re.compile(r"^(.*WARNING:*)$", re.MULTILINE),
+        re.compile(r"^(.*[ERROR]*)$", re.MULTILINE),
+        re.compile(r"^(.*[WARNING]*)$", re.MULTILINE),
     ]
+
 
     # ignorable failure, error, warnings pattern which got confirmed
     _error_fail_warnings_ignorable_str_list: List[Pattern[str]] = [

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -83,8 +83,8 @@ class AzureImageStandard(TestSuite):
     # [WARNING]: Running ['tdnf', '-y', 'upgrade'] resulted in stderr output.
     # cloud-init[958]: photon.py[ERROR]: Error while installing packages
     _ERROR_WARNING_pattern: List[Pattern[str]] = [
-        re.compile(r"^(.*[ERROR]*)$", re.MULTILINE),
-        re.compile(r"^(.*[WARNING]*)$", re.MULTILINE),
+        re.compile(r"^(.*\[ERROR\]:*)", re.MULTILINE),
+        re.compile(r"^(.*\[WARNING\]:*)", re.MULTILINE),
     ]
 
     # ignorable failure, error, warnings pattern which got confirmed

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -87,7 +87,6 @@ class AzureImageStandard(TestSuite):
         re.compile(r"^(.*[WARNING]*)$", re.MULTILINE),
     ]
 
-
     # ignorable failure, error, warnings pattern which got confirmed
     _error_fail_warnings_ignorable_str_list: List[Pattern[str]] = [
         re.compile(r"^(.*Perf event create on CPU 0 failed with -2.*)$", re.M),


### PR DESCRIPTION
Correct pattern matching list _ERROR_WARNING_pattern for cloud-init test in LISA. Previously, it does not properly catch message patter [ERROR] and [WARNING] in cloud-init.log 