### PR TITLE
add templates for sig/vhd for AITL partners

### DIFF
--- a/microsoft/utils/aitl/tier0-sig.json
+++ b/microsoft/utils/aitl/tier0-sig.json
@@ -1,0 +1,25 @@
+{
+    "location": "westus3",
+    "properties": {
+        "jobTemplateInstance": {
+            "templateTags": [],
+            "selections": [
+                {
+                    "casePriority": [
+                        0
+                    ]
+                }
+            ],
+            "region": [],
+            "vmSize": []
+        },
+        "image": {
+            "type": "shared_gallery",
+            "architecture": "x64",
+            "vhdGeneration": 2,
+            "gallery": "<gallery name>",
+            "definition": "<image definition>",
+            "version": "<version>"
+        }
+    }
+}

--- a/microsoft/utils/aitl/tier0-vhd.json
+++ b/microsoft/utils/aitl/tier0-vhd.json
@@ -1,0 +1,23 @@
+{
+    "location": "westus3",
+    "properties": {
+        "jobTemplateInstance": {
+            "templateTags": [],
+            "selections": [
+                {
+                    "casePriority": [
+                        0
+                    ]
+                }
+            ],
+            "region": [],
+            "vmSize": []
+        },
+        "image": {
+            "type": "vhd",
+            "architecture": "x64",
+            "vhdGeneration": 2,
+            "url": "<sas url of vhd>"
+        }
+    }
+}


### PR DESCRIPTION
These templates are necessary for our AITL partners to more easily understand how to interact with the AITL service for vhd, shared image gallery and marketplace image jobs, and the different tiers of tests available to them.