### PR TITLE
Updates to address Semver value errors in verify_device_rss_hash_key_change

### DIFF
--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -368,16 +368,12 @@ class NetworkSettings(TestSuite):
         uname = node.tools[Uname]
         linux_info = uname.get_linux_information()
 
+        min_supported_kernel = linux_info.kernel_version
         if isinstance(node.os, Debian) or isinstance(node.os, Redhat):
-            min_supported_kernel = "5.0.0"
+            min_supported_kernel = parse_version("5.0.0")
         elif isinstance(node.os, Suse):
-            min_supported_kernel = "4.12.14"
-        else:
-            # For other OS, it is not known which minimum kernel version
-            # supports RSS Hash key change. This can be found and later
-            # enhanced after running tests.
-            min_supported_kernel = str(linux_info.kernel_version)
-
+            min_supported_kernel = parse_version("4.12.14")
+            
         if linux_info.kernel_version < min_supported_kernel:
             raise SkippedException(
                 f"The kernel version {linux_info.kernel_version} does not support"

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -373,7 +373,7 @@ class NetworkSettings(TestSuite):
             min_supported_kernel = parse_version("5.0.0")
         elif isinstance(node.os, Suse):
             min_supported_kernel = parse_version("4.12.14")
-            
+
         if linux_info.kernel_version < min_supported_kernel:
             raise SkippedException(
                 f"The kernel version {linux_info.kernel_version} does not support"


### PR DESCRIPTION
**Observation**:
- It was observed that for certain Kernel versions, the '_verify_device_rss_hash_key_change_' test would fail. 
- The _linux_info.kernel_version_ value was being obtained successfully as a Semver object after parsing it through the parse_version() function, although _min_supported_kernel_ value was assigned the Kernel version above directly and during comparison, it was implicitly being converted to a Semver object. 
- Since Semver does not support/recognize certain Kernel version formats, a Value Error was being thrown.

**Solution**:
- Converting the _min_supported_kernel_ value to a Semver object using the parse_version() custom function before comparison itself to address the error.