### PR TITLE
mdatp check: add mdatp health invocation to check for onboarding

### DIFF
--- a/microsoft/testsuites/mdatp/check-mdatp.sh
+++ b/microsoft/testsuites/mdatp/check-mdatp.sh
@@ -113,5 +113,20 @@ if [ -f "$MDATP_OPT_DIR/mdatp_onboard.json" ]; then
     EXIT_CODE=$EXIT_ONBOARD_INFO_FOUND
 fi
 
+# special log line if mdatp installed and reports it is onboarded
+MDATP_ORG_ID=$(\
+    sudo command -v mdatp \
+    && sudo mdatp health \
+    | grep --fixed-strings 'org_id:' \
+    | cut -f 2 -d ':' \
+    | tr -d '[:blank:][:punct:]' \
+)
+if [ -n "$MDATP_ORG_ID" ]; then
+    echo "$ERROR_MSG_HEADER" >&2
+    echo "ERROR: mdatp is installed and reports this device is onboarded:" >&2
+    sudo mdatp health >&2
+    EXIT_CODE=$EXIT_ONBOARD_INFO_FOUND
+fi
+
 # returns nonzero value if defender info is found
 exit $EXIT_CODE

--- a/microsoft/testsuites/mdatp/check-mdatp.sh
+++ b/microsoft/testsuites/mdatp/check-mdatp.sh
@@ -115,8 +115,8 @@ fi
 
 # special log line if mdatp installed and reports it is onboarded
 MDATP_ORG_ID=$(\
-    sudo command -v mdatp \
-    && sudo mdatp health \
+    command -v mdatp \
+    && mdatp health \
     | grep --fixed-strings 'org_id:' \
     | cut -f 2 -d ':' \
     | tr -d '[:blank:][:punct:]' \


### PR DESCRIPTION
After talking with the defender team, I'm adding a second check which uses `mdatp health` to check for the current onboarding state. This avoids the problem of relying entirely on the well known file path to find the onboarding info.