### PR TITLE
CVM: Skip test cases not supporting TDX

### DIFF
--- a/microsoft/testsuites/cpu/cpusuite.py
+++ b/microsoft/testsuites/cpu/cpusuite.py
@@ -19,7 +19,6 @@ from lisa import (
     simple_requirement,
 )
 from lisa.environment import Environment
-from lisa.features.security_profile import CvmDisabled
 from lisa.node import RemoteNode
 from lisa.tools import (
     Ethtool,
@@ -186,7 +185,6 @@ class CPUSuite(TestSuite):
         priority=4,
         requirement=simple_requirement(
             min_core_count=16,
-            supported_features=[CvmDisabled()],
         ),
     )
     def verify_cpu_offline_channel_add(self, log: Logger, node: Node) -> None:

--- a/microsoft/testsuites/cvm/cvm_attestation.py
+++ b/microsoft/testsuites/cvm/cvm_attestation.py
@@ -16,7 +16,8 @@ from lisa.features.security_profile import CvmEnabled
 from lisa.operating_system import Ubuntu
 from lisa.sut_orchestrator import AZURE
 from lisa.testsuite import TestResult, simple_requirement
-from lisa.tools import Ls
+from lisa.tools import Ls, Lscpu
+from lisa.tools.lscpu import CpuType
 from lisa.util import SkippedException, UnsupportedDistroException
 from microsoft.testsuites.cvm.cvm_attestation_tool import (
     AzureCVMAttestationTests,
@@ -39,6 +40,11 @@ class AzureCVMAttestationTestSuite(TestSuite):
                 UnsupportedDistroException(
                     node.os, "CVM attestation report supports only Ubuntu."
                 )
+            )
+
+        if node.tools[Lscpu].get_cpu_type() != CpuType.AMD:
+            raise SkippedException(
+                "CVM attestation report supports only SEV-SNP (AMD) CPU."
             )
 
     @TestCaseMetadata(
@@ -85,6 +91,11 @@ class NestedCVMAttestationTestSuite(TestSuite):
         )
         if not sev_guest_exists:
             raise SkippedException("/dev/sev-guest: Device Not Found")
+
+        if node.tools[Lscpu].get_cpu_type() != CpuType.AMD:
+            raise SkippedException(
+                "CVM attestation report supports only SEV-SNP (AMD) CPU."
+            )
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Attestation report test cases only support AMD SEV-SNP so they should skip on other CPU types.

Also do not skip cpu_offline_channel_add test case as it is supported on all CPU types.