### PR TITLE
libvirt: Add the cloud-init log

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -187,6 +187,12 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
             self.platform_runbook.device_pools,
         )
 
+        _ = self.host_node.execute(
+            cmd="journalctl -u cloud-init --no-page",
+            shell=True,
+            sudo=True,
+        )
+
     def _prepare_environment(self, environment: Environment, log: Logger) -> bool:
         # Ensure environment log directory is created before connecting to any nodes.
         _ = environment.log_path


### PR DESCRIPTION
Sometimes, we have seen that user with which we run the plaform is not having sudo access and it is intermittent issue. We want to check the cloud-init log for at the time of occurrence. Getting log for the same under host initialization for libvirt platform.