### PR TITLE
DpdkPerf: enable annotations on send only tests

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -294,6 +294,7 @@ class DpdkPerformance(TestSuite):
                     variables,
                     pmd,
                     HugePageSize.HUGE_2MB,
+                    result=test_result,
                 )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)


### PR DESCRIPTION
Small change, enabling test annotations on dpdk send-only perf tests.