### PR TITLE
Set env var for bzImage for CH tests

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -199,6 +199,7 @@ class CloudHypervisorTestSuite(TestSuite):
         use_ms_guest_kernel = variables.get("use_ms_guest_kernel", "NO")
         use_ms_hypervisor_fw = variables.get("use_ms_hypervisor_fw", "NO")
         use_ms_ovmf_fw = variables.get("use_ms_ovmf_fw", "NO")
+        use_ms_bz_image = variables.get("use_ms_bz_image", "NO")
 
         # Below three params are for running block_* clh perf test
         # with no disk caching and with direct mode. By Default, we
@@ -224,6 +225,8 @@ class CloudHypervisorTestSuite(TestSuite):
             CloudHypervisorTests.use_ms_hypervisor_fw = use_ms_hypervisor_fw
         if use_ms_ovmf_fw == "YES":
             CloudHypervisorTests.use_ms_ovmf_fw = use_ms_ovmf_fw
+        if use_ms_bz_image == "YES":
+            CloudHypervisorTests.use_ms_bz_image = use_ms_bz_image
 
         if block_size_kb:
             CloudHypervisorTests.block_size_kb = block_size_kb

--- a/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -58,6 +58,7 @@ class CloudHypervisorTests(Tool):
     use_ms_guest_kernel = ""
     use_ms_hypervisor_fw = ""
     use_ms_ovmf_fw = ""
+    use_ms_bz_image = ""
 
     # Block perf related env var
     use_datadisk = ""
@@ -258,6 +259,8 @@ class CloudHypervisorTests(Tool):
                 self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
             if self.use_ms_ovmf_fw:
                 self.env_vars["USE_MS_OVMF_FW"] = self.use_ms_ovmf_fw
+            if self.use_ms_bz_image:
+                self.env_vars["USE_MS_BZ_IMAGE"] = self.use_ms_bz_image
 
             if self.use_datadisk:
                 self.env_vars["USE_DATADISK"] = self.use_datadisk


### PR DESCRIPTION
Read the testcase variable for bzImage and set it accordingly under env var while running the testcase.

This is needed to test the CH tests with shipped bzImage.