### PR TITLE
Use logical timeout

### DIFF
--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -66,6 +66,7 @@ class Provisioning(TestSuite):
         4. Otherwise, fully passed.
         """,
         priority=0,
+        # set_logical_timeout=True,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
             supported_features=[SerialConsole],

--- a/microsoft/testsuites/cpu/stress.py
+++ b/microsoft/testsuites/cpu/stress.py
@@ -27,6 +27,7 @@ class CPUStressSuite(TestSuite):
             Detailed steps please refer case verify_cpu_hot_plug.
             """,
         priority=3,
+        set_logical_timeout=True,
         requirement=simple_requirement(
             min_core_count=32,
         ),


### PR DESCRIPTION
There are two problems we are trying to address related to tests time out:
1. Deployment timeout: Which is currently hardcoded and based on the VM size, this needs to be updated. We often get into this issue, when we attempt to validate VHM VM sizes.
2. Test timeout: In certain cases, e.g. stress tests on VHM, we have observed that the 3600 sec is not enough and eventually we end up getting issue.