### PR TITLE
Add device passthrough support for libvirt/hyperv platforms

### DIFF
--- a/lisa/sut_orchestrator/hyperv/context.py
+++ b/lisa/sut_orchestrator/hyperv/context.py
@@ -1,12 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import PurePath
-from typing import Optional
+from typing import List, Optional
 
 from lisa import Node, RemoteNode
+from lisa.sut_orchestrator.hyperv.schema import DeviceAddressSchema
+from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 from lisa.util.process import Process
+
+
+@dataclass
+class DevicePassthroughContext:
+    pool_type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
+    device_list: List[DeviceAddressSchema] = field(
+        default_factory=list,
+    )
 
 
 @dataclass
@@ -15,6 +25,11 @@ class NodeContext:
     host: Optional[RemoteNode] = None
     working_path = PurePath()
     serial_log_process: Optional[Process] = None
+
+    # Device pass through configuration
+    passthrough_devices: List[DevicePassthroughContext] = field(
+        default_factory=list,
+    )
 
     @property
     def console_log_path(self) -> PurePath:

--- a/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
+++ b/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
@@ -1,0 +1,359 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# Refer: https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/deploy/deploying-graphics-devices-using-dda  # noqa E501
+import re
+from typing import Dict, List, Optional
+
+from lisa.node import Node
+from lisa.tools import PowerShell
+from lisa.util import LisaException, find_group_in_lines, find_groups_in_lines
+from lisa.util.logger import Logger
+
+from .schema import DeviceAddressSchema
+
+
+class HypervAssignableDevices:
+    PKEY_DEVICE_TYPE = "{3AB22E31-8264-4b4e-9AF5-A8D2D8E33E62}  1"
+    PKEY_BASE_CLASS = "{3AB22E31-8264-4b4e-9AF5-A8D2D8E33E62}  3"
+    PKEY_REQUIRES_RESERVED_MEMORY_REGION = "{3AB22E31-8264-4b4e-9AF5-A8D2D8E33E62}  34" # noqa E501
+    PKEY_ACS_COMPATIBLE_UP_HIERARCHY = "{3AB22E31-8264-4b4e-9AF5-A8D2D8E33E62}  31" # noqa E501
+    PROP_DEVICE_TYPE_PCI_EXPRESS_ENDPOINT = "2"
+    PROP_DEVICE_TYPE_PCI_EXPRESS_LEGACY_ENDPOINT = "3"
+    PROP_DEVICE_TYPE_PCI_EXPRESS_ROOT_COMPLEX_INTEGRATED_ENDPOINT = "4"
+    PROP_DEVICE_TYPE_PCI_EXPRESS_TREATED_AS_PCI = "5"
+    PROP_ACS_COMPATIBLE_UP_HIERARCHY_NOT_SUPPORTED = "0"
+    PROP_BASE_CLASS_DISPLAY_CTRL = "3"
+
+    def __init__(self, host_node: Node, log: Logger):
+        self.host_node = host_node
+        self.log = log
+        self.pwsh = self.host_node.tools[PowerShell]
+        self.pnp_allocated_resources: List[Dict[str, str]] = (
+            self.__load_pnp_allocated_resources()
+        )
+
+    def get_assignable_devices(
+        self,
+        vendor_id: str,
+        device_id: str,
+    ) -> List[DeviceAddressSchema]:
+        device_id_list = self.__get_devices_by_vendor_device_id(
+            vendor_id=vendor_id, device_id=device_id
+        )
+
+        devices: List[DeviceAddressSchema] = []
+        for rec in device_id_list:
+            device_id = rec["device_id"]
+            result = self.__get_dda_properties(device_id=device_id)
+            if result:
+                result.friendly_name = rec["friendly_name"]
+                devices.append(result)
+        return devices
+
+    def __get_devices_by_vendor_device_id(
+        self,
+        vendor_id: str,
+        device_id: str,
+    ) -> List[Dict[str, str]]:
+        """
+        Get the device ID list for given vendor/device ID combination
+        """
+        devices: List[Dict[str, str]] = []
+        device_regex = re.compile(
+            r"Description\s+:\s*(?P<desc>.+)\n.*DeviceID\s+:\s*(?P<device_id>.+)"
+        )
+
+        cmd = (
+            "Get-WmiObject Win32_PnPEntity -Filter "
+            f"\"DeviceID LIKE 'PCI\\\\VEN_{vendor_id}&DEV_{device_id}%'\""
+        )
+        stdout = self.pwsh.run_cmdlet(
+            cmdlet=cmd,
+            force_run=True,
+            sudo=True,
+        )
+
+        devices_str = stdout.strip().split("\r\n\r\n")
+        filtered_devices = [i.strip() for i in devices_str if i.strip() != ""]
+        for device_properties in filtered_devices:
+            res = find_group_in_lines(
+                lines=device_properties,
+                pattern=device_regex,
+                single_line=False,
+            )
+            if not res:
+                raise LisaException("Can not extract DeviceId/Description")
+
+            devices.append({
+                "device_id": res["device_id"].strip(),
+                "friendly_name": res["desc"].strip(),
+            })
+        return devices
+
+    def __get_pnp_device_property(self, device_id: str, property_name: str) -> str:
+        """
+        Retrieve a PnP device property by instance ID and property key.
+        """
+        cmd = (
+            "(Get-PnpDeviceProperty -InstanceId "
+            f"'{device_id}' '{property_name}').Data"
+        )
+
+        output = self.pwsh.run_cmdlet(
+            cmdlet=cmd,
+            sudo=True,
+            force_run=True,
+        )
+        return output.strip()
+
+    def __load_pnp_allocated_resources(self) -> List[Dict[str, str]]:
+        # Command output result (just 2 device properties)
+        # ========================================================
+        # __GENUS          : 2
+        # __CLASS          : Win32_PNPAllocatedResource
+        # __SUPERCLASS     : CIM_AllocatedResource
+        # __DYNASTY        : CIM_Dependency
+        # __RELPATH        : Win32_PNPAllocatedResource.Antecedent="\\\\WIN-2IDCNC2D5V
+        #                   C\\root\\cimv2:Win32_DeviceMemoryAddress.StartingAddress=\
+        #                   "2463203328\"",Dependent="\\\\WIN-2IDCNC2D5VC\\root\\cimv2:
+        #                   Win32_PnPEntity.DeviceID=\"PCI\\\\VEN_8086&DEV_A1A3&
+        #                   SUBSYS_07161028&REV_09\\\\3&11583659&0&FC\""
+        # __PROPERTY_COUNT : 2
+        # __DERIVATION     : {CIM_AllocatedResource, CIM_Dependency}
+        # __SERVER         : WIN-2IDCNC2D5VC
+        # __NAMESPACE      : root\cimv2
+        # __PATH           : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_PNPAllocatedResource.
+        #                   Antecedent="\\\\WIN-2IDCNC2D5VC\\root\\cimv2:Win32_
+        #                   DeviceMemoryAddress.StartingAddress=\"2463203328\"",
+        #                   Dependent="\\\\WIN-2IDCNC2D5VC\\root\\cimv2:Win32_PnP
+        #                   Entity.DeviceID=\"PCI\\\\VEN_8086&DEV_A1A3&SUBSYS_07161028&
+        #                   REV_09\\\\3&11583659&0&FC\""
+        # Antecedent       : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_DeviceMemoryAddress.
+        #                    StartingAddress="2463203328"
+        # Dependent        : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_PnPEntity.DeviceID=
+        #                   "PCI\\VEN_8086&DEV_A1A3&SUBSYS_07161028&REV_09\\3
+        #                    &11583659&0&FC"
+        # PSComputerName   : WIN-2IDCNC2D5VC
+
+        # __GENUS          : 2
+        # __CLASS          : Win32_PNPAllocatedResource
+        # __SUPERCLASS     : CIM_AllocatedResource
+        # __DYNASTY        : CIM_Dependency
+        # __RELPATH        : Win32_PNPAllocatedResource.Antecedent="\\\\WIN-2IDCNC2D5VC
+        #                   \\root\\cimv2:Win32_PortResource.StartingAddress=\"8192\"",
+        #                   Dependent="\\\\WIN-2IDCNC2D5VC\\root\\cimv2:Win32_PnPEntity
+        #                   .DeviceID=\"PCI\\\\VEN_8086&DEV_A1A3&SUBSYS_07161028&REV_09
+        #                   \\\\3&11583659&0&FC\""
+        # __PROPERTY_COUNT : 2
+        # __DERIVATION     : {CIM_AllocatedResource, CIM_Dependency}
+        # __SERVER         : WIN-2IDCNC2D5VC
+        # __NAMESPACE      : root\cimv2
+        # __PATH           : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_PNPAllocatedResource.
+        #                    Antecedent="\\\\WIN-2IDCNC2D5VC\\root\\cimv2:Win32_PortR
+        #                    esource.StartingAddress=\"8192\"",Dependent="\\\\WIN-2ID
+        #                    CNC2D5VC\\root\\cimv2:Win32_PnPEntity.DeviceID=\"PCI\\\\
+        #                    VEN_8086&DEV_A1A3&SUBSYS_07161028&REV_09\\\\3&11
+        #                    583659&0&FC\""
+        # Antecedent       : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_PortResource.
+        #                    StartingAddress="8192"
+        # Dependent        : \\WIN-2IDCNC2D5VC\root\cimv2:Win32_PnPEntity.DeviceID=
+        #                    "PCI\\VEN_8086&DEV_A1A3&SUBSYS_07161028&REV_09\\3&
+        #                    11583659&0&FC"
+        # PSComputerName   : WIN-2IDCNC2D5VC
+
+        stdout = self.pwsh.run_cmdlet(
+            cmdlet="gwmi -query 'select * from Win32_PnPAllocatedResource'",
+            sudo=True,
+            force_run=True,
+        )
+        pnp_allocated_resources = stdout.strip().split("\r\n\r\n")
+        result: List[Dict[str, str]] = []
+        # Regular expression to match the key-value pairs
+        pattern = re.compile(r'(?P<key>\S+)\s*:\s*(?P<value>.*?)(?=\n\S|\Z)', re.DOTALL)
+
+        for rec in pnp_allocated_resources:
+            extract_val = {}
+            matches = find_groups_in_lines(
+                lines=rec.strip(),
+                pattern=pattern,
+                single_line=False,
+            )
+            if matches:
+                for element in matches:
+                    key = element["key"]
+                    val = element["value"]
+                    val = val.replace(" ", "")
+                    val = val.replace("\r\n", "")
+                    extract_val[key] = val
+                result.append(extract_val)
+        return result
+
+    def __get_mmio_end_address(self, start_addr: str) -> Optional[str]:
+        # MemoryType   Name                  Status
+        # ----------   ----                  ------
+        # WindowDecode 0xE1800000-0xE1BFFFFF OK
+        #             0xE2000000-0xE2000FFF OK
+        # WindowDecode 0xD4000000-0xD43FFFFF OK
+        #             0xD4800000-0xD4800FFF OK
+        #             0xFED1C000-0xFED3FFFF OK
+
+        device_mem_addr = self.pwsh.run_cmdlet(
+            cmdlet="gwmi -query 'select * from Win32_DeviceMemoryAddress'",
+            sudo=True,
+            force_run=True,
+        )
+        end_addr_rec = None
+        for rec in device_mem_addr.splitlines():
+            rec = rec.strip()
+            if rec.find(start_addr) >= 0:
+                addr = rec.split("-")
+                start_addr_rec = addr[0].split()[-1]
+                end_addr_rec = addr[1].split()[0].strip()
+
+                err = "MMIO Starting address not matching"
+                assert start_addr == start_addr_rec, err
+                break
+        return end_addr_rec
+
+    def __get_dda_properties(self, device_id: str) -> Optional[DeviceAddressSchema]:
+        """
+        Determine if a PCI device is assignable using Discrete Device Assignment (DDA)
+        If so, get DDA proerprties like locationpath, device-id, friendly name
+        """
+        self.log.debug(f"PCI InstanceId: {device_id}")
+
+        rmrr = self.__get_pnp_device_property(
+            device_id=device_id,
+            property_name=self.PKEY_REQUIRES_RESERVED_MEMORY_REGION,
+        )
+        rmrr = rmrr.strip()
+        if rmrr != "False":
+            self.log.debug(
+                "BIOS requires that this device remain attached to BIOS-owned memory."
+                "Not assignable."
+            )
+            return None
+
+        acs_up = self.__get_pnp_device_property(
+            device_id=device_id,
+            property_name=self.PKEY_ACS_COMPATIBLE_UP_HIERARCHY,
+        )
+        acs_up = acs_up.strip()
+        if acs_up == self.PROP_ACS_COMPATIBLE_UP_HIERARCHY_NOT_SUPPORTED:
+            self.log.debug(
+                "Traffic from this device may be redirected to other devices in "
+                "the system. Not assignable."
+            )
+            return None
+
+        dev_type = self.__get_pnp_device_property(
+            device_id=device_id,
+            property_name=self.PKEY_DEVICE_TYPE
+        )
+        dev_type = dev_type.strip()
+        if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_ENDPOINT:
+            self.log.debug("Express Endpoint -- more secure.")
+        else:
+            if dev_type == (
+                self.PROP_DEVICE_TYPE_PCI_EXPRESS_ROOT_COMPLEX_INTEGRATED_ENDPOINT
+            ):
+                self.log.debug("Embedded Endpoint -- less secure.")
+            elif dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_LEGACY_ENDPOINT:
+                dev_base_class = self.__get_pnp_device_property(
+                    device_id=device_id,
+                    property_name=self.PKEY_BASE_CLASS,
+                )
+                dev_base_class = dev_base_class.strip()
+                if dev_base_class == self.PROP_BASE_CLASS_DISPLAY_CTRL:
+                    self.log.debug("Legacy Express Endpoint -- graphics controller.")
+                else:
+                    self.log.debug("Legacy, non-VGA PCI device. Not assignable.")
+                    return None
+            else:
+                if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_TREATED_AS_PCI:
+                    self.log.debug(
+                        "BIOS kept control of PCI Express for this device. "
+                        "Not assignable."
+                    )
+                else:
+                    self.log.debug(
+                        "Old-style PCI device, switch port, etc. "
+                        "Not assignable."
+                    )
+                return None
+
+        # Get the device location path
+        location_path = self.__get_pnp_device_property(
+            device_id=device_id,
+            property_name="DEVPKEY_Device_LocationPaths",
+        )
+        location_path = location_path.strip().splitlines()[0]
+        self.log.debug(f"Device locationpath: {location_path}")
+        assert location_path.find("PCI") == 0, "Location path is wrong"
+
+        cmd = (
+            "(Get-PnpDevice -PresentOnly -InstanceId "
+            f"'{device_id}').ConfigManagerErrorCode"
+        )
+        conf_mng_err_code = self.pwsh.run_cmdlet(
+            cmdlet=cmd,
+            force_run=True,
+            sudo=True,
+        )
+        conf_mng_err_code = conf_mng_err_code.strip()
+        self.log.debug(f"ConfigManagerErrorCode: {conf_mng_err_code}")
+        if conf_mng_err_code == "CM_PROB_DISABLED":
+            self.log.debug(
+                "Device is Disabled, unable to check resource requirements, "
+                "it may be assignable."
+            )
+            self.log.debug("Enable the device and rerun this script to confirm.")
+            return None
+
+        irq_assignements = [
+            i for i in self.pnp_allocated_resources
+            if i["Dependent"].find(device_id.replace("\\", "\\\\")) >= 0
+        ]
+        if irq_assignements:
+            msi_assignments = [
+                i for i in self.pnp_allocated_resources
+                if i["Antecedent"].find("IRQNumber=42949") >= 0
+            ]
+            if not msi_assignments:
+                self.log.debug(
+                    "All of the interrupts are line-based, no assignment can work."
+                )
+                return None
+            else:
+                self.log.debug("Its interrupts are message-based, assignment can work.")
+        else:
+            self.log.debug("It has no interrupts at all -- assignment can work.")
+
+        mmio_assignments = [
+            i for i in self.pnp_allocated_resources
+            if i["Dependent"].find(device_id.replace("\\", "\\\\")) >= 0
+            and i["__RELPATH"].find("Win32_DeviceMemoryAddres") >= 0
+        ]
+        mmio_total = 0
+        if mmio_assignments:
+            for rec in mmio_assignments:
+                antecedent_val = rec["Antecedent"]
+                addresses = antecedent_val.split('"')
+                assert len(addresses) >= 2, "Antecedent: Can't get MMIO Start Address"
+                start_address = hex(int(addresses[1].strip())).upper()
+                start_address_hex = start_address.replace("X", "x")
+                end_address = self.__get_mmio_end_address(start_address_hex)
+                assert end_address, "Can not get MMIO End Address"
+
+                mmio = int(end_address, 16) - int(start_address, 16)
+                mmio_total += mmio
+            if mmio_total:
+                mmio_total = round(mmio_total / (1024 * 1024))
+                self.log.debug(f"Device '{device_id}', Total MMIO = {mmio_total}MB ")
+        else:
+            self.log.debug("It has no MMIO space")
+
+        device = DeviceAddressSchema()
+        device.location_path = location_path
+        device.instance_id = device_id
+        return device

