### PR TITLE
Use subscription client to find the sub id for a storage account

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1290,15 +1290,11 @@ class AzurePlatform(Platform):
             # vhd is higher priority
             vhd = azure_node_runbook.vhd
             vhd.vhd_path = get_deployable_vhd_path(
-                self, vhd.vhd_path, azure_node_runbook.location, log, vhd.subscription
+                self, vhd.vhd_path, azure_node_runbook.location, log
             )
             if vhd.vmgs_path:
                 vhd.vmgs_path = get_deployable_vhd_path(
-                    self,
-                    vhd.vmgs_path,
-                    azure_node_runbook.location,
-                    log,
-                    vhd.subscription,
+                    self, vhd.vmgs_path, azure_node_runbook.location, log
                 )
             azure_node_runbook.vhd = vhd
             azure_node_runbook.marketplace = None

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -388,9 +388,6 @@ class SigTransformerSchema(schema.Transformer):
     # raw vhd URL, it can be the blob under the same subscription of SIG
     # or SASURL
     vhd: str = field(default="", metadata=field_metadata(required=True))
-    # If vhd is a blob fullpath and is in another subscription,
-    # the subscription should be specified
-    subscription: str = ""
     # if not specify gallery_resource_group_name, use shared resource group name
     gallery_resource_group_name: str = field(default=AZURE_SHARED_RG_NAME)
     # if not specified, will use the first location of gallery image
@@ -511,7 +508,7 @@ class SharedGalleryImageTransformer(Transformer):
         if not runbook.gallery_location:
             runbook.gallery_location = image_location
         vhd_path = get_deployable_vhd_path(
-            platform, runbook.vhd, image_location, self._log, runbook.subscription
+            platform, runbook.vhd, image_location, self._log
         )
         vhd_details = get_vhd_details(platform, vhd_path)
         check_blob_exist(


### PR DESCRIPTION
This is related with PR https://github.com/microsoft/lisa/pull/3348 and https://github.com/microsoft/lisa/pull/3329.
In this PR, use subscription client to find a subscription which has the storage account. 

"subscription" is removed from SigTransformerSchema and vhdSchema. So that it doesn't need any changes in AITL for AAD vhd path scenario.

