### PR TITLE
Change performance diagnostics to use Managed Identity

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
+++ b/lisa/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
@@ -28,7 +28,7 @@ from lisa.sut_orchestrator.azure.common import (
     AzureNodeSchema,
     check_or_create_storage_account,
     get_node_context,
-    get_storage_credential,
+    add_system_assign_identity,
     list_blobs,
 )
 from lisa.sut_orchestrator.azure.features import AzureExtension
@@ -92,12 +92,15 @@ class AzurePerformanceDiagnostics(TestSuite):
             log=log,
         )
 
-        account_credential = get_storage_credential(
-            credential=platform.credential,
-            subscription_id=platform.subscription_id,
-            cloud=platform.cloud,
-            account_name=storage_account_name,
-            resource_group_name=resource_group_name,
+        # Assign system identity to VM
+        # This MSI will be pre-configured with the necessary role assigments to Storage Account from Subscription level
+        # Permissions required: Storage Account Contributor, Storage Blob Data Contributor, Storage Blob Data Contributor
+        add_system_assign_identity(
+            platform=platform,
+            resource_group_name=node_context.resource_group_name,
+            vm_name=node_context.vm_name,
+            location=node_context.location,
+            log=log,
         )
 
         # Run VM Extension
@@ -117,7 +120,7 @@ class AzurePerformanceDiagnostics(TestSuite):
 
         protected_settings = {
             "storageAccountName": storage_account_name,
-            "storageAccountKey": account_credential.get("account_key"),
+            "authenticationType": "SystemManagedIdentity"
         }
 
         extension_result = extension.create_or_update(
@@ -168,11 +171,11 @@ class AzurePerformanceDiagnostics(TestSuite):
             CentOs: [6, 7],
             Oracle: [6, 7],
             Debian: [8, 9, 10, 11],
-            Ubuntu: [14, 16, 18, 20],
+            Ubuntu: [14, 16, 18, 20, 22],
             Suse: [12, 15],
             SLES: [12, 15],
             AlmaLinux: [8],
-            CBLMariner: [2],
+            CBLMariner: [2, 3], #AzureLinux uses CBLMariner class
         }
 
         for distro in supported_major_versions:

--- a/lisa/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
+++ b/lisa/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
@@ -26,9 +26,9 @@ from lisa.operating_system import (
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
     AzureNodeSchema,
+    add_system_assign_identity,
     check_or_create_storage_account,
     get_node_context,
-    add_system_assign_identity,
     list_blobs,
 )
 from lisa.sut_orchestrator.azure.features import AzureExtension
@@ -61,7 +61,7 @@ class AzurePerformanceDiagnostics(TestSuite):
          storage account key, which we cannot use currently.
         Will change it back once the extension works with MSI.
         """,
-        priority=5,
+        priority=1,
         requirement=simple_requirement(
             supported_features=[AzureExtension],
         ),
@@ -93,8 +93,12 @@ class AzurePerformanceDiagnostics(TestSuite):
         )
 
         # Assign system identity to VM
-        # This MSI will be pre-configured with the necessary role assigments to Storage Account from Subscription level
-        # Permissions required: Storage Account Contributor, Storage Blob Data Contributor, Storage Blob Data Contributor
+        # This MSI will be pre-configured with the necessary
+        # role assigments to Storage Account from Subscription level
+        # Permissions required:
+        #   Storage Account Contributor
+        #   Storage Blob Data Contributor
+        #   Storage Blob Data Contributor
         add_system_assign_identity(
             platform=platform,
             resource_group_name=node_context.resource_group_name,
@@ -120,7 +124,7 @@ class AzurePerformanceDiagnostics(TestSuite):
 
         protected_settings = {
             "storageAccountName": storage_account_name,
-            "authenticationType": "SystemManagedIdentity"
+            "authenticationType": "SystemManagedIdentity",
         }
 
         extension_result = extension.create_or_update(
@@ -175,7 +179,8 @@ class AzurePerformanceDiagnostics(TestSuite):
             Suse: [12, 15],
             SLES: [12, 15],
             AlmaLinux: [8],
-            CBLMariner: [2, 3], #AzureLinux uses CBLMariner class
+            # AzureLinux uses CBLMariner class
+            CBLMariner: [2, 3],
         }
 
         for distro in supported_major_versions:

--- a/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
+++ b/microsoft/testsuites/vm_extensions/azureperformancediagnostics.py
@@ -26,9 +26,9 @@ from lisa.operating_system import (
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
     AzureNodeSchema,
+    add_system_assign_identity,
     check_or_create_storage_account,
     get_node_context,
-    add_system_assign_identity,
     list_blobs,
 )
 from lisa.sut_orchestrator.azure.features import AzureExtension
@@ -60,7 +60,7 @@ class AzurePerformanceDiagnostics(TestSuite):
          storage account key, which we cannot use currently.
         Will change it back once the extension works with MSI.
         """,
-        priority=5,
+        priority=1,
         requirement=simple_requirement(
             supported_features=[AzureExtension],
         ),
@@ -92,8 +92,12 @@ class AzurePerformanceDiagnostics(TestSuite):
         )
 
         # Assign system identity to VM
-        # This MSI will be pre-configured with the necessary role assigments to Storage Account from Subscription level
-        # Permissions required: Storage Account Contributor, Storage Blob Data Contributor, Storage Blob Data Contributor
+        # This MSI will be pre-configured with the necessary
+        # role assigments to Storage Account from Subscription level
+        # Permissions required:
+        #   Storage Account Contributor
+        #   Storage Blob Data Contributor
+        #   Storage Blob Data Contributor
         add_system_assign_identity(
             platform=platform,
             resource_group_name=node_context.resource_group_name,
@@ -119,7 +123,7 @@ class AzurePerformanceDiagnostics(TestSuite):
 
         protected_settings = {
             "storageAccountName": storage_account_name,
-            "authenticationType": "SystemManagedIdentity"
+            "authenticationType": "SystemManagedIdentity",
         }
 
         extension_result = extension.create_or_update(
@@ -174,7 +178,8 @@ class AzurePerformanceDiagnostics(TestSuite):
             Suse: [12, 15],
             SLES: [12, 15],
             AlmaLinux: [8],
-            CBLMariner: [2, 3], #AzureLinux uses CBLMariner class
+            # AzureLinux uses CBLMariner class
+            CBLMariner: [2, 3],
         }
 
         for distro in supported_major_versions:


### PR DESCRIPTION
Add MSI support for performance diagnostics and remove SAS usage per Security Wave requirements.

Notes:
- This will still not work until the MSI support for Azure Performance Diagnostics is released. The work for that is still on-going.
- The VM will need to be preconfigured with these role assignments for Storage Account at Subscription level so it can inherit the permissions:
         - Storage Account Contributor
         - Storage Account Blob Contributor
         - Storage Account Table Contributor