--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -1,0 +1,220 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from typing import Dict, List, Optional
+
+from lisa.node import RemoteNode
+from lisa.sut_orchestrator.hyperv.get_assignable_devices import HypervAssignableDevices
+from lisa.sut_orchestrator.hyperv.schema import (
+    DeviceAddressSchema,
+    HypervNodeSchema,
+    HypervPlatformSchema,
+)
+from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
+from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
+from lisa.tools import HyperV, PowerShell
+from lisa.util import ResourceAwaitableException
+from lisa.util.logger import Logger
+
+from .context import DevicePassthroughContext, NodeContext
+
+
+class HyperVDevicePool(BaseDevicePool):
+    def __init__(
+        self,
+        node: RemoteNode,
+        runbook: HypervPlatformSchema,
+        log: Logger,
+    ) -> None:
+        # Device Passthrough configs
+        # Mapping of Host Device Passthrough
+        self.available_host_devices: Dict[
+            HostDevicePoolType, List[DeviceAddressSchema]
+        ] = {}
+        self.supported_pool_type = [
+            HostDevicePoolType.PCI_NIC,
+            HostDevicePoolType.PCI_GPU,
+        ]
+        self._server = node
+        self._hyperv_runbook = runbook
+        self.log = log
+
+    def create_device_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        vendor_id: str,
+        device_id: str,
+    ) -> None:
+        hv_dev = HypervAssignableDevices(
+            host_node=self._server,
+            log=self.log,
+        )
+        devices = hv_dev.get_assignable_devices(
+            vendor_id=vendor_id,
+            device_id=device_id,
+        )
+        primary_nic_id_list = self.get_primary_nic_id()
+        pool = self.available_host_devices.get(pool_type, [])
+        for dev in devices:
+            if dev.instance_id not in primary_nic_id_list:
+                pool.append(dev)
+        self.available_host_devices[pool_type] = pool
+
+    def request_devices(
+        self,
+        pool_type: HostDevicePoolType,
+        count: int,
+    ) -> List[DeviceAddressSchema]:
+        pool = self.available_host_devices[pool_type]
+        if len(pool) < count:
+            raise ResourceAwaitableException(
+                f"Not enough devices are available under pool: {pool_type}. "
+                f"Required count is {count}"
+            )
+        devices = pool[:count]
+
+        # Update the pool
+        pool = pool[count:]
+        self.available_host_devices[pool_type] = pool
+
+        return devices
+
+    def release_devices(
+        self,
+        node_context: NodeContext,
+    ) -> None:
+        vm_name = node_context.vm_name
+        devices_ctx = node_context.passthrough_devices
+        confing_commands = []
+        for ctx in devices_ctx:
+            for device in ctx.device_list:
+                confing_commands.append(
+                    f"Remove-VMAssignableDevice "
+                    f"-LocationPath '{device.location_path}' -VMName '{vm_name}'"
+                )
+                confing_commands.append(
+                    f"Mount-VMHostAssignableDevice -LocationPath "
+                    f"'{device.location_path}'"
+                )
+                confing_commands.append(
+                    f"Enable-PnpDevice -InstanceId '{device.instance_id}' "
+                    "-Confirm:$false"
+                )
+
+        powershell = self._server.tools[PowerShell]
+        for cmd in confing_commands:
+            powershell.run_cmdlet(
+                cmdlet=cmd,
+                force_run=True,
+            )
+
+    def get_primary_nic_id(self) -> List[str]:
+        powershell = self._server.tools[PowerShell]
+        ip: str = self._server.public_address
+
+        # Get the NIC name via IP.
+        # We will get vEthernet switch interface name, not actual NIC for baremetal
+        cmd = (
+            "(Get-NetAdapter | Get-NetIPAddress | Where-Object "
+            f"{{ $_.IPAddress -eq '{ip}' }}).InterfaceAlias"
+        )
+        interface_name = powershell.run_cmdlet(
+            cmdlet=cmd,
+            force_run=True,
+        )
+
+        # Get the MAC for above interface
+        cmd = (
+            "(Get-NetAdapter | Where-Object "
+            f"{{ $_.Name -eq '{interface_name}' }}).MacAddress"
+        )
+        mac_address = powershell.run_cmdlet(
+            cmdlet=cmd,
+            force_run=True,
+        )
+
+        # Get all interfaces for above MAC Address
+        cmd = (
+            "(Get-NetAdapter | Where-Object "
+            f"{{ $_.MacAddress -eq '{mac_address}' }}).Name"
+        )
+        inf_names_str = powershell.run_cmdlet(
+            cmdlet=cmd,
+            force_run=True,
+        )
+        inf_names: List[str] = inf_names_str.strip().splitlines()
+
+        # Get device id for all above interface names we got
+        pnp_device_id_list: List[str] = []
+        for name in inf_names:
+            cmd = (
+                "(Get-NetAdapter | Where-Object "
+                f"{{ $_.Name -eq '{name}' }}).PnPDeviceID"
+            )
+            interface_device_id = powershell.run_cmdlet(
+                cmdlet=cmd,
+                force_run=True,
+            )
+            interface_device_id = interface_device_id.strip()
+            pnp_device_id_list.append(interface_device_id)
+
+        return pnp_device_id_list
+
+    def configure_device_passthrough_pool(
+        self,
+        device_configs: Optional[List[HostDevicePoolSchema]],
+    ) -> None:
+        super().configure_device_passthrough_pool(
+            device_configs=device_configs,
+        )
+
+    def _assign_devices_to_vm(
+        self,
+        vm_name: str,
+        devices: List[DeviceAddressSchema],
+    ) -> None:
+        # Assign the devices to the VM
+        confing_commands = []
+        for device in devices:
+            confing_commands.append(
+                f"Disable-PnpDevice -InstanceId '{device.instance_id}' -Confirm:$false"
+            )
+            confing_commands.append(
+                f"Dismount-VMHostAssignableDevice -Force "
+                f"-LocationPath '{device.location_path}'"
+            )
+            confing_commands.append(
+                f"Add-VMAssignableDevice -LocationPath '{device.location_path}' "
+                f"-VMName '{vm_name}'"
+            )
+
+        powershell = self._server.tools[PowerShell]
+        for cmd in confing_commands:
+            powershell.run_cmdlet(
+                cmdlet=cmd,
+                force_run=True,
+            )
+
+    def _set_device_passthrough_node_context(
+        self,
+        node_context: NodeContext,
+        node_runbook: HypervNodeSchema,
+        hv: HyperV,
+        vm_name: str,
+    ) -> None:
+        if not node_runbook.device_passthrough:
+            return
+        hv.enable_device_passthrough(name=vm_name)
+
+        for config in node_runbook.device_passthrough:
+            devices = self.request_devices(
+                pool_type=config.pool_type,
+                count=config.count,
+            )
+            self._assign_devices_to_vm(
+                vm_name=vm_name,
+                devices=devices,
+            )
+            device_context = DevicePassthroughContext()
+            device_context.pool_type = config.pool_type
+            device_context.device_list = devices
+            node_context.passthrough_devices.append(device_context)

