### PR TITLE
Fix verify_serial_console failed due to lack of auth

### DIFF
--- a/lisa/features/serial_console.py
+++ b/lisa/features/serial_console.py
@@ -195,3 +195,7 @@ class SerialConsole(Feature):
 
     def write(self, data: str) -> None:
         raise NotImplementedError
+
+    def close(self) -> None:
+        # it's not required to implement close method.
+        pass

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -345,6 +345,12 @@ class SerialConsole(AzureFeatureMixin, features.SerialConsole):
             self._get_connection()
             raise e
 
+    def close(self) -> None:
+        if self._ws is not None:
+            self._log.debug("Closing connection to serial console")
+            self._get_event_loop().run_until_complete(self._ws.close())
+            self._ws = None
+
     def _get_event_loop(self) -> asyncio.AbstractEventLoop:
         # create asyncio loop if it doesn't exist
         try:

--- a/microsoft/testsuites/core/serial_console.py
+++ b/microsoft/testsuites/core/serial_console.py
@@ -37,13 +37,15 @@ class SerialConsoleSuite(TestSuite):
         serial_console = node.features[SerialConsole]
 
         # retry to read serial console output, because it may not be ready
-        for _ in range(180):
+        for i in range(180):
             _ = serial_console.read()
             serial_console.write(command)
             output = serial_console.read()
 
             # check if the output contains the command
             if command in output:
+                serial_console.close()
+                log.debug(f"called {i} times, get output from serial console: {output}")
                 break
 
             # sleep for 1 second


### PR DESCRIPTION
See commit details

1. Add auth for serial console.
2. Add close method for serial console to close ws connection.