### PR TITLE
io_uring support

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -36,7 +36,7 @@ from .ethtool import Ethtool
 from .fallocate import Fallocate
 from .fdisk import Fdisk
 from .find import Find
-from .fio import FIOMODES, Fio, FIOResult
+from .fio import FIOMODES, Fio, FIOResult, IoEngine
 from .firewall import Firewall, Iptables
 from .free import Free
 from .gcc import Gcc
@@ -159,6 +159,7 @@ __all__ = [
     "Ip",
     "IpInfo",
     "Iperf3",
+    "IoEngine",
     "HibernationSetup",
     "Hostname",
     "Hugepages",

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -44,6 +44,7 @@ from lisa.tools import (
     Ssh,
     Sysctl,
 )
+from lisa.tools.fio import IoEngine
 from lisa.tools.ntttcp import (
     NTTTCP_TCP_CONCURRENCY,
     NTTTCP_TCP_CONCURRENCY_BSD,
@@ -70,12 +71,14 @@ def perf_disk(
     size_mb: int = 0,
     numjob: int = 0,
     overwrite: bool = False,
+    ioengine: IoEngine = IoEngine.LIBAIO,
     cwd: Optional[pathlib.PurePath] = None,
 ) -> None:
     fio_result_list: List[FIOResult] = []
     fio = node.tools[Fio]
     numjobiterator = 0
-    # In fio test, numjob*max_iodepth (aio-nr) should always be less than aio-max-nr.
+    # In fio test with ioengine == 'libaio',
+    # numjob*max_iodepth (aio-nr) should always be less than aio-max-nr.
     # The default value of aio-max-nr is 65536.
     # As max_iodepth is 256, numjob which is equal to 'nproc' should not exceed 256.
     # /proc/sys/fs/aio-nr is the number of events currently active.
@@ -84,7 +87,9 @@ def perf_disk(
     # fail with EAGAIN.
     # read: https://www.kernel.org/doc/Documentation/sysctl/fs.txt
     # So we set numjob to 256 if numjob is larger than 256.
-    numjob = min(numjob, 256)
+    # This limitation is only needed for 'libaio' ioengine but not for 'io_uring'.
+    if ioengine == IoEngine.LIBAIO:
+        numjob = min(numjob, 256)
     for mode in FIOMODES:
         iodepth = start_iodepth
         numjobindex = 0
@@ -102,6 +107,7 @@ def perf_disk(
                 overwrite=overwrite,
                 numjob=numjob,
                 cwd=cwd,
+                ioengine=ioengine,
             )
             fio_result_list.append(fio_result)
             iodepth = iodepth * 2

--- a/microsoft/testsuites/performance/nvmeperf.py
+++ b/microsoft/testsuites/performance/nvmeperf.py
@@ -13,6 +13,7 @@ from lisa.features import Nvme, NvmeSettings
 from lisa.messages import DiskSetupType, DiskType
 from lisa.testsuite import TestResult
 from lisa.tools import Echo, Lscpu
+from lisa.tools.fio import IoEngine
 from microsoft.testsuites.performance.common import perf_disk
 
 
@@ -24,11 +25,12 @@ from microsoft.testsuites.performance.common import perf_disk
     """,
 )
 class NvmePerformace(TestSuite):
-    TIME_OUT = 5000
+    TIME_OUT = 7200
 
     @TestCaseMetadata(
         description="""
-        This test case uses fio to test NVMe disk performance.
+        This test case uses fio to test NVMe disk performance
+        using 'libaio' as ioengine
         """,
         priority=3,
         timeout=TIME_OUT,
@@ -37,6 +39,25 @@ class NvmePerformace(TestSuite):
         ),
     )
     def perf_nvme(self, node: Node, result: TestResult) -> None:
+        self._perf_nvme(node, IoEngine.LIBAIO, result)
+
+    @TestCaseMetadata(
+        description="""
+        This test case uses fio to test NVMe disk performance
+        using 'io_uring' as ioengine.
+        """,
+        priority=3,
+        timeout=TIME_OUT,
+        requirement=simple_requirement(
+            supported_features=[Nvme],
+        ),
+    )
+    def perf_nvme_io_uring(self, node: Node, result: TestResult) -> None:
+        self._perf_nvme(node, IoEngine.IO_URING, result, max_iodepth=1024)
+
+    def _perf_nvme(
+        self, node: Node, ioengine: IoEngine, result: TestResult, max_iodepth: int = 256
+    ) -> None:
         nvme = node.features[Nvme]
         nvme_namespaces = nvme.get_raw_nvme_disks()
         disk_count = len(nvme_namespaces)
@@ -59,7 +80,6 @@ class NvmePerformace(TestSuite):
         cpu = node.tools[Lscpu]
         core_count = cpu.get_core_count()
         start_iodepth = 1
-        max_iodepth = 256
         perf_disk(
             node,
             start_iodepth,
@@ -71,4 +91,5 @@ class NvmePerformace(TestSuite):
             disk_setup_type=DiskSetupType.raw,
             disk_type=DiskType.nvme,
             test_result=result,
+            ioengine=ioengine,
         )


### PR DESCRIPTION
Added 'io_uring' support to LISA io perf tests and a new testcase 'perf_nvme_io_uring'.
io_uring is advanced alternative for libaio with low system overhead and more io depth.