### PR TITLE
Marked Lun based testcases to be skipped as FreeBSD does not use LUN

### DIFF
--- a/microsoft/testsuites/core/storage.py
+++ b/microsoft/testsuites/core/storage.py
@@ -467,7 +467,9 @@ class Storage(TestSuite):
         """,
         priority=2,
         timeout=TIME_OUT,
-        requirement=simple_requirement(disk=DiskStandardSSDLRS()),
+        requirement=simple_requirement(
+            unsupported_os=[Windows, BSD], disk=DiskStandardSSDLRS()
+        ),
     )
     def verify_hot_add_disk_serial_random_lun_standard_ssd(
         self, log: Logger, node: Node
@@ -496,7 +498,9 @@ class Storage(TestSuite):
         """,
         priority=2,
         timeout=TIME_OUT,
-        requirement=simple_requirement(disk=DiskStandardSSDLRS()),
+        requirement=simple_requirement(
+            unsupported_os=[Windows, BSD], disk=DiskStandardSSDLRS()
+        ),
     )
     def verify_hot_add_disk_serial_random_lun_premium_ssd(
         self, log: Logger, node: Node


### PR DESCRIPTION
LUN is not a feature on FreeBSD so this testcase that is focused on using LUN is not applicable and needs to be skipped. Tested on all the current images and it is being skipped correctly.