### PR TITLE
RdmaInstaller: refactor rdma-core dependency and source install

### DIFF
--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -39,7 +39,15 @@ class Meson(Tool):
             self.node.tools[Ln].create_link(
                 f"/home/{username}/.local/bin/meson", "/usr/bin/meson", force=True
             )
-
+            # ensure sudo has access as well
+            self.node.execute(
+                "pip3 install meson",
+                sudo=True,
+                shell=True,
+                no_debug_log=True,
+                no_info_log=True,
+                no_error_log=True,
+            )
         return self._check_exists()
 
     def setup(self, args: str, cwd: PurePath, build_dir: str = "build") -> PurePath:

--- a/lisa/tools/ninja.py
+++ b/lisa/tools/ninja.py
@@ -9,7 +9,7 @@ from lisa.executable import Tool
 from lisa.operating_system import Posix
 from lisa.tools.gcc import Gcc
 from lisa.tools.git import Git
-from lisa.tools.python import Python
+from lisa.tools.python import Pip, Python
 
 
 class Ninja(Tool):
@@ -45,6 +45,7 @@ class Ninja(Tool):
             self._ninja_url,
             cwd=node.working_path,
         )
+        node.tools[Pip].install_packages("pyelftools")
         node.execute(
             "./configure.py --bootstrap",
             cwd=node.get_pure_path(f"{str(ninja_path)}"),

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -391,6 +391,10 @@ class InitializableMixin:
                 self._is_initialized = False
                 raise identifier
 
+    def reinitialize(self, *args: Any, **kwargs: Any) -> None:
+        self._is_initialized = False
+        self.initialize()
+
 
 class BaseClassMixin:
     @classmethod

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -391,10 +391,6 @@ class InitializableMixin:
                 self._is_initialized = False
                 raise identifier
 
-    def reinitialize(self, *args: Any, **kwargs: Any) -> None:
-        self._is_initialized = False
-        self.initialize()
-
 
 class BaseClassMixin:
     @classmethod

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -250,6 +250,8 @@ class PackageManagerInstall(Installer):
             for os_package_check in self._os_dependencies.requirements:
                 if os_package_check.matcher(self._os) and os_package_check.packages:
                     self._os.uninstall_packages(os_package_check.packages)
+                    if os_package_check.stop_on_match:
+                        break
 
     # verify packages on the node have been installed by
     # the package manager
@@ -263,6 +265,8 @@ class PackageManagerInstall(Installer):
                     for pkg in os_package_check.packages:
                         if not self._os.package_exists(pkg):
                             return False
+                    if os_package_check.stop_on_match:
+                        break
         return True
 
     # installing dependencies is the installation in this case, so just return

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -97,13 +97,13 @@ class GitDownloader(Downloader):
         # NOTE: fail on exists is set to True.
         # The expectation is that the parent Installer class should
         # remove any lingering installations
-        self._asset_path = self._node.tools[Git].clone(
+        self.asset_path = self._node.tools[Git].clone(
             self._git_repo,
             cwd=self._node.get_working_path(),
             ref=self._git_ref,
             fail_on_exists=True,
         )
-        return self._asset_path
+        return self.asset_path
 
 
 # parent class for tarball source installations
@@ -151,7 +151,7 @@ class TarDownloader(Downloader):
                 node_path=remote_path,
             )
         # create tarfile dest dir
-        self._asset_path = work_path.joinpath(
+        self.asset_path = work_path.joinpath(
             self.tar_filename[: -(len(tarfile_suffix))]
         )
         # unpack into the dest dir
@@ -161,7 +161,7 @@ class TarDownloader(Downloader):
             dest_dir=str(work_path),
             gzip=True,
         )
-        return self._asset_path
+        return self.asset_path
 
 
 class Installer:
@@ -183,7 +183,7 @@ class Installer:
     # setup the installation (install Ninja, Meson, etc)
     def _download_assets(self) -> None:
         if self._downloader:
-            self._asset_path = self._downloader.download()
+            self.asset_path = self._downloader.download()
         else:
             self._node.log.debug("No downloader assigned to installer.")
 

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from datetime import datetime
 from pathlib import PurePath
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
@@ -60,7 +59,7 @@ class DependencyInstaller:
         )
         # find the match for an OS, install the packages.
         # stop on list end or if exclusive_match parameter is true.
