### PR TITLE
Fix verify_azuremonitoragent_linux for Azure Linux 3.0

### DIFF
--- a/microsoft/testsuites/vm_extensions/AzureMonitorAgentLinux.py
+++ b/microsoft/testsuites/vm_extensions/AzureMonitorAgentLinux.py
@@ -96,7 +96,7 @@ class AzureMonitorAgentLinuxExtension(TestSuite):
             Ubuntu: [16, 18, 20],
             Suse: [12, 15],
             SLES: [12, 15],
-            CBLMariner: [2],
+            CBLMariner: [2, 3],
         }
 
         supported_major_versions_arm64 = {
@@ -105,7 +105,7 @@ class AzureMonitorAgentLinuxExtension(TestSuite):
             Debian: [11],
             Ubuntu: [18, 20],
             SLES: [15],
-            CBLMariner: [2],
+            CBLMariner: [2, 3],
         }
 
         for distro in supported_major_versions_x86_64:


### PR DESCRIPTION
Azure Monitor Agent supports Azure Linux 3.0. So, adding AzLinux 3.0 as supported OS for installing agents.
https://learn.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-extension-versions