### PR TITLE
DPDK: Fix info fetch for mellanox NICs

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1152,15 +1152,18 @@ def annotate_dpdk_test_result(
     try:
         dpdk_version = test_kit.testpmd.get_dpdk_version()
         test_result.information["dpdk_version"] = str(dpdk_version)
+        log.debug(f"Found dpdk version: {dpdk_version}")
     except AssertionError as err:
         test_kit.node.log.debug(f"Could not fetch DPDK version info: {str(err)}")
     try:
         rdma_version = test_kit.rdma_core.get_installed_version()
         test_result.information["rdma_version"] = str(rdma_version)
+        log.debug(f"Found rdma version: {rdma_version}")
     except AssertionError as err:
         test_kit.node.log.debug(f"Could not fetch RDMA version info: {str(err)}")
     try:
         nic_hw = get_node_nic_short_name(test_kit.node)
         test_result.information["nic_hw"] = nic_hw
+        log.debug(f"Found nic version: {nic_hw}")
     except AssertionError as err:
         test_kit.node.log.debug(f"Could not fetch NIC short name: {str(err)}")

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1122,15 +1122,15 @@ def get_node_nic_short_name(node: Node) -> str:
     devices = node.tools[Lspci].get_devices_by_type(DEVICE_TYPE_SRIOV)
     if node.nics.is_mana_device_present():
         return NIC_SHORT_NAMES[NicType.MANA]
-    for nic_name in [NicType.CX3, NicType.CX4, NicType.CX5]:
-        if any([str(nic_name) in x.device_id for x in devices]):
+    non_mana_nics = [NicType.CX3, NicType.CX4, NicType.CX5]
+    for nic_name in non_mana_nics:
+        if any([nic_name.value in x.device_info for x in devices]):
             return NIC_SHORT_NAMES[nic_name]
     # We assert much earlier to enforce that SRIOV is enabled,
     # so we should never hit this unless someone is testing a new platform.
     # Instead of asserting, just log that the short name was not found.
-    known_nic_types = ",".join(
-        map(str, [NicType.CX3, NicType.CX4, NicType.CX5, NicType.MANA])
-    )
+    short_names = map(lambda x: x.value, non_mana_nics)
+    known_nic_types = ",".join(short_names)
     found_nic_types = ",".join(map(str, [x.device_id for x in devices]))
     node.log.debug(
         "Unknown NIC hardware was detected during DPDK test case. "


### PR DESCRIPTION
Fixing the way mlx nic info is fetched, need to match device_id -> device_info.

Also add a log line to make finding future issues easier.