### PR TITLE
Allow max_data_disk_count to work with maximize_capability

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -520,7 +520,7 @@ class DiskOptionSettings(FeatureSettings):
         ),
     )
     max_data_disk_count: search_space.CountSpace = field(
-        default=None,
+        default_factory=partial(search_space.IntRange, min=0),
         metadata=field_metadata(
             allow_none=True, decoder=search_space.decode_count_space
         ),

--- a/microsoft/testsuites/core/storage.py
+++ b/microsoft/testsuites/core/storage.py
@@ -43,6 +43,7 @@ from lisa.tools.kernel_config import KernelConfig
 from lisa.util import (
     BadEnvironmentStateException,
     LisaException,
+    SkippedException,
     generate_random_chars,
     get_matched_str,
 )
@@ -641,7 +642,9 @@ class Storage(TestSuite):
 
         # get max data disk count for the node
         assert node.capability.disk
-        assert isinstance(node.capability.disk.max_data_disk_count, int)
+        assert isinstance(
+            node.capability.disk.max_data_disk_count, int
+        ), f"actual type: {node.capability.disk.max_data_disk_count}"
         max_data_disk_count = node.capability.disk.max_data_disk_count
         log.debug(f"max_data_disk_count: {max_data_disk_count}")
 
@@ -657,6 +660,12 @@ class Storage(TestSuite):
         # Assuming existing disks added sequentially from lun = 0 to
         # (current_data_disk_count - 1)
         free_luns = list(range(current_data_disk_count, max_data_disk_count))
+
+        if len(free_luns) < 1:
+            raise SkippedException(
+                "No data disks can be added. "
+                "Consider manually setting max_data_disk_count in the runbook."
+            )
 
         # Randomize the luns if randomize_luns is set to True
         # Using seed 6 to get consistent randomization across runs
@@ -728,7 +737,9 @@ class Storage(TestSuite):
 
         # get max data disk count for the node
         assert node.capability.disk
-        assert isinstance(node.capability.disk.max_data_disk_count, int)
+        assert isinstance(
+            node.capability.disk.max_data_disk_count, int
+        ), f"actual type: {node.capability.disk.max_data_disk_count}"
         max_data_disk_count = node.capability.disk.max_data_disk_count
         log.debug(f"max_data_disk_count: {max_data_disk_count}")
 
@@ -739,6 +750,12 @@ class Storage(TestSuite):
 
         # disks to be added to the vm
         disks_to_add = max_data_disk_count - current_data_disk_count
+
+        if disks_to_add < 1:
+            raise SkippedException(
+                "No data disks can be added. "
+                "Consider manually setting max_data_disk_count in the runbook."
+            )
 
         # get partition info before adding data disks
         partitions_before_adding_disks = lsblk.get_disks(force_run=True)


### PR DESCRIPTION
Currently maximize_capability breaks any test cases that rely on max_data_disk_count. Trying to manually set the value in the runbook creates a 'no quota available' error.

These changes make the default value (0,) instead of None, allowing a passed in value to merge with max_capability value.