### PR TITLE
Moved user password support to execute_async() for running test case

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -320,19 +320,26 @@ class Process:
             self._shell.close()
             raise
 
+        self.check_and_input_password()
+
     def check_and_input_password(self) -> None:
         if (
             self._sudo
             and isinstance(self._shell, SshShell)
             and self._shell.is_sudo_required_password
         ):
-            if not self._shell.connection_info.password:
-                raise RequireUserPasswordException(
-                    "Running commands with sudo requires user's password,"
-                    " but no password is provided."
-                )
-            self.input(f"{self._shell.connection_info.password}\n")
-            self._log.debug("The user's password is input")
+            timer = create_timer()
+            while self.is_running():
+                time.sleep(0.01)
+                if timer.elapsed(False) > 0.5:
+                    if not self._shell.connection_info.password:
+                        raise RequireUserPasswordException(
+                            "Running commands with sudo requires user's password,"
+                            " but no password is provided."
+                        )
+                    self.input(f"{self._shell.connection_info.password}\n")
+                    self._log.debug("The user's password is input")
+                    break
 
     def input(self, content: str) -> None:
         assert self._process
@@ -347,13 +354,9 @@ class Process:
     ) -> ExecutableResult:
         timer = create_timer()
         is_timeout = False
-        has_checked_password = False
 
         while self.is_running() and timeout >= timer.elapsed(False):
             time.sleep(0.01)
-            if timer.elapsed(False) > 0.5 and not has_checked_password:
-                self.check_and_input_password()
-                has_checked_password = True
 
         if timeout < timer.elapsed():
             if self._process is not None:


### PR DESCRIPTION
Current run of test cases has two methods: 1. call node.execute.async() and then process.wait_result() 2. call node.execute.async and then pgrep.wait_process(). Both works ok if the test run doesn't need username and password while running on target, otherwise the second method will fail due to the missing username and password. The first method works because it has username and password process in process.wait_result() call. This change list is to move the username and password process in process.wait_result() to node.execute.async() so that both methods of running a test case will work. And this change will not cause behavior changes for the first method, which helps avoid the regression issue.