### PR TITLE
updated msg_level test case with an unsupported_os

### DIFF
--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -484,8 +484,14 @@ class NetworkSettings(TestSuite):
                 and name.
             3. Validate changing the message level flag setting.
             4. Revert back the setting to original value.
+
+            Note: BSD does not support the feature tested here and
+            lacks the hv_netvsc module used to support it.
         """,
         priority=2,
+        requirement=simple_requirement(
+            unsupported_os=[BSD, Windows],
+        ),
     )
     def verify_device_msg_level_change(self, node: Node, log: Logger) -> None:
         # Check if feature is supported by the kernel


### PR DESCRIPTION
This test case is not supported on BSD and needs to be skipped and the supported function is also not supported by the os.