--- a/lisa/sut_orchestrator/hyperv/platform_.py
+++ b/lisa/sut_orchestrator/hyperv/platform_.py
@@ -285,6 +285,8 @@ class HypervPlatform(Platform):
                 },
                 extra_args=extra_args,
             )
+            # Start the VM
+            hv.start_vm(name=vm_name, extra_args=extra_args)
 
             ip_addr = hv.get_ip_address(vm_name)
             username = self.runbook.admin_username

--- a/lisa/sut_orchestrator/hyperv/schema.py
+++ b/lisa/sut_orchestrator/hyperv/schema.py
@@ -7,6 +7,10 @@ from typing import List, Optional
 from dataclasses_json import dataclass_json
 
 from lisa import schema
+from lisa.sut_orchestrator.util.schema import (
+    DevicePassthroughSchema,
+    HostDevicePoolSchema,
+)
 from lisa.util import field_metadata
 
 
@@ -54,6 +58,7 @@ class HypervPlatformSchema:
     servers: List[HypervServer] = field(default_factory=list)
     extra_args: List[ExtraArgs] = field(default_factory=list)
     wait_delete: bool = False
+    device_pools: Optional[List[HostDevicePoolSchema]] = None
 
 
 @dataclass_json
@@ -68,3 +73,14 @@ class HypervNodeSchema:
     hyperv_generation: int = 2
     vhd: Optional[VhdSchema] = None
     osdisk_size_in_gb: int = 30
