### PR TITLE
Update junit.py

### DIFF
--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -312,8 +312,7 @@ class JUnit(Notifier):
             failure = ET.SubElement(testcase, "failure")
             if runbook.include_failed_messages:
                 failure.attrib["message"] = message.message
-                # failure.text = message.stacktrace
-                if str(message.stacktrace) != "":
+                if message.stacktrace:
                     failure.attrib["stacktrace"] = str(message.stacktrace)
             testsuite_info.failed_count += 1
 

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -30,10 +30,6 @@ class JUnitSchema(schema.Notifier):
     include_subtest: bool = True
     # show passed case 'message' and 'stacktraces'
     include_passed_messages: bool = False
-    # show 'message' for failed cases and 'stacktrace'
-    include_failed_messages: bool = True
-    # show 'message' for skipped cases
-    include_skipped_messages: bool = True
 
 
 class _TestSuiteInfo:
@@ -310,26 +306,24 @@ class JUnit(Notifier):
 
         if message.status == TestStatus.FAILED:
             failure = ET.SubElement(testcase, "failure")
-            if runbook.include_failed_messages:
-                failure.attrib["message"] = message.message
-                if message.stacktrace:
-                    failure.attrib["stacktrace"] = str(message.stacktrace)
+            failure.attrib["message"] = message.message
+            failure.text = message.stacktrace
             testsuite_info.failed_count += 1
 
         elif message.status in [TestStatus.SKIPPED, TestStatus.ATTEMPTED]:
             skipped = ET.SubElement(testcase, "skipped")
-            if runbook.include_skipped_messages:
-                skipped.attrib["message"] = message.message
-                if str(message.stacktrace) != "":
-                    skipped.attrib["stacktrace"] = str(message.stacktrace)
+            skipped.attrib["message"] = message.message
+            if message.stacktrace:
+                skipped.text = str(message.stacktrace)
         # Only add XML sub element if include_passed_messages is True in runbook
-        # By default, its assumed subtest is a pass
+        # By default, its assumed subtest is a pass as per Junit schema
         elif message.status == TestStatus.PASSED and runbook.include_passed_messages:
             passed = ET.SubElement(testcase, "passed")
             passed.attrib["message"] = message.message
             # passed.text = message.stacktrace
-            if str(message.stacktrace) != "":
-                passed.attrib["stacktrace"] = str(message.stacktrace)
+            if message.stacktrace:
+                passed.text = str(message.stacktrace)
+
         testsuite_info.test_count += 1
 
         # Write out current results to file.

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -28,6 +28,12 @@ class JUnitSchema(schema.Notifier):
     path: str = "lisa.junit.xml"
     # respect the original behavior, include subtest by default
     include_subtest: bool = True
+    # show passed case 'message' and 'stacktraces'
+    include_passed_messages: bool = False
+    # show 'message' for failed cases and 'stacktrace'
+    include_failed_messages: bool = True
+    # show 'message' for skipped cases
+    include_skipped_messages: bool = True
 
 
 class _TestSuiteInfo:
@@ -291,6 +297,8 @@ class JUnit(Notifier):
         class_name: str,
         elapsed: float,
     ) -> None:
+        # Creating a JunitSchema object to read the passed parameters to Junit class
+        runbook: JUnitSchema = cast(JUnitSchema, self.runbook)
         testsuite_info = self._testsuites_info.get(suite_full_name)
         if not testsuite_info:
             raise LisaException("Test suite not started.")
@@ -302,18 +310,27 @@ class JUnit(Notifier):
 
         if message.status == TestStatus.FAILED:
             failure = ET.SubElement(testcase, "failure")
-            failure.attrib["message"] = message.message
-            failure.text = message.stacktrace
-
+            if runbook.include_failed_messages:
+                failure.attrib["message"] = message.message
+                # failure.text = message.stacktrace
+                if str(message.stacktrace) != "":
+                    failure.attrib["stacktrace"] = str(message.stacktrace)
             testsuite_info.failed_count += 1
 
-        elif (
-            message.status == TestStatus.SKIPPED
-            or message.status == TestStatus.ATTEMPTED
-        ):
+        elif message.status in [TestStatus.SKIPPED, TestStatus.ATTEMPTED]:
             skipped = ET.SubElement(testcase, "skipped")
-            skipped.attrib["message"] = message.message
-
+            if runbook.include_skipped_messages:
+                skipped.attrib["message"] = message.message
+                if str(message.stacktrace) != "":
+                    skipped.attrib["stacktrace"] = str(message.stacktrace)
+        # Only add XML sub element if include_passed_messages is True in runbook
+        # By default, its assumed subtest is a pass
+        elif message.status == TestStatus.PASSED and runbook.include_passed_messages:
+            passed = ET.SubElement(testcase, "passed")
+            passed.attrib["message"] = message.message
+            # passed.text = message.stacktrace
+            if str(message.stacktrace) != "":
+                passed.attrib["stacktrace"] = str(message.stacktrace)
         testsuite_info.test_count += 1
 
         # Write out current results to file.


### PR DESCRIPTION
Context : for cases such as XFSTest, iPerf and others where each test case will have multiple nested cases controlled directly by the tool being called, we needed a way to cleanly pass subtests with messages, stacks and other information to Junit XML for parsing and possible injection into databases,

Added 3 new parameters.
    include_passed_messages:  ( Bool ) Include message and stacktrace in Junit XML output. Defaults to False
    include_failed_messages: ( Bool ) Include message and stacktrace in Junit XML output. Defaults to True
    include_skipped_messages: ( Bool ) Include message and stacktrace in Junit XML output. Defaults to True

Enhancements : Stacktrace now exists as an XML subproperty, making XML much cleaner.
If "message" and "stacktrace" properties are empty  in the TestResultMessage object, its relevant subXML objects will not be added, makes XML parsing & viewing cleaner.

note: Ideally this change should not break existing Junit parsing scripts, but its expected that end users are using properly traversing XML tree to ensure they do not end up with an exeception when say..."message" attribute is missing because there was actually no message passed by the TestResultMessage object.

how to call ? Example code from runbook--

notifier:
  - type: html
  - type: env_stats
  - type: junit 
    name: junit.lisa.xml 
    include_subtest: true 
    include_passed_messages: false 
    include_failed_messages: true 
    include_skipped_messages: true