### PR TITLE
Restrict dpdk22 usage only to susu 15 sp5

### DIFF
--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -632,7 +632,7 @@ class DpdkTestpmd(Tool):
                     extra_args=self._backport_repo_args,
                 )
             elif (
-                isinstance(node.os, Suse) and float(node.os.information.release) >= 15.5
+                isinstance(node.os, Suse) and float(node.os.information.release) == 15.5
             ):
                 node.os.install_packages(["dpdk22", "dpdk22-devel"])
             elif isinstance(node.os, (Fedora, Suse)):
@@ -646,7 +646,7 @@ class DpdkTestpmd(Tool):
                 f"Installed DPDK version {str(self._dpdk_version_info)} "
                 "from package manager"
             )
-            if isinstance(node.os, Suse) and float(node.os.information.release) >= 15.5:
+            if isinstance(node.os, Suse) and float(node.os.information.release) == 15.5:
                 self._dpdk_version_info = node.os.get_package_information("dpdk22")
             else:
                 self._dpdk_version_info = node.os.get_package_information("dpdk")


### PR DESCRIPTION
previous condition works for suse 15.6
This change is tested with Dpdk.verify_dpdk_build_failsafe and suse sles-15-sp6 gen2 2024.08.08