+    # Configuration options for device-passthrough.
+    device_passthrough: Optional[List[DevicePassthroughSchema]] = None
+
+
+@dataclass_json()
+@dataclass
+class DeviceAddressSchema:
+    # Host device details for which we want to perform device-passthrough
+    instance_id: str = ""
+    location_path: str = ""
+    friendly_name: str = ""

--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -118,6 +118,11 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         os_kernel.text = node_context.firmware_path
 
         devices = ET.SubElement(domain, "devices")
+        if len(node_context.passthrough_devices) > 0:
+            devices = self.device_pool._add_device_passthrough_xml(
+                devices,
+                node_context,
+            )
 
         console = ET.SubElement(devices, "console")
         console.attrib["type"] = "pty"
@@ -170,6 +175,14 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         node_context.console_logger.attach(
             node_context.domain, node_context.console_log_file_path
         )
+
+        if len(node_context.passthrough_devices) > 0:
+            # Once libvirt domain is created, check if driver attached to device
+            # on the host is vfio-pci for PCI device passthrough to make sure if
+            # pass-through for PCI device is happened properly or not
+            self.device_pool._verify_device_passthrough_post_boot(
+                node_context=node_context,
+            )
 
     # Create the OS disk.
     def _create_node_os_disk(

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -5,9 +5,10 @@ import libvirt  # type: ignore
 
 from lisa.environment import Environment
 from lisa.node import Node
+from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 
 from .console_logger import QemuConsoleLogger
-from .schema import DiskImageFormat
+from .schema import DeviceAddressSchema, DiskImageFormat
 
 
 @dataclass
@@ -34,6 +35,15 @@ class InitSystem:
 
 
 @dataclass
+class DevicePassthroughContext:
+    pool_type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
+    device_list: List[DeviceAddressSchema] = field(
+        default_factory=list,
+    )
+    managed: str = ""
+
+
+@dataclass
 class NodeContext:
     vm_name: str = ""
     firmware_source_path: str = ""
@@ -56,6 +66,11 @@ class NodeContext:
 
     console_logger: Optional[QemuConsoleLogger] = None
     domain: Optional[libvirt.virDomain] = None
+
+    # Device pass through configuration
+    passthrough_devices: List[DevicePassthroughContext] = field(
+        default_factory=list,
+    )
 
 
 def get_environment_context(environment: Environment) -> EnvironmentContext:

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -1,0 +1,348 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+import xml.etree.ElementTree as ET  # noqa: N817
+from itertools import combinations
+from typing import Any, Dict, List, Optional, cast
+
+from lisa.node import Node, RemoteNode
+from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
+from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
+from lisa.tools import Ls, Lspci, Modprobe
+from lisa.util import LisaException, ResourceAwaitableException, find_group_in_lines
+
+from .context import DevicePassthroughContext, NodeContext
+from .schema import (
+    BaseLibvirtNodeSchema,
+    BaseLibvirtPlatformSchema,
+    DeviceAddressSchema,
+)
+
+
+class LibvirtDevicePool(BaseDevicePool):
+    def __init__(
+        self,
+        host_node: Node,
+        runbook: BaseLibvirtPlatformSchema,
+    ) -> None:
+        # Mapping of Host Device Passthrough
+        self.available_host_devices: Dict[
+            HostDevicePoolType, Dict[str, List[DeviceAddressSchema]]
+        ] = {}
+
+        self.supported_pool_type = [
+            HostDevicePoolType.PCI_NIC,
+            HostDevicePoolType.PCI_GPU,
+        ]
+        self.host_node = host_node
+        self.platform_runbook = runbook
+
+    def configure_device_passthrough_pool(
+        self,
+        device_configs: Optional[List[HostDevicePoolSchema]],
+    ) -> None:
+        if not device_configs:
+            return
+
+        # Check if host support device passthrough
+        self._check_passthrough_support(self.host_node)
+
+        super().configure_device_passthrough_pool(
+            device_configs=device_configs,
+        )
+
+        modprobe = self.host_node.tools[Modprobe]
+        allow_unsafe_interrupt = modprobe.load(
+            modules="vfio_iommu_type1",
+            parameters="allow_unsafe_interrupts=1",
+        )
+        if not allow_unsafe_interrupt:
+            raise LisaException("Allowing unsafe interrupt failed")
+
+    def request_devices(
+        self,
+        pool_type: HostDevicePoolType,
+        count: int,
+    ) -> List[DeviceAddressSchema]:
+        pool = self.available_host_devices.get(pool_type, {})
+        keys = list(pool.keys())
+        results = []
+        for r in range(1, len(keys) + 1):
+            for combo in combinations(keys, r):
+                if sum(len(pool.get(key, [])) for key in combo) == count:
+                    results.append(combo)
+        if not results:
+            for r in range(1, len(keys) + 1):
+                for combo in combinations(keys, r):
+                    if sum(len(pool.get(key, [])) for key in combo) >= count:
+                        results.append(combo)
+                        break
+                if results:
+                    break
+
+        if not results:
+            raise ResourceAwaitableException(
+                f"Pool {pool_type} running out of devices: {pool}, "
+                "No IOMMU Group has sufficient count of devices, "
+                f"Refer: {pool}"
+            )
+
+        devices: List[DeviceAddressSchema] = []
+        selected_pools = results[0]
+        for iommu_grp in selected_pools:
+            devices += pool.pop(iommu_grp)
+        self.available_host_devices[pool_type] = pool
+        return devices
+
+    def release_devices(
+        self,
+        node_context: NodeContext,
+    ) -> None:
+        device_context = node_context.passthrough_devices
+        for context in device_context:
+            pool_type = context.pool_type
+            devices_list = context.device_list
+            pool = self.available_host_devices.get(pool_type, {})
+            for device in devices_list:
+                iommu_grp = self._get_device_iommu_group(device)
+                pool_devices = pool.get(iommu_grp, [])
+                pool_devices.append(device)
+                pool[iommu_grp] = pool_devices
+            self.available_host_devices[pool_type] = pool
+
+    def get_primary_nic_id(self) -> List[str]:
+        # This is for baremetal. For azure, we have to get private IP
+        host_ip = cast(RemoteNode, self.host_node).connection_info.get("address")
+        assert host_ip, "Host IP is empty"
+        cmd = "ip -o -4 addr show"
+        err = f"Can not get interface for IP: {host_ip}"
+        result = self.host_node.execute(
+            cmd=cmd,
+            shell=True,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=err,
+        )
+        # Output for above command
+        # ===============================
+        # root [ /home/cloud ]# ip -o -4 addr show
+        # 1: lo    inet 127.0.0.1/8
+        #   scope host lo\       valid_lft forever preferred_lft forever
+        # 3: eth1    inet 10.195.88.216/23 metric 1024 brd 10.195.89.255
+        #   scope global dynamic eth1\       valid_lft 7210sec preferred_lft 7210sec
+        # 6: eth4    inet 10.10.40.135/22 metric 1024 brd 10.10.43.255
+        #   scope global dynamic eth4\       valid_lft 27011sec preferred_lft 27011sec
+
+        interface_name = ""
+        for line in result.stdout.strip().splitlines():
+            if line.find(host_ip) >= 0:
+                interface_name = line.split()[1].strip()
+
+        assert interface_name, "Can not find interface name"
+        result = self.host_node.execute(
+            cmd=f"find /sys/devices/ -name *{interface_name}*",
+            sudo=True,
+            shell=True,
+        )
+        stdout = result.stdout.strip()
+        assert len(stdout.splitlines()) == 1
+        pci_address_pattern = re.compile(
+            r"/(?P<root>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
+            r"(?P<id>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
+        )
+        match = find_group_in_lines(
+            lines=stdout,
+            pattern=pci_address_pattern,
+            single_line=False,
+        )
+        if match:
+            pci_address = match.get("id", "")
+            assert pci_address, "Can not get primary NIC IOMMU Group"
+            device = DeviceAddressSchema()
+            domain, bus, slot, fn = self._parse_pci_address_str(addr=pci_address)
+            device.domain = domain
+            device.bus = bus
+            device.slot = slot
+            device.function = fn
+
+            iommu_grp = self._get_device_iommu_group(device)
+            return [iommu_grp]
+        else:
+            raise LisaException(
+                f"Can't find pci address of for: {interface_name}, "
+                f"stdout for command: {stdout}"
+            )
+
+    def create_device_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        vendor_id: str,
+        device_id: str,
+    ) -> None:
+        self.available_host_devices[pool_type] = {}
+        lspci = self.host_node.tools[Lspci]
+        device_list = lspci.get_devices_by_vendor_device_id(
+            vendor_id=vendor_id,
+            device_id=device_id,
+        )
+        primary_nic_iommu = self.get_primary_nic_id()
+        for item in device_list:
+            device = DeviceAddressSchema()
+            domain, bus, slot, fn = self._parse_pci_address_str(addr=item.slot)
+            device.domain = domain
+            device.bus = bus
+            device.slot = slot
+            device.function = fn
+            iommu_group = self._get_device_iommu_group(device)
+            is_vfio_pci = self._is_driver_vfio_pci(device)
+
+            if not is_vfio_pci and iommu_group not in primary_nic_iommu:
+                pool = self.available_host_devices.get(pool_type, {})
+                devices = pool.get(iommu_group, [])
+                devices.append(device)
+                pool[iommu_group] = devices
+                self.available_host_devices[pool_type] = pool
+
+    def _add_device_passthrough_xml(
+        self,
+        devices: ET.Element,
+        node_context: NodeContext,
+    ) -> ET.Element:
+        for context in node_context.passthrough_devices:
+            for config in context.device_list:
+                hostdev = ET.SubElement(devices, "hostdev")
+                hostdev.attrib["mode"] = "subsystem"
+
+                assert context.managed
+                hostdev.attrib["managed"] = context.managed
+
+                assert context.pool_type
+                if "pci" in context.pool_type.value:
+                    hostdev.attrib["type"] = "pci"
+
+                    source = ET.SubElement(hostdev, "source")
+                    src_addrs = ET.SubElement(source, "address")
+
+                    assert config.domain
+                    src_addrs.attrib["domain"] = f"0x{config.domain}"
+
+                    assert config.bus
+                    src_addrs.attrib["bus"] = f"0x{config.bus}"
+
+                    assert config.slot
+                    src_addrs.attrib["slot"] = f"0x{config.slot}"
+
+                    assert config.function
+                    src_addrs.attrib["function"] = f"0x{config.function}"
+
+                    driver = ET.SubElement(hostdev, "driver")
+                    driver.attrib["name"] = "vfio"
+
+        return devices
+
+    def _get_pci_address_str(
+        self,
+        device_addr: DeviceAddressSchema,
+        with_domain: bool = True,
+    ) -> str:
+        bus = device_addr.bus
+        slot = device_addr.slot
+        fn = device_addr.function
+        domain = device_addr.domain
+        addr = f"{bus}:{slot}.{fn}"
+        if with_domain:
+            addr = f"{domain}:{addr}"
+        return addr
+
+    def _parse_pci_address_str(
+        self,
+        addr: str,
+        with_domain: bool = True,
+    ) -> Any:
+        addr_split = addr.strip().split(":")
+        idx = 1 if with_domain else 0
+
+        bus = addr_split[idx]
+        slot = addr_split[idx + 1].split(".")[0]
+        fn = addr_split[idx + 1].split(".")[1]
+
+        if with_domain:
+            domain = addr_split[0]
+            return domain, bus, slot, fn
+        else:
+            return bus, slot, fn
+
+    def _verify_device_passthrough_post_boot(
+        self,
+        node_context: NodeContext,
+    ) -> None:
+        device_context = node_context.passthrough_devices
+        for context in device_context:
+            devices = context.device_list
+            for device in devices:
+                err = f"Kernel driver is not vfio-pci for device: {device}"
+                pool_type = context.pool_type.value
+                if context.managed == "yes" and "pci" in pool_type:
+                    is_vfio_pci = self._is_driver_vfio_pci(device)
+                    assert is_vfio_pci, err
+
+    def _check_passthrough_support(self, host_node: Node) -> None:
+        ls = host_node.tools[Ls]
+        path = "/dev/vfio/vfio"
+        err = "Host does not support IOMMU"
+        if not ls.path_exists(path=path, sudo=True):
+            raise LisaException(f"{err} : {path} does not exist")
+
+        path = "/sys/kernel/iommu_groups/"
+        if len(ls.list(path=path, sudo=True)) == 0:
+            raise LisaException(f"{err} : {path} does not have any entry")
+
+    def _is_driver_vfio_pci(
+        self,
+        device_addr: DeviceAddressSchema,
+    ) -> bool:
+        lspci = self.host_node.tools[Lspci]
+        device_addr_str = self._get_pci_address_str(device_addr)
+        kernel_module = lspci.get_used_module(device_addr_str)
+        return kernel_module == "vfio-pci"
+
+    def _set_device_passthrough_node_context(
+        self,
+        node_context: NodeContext,
+        node_runbook: BaseLibvirtNodeSchema,
+    ) -> None:
+        if not node_runbook.device_passthrough:
+            return
+        for config in node_runbook.device_passthrough:
+            device_context = DevicePassthroughContext()
+            device_context.managed = config.managed
+            device_context.pool_type = config.pool_type
+            devices = self.request_devices(config.pool_type, config.count)
+            device_context.device_list = devices
+            node_context.passthrough_devices.append(device_context)
+
+    def _get_device_iommu_group(self, device: DeviceAddressSchema) -> str:
+        iommu_pattern = re.compile(r"/sys/kernel/iommu_groups/(?P<id>\d+)/devices/.*")
+        device_id = self._get_pci_address_str(device)
+        command = "find /sys/kernel/iommu_groups/ -type l"
+        err = "Command failed to list IOMMU Groups"
+        result = self.host_node.execute(
+            cmd=command,
+            shell=True,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=err,
+        )
+
+        iommu_grp = ""
+        for line in result.stdout.strip().splitlines():
+            if line.find(device_id) >= 0:
+                iommu_grp_res = find_group_in_lines(
+                    lines=line,
+                    pattern=iommu_pattern,
+                )
+                iommu_grp = iommu_grp_res.get("id", "")
+                break
+        assert iommu_grp, f"Can not get IOMMU group for device: {device}"
+        return f"iommu_grp_{iommu_grp}"

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -4,6 +4,10 @@ from typing import List, Optional, Union
 
 from dataclasses_json import dataclass_json
 
