### PR TITLE
xfstests: add new generic xfstests for ext4 filesystem

### DIFF
--- a/microsoft/testsuites/xfstests/xfstesting.py
+++ b/microsoft/testsuites/xfstests/xfstesting.py
@@ -180,6 +180,44 @@ class Xfstesting(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        This test case will run generic xfstests testing against
+         standard data disk with ext4 type system.
+        """,
+        requirement=simple_requirement(
+            disk=schema.DiskOptionSettings(
+                data_disk_type=schema.DiskType.StandardHDDLRS,
+                os_disk_type=schema.DiskType.StandardHDDLRS,
+                data_disk_iops=500,
+                data_disk_count=search_space.IntRange(min=1),
+            ),
+            unsupported_os=[BSD, Windows],
+        ),
+        timeout=TIME_OUT,
+        use_new_environment=True,
+        priority=3,
+    )
+    def verify_generic_ext4_standard_datadisk(
+        self, log_path: Path, result: TestResult
+    ) -> None:
+        environment = result.environment
+        assert environment, "fail to get environment from testresult"
+        node = cast(RemoteNode, environment.nodes[0])
+        xfstests = self._install_xfstests(node)
+        disk = node.features[Disk]
+        data_disks = disk.get_raw_data_disks()
+        self._execute_xfstests(
+            log_path,
+            xfstests,
+            result,
+            data_disks[0],
+            f"{data_disks[0]}1",
+            f"{data_disks[0]}2",
+            file_system=FileSystem.ext4,
+            excluded_tests=self.excluded_tests,
+        )
+
+    @TestCaseMetadata(
+        description="""
         This test case will run xfs xfstests testing against
          standard data disk with xfs type system.
         """,
@@ -317,6 +355,36 @@ class Xfstesting(TestSuite):
             nvme_data_disks[0],
             f"{nvme_data_disks[0]}p1",
             f"{nvme_data_disks[0]}p2",
+            excluded_tests=self.excluded_tests,
+        )
+    
+    @TestCaseMetadata(
+        description="""
+        This test case will run generic xfstests testing against
+         nvme data disk with ext4 type system.
+        """,
+        timeout=TIME_OUT,
+        priority=3,
+        use_new_environment=True,
+        requirement=simple_requirement(
+            supported_features=[Nvme], unsupported_os=[BSD, Windows]
+        ),
+    )
+    def verify_generic_ext4_nvme_datadisk(self, log_path: Path, result: TestResult) -> None:
+        environment = result.environment
+        assert environment, "fail to get environment from testresult"
+        node = cast(RemoteNode, environment.nodes[0])
+        xfstests = self._install_xfstests(node)
+        nvme_disk = node.features[Nvme]
+        nvme_data_disks = nvme_disk.get_raw_data_disks()
+        self._execute_xfstests(
+            log_path,
+            xfstests,
+            result,
+            nvme_data_disks[0],
+            f"{nvme_data_disks[0]}p1",
+            f"{nvme_data_disks[0]}p2",
+            file_system=FileSystem.ext4,
             excluded_tests=self.excluded_tests,
         )
 
@@ -538,6 +606,7 @@ class Xfstesting(TestSuite):
             test_dev,
             _test_folder,
             test_type,
+            file_system.name,
             mount_opts,
         )
         xfstests.set_excluded_tests(excluded_tests)

--- a/microsoft/testsuites/xfstests/xfstesting.py
+++ b/microsoft/testsuites/xfstests/xfstesting.py
@@ -357,7 +357,7 @@ class Xfstesting(TestSuite):
             f"{nvme_data_disks[0]}p2",
             excluded_tests=self.excluded_tests,
         )
-    
+
     @TestCaseMetadata(
         description="""
         This test case will run generic xfstests testing against
@@ -370,7 +370,9 @@ class Xfstesting(TestSuite):
             supported_features=[Nvme], unsupported_os=[BSD, Windows]
         ),
     )
-    def verify_generic_ext4_nvme_datadisk(self, log_path: Path, result: TestResult) -> None:
+    def verify_generic_ext4_nvme_datadisk(
+        self, log_path: Path, result: TestResult
+    ) -> None:
         environment = result.environment
         assert environment, "fail to get environment from testresult"
         node = cast(RemoteNode, environment.nodes[0])

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -304,14 +304,14 @@ class Xfstests(Tool):
         test_dev: str,
         test_folder: str,
         test_type: str,
+        fs_type: str,
         mount_opts: str = "",
     ) -> None:
         xfstests_path = self.get_xfstests_path()
         config_path = xfstests_path.joinpath("local.config")
         if self.node.shell.exists(config_path):
             self.node.shell.remove(config_path)
-        if "generic" == test_type:
-            test_type = "xfs"
+
         echo = self.node.tools[Echo]
         if mount_opts:
             content = "\n".join(
@@ -326,7 +326,7 @@ class Xfstests(Tool):
             content = "\n".join(
                 [
                     f"[{test_type}]",
-                    f"FSTYP={test_type}",
+                    f"FSTYP={fs_type}",
                 ]
             )
         echo.write_to_file(content, config_path, append=True)


### PR DESCRIPTION
This PR adds new generic xfstests for the ext4 filesystem.

New Testcases:
1. `verify_generic_ext4_standard_datadisk`: This test case will run generic xfstests testing against a standard(hdd) data disk with an `ext4` file system.
2. `verify_generic_ext4_nvme_datadisk`: This test case will run generic xfstests testing against a nvme data disk with an `ext4` file system

This also modifies `set_local_config` method to run generic xfstests against any filesystem.