### PR TITLE
Remove SecurityProfileType.Standard from CVM images

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -378,16 +378,19 @@ class AzureImageSchema(schema.ImageSchema):
         self, raw_features: Dict[str, Any], log: Logger
     ) -> None:
         security_profile = raw_features.get("SecurityType")
-        capabilities: List[SecurityProfileType] = [SecurityProfileType.Standard]
+        capabilities: List[SecurityProfileType] = []
         if security_profile in ["TrustedLaunchSupported", "TrustedLaunch"]:
+            capabilities.append(SecurityProfileType.Standard)
             capabilities.append(SecurityProfileType.SecureBoot)
         elif security_profile in (
             "TrustedLaunchAndConfidentialVmSupported",
             "ConfidentialVmSupported",
         ):
-            capabilities.append(SecurityProfileType.SecureBoot)
             capabilities.append(SecurityProfileType.CVM)
             capabilities.append(SecurityProfileType.Stateless)
+        else:
+            capabilities.append(SecurityProfileType.Standard)
+
         self.security_profile = search_space.SetSpace(True, capabilities)
 
 


### PR DESCRIPTION
When calculating image capabilities, do not include `Standard` for images supporting CVM. 
Currently LISA will default to a standard SKU for CVM images, but this is not really a valid testing scenario.

For example, all automated testing of CVM Ubuntu 24.04 has been on non-CVM SKUs
### canonical ubuntu-24_04-lts cvm
| VMSize| TestCount|
|--------|--------|
| Standard_DS3_v2	|  116 |
| Standard_DS2_v2	|  55 |
| Standard_D2s_v3	|  21 |
| Standard_D2s_v5	|  13 | 
| Standard_E2as_v5	| 10 |
| Standard_D4s_v3	| 4 |