+from lisa.sut_orchestrator.util.schema import (
+    DevicePassthroughSchema,
+    HostDevicePoolSchema,
+)
 from lisa.util import LisaException
 
 FIRMWARE_TYPE_BIOS = "bios"
@@ -34,6 +38,17 @@ class LibvirtHost:
         return self.address is not None
 
 
+@dataclass_json()
+@dataclass
+class DeviceAddressSchema:
+    # Host device details for which we want to perform device-passthrough
+    # we can get it using lspci command
+    domain: str = ""
+    bus: str = ""
+    slot: str = ""
+    function: str = ""
+
+
 # QEMU orchestrator's global configuration options.
 @dataclass_json()
 @dataclass
@@ -50,6 +65,14 @@ class BaseLibvirtPlatformSchema:
     network_boot_timeout: Optional[float] = None
 
     capture_libvirt_debug_logs: bool = False
+
+    device_pools: Optional[List[HostDevicePoolSchema]] = None
+
+
+@dataclass_json()
+@dataclass
+class LibvirtDevicePassthroughSchema(DevicePassthroughSchema):
+    managed: str = ""
 
 
 # Possible disk image formats
@@ -84,6 +107,9 @@ class BaseLibvirtNodeSchema:
     machine_type: str = ""
     # Whether to enable secure boot.
     enable_secure_boot: bool = False