-        packages = []
+        packages: List[Union[str, Tool, Type[Tool]]] = []
         for requirement in self.requirements:
             if requirement.matcher(os) and requirement.packages:
                 packages += requirement.packages
@@ -275,43 +274,25 @@ def force_dpdk_default_source(variables: Dict[str, Any]) -> None:
         variables["dpdk_source"] = DPDK_STABLE_GIT_REPO
 
 
-# rough check for ubuntu supported versions.
-# assumes:
-# - canonical convention of YEAR.MONTH for major versions
-# - canoical release cycle of EVEN_YEAR.04 for lts versions.
-# - 4 year support cycle. 6 year for ESM
-# get the age of the distro, if negative or 0, release is new.
-# if > 6, distro is out of support
+# Ubuntu LTS releases
+# TODO: set calendar reminder to update every two years.
+UBUNTU_LTS_VERSIONS = ["24.4.0", "22.4.0", "20.4.0"]
+
+
 def is_ubuntu_lts_version(distro: Ubuntu) -> bool:
-    # asserts if not ubuntu OS object
-    version_info = distro.information.version
-    distro_age = _get_ubuntu_distro_age(distro)
-    is_even_year = (version_info.major % 2) == 0
-    is_april_release = version_info.minor == 4
-    is_within_support_window = distro_age <= 6
-    return is_even_year and is_april_release and is_within_support_window
+    version = distro.information.version
+    # check major version matches
+    major_match = [
+        version.major == x.split(".", maxsplit=1)[0] for x in UBUNTU_LTS_VERSIONS
+    ]
+    # check minor version matches
+    minor_match = [version.minor == x.split(".")[1] for x in UBUNTU_LTS_VERSIONS]
+    # check if a major and minor version matched for any items in the list
+    return any([(x == y) for x, y in zip(major_match, minor_match)])
 
 
 def is_ubuntu_latest_or_prerelease(distro: Ubuntu) -> bool:
-    distro_age = _get_ubuntu_distro_age(distro)
-    return distro_age <= 2
-
-
-def _get_ubuntu_distro_age(distro: Ubuntu) -> int:
-    version_info = distro.information.version
-    # check release is within esm window
-    year_string = str(datetime.today().year)
-    assert_that(len(year_string)).described_as(
-        "Package bug: The year received from datetime module is an "
-        "unexpected size. This indicates a broken package or incorrect "
-        "date in this computer."
-    ).is_greater_than_or_equal_to(4)
-    # TODO: handle the century rollover edge case in 2099
-    current_year = int(year_string[-2:])
-    release_year = int(version_info.major)
-    # 23-18 == 5
-    # long term support and extended security updates for ~6 years
-    return current_year - release_year
+    return bool(distro.information.version >= max(UBUNTU_LTS_VERSIONS))
 
 
 def check_dpdk_support(node: Node) -> None:
@@ -385,3 +366,52 @@ def unsupported_os_thrower(os: Posix) -> bool:
         os,
         message=("Installer did not define dependencies for this os."),
     )
+
+
+def get_debian_backport_repo_args(os: Debian) -> List[str]:
+    # ex: 'bionic-backports' or 'buster-backports'
+    # these backport repos are available for the older OS's
+    # and include backported fixes which need to be opted into.
+    # So filter for recent OS's and
+    # add the backports repo if it's available.
+    if not isinstance(os, Debian):
+        return []
+    # workaround for recent Ubuntu distros which may have a
+    # backport repo defined but will raise an error if you
+    # try to use it explicitly for our packages.
+    if isinstance(os, Ubuntu) and (
+        is_ubuntu_latest_or_prerelease(os) or not is_ubuntu_lts_version(os)
+    ):
+        return []
+    repos = os.get_repositories()
+    backport_repo = f"{os.information.codename}-backports"
+    if any([backport_repo in repo.name for repo in repos]):
+        return [f"-t {backport_repo}"]
+    return []
+
+
+# NOTE: mana_ib was added in 6.2 and backported to 5.15
+# this ends up lining up with kernels that need to be updated before
+# starting our DPDK tests. This function is not meant for general use
+# outside of the DPDK suite.
+def update_kernel_from_repo(node: Node) -> None:
+    assert isinstance(
+        node.os, (Debian, Fedora, Suse)
+    ), f"DPDK test does not support OS type: {type(node.os)}"
+    if (
+        isinstance(node.os, Debian)
+        and node.os.get_kernel_information().version < "6.5.0"
+    ):
+        package = "linux-azure"
+    elif (
+        isinstance(node.os, (Fedora, Suse))
+        and node.os.get_kernel_information().version < "5.15.0"
+    ):
+        package = "kernel"
+    else:
+        return
+    if node.os.is_package_in_repo(package):
+        node.os.install_packages(package)
+        node.reboot()
+    else:
+        node.log.debug(f"Kernel update package '{package}' was not found.")

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -208,7 +208,8 @@ class Installer:
 
     def _should_install(self, required_version: Optional[VersionInfo] = None) -> bool:
         return (not self._check_if_installed()) or (
-            required_version is None and required_version > self.get_installed_version()
+            required_version is not None
+            and required_version > self.get_installed_version()
         )
 
     # run the defined setup and installation steps.

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -192,7 +192,7 @@ class Installer:
         self._download_assets()
 
     # remove an installation
