### PR TITLE
Updated to handle time source issues on FreeBSD

### DIFF
--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -445,16 +445,14 @@ class BSDLscpu(Lscpu):
 
     def get_cpu_type(self, force_run: bool = False) -> CpuType:
         result = self.run("-n hw.model", force_run=force_run).stdout.strip()
-        if "AMD" in result.stdout:
+        if "AMD" in result:
             return CpuType.AMD
-        elif "Intel" in result.stdout:
+        elif "Intel" in result:
             return CpuType.Intel
-        elif "ARM" in result.stdout or "aarch64" in result.stdout:
+        elif "ARM" in result or "aarch64" in result:
             return CpuType.ARM
         else:
-            raise LisaException(
-                f"Unknow cpu type. The output of lscpu is {result.stdout}"
-            )
+            raise LisaException(f"Unknow cpu type. The output of lscpu is {result}")
 
 
 class VMWareESXiLscpu(Lscpu):

--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -443,6 +443,19 @@ class BSDLscpu(Lscpu):
             * self.get_thread_per_core_count()
         )
 
+    def get_cpu_type(self, force_run: bool = False) -> CpuType:
+        result = self.run("-n hw.model", force_run=force_run).stdout.strip()
+        if "AMD" in result.stdout:
+            return CpuType.AMD
+        elif "Intel" in result.stdout:
+            return CpuType.Intel
+        elif "ARM" in result.stdout or "aarch64" in result.stdout:
+            return CpuType.ARM
+        else:
+            raise LisaException(
+                f"Unknow cpu type. The output of lscpu is {result.stdout}"
+            )
+
 
 class VMWareESXiLscpu(Lscpu):
     #    CPU Threads: 208

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -212,6 +212,7 @@ class TimeSync(TestSuite):
             ).is_subset_of(clocksource)
 
             # 2. Check CPU flag contains constant_tsc from /proc/cpuinfo.
+            dmesg = node.tools[Dmesg]
             if CpuArchitecture.X64 == arch:
                 if not isinstance(node.os, BSD):
                     cpu_info_result = cat.run("/proc/cpuinfo")
@@ -225,7 +226,6 @@ class TimeSync(TestSuite):
                         f" equal to cpu count."
                     ).is_equal_to(lscpu.get_core_count())
                 else:
-                    dmesg = node.tools[Dmesg]
                     cpu_info_results = self.__freebsd_tsc_filter.findall(
                         dmesg.get_output()
                     )

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -86,6 +86,9 @@ class TimeSync(TestSuite):
     )
     current_clockevent = "/sys/devices/system/clockevents/clockevent0/current_device"
     unbind_clockevent = "/sys/devices/system/clockevents/clockevent0/unbind_device"
