### PR TITLE
Libvirt: Remove firmware parameter from clh platform runbook schema

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -62,22 +62,14 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
 
         assert isinstance(node_runbook, CloudHypervisorNodeSchema)
         node_context = get_node_context(node)
-        if node_runbook.kernel:
-            if self.host_node.is_remote and not node_runbook.kernel.is_remote_path:
-                node_context.kernel_source_path = node_runbook.kernel.path
-                node_context.kernel_path = os.path.join(
-                    self.vm_disks_dir, os.path.basename(node_runbook.kernel.path)
-                )
-            else:
-                node_context.kernel_path = node_runbook.kernel.path
+        assert node_runbook.kernel, "Kernel parameter is required for clh platform"
+        if self.host_node.is_remote and not node_runbook.kernel.is_remote_path:
+            node_context.kernel_source_path = node_runbook.kernel.path
+            node_context.kernel_path = os.path.join(
+                self.vm_disks_dir, os.path.basename(node_runbook.kernel.path)
+            )
         else:
-            if self.host_node.is_remote:
-                node_context.kernel_source_path = node_runbook.firmware
-                node_context.kernel_path = os.path.join(
-                    self.vm_disks_dir, os.path.basename(node_runbook.firmware)
-                )
-            else:
-                node_context.kernel_path = node_runbook.firmware
+            node_context.kernel_path = node_runbook.kernel.path
 
     def _create_node(
         self,

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -143,10 +143,5 @@ class KernelSchema:
 @dataclass_json()
 @dataclass
 class CloudHypervisorNodeSchema(BaseLibvirtNodeSchema):
-    # DEPRECATED: use the 'kernel' field instead.
-    # Local path to the cloud-hypervisor firmware.
-    # Can be obtained from:
-    # https://github.com/cloud-hypervisor/rust-hypervisor-firmware
-    firmware: str = ""
     # Local or remote path to the cloud-hypervisor kernel.
     kernel: Optional[KernelSchema] = None


### PR DESCRIPTION
- Change cloud-hypervisor schema in libvirt, remove firmware parameter.
- Use kernel parameter to pass firmware/remote kernel path.

USAGE:
```
requirement:
      core_count: 1
      memory_mb: 1000
      features:
        items:
          - type: Security_Profile
            security_profile: "cvm"
      cloud-hypervisor:
        disk_img: ""
        disk_img_format: ""
        kernel: 
          path: ""
          is_remote_path: True
        cloud_init:
          extra_user_data: ""
        disk_img_resize_gib: 25     
```