### PR TITLE
Allow File share creation with Access key with default false

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3254,7 +3254,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
-            allow_shared_key_access=allow_shared_key_access
+            allow_shared_key_access=allow_shared_key_access,
         )
 
         for share_name in file_share_names:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,7 +2718,6 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
-            
         )
         get_or_create_file_share(
             credential=platform.credential,

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,7 +3233,10 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
+        self, 
+        file_share_names: List[str], 
+        environment: Environment, 
+        allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,9 +3233,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, 
-        file_share_names: List[str], 
-        environment: Environment, 
+        self,
+        file_share_names: List[str],
+        environment: Environment,
         allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3236,7 +3236,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         self,
         file_share_names: List[str],
         environment: Environment,
-        allow_shared_key_access: bool = False
+        allow_shared_key_access: bool = False,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,6 +2718,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
+            
         )
         get_or_create_file_share(
             credential=platform.credential,
@@ -3233,7 +3234,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment
+        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3251,6 +3252,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
+            allow_shared_key_access=allow_shared_key_access
         )
 
         for share_name in file_share_names:


### PR DESCRIPTION
Currently Azure files Does not supports MSI based authentication. To allow AD based authentication will require additional work such as setting up ADDS ( linux only ) and performing file share + node domain join.
As such, the documented and supported approach is to mount SMB with storage account name / access key as user/pass k:p.
This PR adds two params to the definition "create_file_share" within features.py to allow creation of file shares with access key enabled. This feature is default to false and will require specifying in extensions such as xfstesting within Microsoft test cases.

Note: this PR is required to support XFStesting SMB tests.