### PR TITLE
Add support for Private endpoint to SMB file share

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -172,9 +172,9 @@ class StartStop(AzureFeatureMixin, features.StartStop):
         node_info = self._node.connection_info
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_PUBLIC_ADDRESS] = public_ip
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS] = private_ip
-        node_info[constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS] = (
-            platform._azure_runbook.use_public_address
-        )
+        node_info[
+            constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS
+        ] = platform._azure_runbook.use_public_address
         self._node.set_connection_info(**node_info)
         self._node._is_initialized = False
         self._node.initialize()
@@ -2347,14 +2347,14 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                 settings = security_profile[0]
                 assert isinstance(settings, SecurityProfileSettings)
                 assert isinstance(settings.security_profile, SecurityProfileType)
-                node_parameters.security_profile["security_type"] = (
-                    cls._security_profile_mapping[settings.security_profile]
-                )
+                node_parameters.security_profile[
+                    "security_type"
+                ] = cls._security_profile_mapping[settings.security_profile]
                 if settings.security_profile == SecurityProfileType.Stateless:
                     node_parameters.security_profile["secure_boot"] = False
-                    node_parameters.security_profile["encryption_type"] = (
-                        "NonPersistedTPM"
-                    )
+                    node_parameters.security_profile[
+                        "encryption_type"
+                    ] = "NonPersistedTPM"
                 else:
                     node_parameters.security_profile["secure_boot"] = True
                     node_parameters.security_profile["encryption_type"] = (
@@ -2362,9 +2362,9 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                         if settings.encrypt_disk
                         else "VMGuestStateOnly"
                     )
-                node_parameters.security_profile["disk_encryption_set_id"] = (
-                    settings.disk_encryption_set_id
-                )
+                node_parameters.security_profile[
+                    "disk_encryption_set_id"
+                ] = settings.disk_encryption_set_id
 
                 if node_parameters.security_profile["security_type"] == "":
                     node_parameters.security_profile.clear()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3254,7 +3254,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
-            allow_shared_key_access=allow_shared_key_access
+            allow_shared_key_access=allow_shared_key_access,
         )
 
         for share_name in file_share_names:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3305,7 +3305,6 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 ["file"],
                 self._log,
             )
-            
             # Create private zone
             private_dns_zone_id = create_update_private_zones(
                 platform, resource_group_name, self._log

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,7 +2718,6 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
-            
         )
         get_or_create_file_share(
             credential=platform.credential,

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3305,11 +3305,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 ["file"],
                 self._log,
             )
-
-            # create private zone
-            private_dns_zone_id = create_update_private_zones(
-                platform, resource_group_name, self._log
-            )
+            
             # Create private zone
             private_dns_zone_id = create_update_private_zones(
                 platform, resource_group_name, self._log

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3263,8 +3263,8 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             enable_https_traffic_only=enable_https_traffic_only,
             allow_shared_key_access=allow_shared_key_access,
         )
-
-        # If enable_private_endpoint is true, SMB share endpoint 
+        
+        # If enable_private_endpoint is true, SMB share endpoint
         # will dns resolve to <share>.privatelink.file.core.windows.net
         # No changes need to be done in code calling function
         for share_name in file_share_names:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3264,8 +3264,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             allow_shared_key_access=allow_shared_key_access,
         )
 
-        # The SMB endpoint https://<share>.file.core.windows.net
-        # will auto point to <share>.privatelink.file.core.windows.net
+        # If enable_private_endpoint is true, SMB share endpoint 
+        # will dns resolve to <share>.privatelink.file.core.windows.net
+        # No changes need to be done in code calling function
         for share_name in file_share_names:
             fs_url_dict[share_name] = get_or_create_file_share(
                 credential=platform.credential,
@@ -3277,7 +3278,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 log=self._log,
             )
 
-        # Create file private endpoint, always after all shares are created
+        # Create file private endpoint, always after all shares have been created
+        # There is a known issue in API preventing access to data plane
+        # once private endpoint is created. Observed in Terraform provider as well
         if enable_private_endpoint:
             storage_account_resource_id = (
                 f"/subscriptions/{platform.subscription_id}/resourceGroups/"

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3264,7 +3264,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             allow_shared_key_access=allow_shared_key_access,
         )
 
-        # If private endpoints are enabled, the SMB endpoint https://<share>.file.core.windows.net
+        # The SMB endpoint https://<share>.file.core.windows.net
         # will auto point to <share>.privatelink.file.core.windows.net
         for share_name in file_share_names:
             fs_url_dict[share_name] = get_or_create_file_share(
@@ -3278,7 +3278,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             )
 
         # Create file private endpoint, always after all shares are created
-        if enable_private_endpoint == True:
+        if enable_private_endpoint is True:
             storage_account_resource_id = (
                 f"/subscriptions/{platform.subscription_id}/resourceGroups/"
                 f"{resource_group_name}/providers/Microsoft.Storage/storageAccounts"

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,7 +3233,10 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
+        self, 
+        file_share_names: List[str], 
+        environment: Environment, 
+        allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3233,9 +3233,9 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, 
-        file_share_names: List[str], 
-        environment: Environment, 
+        self,
+        file_share_names: List[str],
+        environment: Environment,
         allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3278,7 +3278,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             )
 
         # Create file private endpoint, always after all shares are created
-        if enable_private_endpoint is True:
+        if enable_private_endpoint:
             storage_account_resource_id = (
                 f"/subscriptions/{platform.subscription_id}/resourceGroups/"
                 f"{resource_group_name}/providers/Microsoft.Storage/storageAccounts"

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3263,7 +3263,6 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             enable_https_traffic_only=enable_https_traffic_only,
             allow_shared_key_access=allow_shared_key_access,
         )
-        
         # If enable_private_endpoint is true, SMB share endpoint
         # will dns resolve to <share>.privatelink.file.core.windows.net
         # No changes need to be done in code calling function
@@ -3277,7 +3276,6 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 resource_group_name=resource_group_name,
                 log=self._log,
             )
-
         # Create file private endpoint, always after all shares have been created
         # There is a known issue in API preventing access to data plane
         # once private endpoint is created. Observed in Terraform provider as well

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3236,7 +3236,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         self,
         file_share_names: List[str],
         environment: Environment,
-        allow_shared_key_access: bool = False
+        allow_shared_key_access: bool = False,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2718,6 +2718,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             sku="Premium_LRS",
             kind="FileStorage",
             enable_https_traffic_only=False,
+            
         )
         get_or_create_file_share(
             credential=platform.credential,
@@ -3233,7 +3234,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         )
 
     def create_file_share(
-        self, file_share_names: List[str], environment: Environment
+        self, file_share_names: List[str], environment: Environment, allow_shared_key_access: bool = False
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3251,6 +3252,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
             resource_group_name=resource_group_name,
             location=location,
             log=self._log,
+            allow_shared_key_access=allow_shared_key_access
         )
 
         for share_name in file_share_names:


### PR DESCRIPTION
This PR ports some code from class NFS to class AzureFileShare.
This enables creation of private endpoint, DNS zone and records which is necessary for scenarios where policy does not allows access to SMB share over public endpoint.

note: private endpoint must be created after shares are created. There is no workaround at the moment to do otherwise via API at the moment.