+
+    # Configuration options for device-passthrough.
+    device_passthrough: Optional[List[LibvirtDevicePassthroughSchema]] = None
 
 
 # QEMU orchestrator's per-node configuration options.

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -1,0 +1,65 @@
+from typing import Any, List, Optional
+
+from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
+from lisa.util import LisaException
+
+
+class BaseDevicePool:
+    def __init__(self) -> None:
+        self.supported_pool_type: List[Any] = []
+
+    def create_device_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        vendor_id: str,
+        device_id: str,
+    ) -> None:
+        raise NotImplementedError()
+
+    def get_primary_nic_id(self) -> List[str]:
+        raise NotImplementedError()
+
+    def request_devices(
+        self,
+        pool_type: HostDevicePoolType,
+        count: int,
+    ) -> Any:
+        raise NotImplementedError()
+
+    def release_devices(
+        self,
+        node_context: Any,
+    ) -> None:
+        raise NotImplementedError()
+
+    def configure_device_passthrough_pool(
+        self,
+        device_configs: Optional[List[HostDevicePoolSchema]],
+    ) -> None:
+        if device_configs:
+            pool_types_from_runbook = [config.type for config in device_configs]
+            for pool_type in pool_types_from_runbook:
+                if pool_type not in self.supported_pool_type:
+                    raise LisaException(
+                        f"Pool type '{pool_type}' is not supported by platform"
+                    )
+            for config in device_configs:
+                vendor_device_list = config.devices
+                if len(vendor_device_list) > 1:
+                    raise LisaException(
+                        "Device Pool does not support more than one "
+                        "vendor/device id list for given pool type"
+                    )
+
+                vendor_device_id = vendor_device_list[0]
+                assert vendor_device_id.vendor_id.strip()
+                vendor_id = vendor_device_id.vendor_id.strip()
+
+                assert vendor_device_id.device_id.strip()
+                device_id = vendor_device_id.device_id.strip()
+
+                self.create_device_pool(
+                    pool_type=config.type,
+                    vendor_id=vendor_id,
+                    device_id=device_id,
+                )

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List
+
+from dataclasses_json import dataclass_json
+
+
+class HostDevicePoolType(Enum):
+    PCI_NIC = "pci_net"
+    PCI_GPU = "pci_gpu"
+
+
+@dataclass_json()
+@dataclass
+class DeviceIdentifier:
+    vendor_id: str = ""
+    device_id: str = ""
+
+
+# Configuration options for device-passthrough for the VM.
+@dataclass_json()
+@dataclass
+class HostDevicePoolSchema:
+    type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
+    devices: List[DeviceIdentifier] = field(default_factory=list)
+
+
+@dataclass_json()
+@dataclass
+class DevicePassthroughSchema:
+    pool_type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
+    count: int = 0

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -8,7 +8,14 @@ from retry import retry
 from lisa.executable import Tool
 from lisa.operating_system import Posix
 from lisa.tools import Echo
