### PR TITLE
Libvirt: Change supported features for nested cvm attestation 

### DIFF
--- a/microsoft/testsuites/cvm/cvm_attestation.py
+++ b/microsoft/testsuites/cvm/cvm_attestation.py
@@ -10,11 +10,10 @@ from lisa import (
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
-    features,
 )
 from lisa.features.security_profile import CvmEnabled
 from lisa.operating_system import Ubuntu
-from lisa.sut_orchestrator import AZURE
+from lisa.sut_orchestrator import AZURE, CLOUD_HYPERVISOR
 from lisa.testsuite import TestResult, simple_requirement
 from lisa.tools import Ls, Lscpu
 from lisa.tools.lscpu import CpuType
@@ -104,7 +103,8 @@ class NestedCVMAttestationTestSuite(TestSuite):
         """,
         priority=3,
         requirement=simple_requirement(
-            supported_features=[features.CVMNestedVirtualization],
+            supported_features=[CvmEnabled()],
+            supported_platform_type=[CLOUD_HYPERVISOR],
         ),
     )
     def verify_nested_cvm_attestation_report(


### PR DESCRIPTION
This change is required to enable verify_cvm_attestation_report test on libvirt platform.