### PR TITLE
Fix CVM attestation test for cloud hypervisor platform

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -70,6 +70,7 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             )
         else:
             node_context.kernel_path = node_runbook.kernel.path
+        node_context.host_data = secrets.token_hex(32)
 
     def _create_node(
         self,
@@ -131,7 +132,7 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             policy = ET.SubElement(launch_sec, "policy")
             policy.text = "0"
             host_data = ET.SubElement(launch_sec, "host_data")
-            host_data.text = secrets.token_hex(32)
+            host_data.text = node_context.host_data
 
         devices = ET.SubElement(domain, "devices")
         if len(node_context.passthrough_devices) > 0:

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -55,6 +55,7 @@ class NodeContext:
     vm_name: str = ""
     kernel_source_path: str = ""
     kernel_path: str = ""
+    host_data: str = ""
     guest_vm_type: GuestVmType = field(default_factory=lambda: GuestVmType.Standard)
     cloud_init_file_path: str = ""
     ignition_file_path: str = ""

--- a/microsoft/testsuites/cvm/cvm_attestation.py
+++ b/microsoft/testsuites/cvm/cvm_attestation.py
@@ -14,6 +14,7 @@ from lisa import (
 from lisa.features.security_profile import CvmEnabled
 from lisa.operating_system import Ubuntu
 from lisa.sut_orchestrator import AZURE, CLOUD_HYPERVISOR
+from lisa.sut_orchestrator.libvirt.context import get_node_context
 from lisa.testsuite import TestResult, simple_requirement
 from lisa.tools import Ls, Lscpu
 from lisa.tools.lscpu import CpuType
@@ -116,7 +117,8 @@ class NestedCVMAttestationTestSuite(TestSuite):
         result: TestResult,
         variables: Dict[str, Any],
     ) -> None:
-        host_data = variables.get("host_data", "")
+        node_context = get_node_context(node)
+        host_data = node_context.host_data
         if not host_data:
             raise SkippedException("host_data is empty")
         node.tools[NestedCVMAttestationTests].run_cvm_attestation(

--- a/microsoft/testsuites/cvm/cvm_attestation_tool.py
+++ b/microsoft/testsuites/cvm/cvm_attestation_tool.py
@@ -157,11 +157,12 @@ class NestedCVMAttestationTests(Tool):
         output: str = command.stdout
         result = self._extract_result(output)
         self._log.debug(f"Attestation result: {result}")
+        attestation_host_data = result["host_data"].replace(" ", "").strip()
 
         assert_that(
             host_data,
             "'host_data' passed to testcase is not matching with attestation result",
-        ).is_equal_to(result["host_data"].strip())
+        ).is_equal_to(attestation_host_data)
 
         # save the attestation report under log_path as cvm_attestation_report.txt
         self._save_attestation_report(output, log_path)


### PR DESCRIPTION
- Add host data to node context in cloud hypervisor platform
- Use node context instead of testcase variable host_data for nested cvm attestation report