### PR TITLE
Add tool "diff" for Linux and Unix

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -27,6 +27,7 @@ from .curl import Curl
 from .date import Date
 from .df import Df
 from .dhclient import Dhclient
+from .diff import Diff
 from .dmesg import Dmesg
 from .dnsmasq import Dnsmasq
 from .docker import Docker
@@ -140,6 +141,7 @@ __all__ = [
     "Date",
     "Df",
     "Dhclient",
+    "Diff",
     "Dmesg",
     "Dnsmasq",
     "Docker",

--- a/lisa/tools/diff.py
+++ b/lisa/tools/diff.py
@@ -66,5 +66,5 @@ class Diff(Tool):
         # Diff generated difference between FILE1 FILE2 or DIR1 DIR2 or DIR FILE
         # for FILE DIR
         # EXit status is 0 if inputs are the same. 1 if different, 2 if trouble
-        result.assert_exit_code([0, 1], message=(f"Diff Error: {result.stderr}"))
+        result.assert_exit_code([0, 1], f"Diff Error: {result.stderr}")
         return result.stdout

--- a/lisa/tools/diff.py
+++ b/lisa/tools/diff.py
@@ -1,0 +1,70 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from pathlib import PurePath
+from typing import Optional
+
+from lisa.executable import Tool
+
+
+class Diff(Tool):
+    """
+    Diff is a tool class for comparing files or directories using the 'diff' command.
+
+    Attributes:
+        command (str): The command to be executed, which is 'diff'.
+        can_install (bool): Indicates whether the tool can be installed.
+            Always False for this tool.
+
+    Methods:
+        _check_exists() -> bool:
+            Checks if the tool exists. Always returns True for this tool.
+
+        comparefiles(
+            timeout: int = 600
+            Compares two files or directories.
+
+            Args:
+                src (PurePath): The source file or directory.
+                dest (PurePath): The destination file or directory.
+                cwd (Optional[PurePath]): The current working directory for the command.
+                Defaults to None.
+                sudo (bool): Whether to run the command with sudo. Defaults to False.
+                timeout (int): The timeout for the command in seconds. Defaults to 600.
+
+            Returns:
+                str: The output of the diff command.
+
+            Raises:
+                AssertionError: If the exit code of the diff command is not 0 or 1.
+    """
+
+    @property
+    def command(self) -> str:
+        return "diff"
+
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    def comparefiles(
+        self,
+        src: PurePath,
+        dest: PurePath,
+        cwd: Optional[PurePath] = None,
+        sudo: bool = False,
+        timeout: int = 600,
+    ) -> str:
+        cmd = f"{self.node.get_str_path(src)} {self.node.get_str_path(dest)}"
+        result = self.run(
+            cmd,
+            force_run=True,
+            sudo=sudo,
+            cwd=cwd,
+            shell=True,
+            timeout=timeout,
+        )
+        # Diff generated difference between FILE1 FILE2 or DIR1 DIR2 or DIR FILE
+        # for FILE DIR
+        # EXit status is 0 if inputs are the same. 1 if different, 2 if trouble
+        result.assert_exit_code([0, 1], message=(f"Diff Error: {result.stderr}"))
+        return result.stdout


### PR DESCRIPTION
Diff is used in Linux/Unix to compare two files, two directories or two streams.

In our case, Diff is used in XFStest since we need to compare *.full and *.out.full files for failed subtests to know what has went wrong. 

TODO : Currently this tool is only for Linux and Unix, Windows alternative is FC which needs to be implemented.
Currently only "comparefiles" is implemented. as we come across requirements to compare directories and streams, we will add support for them.

            Args:
                src (PurePath): The source file or directory.
                dest (PurePath): The destination file or directory.
                cwd (Optional[PurePath]): The current working directory for the command.
                Defaults to None.
                sudo (bool): Whether to run the command with sudo. Defaults to False.
                timeout (int): The timeout for the command in seconds. Defaults to 600.
            Returns:
                str: The output of the diff command.

            Raises:
                AssertionError: If the exit code of the diff command is not 0 or 1.

# 0 means no changes, 1 means changes detected. 2 means general failure.

Edit: Due to a checksum issue, Github was treating _init_.py as new file. This has been fixed with a new commit and a new PR is being raised.