### PR TITLE
added filter for benign mellanox warning on freebsd

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -243,7 +243,7 @@ class AzureImageStandard(TestSuite):
         ),
         # pam_unix,pam_faillock
         re.compile(r"^(.*pam_unix,pam_faillock.*)$", re.M),
-        # benign warning from mellanox on freebsd
+        # hamless mellanox warning that does not affect functionality of the system
         re.compile(
             r"^(.*mlx5_core0: WARN: mlx5_fwdump_prep:92:\(pid 0\).*)$",
             re.M,

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -243,6 +243,11 @@ class AzureImageStandard(TestSuite):
         ),
         # pam_unix,pam_faillock
         re.compile(r"^(.*pam_unix,pam_faillock.*)$", re.M),
+        # benign warning from mellanox on freebsd
+        re.compile(
+            r"^(.*mlx5_core0: WARN: mlx5_fwdump_prep:92:\(pid 0\).*)$",
+            re.M,
+        ),
     ]
 
     @TestCaseMetadata(


### PR DESCRIPTION
Added a filter for a benign warning on freebsd to resolve an issue with the verify_boot_error_warnings test case.