### PR TITLE
Resolve path for download the file by wget.

### DIFF
--- a/lisa/tools/lsvmbus.py
+++ b/lisa/tools/lsvmbus.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Set, Type
 from lisa.base_tools.wget import Wget
 from lisa.executable import Tool
 from lisa.operating_system import Redhat, Suse, Ubuntu
-from lisa.tools import Dmesg
+from lisa.tools import Dmesg, Echo
 from lisa.util import LisaException, find_groups_in_lines
 
 from .python import Python
@@ -189,9 +189,16 @@ class Lsvmbus(Tool):
 
     def _install_from_src(self) -> None:
         wget_tool = self.node.tools[Wget]
-        file_path = wget_tool.get(
-            self._lsvmbus_repo, "$HOME/.local/bin", executable=True
-        )
+        echo = self.node.tools[Echo]
+        tool_path = echo.run(
+            "$HOME/.local/bin",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to get $HOME/.local/bin via echo"
+            ),
+        ).stdout
+        file_path = wget_tool.get(self._lsvmbus_repo, tool_path, executable=True)
         self._command = file_path
 
     def install(self) -> bool:


### PR DESCRIPTION
After this change https://github.com/microsoft/lisa/pull/3505/files#diff-c566c41343c1a6fe4f895dcfef9ad47e016dda9614454e126cb56c9a6f3fdc54R62, I started to see lsvmbus related issues, during investigation found that "$HOME/.local/bin" is not resolved as we expected in self.node.shell.mkdir(self.node.get_pure_path(path), exist_ok=True) of _ensure_download_path
It fails on all distro which install lsvmbus from source.