### PR TITLE
Updating test case logic to check if netsvc_module exists

### DIFF
--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -3,7 +3,6 @@
 
 import re
 import time
-from pathlib import PurePosixPath
 from typing import Any, Dict, List, Tuple, Union, cast
 
 from assertpy import assert_that
@@ -24,7 +23,7 @@ from lisa import (
 )
 from lisa.base_tools import Uname
 from lisa.operating_system import BSD, Debian, Redhat, Suse, Ubuntu, Windows
-from lisa.tools import Ethtool, Iperf3, KernelConfig, Modinfo, Nm, Ls
+from lisa.tools import Ethtool, Iperf3, KernelConfig, Ls, Modinfo, Nm
 from lisa.util import parse_version
 from microsoft.testsuites.network.common import cleanup_iperf3
 
@@ -732,8 +731,9 @@ class NetworkSettings(TestSuite):
                 ).stdout
 
             ls = node.tools[Ls]
-            assert ls.path_exists(f"{netvsc_module}", sudo=True), f"{netvsc_module} doesn't exist."
-
+            assert ls.path_exists(
+                f"{netvsc_module}", sudo=True
+            ), f"{netvsc_module} doesn't exist."
             nm = node.tools[Nm]
             msg_level_symbols = nm.get_symbol_table(netvsc_module)
         else:

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -732,7 +732,7 @@ class NetworkSettings(TestSuite):
 
             ls = node.tools[Ls]
             assert ls.path_exists(
-                f"{netvsc_module}", sudo=True
+                netvsc_module, sudo=True
             ), f"{netvsc_module} doesn't exist."
             nm = node.tools[Nm]
             msg_level_symbols = nm.get_symbol_table(netvsc_module)

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -24,7 +24,7 @@ from lisa import (
 )
 from lisa.base_tools import Uname
 from lisa.operating_system import BSD, Debian, Redhat, Suse, Ubuntu, Windows
-from lisa.tools import Ethtool, Iperf3, KernelConfig, Modinfo, Nm
+from lisa.tools import Ethtool, Iperf3, KernelConfig, Modinfo, Nm, Ls
 from lisa.util import parse_version
 from microsoft.testsuites.network.common import cleanup_iperf3
 
@@ -731,9 +731,8 @@ class NetworkSettings(TestSuite):
                     cwd=node.working_path,
                 ).stdout
 
-            assert node.shell.exists(
-                PurePosixPath(netvsc_module)
-            ), f"{netvsc_module} doesn't exist."
+            ls = node.tools[Ls]
+            assert ls.path_exists(f"{netvsc_module}", sudo=True), f"{netvsc_module} doesn't exist."
 
             nm = node.tools[Nm]
             msg_level_symbols = nm.get_symbol_table(netvsc_module)


### PR DESCRIPTION
For the test case 'verify_device_msg_level_change', the path check of the netsvc_module file would usually throw a 'Permission Error' since the command was not using sudo. Hence updating the code to use the 'Ls' tool with sudo to check if the file is present.

Tested the change with both scenarios - one where the path exists and one where it does not.