### PR TITLE
Script Transformer: Enable Compound Types

### DIFF
--- a/lisa/transformers/script_transformer.py
+++ b/lisa/transformers/script_transformer.py
@@ -61,7 +61,7 @@ class ScriptTransformer(Transformer):
                 key: self._runbook_builder.variables[key].data for key in item.variables
             }
 
-            evaluator = simpleeval.SimpleEval(
+            evaluator = simpleeval.EvalWithCompoundTypes(
                 # Update ex: DEFAULT_OPERATORS | {ast.BitXor, operator.xor}
                 operators=simpleeval.DEFAULT_OPERATORS | {},
                 # Update ex: DEFAULT_FUNCTIONS | {'floor': math.floor}


### PR DESCRIPTION
This will allow for the use of list, tuple, set, dict in the scripts of the script transformer.