### PR TITLE
set default value to avoid missing credential exception

### DIFF
--- a/lisa/sut_orchestrator/baremetal/context.py
+++ b/lisa/sut_orchestrator/baremetal/context.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from functools import partial
 
 from lisa import schema
 from lisa.environment import Environment
@@ -14,7 +15,9 @@ class EnvironmentContext:
 
 @dataclass
 class NodeContext:
-    connection: schema.ConnectionInfo = field(default_factory=schema.ConnectionInfo)
+    connection: schema.ConnectionInfo = field(
+        default_factory=partial(schema.ConnectionInfo, password="mock")
+    )
 
 
 @dataclass


### PR DESCRIPTION
Reverts microsoft/lisa#3395

it breaks current baremetal run
```
    raise LisaException(
lisa.util.LisaException: at least one of password or private_key_file need to be set when connecting
```