### PR TITLE
Dpdk: add package info to test results

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -836,7 +836,7 @@ class Debian(Linux):
         if not match:
             raise LisaException(
                 f"Could not parse version info: {version_str} "
-                "for package {package_name}"
+                f"for package {package_name}"
             )
         self._node.log.debug(f"Attempting to parse version string: {version_str}")
         version_info = self._get_version_info_from_named_regex_match(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -532,7 +532,7 @@ class Posix(OperatingSystem, BaseClassMixin):
     def _get_version_info_from_named_regex_match(
         self, package_name: str, named_matches: Match[str]
     ) -> VersionInfo:
-        essential_matches = ["major", "minor", "build"]
+        essential_matches = ["major", "minor"]
 
         # verify all essential keys are in our match dict
         assert_that(
@@ -547,7 +547,6 @@ class Posix(OperatingSystem, BaseClassMixin):
             patch_match = "0"
         major_match = named_matches.group("major")
         minor_match = named_matches.group("minor")
-        build_match = named_matches.group("build")
         major, minor, patch = map(
             int,
             [major_match, minor_match, patch_match],
@@ -752,8 +751,8 @@ class Debian(Linux):
     _debian_version_splitter_regex = re.compile(
         r"([0-9]+:)?"  # some examples have a mystery number followed by a ':' (git)
         r"(?P<major>[0-9]+)\."  # major
-        r"(?P<minor>[0-9]+)[\-\.]"  # minor
-        r"(?P<patch>[0-9]+)"  # patch
+        r"(?P<minor>[0-9]+)"  # minor
+        r"([\-\.](?P<patch>[0-9]+))?"  # patch
         r"(?:-)?(?P<build>[a-zA-Z0-9-_\.~+]+)"  # build
         # '-' is added after minor and made optional before build
         # due to the formats like 23.11-1build3

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -750,6 +750,10 @@ class Debian(Linux):
         r"Package: ([a-zA-Z0-9:_\-\.]+)\r?\n"  # package name group
         r"Version: ([a-zA-Z0-9:_\-\.~+]+)\r?\n"  # version number group
     )
+    # ex: 3.10
+    # ex: 3.10.5-git
+    # ex: 3.10-5git3
+    # ex: 3.10.1-build3
     _debian_version_splitter_regex = re.compile(
         r"([0-9]+:)?"  # some examples have a mystery number followed by a ':' (git)
         r"(?P<major>[0-9]+)\."  # major

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -554,10 +554,9 @@ class Posix(OperatingSystem, BaseClassMixin):
         build_match = named_matches.group("build")
         log_message = (
             f"Found {package_name} version "
-            f"{major_match}.{minor_match}.{patch_match}"
+            f"major:{major_match} minor:{minor_match} "
+            f"patch:{patch_match} build:{build_match}"
         )
-        if build_match:
-            log_message += f"-{build_match}"
         self._node.log.debug(log_message)
         return VersionInfo(major, minor, patch, build=build_match)
 

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1979,9 +1979,9 @@ class Suse(Linux):
     _suse_version_splitter_regex = re.compile(
         r"([0-9]+:)?"  # some examples have a mystery number followed by a ':' (git)
         r"(?P<major>[0-9]+)\."  # major
-        r"(?P<minor>[0-9]+)\."  # minor
-        r"(?P<patch>[0-9]+)"  # patch
-        r"-(?P<build>[a-zA-Z0-9-_\.~+]+)"  # build
+        r"(?P<minor>[0-9]+)"  # minor
+        r"([\-\.](?P<patch>[0-9]+))?"  # patch
+        r"((?:-)?(?P<build>[a-zA-Z0-9-_\.~+]+))?"  # build
     )
     _ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
@@ -2138,7 +2138,7 @@ class Suse(Linux):
         if not match:
             raise LisaException(
                 f"Could not parse version info: {version_str} "
-                "for package {package_name}"
+                f"for package {package_name}"
             )
         self._node.log.debug(f"Attempting to parse version string: {version_str}")
         version_info = self._get_version_info_from_named_regex_match(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -552,10 +552,13 @@ class Posix(OperatingSystem, BaseClassMixin):
             [major_match, minor_match, patch_match],
         )
         build_match = named_matches.group("build")
-        self._node.log.debug(
+        log_message = (
             f"Found {package_name} version "
-            f"{major_match}.{minor_match}.{patch_match}-{build_match}"
+            f"{major_match}.{minor_match}.{patch_match}"
         )
+        if build_match:
+            log_message += f"-{build_match}"
+        self._node.log.debug(log_message)
         return VersionInfo(major, minor, patch, build=build_match)
 
     def _cache_and_return_version_info(
@@ -753,7 +756,7 @@ class Debian(Linux):
         r"(?P<major>[0-9]+)\."  # major
         r"(?P<minor>[0-9]+)"  # minor
         r"([\-\.](?P<patch>[0-9]+))?"  # patch
-        r"(?:-)?(?P<build>[a-zA-Z0-9-_\.~+]+)"  # build
+        r"((?:-)?(?P<build>[a-zA-Z0-9-_\.~+]+))?"  # build
         # '-' is added after minor and made optional before build
         # due to the formats like 23.11-1build3
     )

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -189,7 +189,8 @@ class Installer:
             self._node.log.debug("No downloader assigned to installer.")
 
     # do the build and installation
-    def _install(self) -> None: ...
+    def _install(self) -> None:
+        pass
 
     # remove an installation
     def _uninstall(self) -> None:

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -189,8 +189,7 @@ class Installer:
             self._node.log.debug("No downloader assigned to installer.")
 
     # do the build and installation
-    def _install(self) -> None:
-        ...
+    def _install(self) -> None: ...
 
     # remove an installation
     def _uninstall(self) -> None:

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -273,7 +273,6 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
         use_queues: bool = False,
-        service_cores: int = 1,
     ) -> None:
         environment = test_result.environment
         assert environment, "fail to get environment from testresult"
@@ -287,7 +286,6 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
-                    use_service_cores=service_cores,
                 )
             else:
                 send_kit, receive_kit = verify_dpdk_send_receive(
@@ -296,7 +294,6 @@ class DpdkPerformance(TestSuite):
                     variables,
                     pmd,
                     HugePageSize.HUGE_2MB,
-                    use_service_cores=service_cores,
                 )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)

--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -64,7 +64,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         sender_kit = verify_dpdk_build(
-            node, log, variables, "failsafe", HugePageSize.HUGE_2MB
+            node, log, variables, "failsafe", HugePageSize.HUGE_2MB, result=result
         )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
@@ -110,7 +110,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         sender_kit = verify_dpdk_build(
-            node, log, variables, "netvsc", HugePageSize.HUGE_2MB
+            node, log, variables, "netvsc", HugePageSize.HUGE_2MB, result=result
         )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
@@ -319,10 +319,6 @@ class DpdkPerformance(TestSuite):
         sender_fields: Dict[str, Any] = {}
         receiver_fields: Dict[str, Any] = {}
         test_case_name = test_result.runtime_data.metadata.name
-        testpmd = send_kit.testpmd
-        if testpmd.has_dpdk_version():
-            dpdk_version = testpmd.get_dpdk_version()
-            test_result.information["dpdk_version"] = str(dpdk_version)
 
         # shared results fields
         for result_fields in [sender_fields, receiver_fields]:

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -22,7 +22,7 @@ from lisa import (
 )
 from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
 from lisa.operating_system import BSD, CBLMariner, Ubuntu, Windows
-from lisa.testsuite import simple_requirement
+from lisa.testsuite import TestResult, simple_requirement
 from lisa.tools import Echo, Git, Hugepages, Ip, Kill, Lsmod, Make, Modprobe
 from lisa.tools.hugepages import HugePageSize
 from lisa.util.constants import SIGINT
@@ -91,9 +91,15 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_build_netvsc(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
-        verify_dpdk_build(node, log, variables, "netvsc", HugePageSize.HUGE_2MB)
+        verify_dpdk_build(
+            node, log, variables, "netvsc", HugePageSize.HUGE_2MB, result=result
+        )
 
     @TestCaseMetadata(
         description="""
@@ -113,9 +119,15 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_build_gb_hugepages_netvsc(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
-        verify_dpdk_build(node, log, variables, "netvsc", HugePageSize.HUGE_1GB)
+        verify_dpdk_build(
+            node, log, variables, "netvsc", HugePageSize.HUGE_1GB, result=result
+        )
 
     @TestCaseMetadata(
         description="""
@@ -135,9 +147,15 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_build_failsafe(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
-        verify_dpdk_build(node, log, variables, "failsafe", HugePageSize.HUGE_2MB)
+        verify_dpdk_build(
+            node, log, variables, "failsafe", HugePageSize.HUGE_2MB, result=result
+        )
 
     @TestCaseMetadata(
         description="""
@@ -157,9 +175,15 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_build_gb_hugepages_failsafe(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
-        verify_dpdk_build(node, log, variables, "failsafe", HugePageSize.HUGE_1GB)
+        verify_dpdk_build(
+            node, log, variables, "failsafe", HugePageSize.HUGE_1GB, result=result
+        )
 
     @TestCaseMetadata(
         description="""
@@ -362,10 +386,18 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_sriov_rescind_failover_receiver(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         test_kits = init_nodes_concurrent(
-            environment, log, variables, "failsafe", HugePageSize.HUGE_2MB
+            environment,
+            log,
+            variables,
+            "failsafe",
+            HugePageSize.HUGE_2MB,
         )
 
         try:

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -390,7 +390,6 @@ class Dpdk(TestSuite):
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
-        result: TestResult,
     ) -> None:
         test_kits = init_nodes_concurrent(
             environment,
@@ -633,11 +632,15 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, "failsafe"
+                environment, log, variables, "failsafe", result=result
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -663,10 +666,11 @@ class Dpdk(TestSuite):
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, "netvsc"
+                environment, log, variables, "netvsc", result=result
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -688,11 +692,20 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_send_receive_failsafe(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive(
-                environment, log, variables, "failsafe", HugePageSize.HUGE_2MB
+                environment,
+                log,
+                variables,
+                "failsafe",
+                HugePageSize.HUGE_2MB,
+                result=result,
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -715,7 +728,11 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_send_receive_gb_hugepages_failsafe(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive(
@@ -724,6 +741,7 @@ class Dpdk(TestSuite):
                 variables,
                 "failsafe",
                 HugePageSize.HUGE_1GB,
+                result=result,
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -745,11 +763,20 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_send_receive_netvsc(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive(
-                environment, log, variables, "netvsc", HugePageSize.HUGE_2MB
+                environment,
+                log,
+                variables,
+                "netvsc",
+                HugePageSize.HUGE_2MB,
+                result=result,
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -772,7 +799,11 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_send_receive_gb_hugepages_netvsc(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         try:
             verify_dpdk_send_receive(
@@ -781,6 +812,7 @@ class Dpdk(TestSuite):
                 variables,
                 "netvsc",
                 HugePageSize.HUGE_1GB,
+                result=result,
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -808,12 +840,16 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_l3fwd_ntttcp_tcp(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         force_dpdk_default_source(variables)
         pmd = "netvsc"
         verify_dpdk_l3fwd_ntttcp_tcp(
-            environment, log, variables, HugePageSize.HUGE_2MB, pmd=pmd
+            environment, log, variables, HugePageSize.HUGE_2MB, pmd=pmd, result=result
         )
 
     @TestCaseMetadata(
@@ -837,12 +873,21 @@ class Dpdk(TestSuite):
         ),
     )
     def verify_dpdk_l3fwd_ntttcp_tcp_gb_hugepages(
-        self, environment: Environment, log: Logger, variables: Dict[str, Any]
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
     ) -> None:
         force_dpdk_default_source(variables)
         pmd = "netvsc"
         verify_dpdk_l3fwd_ntttcp_tcp(
-            environment, log, variables, hugepage_size=HugePageSize.HUGE_1GB, pmd=pmd
+            environment,
+            log,
+            variables,
+            hugepage_size=HugePageSize.HUGE_1GB,
+            pmd=pmd,
+            result=result,
         )
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -71,7 +71,7 @@ DPDK_PACKAGE_MANAGER_PACKAGES = DependencyInstaller(
         ),
         OsPackageDependencies(
             matcher=lambda x: isinstance(x, Suse)
-            and parse_version(x.information.release) == "15.5.0",
+            and bool(parse_version(x.information.release) == "15.5.0"),
             packages=["dpdk22", "dpdk22-devel"],
             stop_on_match=True,
         ),

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -2,8 +2,9 @@ import itertools
 import time
 from collections import deque
 from decimal import Decimal
+from enum import Enum
 from functools import partial
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from assertpy import assert_that
 from semver import VersionInfo
@@ -26,6 +27,7 @@ from lisa.base_tools.uname import Uname
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
+from lisa.testsuite import TestResult
 from lisa.tools import (
     Dmesg,
     Echo,
@@ -43,7 +45,7 @@ from lisa.tools import (
     Timeout,
 )
 from lisa.tools.hugepages import HugePageSize
-from lisa.util.constants import SIGINT
+from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.common import (
     AZ_ROUTE_ALL_TRAFFIC,
@@ -102,13 +104,16 @@ class UnsupportedPackageVersionException(LisaException):
 
 # container class for test resources to be passed to run_testpmd_concurrent
 class DpdkTestResources:
-    def __init__(self, _node: Node, _testpmd: DpdkTestpmd) -> None:
+    def __init__(
+        self, _node: Node, _testpmd: DpdkTestpmd, _rdma_core: Installer
+    ) -> None:
         self.testpmd = _testpmd
         self.node = _node
         self.nic_controller = _node.features[NetworkInterface]
         self.dmesg = _node.tools[Dmesg]
         self._last_dmesg = ""
         self.switch_sriov = True
+        self.rdma_core = _rdma_core
 
 
 def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
@@ -363,7 +368,7 @@ def initialize_node_resources(
         for extra_nic in extra_nics:
             do_pmd_driver_setup(node=node, test_nic=extra_nic, testpmd=testpmd, pmd=pmd)
 
-    return DpdkTestResources(node, testpmd)
+    return DpdkTestResources(_node=node, _testpmd=testpmd, _rdma_core=rdma_core)
 
 
 def check_send_receive_compatibility(test_kits: List[DpdkTestResources]) -> None:
@@ -486,6 +491,7 @@ def verify_dpdk_build(
     pmd: str,
     hugepage_size: HugePageSize,
     multiple_queues: bool = False,
+    result: Optional[TestResult] = None,
 ) -> DpdkTestResources:
     # setup and unwrap the resources for this test
     try:
@@ -511,7 +517,9 @@ def verify_dpdk_build(
     assert_that(tx_pps).described_as(
         f"TX-PPS ({tx_pps}) should have been greater than 2^20 (~1m) PPS."
     ).is_greater_than(2**20)
-    return DpdkTestResources(node, testpmd)
+    if result is not None:
+        annotate_dpdk_test_result(test_kit, test_result=result, log=log)
+    return test_kit
 
 
 def verify_dpdk_send_receive(
@@ -543,8 +551,12 @@ def verify_dpdk_send_receive(
     )
 
     check_send_receive_compatibility(test_kits)
-
     sender, receiver = test_kits
+
+    # annotate test result before starting
+    annotate_dpdk_send_receive_test_result(
+        test_kit=sender, environment=environment, log=log
+    )
 
     kit_cmd_pairs = generate_send_receive_run_info(
         pmd,
@@ -871,7 +883,9 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         )
     except (NotEnoughMemoryException, UnsupportedOperationException) as err:
         raise SkippedException(err)
-
+    annotate_dpdk_send_receive_test_result(
+        test_kit=fwd_kit, environment=environment, log=log
+    )
     # NOTE: we're cheating here and not dynamically picking the port IDs
     # Why? You can't do it with the sdk tools for netvsc without writing your own app.
     # SOMEONE is supposed to publish an example to MSDN but I haven't yet. -mcgov
@@ -1085,4 +1099,80 @@ def create_l3fwd_rules_files(
     )
 
 
-DPDK_VERSION_TO_RDMA_CORE_MAP = {"20.11": "46.1", "21.11": ""}
+# Device name match for LSPCI
+class NicType(Enum):
+    CX3 = "ConnectX-3"
+    CX4 = "ConnectX-4"
+    CX5 = "ConnectX-5"
+    MANA = "Device 00ba"
+
+
+# Short name for nic types
+NIC_SHORT_NAMES = {
+    NicType.CX3: "cx3",
+    NicType.CX4: "cx4",
+    NicType.CX5: "cx5",
+    NicType.MANA: "mana",
+}
+
+
+# Get the short name for the type of nic on a node
+def get_node_nic_short_name(node: Node) -> str:
+    devices = node.tools[Lspci].get_devices_by_type(DEVICE_TYPE_SRIOV)
+    if node.nics.is_mana_device_present():
+        return NIC_SHORT_NAMES[NicType.MANA]
+    for nic_name in [NicType.CX3, NicType.CX4, NicType.CX5]:
+        if any([str(nic_name) in x.device_id for x in devices]):
+            return NIC_SHORT_NAMES[nic_name]
+    # We assert much earlier to enforce that SRIOV is enabled,
+    # so we should never hit this unless someone is testing a new platform.
+    # Instead of asserting, just log that the short name was not found.
+    known_nic_types = ",".join(
+        map(str, [NicType.CX3, NicType.CX4, NicType.CX5, NicType.MANA])
+    )
+    found_nic_types = ",".join(map(str, [x.device_id for x in devices]))
+    node.log.debug(
+        "Unknown NIC hardware was detected during DPDK test case. "
+        f"Expected one of: {known_nic_types}. Found {found_nic_types}. "
+    )
+    # this is just a function for annotating a result, so don't assert
+    # if there's
+    return ""
+
+
+# Add dpdk/rdma/nic info to dpdk test result
+# Enables rich reporting, coverage, and issue triage.
+def annotate_dpdk_test_result(
+    test_kit: DpdkTestResources, test_result: TestResult, log: Logger
+) -> None:
+    dpdk_version = None
+    rdma_version = None
+    nic_hw = None
+    try:
+        dpdk_version = test_kit.testpmd.get_dpdk_version()
+    except AssertionError:
+        test_kit.node.log.debug("Could not fetch DPDK version info.")
+    try:
+        rdma_version = test_kit.rdma_core.get_installed_version()
+    except AssertionError:
+        test_kit.node.log.debug("Could not fetch RDMA version info.")
+    try:
+        nic_hw = get_node_nic_short_name(test_kit.node)
+    except AssertionError:
+        test_kit.node.log.debug("Could not fetch NIC short name.")
+    if dpdk_version:
+        test_result.information["dpdk_version"] = str(dpdk_version)
+    if rdma_version:
+        test_result.information["rdma_version"] = str(rdma_version)
+    if nic_hw:
+        test_result.information["nic_hw"] = nic_hw
+
+
+def annotate_dpdk_send_receive_test_result(
+    test_kit: DpdkTestResources, environment: Environment, log: Logger
+) -> None:
+    test_result = environment.source_test_result
+    if not test_result:
+        log.debug("Cannot annotate DPDK info into test result!")
+        return
+    annotate_dpdk_test_result(test_kit=test_kit, test_result=test_result, log=log)


### PR DESCRIPTION
Swap to adding dpdk/rdma/nic info to dpdk test results for both functional and performance tests.

This makes triaging issues much quicker and enables rich coverage and test status reporting, it's not possible to graph (dpdk_version x hardware_type) or (rdma_version x dpdk_version x hardware type) without this annotation. 