### PR TITLE
Add TestCategory and MachineName to JUnitReport

### DIFF
--- a/LISAv2-Framework.psm1
+++ b/LISAv2-Framework.psm1
@@ -252,7 +252,7 @@ function Start-LISAv2 {
 				}
 			}
 
-			if (($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -gt 0) -or (-not $RunInParallel -and $TestIdInParallel)) {
+			if (($failedCount -eq 0 -and $errorCount -eq 0 -and $testCount -ge 0) -or (-not $RunInParallel -and $TestIdInParallel)) {
 				$ExitCode = 0
 			} else {
 				$ExitCode = 1

--- a/Libraries/TestReport.psm1
+++ b/Libraries/TestReport.psm1
@@ -123,8 +123,9 @@ Class JUnitReportGenerator
 	[System.Xml.XmlElement] $ReportRootNode
 	[object] $TestSuiteLogTable
 	[object] $TestSuiteCaseLogTable
-
-	JUnitReportGenerator([string]$ReportPath)
+    [string] $TestCategory
+	[string] $MachineName
+	JUnitReportGenerator([string]$ReportPath,[string]$TestCategory,[string]$MachineName)
 	{
 		$this.JunitReportPath = $ReportPath
 		$this.JunitReport = New-Object System.Xml.XmlDocument
@@ -132,6 +133,8 @@ Class JUnitReportGenerator
 		$this.ReportRootNode = $this.JunitReport.AppendChild($newElement)
 		$this.TestSuiteLogTable = @{}
 		$this.TestSuiteCaseLogTable = @{}
+		$this.TestCategory=$TestCategory
+		$this.MachineName=$MachineName
 	}
 
 	[void] SaveLogReport()
@@ -156,6 +159,11 @@ Class JUnitReportGenerator
 		$newElement.SetAttribute("errors", 0)
 		$newElement.SetAttribute("skipped", 0)
 		$newElement.SetAttribute("time", 0)
+		$newElement.SetAttribute("TestCategory", $this.TestCategory)
+		$newElement.SetAttribute("MachineName", $this.MachineName)
+		if ( $global:BaseOSVHD ) {
+			$newElement.SetAttribute("ImageUnderTest",  $global:BaseOSVHD )
+		}
 		$testsuiteNode = $this.ReportRootNode.AppendChild($newElement)
 
 		$testsuite = [ReportNode]::New($testsuiteNode)


### PR DESCRIPTION
Add TestCategory and MachineName to JUnitReport

Update ExitCode=0 when 0 test case detected, this is done as "if a pipeline fails/cancelled just after all test cases ran and passed but before the summary generation, in rerun our pipeline optimisation script will return "0 test case" and this should be a valid case and only report should be generated and rerun and pipeline should pass.