### PR TITLE
Standardize CpuArchitecture enum

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -62,6 +62,7 @@ _get_init_logger = partial(get_logger, name="os")
 class CpuArchitecture(str, Enum):
     X64 = "x86_64"
     ARM64 = "aarch64"
+    I386 = "i386"
 
 
 class AzureCoreRepo(str, Enum):

--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -57,7 +57,6 @@ ArchitectureNames = {
     "aarch64": CpuArchitecture.ARM64,
     "amd64": CpuArchitecture.X64,
     "arm64": CpuArchitecture.ARM64,
-    "i386": CpuArchitecture.I386,
 }
 
 

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -580,7 +580,7 @@ class AzureImageStandard(TestSuite):
                 }
                 lscpu = node.tools[Lscpu]
                 arch = lscpu.get_architecture()
-                repo_url = repo_url_map.get(CpuArchitecture(arch), None)
+                repo_url = repo_url_map.get(arch, None)
                 contains_security_keyword = any(
                     [
                         "-security" in repository.name
@@ -823,7 +823,7 @@ class AzureImageStandard(TestSuite):
 
         lscpu = node.tools[Lscpu]
         arch = lscpu.get_architecture()
-        current_console_device = console_device[CpuArchitecture(arch)]
+        current_console_device = console_device[arch]
         console_enabled_pattern = re.compile(
             rf"^(.*console \[{current_console_device}\] enabled.*)$", re.M
         )

--- a/microsoft/testsuites/core/msr.py
+++ b/microsoft/testsuites/core/msr.py
@@ -12,10 +12,16 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import CBLMariner, Debian, Fedora, Linux, Suse
+from lisa.operating_system import (
+    CBLMariner,
+    CpuArchitecture,
+    Debian,
+    Fedora,
+    Linux,
+    Suse,
+)
 from lisa.sut_orchestrator import AZURE
 from lisa.tools import Lscpu, Modprobe
-from lisa.tools.lscpu import ARCH_AARCH64, ARCH_X86_64
 from lisa.util import MissingPackagesException
 
 # See docs for hypercall spec, sharing os info
@@ -44,8 +50,8 @@ class HvOsPlatformInfo:
     # HV_REGISTER_GUEST_OSID constant declared in linus kernel source:
     # arch/{ARCH_NAME}/include/asm/hyperv-tlfs.h
     HV_REGISTER_GUEST_OSID = {
-        ARCH_AARCH64: "0x00090002",
-        ARCH_X86_64: "0x40000000",
+        CpuArchitecture.ARM64: "0x00090002",
+        CpuArchitecture.X64: "0x40000000",
     }
     OS_ID_UNDEFINED = 0
     OS_ID_MSDOS = 1

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -250,7 +250,7 @@ class TimeSync(TestSuite):
             }
             lscpu = node.tools[Lscpu]
             arch = lscpu.get_architecture()
-            clock_event_name = clockevent_map.get(CpuArchitecture(arch), None)
+            clock_event_name = clockevent_map.get(arch, None)
             if not clock_event_name:
                 raise UnsupportedCpuArchitectureException(arch)
             cat = node.tools[Cat]
@@ -382,7 +382,7 @@ class TimeSync(TestSuite):
     def verify_pmu_disabled_for_arm64(self, node: Node) -> None:
         lscpu = node.tools[Lscpu]
         arch = lscpu.get_architecture()
-        if CpuArchitecture(arch) != CpuArchitecture.ARM64:
+        if arch != CpuArchitecture.ARM64:
             raise SkippedException(
                 f"This test case does not support {arch}. "
                 "This validation is only for ARM64."

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -159,7 +159,7 @@ class TimeSync(TestSuite):
             }
             lscpu = node.tools[Lscpu]
             arch = lscpu.get_architecture()
-            clocksource = clocksource_map.get(CpuArchitecture(arch), None)
+            clocksource = clocksource_map.get(arch, None)
             if not clocksource:
                 raise UnsupportedCpuArchitectureException(arch)
             cat = node.tools[Cat]
@@ -382,7 +382,7 @@ class TimeSync(TestSuite):
     def verify_pmu_disabled_for_arm64(self, node: Node) -> None:
         lscpu = node.tools[Lscpu]
         arch = lscpu.get_architecture()
-        if CpuArchitecture(arch) != "aarch64":
+        if CpuArchitecture(arch) != CpuArchitecture.ARM64:
             raise SkippedException(
                 f"This test case does not support {arch}. "
                 "This validation is only for ARM64."


### PR DESCRIPTION
Preparing for the DPDK 32bit test by cleaning up how we handle cpu arch names.

- Replaces adhoc handling of arch enums using a shared CpuArchitecture Enum.
- Adds i386 to CpuArchitecture enum
- get_architecture now returns CpuArchitecture instead of a bare string.