### PR TITLE
skip mariner3 and add timeout to wait_operation()

### DIFF
--- a/microsoft/testsuites/vm_extensions/linux_patch_extension.py
+++ b/microsoft/testsuites/vm_extensions/linux_patch_extension.py
@@ -32,7 +32,7 @@ def _verify_unsupported_images(node: Node) -> None:
     unsupported_versions_x86_64 = {
         # major minor gen
         SLES: ["15-5 1"],
-        CBLMariner: ["2-0 1"],
+        CBLMariner: ["2-0 1", "3-0 1"],
     }
 
     # Get the full version string of the OS
@@ -189,7 +189,7 @@ class LinuxPatchExtensionBVT(TestSuite):
             )
             # set wait operation timeout 10 min, status file should be generated
             # before timeout
-            assess_result = wait_operation(operation)
+            assess_result = wait_operation(operation, 600)
 
         except HttpResponseError as identifier:
             if any(


### PR DESCRIPTION
[x] skip mariner 3 image
[x] add timeout to wait_operation so LISA will raise LISA exception

![image](https://github.com/user-attachments/assets/207301c2-66bc-45ae-9cbf-bbc75d65c602)
