### PR TITLE
Enable deployment of Premium file share, enable SMB2.0 support

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3258,7 +3258,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             location=location,
             log=self._log,
             sku=sku,
-            kind=skind,
+            kind=kind,
             enable_https_traffic_only=enable_https_traffic_only,
             allow_shared_key_access=allow_shared_key_access,
         )

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3254,7 +3254,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
-            allow_shared_key_access=allow_shared_key_access
+            allow_shared_key_access=allow_shared_key_access,
         )
 
         for share_name in file_share_names:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3237,9 +3237,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         file_share_names: List[str],
         environment: Environment,
         allow_shared_key_access: bool = False,
-        sku: str="Standard_LRS",
-        kind: str="StorageV2",
-        enable_https_traffic_only: bool=True,
+        sku: str = "Standard_LRS",
+        kind: str = "StorageV2",
+        enable_https_traffic_only: bool = True,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3237,9 +3237,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         file_share_names: List[str],
         environment: Environment,
         allow_shared_key_access: bool = False,
-        sku="Standard_LRS",
-        kind="StorageV2",
-        enable_https_traffic_only=True,
+        sku: str="Standard_LRS",
+        kind: str="StorageV2",
+        enable_https_traffic_only: bool=True,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,7 +2718,6 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
-            
         )
         get_or_create_file_share(
             credential=platform.credential,

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3237,6 +3237,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         file_share_names: List[str],
         environment: Environment,
         allow_shared_key_access: bool = False,
+        sku="Standard_LRS",
+        kind="StorageV2",
+        enable_https_traffic_only=True,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3254,6 +3257,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
+            sku=sku,
+            kind=skind,
+            enable_https_traffic_only=enable_https_traffic_only,
             allow_shared_key_access=allow_shared_key_access,
         )
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,7 +3233,10 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
+        self, 
+        file_share_names: List[str], 
+        environment: Environment, 
+        allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,9 +3233,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, 
-        file_share_names: List[str], 
-        environment: Environment, 
+        self,
+        file_share_names: List[str],
+        environment: Environment,
         allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3236,7 +3236,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         self,
         file_share_names: List[str],
         environment: Environment,
-        allow_shared_key_access: bool = False
+        allow_shared_key_access: bool = False,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,6 +2718,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
+            
         )
         get_or_create_file_share(
             credential=platform.credential,
@@ -3233,7 +3234,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment
+        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3251,6 +3252,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
+            allow_shared_key_access=allow_shared_key_access
         )
 
         for share_name in file_share_names:


### PR DESCRIPTION
Added parameters to existing create_file_share() definition to accept params for storage account sku, kind and enable_https_traffic_only ( for enabling SMB 2.0 share , supported in azfiles but need this property disabled ) 