### PR TITLE
force_run wget

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -42,7 +42,7 @@ class Wget(Tool):
         overwrite: bool = True,
         executable: bool = False,
         sudo: bool = False,
-        force_run: bool = False,
+        force_run: bool = True,
         timeout: int = 600,
     ) -> str:
         is_valid_url(url)


### PR DESCRIPTION
If wget loads a cached version, you will get an error: 

```
AssertionError: [Error : cat: wget_temp.log: No such file or directory Get unexpected exit code on cmd ['sudo', 'sh', '-c', 'cat wget_temp.log']] Expected <[0]> to contain item <1>, but did not.
```