### PR TITLE
DpdkPerf: add dpdk version to test info

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -319,6 +319,11 @@ class DpdkPerformance(TestSuite):
         sender_fields: Dict[str, Any] = {}
         receiver_fields: Dict[str, Any] = {}
         test_case_name = test_result.runtime_data.metadata.name
+        testpmd = send_kit.testpmd
+        if testpmd.has_dpdk_version():
+            dpdk_version = testpmd.get_dpdk_version()
+            test_result.information["dpdk_version"] = str(dpdk_version)
+
         # shared results fields
         for result_fields in [sender_fields, receiver_fields]:
             result_fields["tool"] = constants.NETWORK_PERFORMANCE_TOOL_DPDK_TESTPMD


### PR DESCRIPTION
Add DPDK version information to performance tests to enable dpdk version coverage & health telemetry dashboard.