-from lisa.util import LisaException, constants, find_patterns_in_lines, get_matched_str
+from lisa.util import (
+    LisaException,
+    constants,
+    find_group_in_lines,
+    find_groups_in_lines,
+    find_patterns_in_lines,
+    get_matched_str,
+)
 
 # Example output of lspci command -
 # lspci -m
@@ -36,6 +43,13 @@ PATTERN_PCI_DEVICE = re.compile(
     re.MULTILINE,
 )
 
+# With -mnn option, result would be with vendor/device id
+# d8:00.0 "Ethernet controller [0200]" "Mellanox Technologies [15b3]"
+#   "MT27520 Family [ConnectX-3 Pro] [1007]" "Mellanox Technologies [15b3]"
+#   "Mellanox Technologies ConnectX-3 Pro Stand-up dual-port 40GbE MCX314A-BCCT [0006]"
+PATTERN_DEVICE_ID = re.compile(r"\[(?P<id>[^\]]{4})\]")
+
+
 DEVICE_TYPE_DICT: Dict[str, List[str]] = {
     constants.DEVICE_TYPE_SRIOV: ["Ethernet controller"],
     constants.DEVICE_TYPE_NVME: ["Non-Volatile memory controller"],
@@ -59,19 +73,48 @@ class PciDevice:
 
     def __str__(self) -> str:
         return (
-            f"PCI device: {self.slot} "
-            f"class {self.device_class} "
-            f"vendor {self.vendor} "
-            f"info: {self.device_info} "
+            f"PCI device: {self.slot}, "
+            f"class: {self.device_class}, "
+            f"vendor: {self.vendor}, "
+            f"info: {self.device_info}, "
+            f"vendor_id: {self.vendor_id}, "
+            f"device_id: {self.device_id}"
         )
 
     def parse(self, raw_str: str) -> None:
-        matched_pci_device_info = PATTERN_PCI_DEVICE.match(raw_str)
-        if matched_pci_device_info:
-            self.slot = matched_pci_device_info.group("slot")
-            self.device_class = matched_pci_device_info.group("device_class")
-            self.vendor = matched_pci_device_info.group("vendor")
-            self.device_info = matched_pci_device_info.group("device")
+        matched_pci_device_info_list = find_groups_in_lines(
+            lines=raw_str,
+            pattern=PATTERN_PCI_DEVICE,
+        )
+        if matched_pci_device_info_list:
+            matched_pci_device_info = matched_pci_device_info_list[0]
+            self.slot = matched_pci_device_info.get("slot", "").strip()
+            assert self.slot, f"Can not find slot info for: {raw_str}"
+
+            device_class = matched_pci_device_info.get("device_class", "")
+            assert device_class, f"Can not find device class for: {raw_str}"
+            self.device_class = PATTERN_DEVICE_ID.sub("", device_class).strip()
+
+            vendor = matched_pci_device_info.get("vendor", "")
+            assert vendor, f"Can not find vendor info for: {raw_str}"
+            vendor_id_raw = find_group_in_lines(
+                lines=vendor,
+                pattern=PATTERN_DEVICE_ID,
+                single_line=False,
+            )
+            self.vendor_id = vendor_id_raw.get("id", "")
+            assert self.vendor_id, f"cannot find vendor id from {raw_str}"
+            self.vendor = PATTERN_DEVICE_ID.sub("", vendor).strip()
+
+            self.device_info = matched_pci_device_info.get("device", "")
+            assert self.device_info, f"Can not find device info for: {raw_str}"
+            device_id_raw = find_group_in_lines(
+                lines=self.device_info,
+                pattern=PATTERN_DEVICE_ID,
+                single_line=False,
+            )
+            self.device_id = device_id_raw.get("id", "")
+            assert self.device_id, f"cannot find device id from {raw_str}"
         else:
             raise LisaException("cannot find any matched pci devices")
 
@@ -126,7 +169,7 @@ class Lspci(Tool):
             # Ensure pci device ids and name mappings are updated.
             self.node.execute("update-pciids", sudo=True, shell=True)
             result = self.run(
-                "-m",
+                "-Dmnn",
                 force_run=force_run,
                 shell=True,
                 expected_exit_code=0,
@@ -183,6 +226,19 @@ class Lspci(Tool):
             if x.device_class in class_names and x.vendor in vendor_names
         ]
         return gpu_device_list
+
+    def get_devices_by_vendor_device_id(
+        self,
+        vendor_id: str,
+        device_id: str,
+        force_run: bool = False,
+    ) -> List[PciDevice]:
+        full_list = self.get_devices(force_run=force_run)
+        devices_list = []
+        for device in full_list:
+            if device.device_id == device_id and device.vendor_id == vendor_id:
+                devices_list.append(device)
+        return devices_list
 
 
 class LspciBSD(Lspci):


### PR DESCRIPTION
Add device passthrough support for libvirt/hyperv platform. Create device pool based on given vendor/device ID list. Platform will get device from pool when needed while creating node and put it back into pool when node is getting deleted. 

There are changes in LISA tools like lspci to provide information like domain and list of devices for given vendor-device id, hyperv tool to have support to perform start/stop/restart/enable-passthrough for a given vm

Example runbooks for platforms are

```
platform:
  - type: cloud-hypervisor
    admin_private_key_file: '<PATH>'
    keep_environment: "no"
    cloud-hypervisor:
      network_boot_timeout: 120
      hosts:
        - address: "<IP>"
          username: "<USERNAME>"
          private_key_file: '<PATH>'
      capture_libvirt_debug_logs: true
      device_pools:
        - type: "pci_net"
          devices:
            - vendor_id: "8086"
              device_id: "1572"
        - type: "pci_gpu"
          devices:
            - vendor_id: "15b3"
              device_id: "1007"
    requirement:
      core_count: 1
      memory_mb: 1024
      cloud-hypervisor:
        disk_img: '<PATH>'
        disk_img_format: "qcow2"
        firmware: '<PATH>'
        cloud_init:
          extra_user_data: ""
        device_passthrough:
          - pool_type: "pci_net" 
            managed: "yes"
            count: 1
        disk_img_resize_gib: 25
```


```
platform:
  - type: hyperv
    keep_environment: $(keep_environment)
    admin_username: <USERNAME>
    admin_password: <PASSWD>
    requirement:
      core_count:
        min: 32
      memory_mb:
        min: 65536
      hyperv:
        hyperv_generation: 2
        osdisk_size_in_gb: $(osdisk_size_in_gb)
        device_passthrough:
          - pool_type: "pci_net"
            count: 1
    hyperv:
      source:
        type: local
        files:
          - source: <LOCAL VHD PATH>
            unzip: true
      extra_args:
        - command: "<CMD1>"
          args: "<CMD1 ARGS>"
        - command: "<CMD2>"
          args: "<CMD2 ARGS>"
      servers:
        - address: <IP>
          username: <USERNAME>
          password: <PASSWD>
      device_pools:
        - type: "pci_net"
          devices:
            - vendor_id: "8086"
              device_id: "1572"

```