### PR TITLE
Fix test cases for Azure Linux 3.0

### DIFF
--- a/lisa/tools/netperf.py
+++ b/lisa/tools/netperf.py
@@ -94,6 +94,7 @@ class Netperf(Tool):
                 "binutils",
                 "glibc-devel",
                 "zlib-devel",
+                "perl-CPAN",
                 "automake",
                 "autoconf",
             ]

--- a/lisa/tools/vdsotest.py
+++ b/lisa/tools/vdsotest.py
@@ -56,6 +56,7 @@ class Vdsotest(Tool):
                     "binutils",
                     "glibc-devel",
                     "kernel-headers",
+                    "perl-CPAN",
                 ]
             )
         else:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -737,14 +737,23 @@ class AzureImageStandard(TestSuite):
             mariner_repositories = [
                 cast(RPMRepositoryInfo, repo) for repo in repositories
             ]
-            expected_repo_list = [
-                "mariner-official-base",
-                "mariner-official-microsoft",
-            ]
-            if 1 == node.os.information.version.major:
-                expected_repo_list += ["mariner-official-update"]
-            elif 2 == node.os.information.version.major:
-                expected_repo_list += ["mariner-official-extras"]
+
+            if 3 == node.os.information.version.major:
+                expected_repo_list = [
+                    "azurelinux-official-base",
+                    "azurelinux-official-ms-non-oss",
+                    "azurelinux-official-ms-oss",
+                ]
+            else:
+                expected_repo_list = [
+                    "mariner-official-base",
+                    "mariner-official-microsoft",
+                ]
+                if 1 == node.os.information.version.major:
+                    expected_repo_list += ["mariner-official-update"]
+                elif 2 == node.os.information.version.major:
+                    expected_repo_list += ["mariner-official-extras"]
+
             for id_ in expected_repo_list:
                 is_repository_present = any(
                     id_ in repository.id for repository in mariner_repositories

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -113,6 +113,7 @@ class Xfstests(Tool):
         "kernel-headers",
         "util-linux-devel",
         "psmisc",
+        "perl-CPAN",
     ]
     # Passed all 35 tests
     __all_pass_pattern = re.compile(


### PR DESCRIPTION
1. Fix expected repo for Azure Linux 3.0 in verify_repository_installed test case
2. Install perl-CPAN before xfstestsuite, perf_tcp, vdso test for Azure Linux 3.0