-    def uninstall(self) -> None:
+    def _uninstall(self) -> None:
         raise NotImplementedError(f"_clean_previous_installation {self._err_msg}")
 
     # install the dependencies
@@ -216,7 +216,7 @@ class Installer:
     def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
         self._setup_node()
         if self._should_install():
-            self.uninstall()
+            self._uninstall()
             self._install_dependencies()
             self._install()
 
@@ -243,7 +243,7 @@ class PackageManagerInstall(Installer):
         super().__init__(node, os_dependencies)
 
     # uninstall from the package manager
-    def uninstall(self) -> None:
+    def _uninstall(self) -> None:
         if not (isinstance(self._os, Posix) and self._check_if_installed()):
             return
         if self._os_dependencies is not None:

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -60,11 +60,14 @@ class DependencyInstaller:
         )
         # find the match for an OS, install the packages.
         # stop on list end or if exclusive_match parameter is true.
+        packages = []
         for requirement in self.requirements:
             if requirement.matcher(os) and requirement.packages:
-                os.install_packages(requirement.packages, extra_args=extra_args)
+                packages += requirement.packages
                 if requirement.stop_on_match:
-                    return
+                    break
+        os.install_packages(packages=packages, extra_args=extra_args)
+
         # NOTE: It is up to the caller to raise an exception on an invalid OS
 
 

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -192,7 +192,7 @@ class Installer:
         self._download_assets()
 
     # remove an installation
-    def _uninstall(self) -> None:
+    def uninstall(self) -> None:
         raise NotImplementedError(f"_clean_previous_installation {self._err_msg}")
 
     # install the dependencies
@@ -216,7 +216,7 @@ class Installer:
     def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
         self._setup_node()
         if self._should_install():
-            self._uninstall()
+            self.uninstall()
             self._install_dependencies()
             self._install()
 
@@ -243,7 +243,7 @@ class PackageManagerInstall(Installer):
         super().__init__(node, os_dependencies)
 
     # uninstall from the package manager
-    def _uninstall(self) -> None:
+    def uninstall(self) -> None:
         if not (isinstance(self._os, Posix) and self._check_if_installed()):
             return
         if self._os_dependencies is not None:

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -101,7 +101,7 @@ class GitDownloader(Downloader):
             self._git_repo,
             cwd=self._node.get_working_path(),
             ref=self._git_ref,
-            fail_on_exists=True,
+            fail_on_exists=False,
         )
         return self.asset_path
 
@@ -139,7 +139,6 @@ class TarDownloader(Downloader):
                 self._tar_url,
                 file_path=str(work_path),
                 overwrite=False,
-                force_run=True,
             )
             remote_path = node.get_pure_path(tarfile)
             self.tar_filename = remote_path.name
@@ -171,8 +170,10 @@ class Installer:
 
     # setup the node before starting
     # ex: updating the kernel, enabling features, checking drivers, etc.
+    # First we download the assets to ensure asset_path is set
+    # even if we end up skipping re-installation
     def _setup_node(self) -> None:
-        raise NotImplementedError(f"_setup_node {self._err_msg}")
+        self._download_assets()
 
     # check if the package is already installed:
     # Is the package installed from source? Or from the package manager?
@@ -189,7 +190,7 @@ class Installer:
 
     # do the build and installation
     def _install(self) -> None:
-        self._download_assets()
+        ...
 
     # remove an installation
     def _uninstall(self) -> None:
@@ -268,10 +269,6 @@ class PackageManagerInstall(Installer):
                     if os_package_check.stop_on_match:
                         break
         return True
