### PR TITLE
file notifier: change the encoding to resolve UnicodeEncodeError error

### DIFF
--- a/lisa/notifiers/file.py
+++ b/lisa/notifiers/file.py
@@ -39,7 +39,7 @@ class Console(notifier.Notifier):
     def _received_message(self, message: messages.MessageBase) -> None:
         simplify_message(message)
         # write every time to refresh the content immediately.
-        with open(self._file_path, "a") as f:
+        with open(self._file_path, "a", encoding="utf-8") as f:
             f.write(f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S.%ff}: {message}\n")
 
     def _subscribed_message_type(self) -> List[Type[messages.MessageBase]]:


### PR DESCRIPTION
Fix below exception.

```
2024-08-21T21:24:48.3996697Z   File "C:\hostedtoolcache\windows\Python\3.10.16\x64\lib\concurrent\futures\_base.py", line 403, in __get_result
2024-08-21T21:24:48.3997161Z     raise self._exception
2024-08-21T21:24:48.3997636Z   File "C:\hostedtoolcache\windows\Python\3.10.16\x64\lib\concurrent\futures\thread.py", line 58, in run
2024-08-21T21:24:48.3998100Z     result = self.fn(*self.args, **self.kwargs)
2024-08-21T21:24:48.3998523Z   File "D:\a\_work\1\s\lisa\lisa\util\parallel.py", line 58, in __call__
2024-08-21T21:24:48.3998912Z     output = self._task()
2024-08-21T21:24:48.3999305Z   File "D:\a\_work\1\s\lisa\lisa\notifiers\file.py", line 43, in _received_message
2024-08-21T21:24:48.3999886Z     f.write(f"{datetime.now(timezone.utc):%Y-%m-%d %H:%M:%S.%ff}: {message}\n")
2024-08-21T21:24:48.4000640Z   File "C:\hostedtoolcache\windows\Python\3.10.16\x64\lib\encodings\cp1252.py", line 19, in encode
2024-08-21T21:24:48.4001211Z     return codecs.charmap_encode(input,self.errors,encoding_table)[0]
2024-08-21T21:24:48.4001894Z UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 29537: character maps to <undefined>
2024-08-21T21:24:51.7851471Z ##[error]Script failed with exit code: 1
```