### PR TITLE
StartStop use_public_address

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -168,6 +168,9 @@ class StartStop(AzureFeatureMixin, features.StartStop):
         node_info = self._node.connection_info
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_PUBLIC_ADDRESS] = public_ip
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS] = private_ip
+        node_info[
+            constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS
+        ] = platform._azure_runbook.use_public_address
         self._node.set_connection_info(**node_info)
         self._node._is_initialized = False
         self._node.initialize()


### PR DESCRIPTION
The StartStop feature should honor the `use_public_address` settings in the runbook.