+    # Positive Example:
+    # Features=0x1c77b221<FPU,VME,DE,PSE,TSC,MSR,PAE,MCE,CX8,APIC,SEP,MTRR,PGE,MCA,CMOV,PAT,PSE36,CLFLUSH,MMX,FXSR,SSE,SSE2,HTT>
+    __freebsd_tsc_filter = re.compile(r"Features=.*<.*,TSC,.*>")
 
     @TestCaseMetadata(
         description="""
@@ -190,7 +193,6 @@ class TimeSync(TestSuite):
             lscpu = node.tools[Lscpu]
             sysctl = node.tools[Sysctl]
             dmesg = node.tools[Dmesg]
-            freebsd_tsc_filter = re.compile(r"Features=.*<.*,TSC,.*>")
             arch = lscpu.get_architecture()
             clocksource = clocksource_map.get(arch, None)
             if not clocksource:
@@ -222,7 +224,9 @@ class TimeSync(TestSuite):
                         f" equal to cpu count."
                     ).is_equal_to(lscpu.get_core_count())
                 else:
-                    cpu_info_result = freebsd_tsc_filter.findall(dmesg.get_output())
+                    cpu_info_result = self.__freebsd_tsc_filter.findall(
+                        dmesg.get_output()
+                    )
                     count_of_results = len(cpu_info_result)
                     assert_that(count_of_results).described_as(
                         "Expected TSC shown up times in cpu flags is"

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -195,18 +195,18 @@ class TimeSync(TestSuite):
             clocksource = clocksource_map.get(arch, None)
             if not clocksource:
                 raise UnsupportedCpuArchitectureException(arch)
-            if isinstance(node.os, BSD):
+            if not isinstance(node.os, BSD):
+                clock_source_result = cat.run(self.current_clocksource)
+                assert_that([clock_source_result.stdout]).described_as(
+                    f"Expected clocksource name is one of {clocksource}, "
+                    f"but actual it is {clock_source_result.stdout}."
+                ).is_subset_of(clocksource)
+            else:
                 sysctl = node.tools[Sysctl]
                 clock_source_result = sysctl.get("kern.timecounter.hardware")
                 assert_that([clock_source_result]).described_as(
                     f"Expected clocksource name is one of {clocksource}, "
                     f"but actual it is {clock_source_result}."
-                ).is_subset_of(clocksource)
-            else:
-                clock_source_result = cat.run(self.current_clocksource)
-                assert_that([clock_source_result.stdout]).described_as(
-                    f"Expected clocksource name is one of {clocksource}, "
-                    f"but actual it is {clock_source_result.stdout}."
                 ).is_subset_of(clocksource)
 
             # 2. Check CPU flag contains constant_tsc from /proc/cpuinfo.

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -1,3 +1,4 @@
+import re
 import time
 from copy import deepcopy
 from datetime import timedelta
@@ -21,7 +22,18 @@ from lisa import (
     simple_requirement,
 )
 from lisa.operating_system import BSD, CpuArchitecture, Redhat, Suse, Windows
-from lisa.tools import Cat, Chrony, Dmesg, Hwclock, Ls, Lscpu, Ntp, Ntpstat, Service
+from lisa.tools import (
+    Cat,
+    Chrony,
+    Dmesg,
+    Hwclock,
+    Ls,
+    Lscpu,
+    Ntp,
+    Ntpstat,
+    Service,
+    Sysctl,
+)
 from lisa.tools.date import Date
 from lisa.tools.lscpu import CpuType
 from lisa.util import constants
@@ -167,41 +179,67 @@ class TimeSync(TestSuite):
                     "lis_hyperv_clocksource_tsc_page",
                     "hyperv_clocksource",
                     "tsc",
+                    "Hyper-V-TSC",
                 ],
                 CpuArchitecture.ARM64: [
                     "arch_sys_counter",
+                    "ARM MPCore Timecounter",
                 ],
             }
+            cat = node.tools[Cat]
             lscpu = node.tools[Lscpu]
+            sysctl = node.tools[Sysctl]
+            dmesg = node.tools[Dmesg]
+            freebsd_tsc_filter = re.compile(r"Features=.*<.*,TSC,.*>")
             arch = lscpu.get_architecture()
             clocksource = clocksource_map.get(arch, None)
             if not clocksource:
                 raise UnsupportedCpuArchitectureException(arch)
-            cat = node.tools[Cat]
-            clock_source_result = cat.run(self.current_clocksource)
-            assert_that([clock_source_result.stdout]).described_as(
-                f"Expected clocksource name is one of {clocksource},"
-                f" but actual it is {clock_source_result.stdout}."
-            ).is_subset_of(clocksource)
+            if "FreeBSD" in node.os.name:
+                clock_source_result = sysctl.get("kern.timecounter.hardware")
+                assert_that([clock_source_result]).described_as(
+                    f"Expected clocksource name is one of {clocksource}, "
+                    f"but actual it is {clock_source_result}."
+                ).is_subset_of(clocksource)
+            else:
+                clock_source_result = cat.run(self.current_clocksource)
+                assert_that([clock_source_result.stdout]).described_as(
+                    f"Expected clocksource name is one of {clocksource}, "
+                    f"but actual it is {clock_source_result.stdout}."
+                ).is_subset_of(clocksource)
 
             # 2. Check CPU flag contains constant_tsc from /proc/cpuinfo.
             if CpuArchitecture.X64 == arch:
-                cpu_info_result = cat.run("/proc/cpuinfo")
-                if CpuType.Intel == lscpu.get_cpu_type():
-                    expected_tsc_str = " constant_tsc "
-                elif CpuType.AMD == lscpu.get_cpu_type():
-                    expected_tsc_str = " tsc "
-                shown_up_times = cpu_info_result.stdout.count(expected_tsc_str)
-                assert_that(shown_up_times).described_as(
-                    f"Expected {expected_tsc_str} shown up times in cpu flags is"
-                    " equal to cpu count."
-                ).is_equal_to(lscpu.get_core_count())
+                if "FreeBSD" not in node.os.name:
+                    cpu_info_result = cat.run("/proc/cpuinfo")
+                    if CpuType.Intel == lscpu.get_cpu_type():
+                        expected_tsc_str = " constant_tsc "
+                    elif CpuType.AMD == lscpu.get_cpu_type():
+                        expected_tsc_str = " tsc "
+                    shown_up_times = cpu_info_result.stdout.count(expected_tsc_str)
+                    assert_that(shown_up_times).described_as(
+                        f"Expected {expected_tsc_str} shown up times in cpu flags is"
+                        f" equal to cpu count."
+                    ).is_equal_to(lscpu.get_core_count())
+                else:
+                    cpu_info_result = freebsd_tsc_filter.findall(dmesg.get_output())
+                    count_of_results = len(cpu_info_result)
+                    assert_that(count_of_results).described_as(
+                        "Expected TSC shown up times in cpu flags is"
+                        " equal to cpu count."
+                    ).is_equal_to(lscpu.get_core_count())
 
             # 3. Check clocksource name shown up in dmesg.
-            dmesg = node.tools[Dmesg]
-            assert_that(dmesg.get_output()).described_as(
-                f"Expected clocksource {clock_source_result.stdout} shown up in dmesg."
-            ).contains(f"clocksource {clock_source_result.stdout}")
+            if "FreeBSD" in node.os.name:
+                assert_that(dmesg.get_output()).described_as(
+                    f'Expected Timecounter "{clock_source_result}"'
+                    f" shown up in dmesg."
+                ).contains(f'Timecounter "{clock_source_result}"')
+            else:
+                assert_that(dmesg.get_output()).described_as(
+                    f"Expected clocksource {clock_source_result.stdout}"
+                    f" shown up in dmesg."
+                ).contains(f"clocksource {clock_source_result.stdout}")
 
             # 4. Unbind current clock source if there are 2+ clock sources,
             # check current clock source can be switched to a different one.


### PR DESCRIPTION
Added updates to the clock source test to handle freebsd specifics and clocksource names as well as how to filter through the dmesg output. Also added a freebsd specific version of the lscpu function to get the cpu type.