### PR TITLE
limit cloud-init test for Mariner 2.0 or later

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -928,6 +928,10 @@ class AzureImageStandard(TestSuite):
     def verify_cloud_init_error_status(self, node: Node) -> None:
         cat = node.tools[Cat]
         if isinstance(node.os, CBLMariner):
+            if node.os.information.version < "2.0.0":
+                raise SkippedException(
+                    "CBLMariner 1.0 is now obsolete so skip the test."
+                )
             cloud_init_log = "/var/log/cloud-init.log"
             if node.shell.exists(node.get_pure_path(cloud_init_log)):
                 log_output = cat.read(cloud_init_log, force_run=True, sudo=True)


### PR DESCRIPTION
limit cloud-init test for Mariner 2.0 or later (azl2 and azl3). Mariner 1.0 is now obsolete. 