### PR TITLE
Support retry failed case by redeploy a new enironment

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -440,6 +440,7 @@ class Environment(ContextMixin, InitializableMixin):
         self.remove_context()
 
         self._retries += 1
+        self._is_initialized = False
 
     def _validate_single_default(
         self, has_default: bool, is_default: Optional[bool]

--- a/lisa/notifiers/file.py
+++ b/lisa/notifiers/file.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, List, Type, cast
 
 from dataclasses_json import dataclass_json
@@ -40,7 +40,7 @@ class Console(notifier.Notifier):
         simplify_message(message)
         # write every time to refresh the content immediately.
         with open(self._file_path, "a") as f:
-            f.write(f"{datetime.now():%Y-%m-%d %H:%M:%S.%ff}: {message}\n")
+            f.write(f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S.%ff}: {message}\n")
 
     def _subscribed_message_type(self) -> List[Type[messages.MessageBase]]:
         return [messages.MessageBase]

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -84,6 +84,7 @@ class TestResult:
     information: Dict[str, Any] = field(default_factory=dict)
     log_file: str = ""
     stacktrace: Optional[str] = None
+    retried_times: int = 0
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         self._send_result_message()

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -23,6 +23,7 @@ def generate_runner(
     env_runbook: Optional[schema.EnvironmentRoot] = None,
     case_use_new_env: bool = False,
     times: int = 1,
+    retry: int = 0,
     platform_schema: Optional[test_platform.MockPlatformSchema] = None,
 ) -> LisaRunner:
     platform_runbook = schema.Platform(
@@ -40,6 +41,7 @@ def generate_runner(
             criteria=schema.Criteria(priority=[0, 1, 2]),
             use_new_environment=case_use_new_env,
             times=times,
+            retry=retry,
         )
     ]
     runbook.wait_resource_timeout = 0
@@ -549,6 +551,47 @@ class RunnerTestCase(TestCase):
             ],
             expected_message=[no_available_env, no_available_env, no_available_env],
             test_results=test_results,
+        )
+
+    def test_env_retry(self) -> None:
+        # env prepared, but deployment failed, so cases failed
+        platform_schema = test_platform.MockPlatformSchema()
+
+        test_testsuite.generate_cases_metadata()
+        test_testsuite.retry_failed_count = 1
+        env_runbook = generate_env_runbook()
+        runner = generate_runner(env_runbook, platform_schema=platform_schema, retry=2)
+        test_result_messages = self._run_all_tests(runner)
+
+        self.verify_env_results(
+            expected_prepared=[
+                "generated_0",
+                "generated_1",
+                "generated_2",
+                "generated_0",
+            ],
+            expected_deployed_envs=[
+                "generated_0",
+                "generated_0",
+                "generated_2",
+            ],
+            expected_deleted_envs=[
+                "generated_0",
+                "generated_0",
+                "generated_2",
+            ],
+            runner=runner,
+        )
+        self.verify_test_results(
+            expected_test_order=["mock_ut1", "mock_ut2", "mock_ut3"],
+            expected_envs=["generated_0", "generated_0", "generated_2"],
+            expected_status=[
+                TestStatus.PASSED,
+                TestStatus.PASSED,
+                TestStatus.PASSED,
+            ],
+            expected_message=["", "", ""],
+            test_results=test_result_messages,
         )
 
     def test_env_skipped_no_case(self) -> None:

--- a/selftests/test_testsuite.py
+++ b/selftests/test_testsuite.py
@@ -35,6 +35,7 @@ skipped = False
 queued = False
 fail_case_count = 0
 check_variable = False
+retry_failed_count = 0
 
 
 class MockTestSuite(TestSuite):
@@ -81,6 +82,10 @@ class MockTestSuite(TestSuite):
         while self.fail_case_count > 0:
             self.fail_case_count -= 1
             raise LisaException("mock_ut1 failed")
+        global retry_failed_count
+        if retry_failed_count > 0:
+            retry_failed_count -= 1
+            raise LisaException("mock_ut1 failed by retry")
 
     def mock_ut2(self, variables: Dict[str, Any], **kwargs: Any) -> None:
         if self.check_variable:
@@ -259,22 +264,6 @@ class TestSuiteTestCase(TestCase):
         result = self.case_results[0]
         self.assertEqual(TestStatus.FAILED, result.status)
         self.assertEqual("failed. LisaException: mock_ut1 failed", result.message)
-        result = self.case_results[1]
-        self.assertEqual(TestStatus.PASSED, result.status)
-        self.assertEqual("", result.message)
-
-    def test_retry_passed(self) -> None:
-        test_suite = self.generate_suite_instance()
-        test_suite.set_fail_phase(fail_case_count=1)
-        result = self.case_results[0]
-        result.runtime_data.retry = 1
-        test_suite.start(
-            environment=self.default_env,
-            case_results=self.case_results,
-            case_variables={},
-        )
-        self.assertEqual(TestStatus.PASSED, result.status)
-        self.assertEqual("", result.message)
         result = self.case_results[1]
         self.assertEqual(TestStatus.PASSED, result.status)
         self.assertEqual("", result.message)


### PR DESCRIPTION
Previously, the retry just rerun the test case only. With this change, the retry will deploy a new environment. So, if the environment deployment is not stable, the retry can mitigate it.

See commits and code comments for details.

