### PR TITLE
Hibernation Test case fixes

### DIFF
--- a/microsoft/testsuites/power/common.py
+++ b/microsoft/testsuites/power/common.py
@@ -10,7 +10,7 @@ from lisa import Environment, Logger, Node, RemoteNode, features
 from lisa.base_tools.cat import Cat
 from lisa.features import StartStop
 from lisa.features.startstop import VMStatus
-from lisa.operating_system import CBLMariner, Redhat, Suse, Ubuntu
+from lisa.operating_system import Debian, Redhat, Ubuntu
 from lisa.tools import (
     Dmesg,
     Fio,
@@ -37,11 +37,10 @@ def is_distro_supported(node: Node) -> None:
             f"version {node.os.information.version}"
         )
 
-    if (
-        (isinstance(node.os, Redhat) and node.os.information.version < "8.3.0")
-        or (isinstance(node.os, Ubuntu) and node.os.information.version < "18.4.0")
-        or (isinstance(node.os, Suse) and node.os.information.version < "15.3.0")
-        or (isinstance(node.os, CBLMariner))
+    if not (
+        (type(node.os) == Ubuntu and node.os.information.version >= "18.04.0")
+        or (type(node.os) == Redhat and node.os.information.version >= "8.3.0")
+        or (type(node.os) == Debian and node.os.information.version >= "10.0.0")
     ):
         raise SkippedException(
             f"hibernation setup tool doesn't support current distro {node.os.name}, "

--- a/microsoft/testsuites/power/common.py
+++ b/microsoft/testsuites/power/common.py
@@ -10,7 +10,7 @@ from lisa import Environment, Logger, Node, RemoteNode, features
 from lisa.base_tools.cat import Cat
 from lisa.features import StartStop
 from lisa.features.startstop import VMStatus
-from lisa.operating_system import Redhat, Suse, Ubuntu, CBLMariner
+from lisa.operating_system import CBLMariner, Redhat, Suse, Ubuntu
 from lisa.tools import (
     Dmesg,
     Fio,
@@ -21,7 +21,6 @@ from lisa.tools import (
     Lscpu,
     Mount,
 )
-from lisa.tools.uptime import Uptime
 from lisa.util import (
     LisaException,
     SkippedException,
@@ -73,6 +72,13 @@ def verify_hibernation(
 
     # only set up hibernation setup tool for the first time
     hibernation_setup_tool.start()
+    # This is a temporary workaround for a bug observed in Redhat Distros
+    # where the VM is not able to hibernate immediately after installing
+    # the hibernation-setup tool.
+    # A sleep(100) also works, but we are unsure of the exact time required.
+    # So it is safer to reboot the VM.
+    if type(node.os) == Redhat:
+        node.reboot()
 
     boot_time_before_hibernation = node.execute(
         "echo \"$(last reboot -F | head -n 1 | awk '{print $5, $6, $7, $8, $9}')\"",

--- a/microsoft/testsuites/power/common.py
+++ b/microsoft/testsuites/power/common.py
@@ -10,7 +10,7 @@ from lisa import Environment, Logger, Node, RemoteNode, features
 from lisa.base_tools.cat import Cat
 from lisa.features import StartStop
 from lisa.features.startstop import VMStatus
-from lisa.operating_system import Redhat, Suse, Ubuntu
+from lisa.operating_system import Redhat, Suse, Ubuntu, CBLMariner
 from lisa.tools import (
     Dmesg,
     Fio,
@@ -42,6 +42,7 @@ def is_distro_supported(node: Node) -> None:
         (isinstance(node.os, Redhat) and node.os.information.version < "8.3.0")
         or (isinstance(node.os, Ubuntu) and node.os.information.version < "18.4.0")
         or (isinstance(node.os, Suse) and node.os.information.version < "15.3.0")
+        or (isinstance(node.os, CBLMariner))
     ):
         raise SkippedException(
             f"hibernation setup tool doesn't support current distro {node.os.name}, "


### PR DESCRIPTION
PR includes 3 commits
1. Reboot after running hibernation-setup-tool on RHEL
2. Skip Hibernation on Mariner. It is not supported.
3. Change use of `uptime -s` to `last` command