### PR TITLE
Add method to increase os partition for Redhat LVM

### DIFF
--- a/microsoft/testsuites/power/common.py
+++ b/microsoft/testsuites/power/common.py
@@ -24,7 +24,7 @@ from lisa.util import (
     LisaException,
     SkippedException,
     UnsupportedDistroException,
-    find_groups_in_lines,
+    find_group_in_lines,
 )
 from lisa.util.perf_timer import create_timer
 
@@ -179,13 +179,13 @@ def _expand_os_partition(node: Node, log: Logger) -> None:
         # The output of pvscan -s is like below.:
         #  /dev/sda4
         #  Total: 1 [299.31 GiB] / in use: 1 [299.31 GiB] / in no VG: 0 [0   ]
-        pattern = re.compile(r"(?P<disk>.*)(?P<number>[\d]+)", re.M)
-        matched = find_groups_in_lines(pv_result, pattern)
+        pattern = re.compile(r"(?P<disk>.*)(?P<number>[\d]+)$", re.M)
+        matched = find_group_in_lines(pv_result, pattern)
         if not matched:
             log.debug("No physical volume found. Does not require partition resize.")
             return
-        disk = matched[0].get("disk")
-        number = matched[0].get("number")
+        disk = matched.get("disk")
+        number = matched.get("number")
         node.execute(f"growpart {disk} {number}", sudo=True)
         node.execute(f"pvresize {pv_result.splitlines()[0]}", sudo=True)
         root_partition = node.tools[Mount].get_partition_info("/")[0]

--- a/microsoft/testsuites/power/common.py
+++ b/microsoft/testsuites/power/common.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import re
 from decimal import Decimal
 from typing import cast
 
@@ -9,8 +10,22 @@ from lisa import Environment, Logger, Node, RemoteNode, features
 from lisa.features import StartStop
 from lisa.features.startstop import VMStatus
 from lisa.operating_system import Redhat, Suse, Ubuntu
-from lisa.tools import Dmesg, Fio, HibernationSetup, Iperf3, KernelConfig, Kill, Lscpu
-from lisa.util import LisaException, SkippedException
+from lisa.tools import (
+    Dmesg,
+    Fio,
+    HibernationSetup,
+    Iperf3,
+    KernelConfig,
+    Kill,
+    Lscpu,
+    Mount,
+)
+from lisa.util import (
+    LisaException,
+    SkippedException,
+    UnsupportedDistroException,
+    find_groups_in_lines,
+)
 from lisa.util.perf_timer import create_timer
 
 
@@ -37,6 +52,12 @@ def verify_hibernation(
     log: Logger,
     throw_error: bool = True,
 ) -> None:
+    if isinstance(node.os, Redhat):
+        # Hibernation tests are run with higher os disk size.
+        # In case of LVM enabled Redhat images, increasing the os disk size
+        # does not increase the root partition. It requires growpart to grow the
+        # partition size.
+        _expand_os_partition(node, log)
     hibernation_setup_tool = node.tools[HibernationSetup]
     startstop = node.features[StartStop]
 
@@ -150,3 +171,37 @@ def cleanup_env(environment: Environment) -> None:
         kill.by_name("iperf3")
         kill.by_name("fio")
         kill.by_name("stress-ng")
+
+
+def _expand_os_partition(node: Node, log: Logger) -> None:
+    if isinstance(node.os, Redhat):
+        pv_result = node.execute("pvscan -s", sudo=True, shell=True).stdout
+        # The output of pvscan -s is like below.:
+        #  /dev/sda4
+        #  Total: 1 [299.31 GiB] / in use: 1 [299.31 GiB] / in no VG: 0 [0   ]
+        pattern = re.compile(r"(?P<disk>.*)(?P<number>[\d]+)", re.M)
+        matched = find_groups_in_lines(pv_result, pattern)
+        if not matched:
+            log.debug("No physical volume found. Does not require partition resize.")
+            return
+        disk = matched[0].get("disk")
+        number = matched[0].get("number")
+        node.execute(f"growpart {disk} {number}", sudo=True)
+        node.execute(f"pvresize {pv_result.splitlines()[0]}", sudo=True)
+        root_partition = node.tools[Mount].get_partition_info("/")[0]
+        device_name = root_partition.name
+        device_type = root_partition.type
+        cmd_result = node.execute(f"lvdisplay {device_name}", sudo=True)
+        if cmd_result.exit_code == 0:
+            node.execute(f"lvextend -l 100%FREE {device_name}", sudo=True, shell=True)
+            if device_type == "xfs":
+                node.execute(f"xfs_growfs {device_name}", sudo=True)
+            elif device_type == "ext4":
+                node.execute(f"resize2fs {device_name}", sudo=True)
+            else:
+                raise LisaException(f"Unknown partition type: {device_type}")
+        else:
+            log.debug("No LV found. Does not require LV resize.")
+            return
+    else:
+        raise UnsupportedDistroException(node.os, "OS Partition Resize not supported")


### PR DESCRIPTION
Newer Redhat Distro uses LVM, Hence using osdisk_size increases the disk size but not the os partition size. This method increases the root partition size