### PR TITLE
Make test criteria case-insensitive

### DIFF
--- a/lisa/testselector.py
+++ b/lisa/testselector.py
@@ -175,7 +175,7 @@ def _apply_filter(  # noqa: C901
             constants.TESTCASE_CRITERIA_CATEGORY,
         ]:
             pattern = cast(str, criteria_runbook_dict[runbook_key])
-            expression = re.compile(pattern)
+            expression = re.compile(pattern, re.IGNORECASE)
             patterns.append(
                 partial(_match_string, pattern=expression, attr_name=runbook_key)
             )


### PR DESCRIPTION
No testcase names, areas, or categories should differ only by case.

In many places, testcase areas are formatted with the first letter capitalized (ie. 'Sriov') however if anything other than all lowercase is used in the test critera, all tests will be skipped. This is bad user experience since it does not result in an error and it is unclear why no tests were selected.