-
-    # installing dependencies is the installation in this case, so just return
-    def _install(self) -> None:
-        return
 
 
 def force_dpdk_default_source(variables: Dict[str, Any]) -> None:

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -28,6 +28,7 @@ from lisa.tools.hugepages import HugePageSize
 from lisa.util.constants import SIGINT
 from microsoft.testsuites.dpdk.common import (
     DPDK_STABLE_GIT_REPO,
+    PackageManagerInstall,
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
@@ -527,7 +528,10 @@ class Dpdk(TestSuite):
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
         testpmd = test_kit.testpmd
-
+        if isinstance(testpmd.installer, PackageManagerInstall):
+            testpmd.installer.uninstall()
+            testpmd.reinitialize()
+            testpmd.install()
         # grab a nic and run testpmd
         git = node.tools[Git]
         make = node.tools[Make]

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -534,7 +534,7 @@ class Dpdk(TestSuite):
         echo = node.tools[Echo]
         rping_build_env_vars = [
             "export RTE_TARGET=build",
-            f"export RTE_SDK={str(testpmd.dpdk_path)}",
+            f"export RTE_SDK={str(testpmd.installer.asset_path)}",
         ]
         echo.write_to_file(
             ";".join(rping_build_env_vars), node.get_pure_path("~/.bashrc"), append=True

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -28,6 +28,7 @@ from lisa.tools.hugepages import HugePageSize
 from lisa.util.constants import SIGINT
 from microsoft.testsuites.dpdk.common import (
     DPDK_STABLE_GIT_REPO,
+    PackageManagerInstall,
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
@@ -527,6 +528,13 @@ class Dpdk(TestSuite):
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
         testpmd = test_kit.testpmd
+        if isinstance(testpmd.installer, PackageManagerInstall):
+            # The Testpmd tool doesn't get re-initialized
+            # even if you invoke it with new arguments.
+            raise SkippedException(
+                "DPDK ring_ping test is not implemented for "
+                " package manager installation."
+            )
 
         # grab a nic and run testpmd
         git = node.tools[Git]

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -28,7 +28,6 @@ from lisa.tools.hugepages import HugePageSize
 from lisa.util.constants import SIGINT
 from microsoft.testsuites.dpdk.common import (
     DPDK_STABLE_GIT_REPO,
-    PackageManagerInstall,
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
@@ -528,10 +527,7 @@ class Dpdk(TestSuite):
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
         testpmd = test_kit.testpmd
-        if isinstance(testpmd.installer, PackageManagerInstall):
-            testpmd.installer.uninstall()
-            testpmd.reinitialize()
-            testpmd.install()
+
         # grab a nic and run testpmd
         git = node.tools[Git]
         make = node.tools[Make]

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -208,7 +208,7 @@ class DpdkSourceInstall(Installer):
         self._node.tools[Ninja].install()
         self._node.tools[Pip].install_packages("pyelftools")
 
-    def _uninstall(self) -> None:
+    def uninstall(self) -> None:
         # undo source installation (thanks ninja)
         if not self._check_if_installed():
             return

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -208,7 +208,7 @@ class DpdkSourceInstall(Installer):
         self._node.tools[Ninja].install()
         self._node.tools[Pip].install_packages("pyelftools")
 
-    def uninstall(self) -> None:
+    def _uninstall(self) -> None:
         # undo source installation (thanks ninja)
         if not self._check_if_installed():
             return

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -215,7 +215,7 @@ class DpdkSourceInstall(Installer):
         self._node.tools[Ninja].run(
             "uninstall", shell=True, sudo=True, cwd=self.dpdk_build_path
         )
-        source_path = str(self._asset_path)
+        source_path = str(self.asset_path)
         working_path = str(self._node.get_working_path())
         assert_that(str(source_path)).described_as(
             "DPDK Installer source path was empty during attempted cleanup!"
@@ -246,7 +246,7 @@ class DpdkSourceInstall(Installer):
         # save the pythonpath for later
         python_path = node.tools[Python].get_python_path()
         self.dpdk_build_path = node.tools[Meson].setup(
-            args=sample_apps, build_dir="build", cwd=self._asset_path
+            args=sample_apps, build_dir="build", cwd=self.asset_path
         )
         node.tools[Ninja].run(
             cwd=self.dpdk_build_path,
@@ -297,10 +297,10 @@ class DpdkGitDownloader(GitDownloader):
         if not self._git_ref:
             git = self._node.tools[Git]
             self._git_ref = git.get_tag(
-                self._asset_path, filter_=r"^v.*"  # starts w 'v'
+                self.asset_path, filter_=r"^v.*"  # starts w 'v'
             )
-            git.checkout(self._git_ref, cwd=self._asset_path)
-        return self._asset_path
+            git.checkout(self._git_ref, cwd=self.asset_path)
+        return self.asset_path
 
 
 class DpdkTestpmd(Tool):

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -166,6 +166,10 @@ class DpdkPackageManagerInstall(PackageManagerInstall):
         elif isinstance(self._os, Fedora):
             self._os.install_epel()
 
+        # super setup node last in this case, since we must set
+        # repo args before download/install
+        super()._setup_node()
+
     def get_installed_version(self) -> VersionInfo:
         return self._os.get_package_information("dpdk", use_cached=False)
 
@@ -197,6 +201,7 @@ class DpdkSourceInstall(Installer):
             return False
 
     def _setup_node(self) -> None:
+        super()._setup_node()
         if isinstance(self._os, Debian):
             self._package_manager_extra_args = get_debian_backport_repo_args(self._os)
             if isinstance(self._os, Ubuntu) and self._os.information.version < "22.4.0":

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -48,9 +48,23 @@ from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_asy
 from microsoft.testsuites.dpdk.common import (
     AZ_ROUTE_ALL_TRAFFIC,
     DPDK_STABLE_GIT_REPO,
+    Downloader,
+    GitDownloader,
+    Installer,
+    TarDownloader,
     check_dpdk_support,
+    is_url_for_git_repo,
+    is_url_for_tarball,
+    update_kernel_from_repo,
 )
 from microsoft.testsuites.dpdk.dpdktestpmd import PACKAGE_MANAGER_SOURCE, DpdkTestpmd
+from microsoft.testsuites.dpdk.rdmacore import (
+    RDMA_CORE_MANA_DEFAULT_SOURCE,
+    RDMA_CORE_PACKAGE_MANAGER_DEPENDENCIES,
+    RDMA_CORE_SOURCE_DEPENDENCIES,
+    RdmaCorePackageManagerInstall,
+    RdmaCoreSourceInstaller,
+)
 
 
 # DPDK added new flags in 19.11 that some tests rely on for send/recv
@@ -106,6 +120,35 @@ def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
     if isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
         variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
+
+
+def get_rdma_core_installer(
+    node: Node, dpdk_source: str, dpdk_branch: str, rdma_source: str, rdma_branch: str
+) -> Installer:
+    # set rdma-core installer type.
+    if rdma_source:
+        if is_url_for_git_repo(rdma_source):
+            # else, if we have a user provided rdma-core source, use it
+            downloader: Downloader = GitDownloader(node, rdma_source, rdma_branch)
+        elif is_url_for_tarball(rdma_branch):
+            downloader = TarDownloader(node, rdma_source)
+        else:
+            # throw on unrecognized rdma core source type
+            raise AssertionError(
+                f"Invalid rdma-core source uri provided: {rdma_source}"
+            )
+    # handle MANA special case, build a default rdma-core with mana provider
+    elif not rdma_source and node.nics.is_mana_device_present():
+        downloader = TarDownloader(node, RDMA_CORE_MANA_DEFAULT_SOURCE)
+    else:
+        # no rdma_source and not mana, just use the package manager
+        return RdmaCorePackageManagerInstall(
+            node, os_dependencies=RDMA_CORE_PACKAGE_MANAGER_DEPENDENCIES
+        )
+    # return the installer with the downloader we've picked
+    return RdmaCoreSourceInstaller(
+        node, os_dependencies=RDMA_CORE_SOURCE_DEPENDENCIES, downloader=downloader
+    )
 
 
 def _ping_all_nodes_in_environment(environment: Environment) -> None:
@@ -245,6 +288,8 @@ def initialize_node_resources(
 
     dpdk_source = variables.get("dpdk_source", PACKAGE_MANAGER_SOURCE)
     dpdk_branch = variables.get("dpdk_branch", "")
+    rdma_source = variables.get("rdma_source", "")
+    rdma_branch = variables.get("rdma_branch", "")
     force_net_failsafe_pmd = variables.get("dpdk_force_net_failsafe_pmd", False)
     log.info(
         "Dpdk initialize_node_resources running"
@@ -273,7 +318,11 @@ def initialize_node_resources(
 
     # verify SRIOV is setup as-expected on the node after compat check
     node.nics.check_pci_enabled(pci_enabled=True)
-
+    update_kernel_from_repo(node)
+    rdma_core = get_rdma_core_installer(
+        node, dpdk_source, dpdk_branch, rdma_source, rdma_branch
+    )
+    rdma_core.do_installation()
     # create tool, initialize testpmd tool (installs dpdk)
     testpmd: DpdkTestpmd = node.tools.get(
         DpdkTestpmd,
@@ -1027,3 +1076,6 @@ def create_l3fwd_rules_files(
     forwarder.tools[Echo].write_to_file(
         "\n".join(sample_rules_v6), rules_v6, append=True
     )
+
+
+DPDK_VERSION_TO_RDMA_CORE_MAP = {"20.11": "46.1", "21.11": ""}

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -324,7 +324,9 @@ def initialize_node_resources(
     )
     rdma_core.do_installation()
     # create tool, initialize testpmd tool (installs dpdk)
-    testpmd: DpdkTestpmd = node.tools.get(
+    # use create over get to avoid skipping
+    # reinitialization of tool when new arguments are present
+    testpmd: DpdkTestpmd = node.tools.create(
         DpdkTestpmd,
         dpdk_source=dpdk_source,
         dpdk_branch=dpdk_branch,

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -333,6 +333,11 @@ def initialize_node_resources(
         sample_apps=sample_apps,
         force_net_failsafe_pmd=force_net_failsafe_pmd,
     )
+    # Tools will skip installation if the binary is present, so
+    # force invoke install. Installer will skip if the correct
+    # *type* of installation is already installed,
+    # taking it's creation arguments into account.
+    testpmd.install()
 
     # init and enable hugepages (required by dpdk)
     hugepages = node.tools[Hugepages]

--- a/microsoft/testsuites/dpdk/rdmacore.py
+++ b/microsoft/testsuites/dpdk/rdmacore.py
@@ -1,0 +1,196 @@
+from assertpy import assert_that
+from semver import VersionInfo
+
+from lisa.operating_system import Debian, Fedora, Suse
+from lisa.tools import Make, Pkgconfig
+from microsoft.testsuites.dpdk.common import (
+    DependencyInstaller,
+    Installer,
+    OsPackageDependencies,
+    PackageManagerInstall,
+    get_debian_backport_repo_args,
+    unsupported_os_thrower,
+)
+
+RDMA_CORE_MANA_DEFAULT_SOURCE = (
+    "https://github.com/linux-rdma/rdma-core/"
+    "releases/download/v50.1/rdma-core-50.1.tar.gz"
+)
+RDMA_CORE_SOURCE_DEPENDENCIES = DependencyInstaller(
+    [
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Debian)
+            # install linux-modules-extra-azure if it's available for mana_ib
+            # older debian kernels won't have mana_ib packaged,
+            # so skip the check on those kernels.
+            and bool(x.get_kernel_information().version >= "5.15.0")
+            and x.is_package_in_repo("linux-modules-extra-azure"),
+            packages=["linux-modules-extra-azure"],
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Debian),
+            packages=[
+                "cmake",
+                "libudev-dev",
+                "libnl-3-dev",
+                "libnl-route-3-dev",
+                "ninja-build",
+                "pkg-config",
+                "valgrind",
+                "python3-dev",
+                "cython3",
+                "python3-docutils",
+                "pandoc",
+                "libssl-dev",
+                "libelf-dev",
+                "python3-pip",
+                "libnuma-dev",
+            ],
+            stop_on_match=True,
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Fedora),
+            packages=[
+                "cmake",
+                "libudev-devel",
+                "libnl3-devel",
+                "pkg-config",
+                "valgrind",
+                "python3-devel",
+                "openssl-devel",
+                "unzip",
+                "elfutils-devel",
+                "python3-pip",
+                "tar",
+                "wget",
+                "dos2unix",
+                "psmisc",
+                "kernel-devel-$(uname -r)",
+                "librdmacm-devel",
+                "libmnl-devel",
+                "kernel-modules-extra",
+                "numactl-devel",
+                "kernel-headers",
+                "elfutils-libelf-devel",
+                "libbpf-devel",
+            ],
+            stop_on_match=True,
+        ),
+        # FIXME: SUSE rdma-core build packages not implemented
+        #        for source builds.
+        OsPackageDependencies(matcher=unsupported_os_thrower),
+    ]
+)
+
+RDMA_CORE_PACKAGE_MANAGER_DEPENDENCIES = DependencyInstaller(
+    [
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Debian)
+            # install linux-modules-extra-azure if it's available for mana_ib
+            # older debian kernels won't have mana_ib packaged,
+            # so skip the check on those kernels.
+            and bool(x.get_kernel_information().version >= "5.15.0")
+            and x.is_package_in_repo("linux-modules-extra-azure"),
+            packages=["linux-modules-extra-azure"],
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Debian),
+            packages=["ibverbs-providers", "libibverbs-dev"],
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Suse),
+            packages=["rdma-core-devel", "librdmacm1"],
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, Fedora),
+            packages=["librdmacm-devel"],
+        ),
+        OsPackageDependencies(
+            matcher=lambda x: isinstance(x, (Fedora, Debian, Suse)),
+            packages=["rdma-core"],
+            stop_on_match=True,
+        ),
+        OsPackageDependencies(matcher=unsupported_os_thrower),
+    ]
+)
+
+
+class RdmaCorePackageManagerInstall(PackageManagerInstall):
+    def _setup_node(self) -> None:
+        if isinstance(self._os, Fedora):
+            self._os.install_epel()
+        if isinstance(self._os, Debian):
+            self._package_manager_extra_args = get_debian_backport_repo_args(self._os)
+
+    def get_installed_version(self) -> VersionInfo:
+        return self._os.get_package_information("libibverbs", use_cached=False)
+
+    def _check_if_installed(self) -> bool:
+        return self._os.package_exists("rdma-core")
+
+
+# implement SourceInstall for DPDK
+class RdmaCoreSourceInstaller(Installer):
+    def _download_assets(self) -> None:
+        super()._download_assets()
+        self._asset_path = self._asset_path
+
+    def _check_if_installed(self) -> bool:
+        try:
+            package_manager_install = self._os.package_exists("rdma-core")
+            # _get_installed_version for source install throws
+            # if package is not found. So we don't need the result,
+            # if the function doesn't throw, the version was found.
+            _ = self.get_installed_version()
+            # this becomes '(not package manager installed) and
+            #                _get_installed_version() doesn't throw'
+            return not package_manager_install
+        except AssertionError:
+            # _get_installed_version threw an AssertionError
+            # so PkgConfig info was not found
+            return False
+
+    def _setup_node(self) -> None:
+        if isinstance(self._os, (Debian, Fedora, Suse)):
+            self._os.uninstall_packages("rdma-core")
+        if isinstance(self._os, Fedora):
+            self._os.group_install_packages("Development Tools")
+
+    def _uninstall(self) -> None:
+        # undo source installation (thanks ninja)
+        if not self._check_if_installed():
+            return
+        self._node.tools[Make].run(
+            parameters="uninstall", shell=True, sudo=True, cwd=self._asset_path
+        )
+        working_path = str(self._node.get_working_path())
+        assert_that(str(self._asset_path)).described_as(
+            "RDMA Installer source path was empty during attempted cleanup!"
+        ).is_not_empty()
+        assert_that(str(self._asset_path)).described_as(
+            "RDMA Installer source path was set to root dir "
+            "'/' during attempted cleanup!"
+        ).is_not_equal_to("/")
+        assert_that(str(self._asset_path)).described_as(
+            f"RDMA Installer source path {self._asset_path} was set to "
+            f"working path '{working_path}' during attempted cleanup!"
+        ).is_not_equal_to(working_path)
+        # remove source code directory
+        self._node.execute(f"rm -rf {str(self._asset_path)}", shell=True)
+
+    def get_installed_version(self) -> VersionInfo:
+        return self._node.tools[Pkgconfig].get_package_version(
+            "libibverbs", update_cached=True
+        )
+
+    def _install(self) -> None:
+        super()._install()
+        node = self._node
+        make = node.tools[Make]
+        node.execute(
+            "cmake -DIN_PLACE=0 -DNO_MAN_PAGES=1 -DCMAKE_INSTALL_PREFIX=/usr",
+            shell=True,
+            cwd=self._asset_path,
+            sudo=True,
+        )
+        make.make_install(self._asset_path)

--- a/microsoft/testsuites/dpdk/rdmacore.py
+++ b/microsoft/testsuites/dpdk/rdmacore.py
@@ -133,7 +133,6 @@ class RdmaCorePackageManagerInstall(PackageManagerInstall):
 class RdmaCoreSourceInstaller(Installer):
     def _download_assets(self) -> None:
         super()._download_assets()
-        self._asset_path = self._asset_path
 
     def _check_if_installed(self) -> bool:
         try:
@@ -161,22 +160,22 @@ class RdmaCoreSourceInstaller(Installer):
         if not self._check_if_installed():
             return
         self._node.tools[Make].run(
-            parameters="uninstall", shell=True, sudo=True, cwd=self._asset_path
+            parameters="uninstall", shell=True, sudo=True, cwd=self.asset_path
         )
         working_path = str(self._node.get_working_path())
-        assert_that(str(self._asset_path)).described_as(
+        assert_that(str(self.asset_path)).described_as(
             "RDMA Installer source path was empty during attempted cleanup!"
         ).is_not_empty()
-        assert_that(str(self._asset_path)).described_as(
+        assert_that(str(self.asset_path)).described_as(
             "RDMA Installer source path was set to root dir "
             "'/' during attempted cleanup!"
         ).is_not_equal_to("/")
-        assert_that(str(self._asset_path)).described_as(
-            f"RDMA Installer source path {self._asset_path} was set to "
+        assert_that(str(self.asset_path)).described_as(
+            f"RDMA Installer source path {self.asset_path} was set to "
             f"working path '{working_path}' during attempted cleanup!"
         ).is_not_equal_to(working_path)
         # remove source code directory
-        self._node.execute(f"rm -rf {str(self._asset_path)}", shell=True)
+        self._node.execute(f"rm -rf {str(self.asset_path)}", shell=True)
 
     def get_installed_version(self) -> VersionInfo:
         return self._node.tools[Pkgconfig].get_package_version(
@@ -190,7 +189,7 @@ class RdmaCoreSourceInstaller(Installer):
         node.execute(
             "cmake -DIN_PLACE=0 -DNO_MAN_PAGES=1 -DCMAKE_INSTALL_PREFIX=/usr",
             shell=True,
-            cwd=self._asset_path,
+            cwd=self.asset_path,
             sudo=True,
         )
-        make.make_install(self._asset_path)
+        make.make_install(self.asset_path)

--- a/microsoft/testsuites/dpdk/rdmacore.py
+++ b/microsoft/testsuites/dpdk/rdmacore.py
@@ -121,6 +121,7 @@ class RdmaCorePackageManagerInstall(PackageManagerInstall):
             self._os.install_epel()
         if isinstance(self._os, Debian):
             self._package_manager_extra_args = get_debian_backport_repo_args(self._os)
+        super()._setup_node()
 
     def get_installed_version(self) -> VersionInfo:
         return self._os.get_package_information("rdma-core", use_cached=False)
@@ -131,9 +132,6 @@ class RdmaCorePackageManagerInstall(PackageManagerInstall):
 
 # implement SourceInstall for DPDK
 class RdmaCoreSourceInstaller(Installer):
-    def _download_assets(self) -> None:
-        super()._download_assets()
-
     def _check_if_installed(self) -> bool:
         try:
             package_manager_install = self._os.package_exists("rdma-core")
@@ -154,6 +152,7 @@ class RdmaCoreSourceInstaller(Installer):
             self._os.uninstall_packages("rdma-core")
         if isinstance(self._os, Fedora):
             self._os.group_install_packages("Development Tools")
+        super()._setup_node()
 
     def _uninstall(self) -> None:
         # undo source installation (thanks ninja)

--- a/microsoft/testsuites/dpdk/rdmacore.py
+++ b/microsoft/testsuites/dpdk/rdmacore.py
@@ -123,7 +123,7 @@ class RdmaCorePackageManagerInstall(PackageManagerInstall):
             self._package_manager_extra_args = get_debian_backport_repo_args(self._os)
 
     def get_installed_version(self) -> VersionInfo:
-        return self._os.get_package_information("libibverbs", use_cached=False)
+        return self._os.get_package_information("rdma-core", use_cached=False)
 
     def _check_if_installed(self) -> bool:
         return self._os.package_exists("rdma-core")


### PR DESCRIPTION
refactors how the DPDK tests handle the rdma-core dependency by implementing the Installer class for it.
Now allows arbitrary source builds via tar or git as well as handling the MANA special case of building a recent rdma-core version.