### PR TITLE
Improve VhdTransformer with CVM

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -523,7 +523,24 @@ class VhdSchema(AzureImageSchema):
     vmgs_path: Optional[str] = None
 
     def load_from_platform(self, platform: "AzurePlatform") -> None:
-        return
+        # There are no platform tags to parse, but we can assume the
+        # security profile based on the presence of a VMGS path.
+        if self.vmgs_path:
+            self.security_profile = search_space.SetSpace(
+                True,
+                [
+                    SecurityProfileType.CVM,
+                    SecurityProfileType.Stateless,
+                ],
+            )
+        else:
+            self.security_profile = search_space.SetSpace(
+                True,
+                [
+                    SecurityProfileType.Standard,
+                    SecurityProfileType.SecureBoot,
+                ],
+            )
 
 
 @dataclass_json()


### PR DESCRIPTION
Have the VhdTransformer support CVM by exporting the VMGS along with the VHD.

Then restrict the Security Profile of the VhdSchema based on the presence of a VMGS file.

Together, these changes allow the VhdTransformer to take a VM and test the exported VHD without knowing whether the image is CVM or not. The presence of the VMGS file during disk export provides the necessary information.