### PR TITLE
sut_orchestrator: hyperv: don't automatically add disks

### DIFF
--- a/lisa/sut_orchestrator/hyperv/platform_.py
+++ b/lisa/sut_orchestrator/hyperv/platform_.py
@@ -296,6 +296,7 @@ class HypervPlatform(Platform):
                     1: com1_pipe_path,
                 },
                 extra_args=extra_args,
+                attach_offline_disks=False,
             )
             # perform device passthrough for the VM
             self.device_pool._set_device_passthrough_node_context(


### PR DESCRIPTION
The create_vm() method of the HyperV tool, automatically finds offline disks and adds them to the VM. This behavior is not required for hyperv platform. So, introduce a parameter to control it and modify hyperv platform to disable that behavior.