### PR TITLE
Enforce stricter target criteria for DPDK 

### DIFF
--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -11,7 +11,7 @@ from urllib3.util.url import parse_url
 
 from lisa import Node
 from lisa.executable import Tool
-from lisa.operating_system import Debian, Fedora, Oracle, Posix, Redhat, Suse, Ubuntu
+from lisa.operating_system import Debian, Fedora, Oracle, Posix, Suse, Ubuntu
 from lisa.tools import Git, Lscpu, Tar, Wget
 from lisa.tools.lscpu import CpuArchitecture
 from lisa.util import UnsupportedDistroException
@@ -327,7 +327,7 @@ def check_dpdk_support(node: Node) -> None:
             )
         else:
             supported = node.os.information.version >= "11.0.0"
-    elif isinstance(node.os, Redhat) and not isinstance(node.os, Oracle):
+    elif isinstance(node.os, Fedora) and not isinstance(node.os, Oracle):
         supported = node.os.information.version >= "7.5.0"
     elif isinstance(node.os, Suse):
         supported = node.os.information.version >= "15.0.0"

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -310,7 +310,7 @@ def check_dpdk_support(node: Node) -> None:
     arch = node.tools[Lscpu].get_architecture()
     if arch == CpuArchitecture.ARM64 and not isinstance(node.os, Ubuntu):
         raise UnsupportedDistroException(
-            node.os, "ARM64 tests are only supported on Ubuntu."
+            node.os, "ARM64 tests are only supported on Ubuntu + failsafe."
         )
     if isinstance(node.os, Debian):
         if isinstance(node.os, Ubuntu):

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -12,7 +12,8 @@ from urllib3.util.url import parse_url
 from lisa import Node
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Fedora, Oracle, Posix, Redhat, Suse, Ubuntu
-from lisa.tools import Git, Tar, Wget
+from lisa.tools import Git, Lscpu, Tar, Wget
+from lisa.tools.lscpu import CpuArchitecture
 from lisa.util import UnsupportedDistroException
 
 DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
@@ -306,6 +307,11 @@ def check_dpdk_support(node: Node) -> None:
     # check requirements according to:
     # https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk
     supported = False
+    arch = node.tools[Lscpu].get_architecture()
+    if arch == CpuArchitecture.ARM64 and not isinstance(node.os, Ubuntu):
+        raise UnsupportedDistroException(
+            node.os, "ARM64 tests are only supported on Ubuntu."
+        )
     if isinstance(node.os, Debian):
         if isinstance(node.os, Ubuntu):
             node.log.debug(

--- a/microsoft/testsuites/dpdk/dpdknffgo.py
+++ b/microsoft/testsuites/dpdk/dpdknffgo.py
@@ -5,8 +5,9 @@ from typing import List, Type
 
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Ubuntu
-from lisa.tools import Echo, Git, Make, Tar, Wget
-from lisa.util import UnsupportedDistroException
+from lisa.tools import Echo, Git, Lscpu, Make, Tar, Wget
+from lisa.tools.lscpu import CpuArchitecture
+from lisa.util import UnsupportedCpuArchitectureException, UnsupportedDistroException
 
 
 class DpdkNffGo(Tool):
@@ -52,7 +53,10 @@ class DpdkNffGo(Tool):
         node = self.node
         os = node.os
         version = os.information.version
-        if isinstance(os, Ubuntu):
+        node_arch = node.tools[Lscpu].get_architecture()
+        if node_arch != CpuArchitecture.X64:
+            raise UnsupportedCpuArchitectureException(arch=str(node_arch.value))
+        elif isinstance(os, Ubuntu):
             if version != "18.4.0":
                 raise UnsupportedDistroException(
                     os, "NFF-GO test is not supported on Ubuntu != 18.04"

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -207,6 +207,9 @@ class Dpdk(TestSuite):
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         # initialize DPDK first, OVS requires it built from source before configuring.
+        if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
+            raise SkippedException("OVS test not supported on ARM64")
+
         force_dpdk_default_source(variables)
         try:
             test_kit = initialize_node_resources(

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -782,10 +782,10 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     receive_side = 2
     # arbitrarily pick fwd/snd/recv nodes.
     forwarder, sender, receiver = environment.nodes.list()
-    if (
-        forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64
-        or not isinstance(forwarder.os, Ubuntu)
-        or forwarder.os.information.version < "22.4.0"
+    if not (
+        forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.X64
+        and isinstance(forwarder.os, Ubuntu)
+        and forwarder.os.information.version >= "22.4.0"
     ):
         raise SkippedException("l3fwd test not compatible, use X64 Ubuntu >= 22.04")
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -45,6 +45,7 @@ from lisa.tools import (
     Timeout,
 )
 from lisa.tools.hugepages import HugePageSize
+from lisa.tools.lscpu import CpuArchitecture
 from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
 from microsoft.testsuites.dpdk.common import (
@@ -782,10 +783,11 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     # arbitrarily pick fwd/snd/recv nodes.
     forwarder, sender, receiver = environment.nodes.list()
     if (
-        not isinstance(forwarder.os, Ubuntu)
+        forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64
+        or not isinstance(forwarder.os, Ubuntu)
         or forwarder.os.information.version < "22.4.0"
     ):
-        raise SkippedException("l3fwd test not compatible, use Ubuntu >= 22.04")
+        raise SkippedException("l3fwd test not compatible, use X64 Ubuntu >= 22.04")
 
     # get core count, quick skip if size is too small.
     available_cores = forwarder.tools[Lscpu].get_core_count()

--- a/microsoft/testsuites/dpdk/dpdkvpp.py
+++ b/microsoft/testsuites/dpdk/dpdkvpp.py
@@ -6,14 +6,9 @@ from typing import List, Type
 from assertpy import assert_that
 
 from lisa.executable import Tool
-from lisa.operating_system import Debian, Fedora, Suse
-from lisa.tools import Cat, Echo, Gcc, Git, Lscpu, Make, Modprobe
-from lisa.tools.lscpu import CpuArchitecture
-from lisa.util import (
-    SkippedException,
-    UnsupportedCpuArchitectureException,
-    UnsupportedDistroException,
-)
+from lisa.operating_system import Debian, Fedora, Oracle, Suse
+from lisa.tools import Cat, Echo, Gcc, Git, Make, Modprobe
+from lisa.util import SkippedException, UnsupportedDistroException
 
 
 class DpdkVpp(Tool):
@@ -97,11 +92,11 @@ class DpdkVpp(Tool):
 
     def _install(self) -> bool:
         node = self.node
-        if isinstance(node.os, Fedora):
-            node.os.install_epel()
         if isinstance(node.os, Debian):
             pkg_type = "deb"
-        elif isinstance(node.os, Fedora) or isinstance(node.os, Suse):
+        elif not isinstance(node.os, Oracle) and (
+            isinstance(node.os, Fedora) or isinstance(node.os, Suse)
+        ):
             pkg_type = "rpm"
         else:
             raise SkippedException(
@@ -110,6 +105,8 @@ class DpdkVpp(Tool):
                 )
             )
 
+        if isinstance(node.os, Fedora):
+            node.os.install_epel()
         node.execute(
             (
                 "curl -s https://packagecloud.io/install/repositories/fdio/release/"

--- a/microsoft/testsuites/dpdk/dpdkvpp.py
+++ b/microsoft/testsuites/dpdk/dpdkvpp.py
@@ -7,8 +7,13 @@ from assertpy import assert_that
 
 from lisa.executable import Tool
 from lisa.operating_system import Debian, Fedora, Suse
-from lisa.tools import Cat, Echo, Gcc, Git, Make, Modprobe
-from lisa.util import SkippedException, UnsupportedDistroException
+from lisa.tools import Cat, Echo, Gcc, Git, Lscpu, Make, Modprobe
+from lisa.tools.lscpu import CpuArchitecture
+from lisa.util import (
+    SkippedException,
+    UnsupportedCpuArchitectureException,
+    UnsupportedDistroException,
+)
 
 
 class DpdkVpp(Tool):


### PR DESCRIPTION
Enforcing supported targets to be CentOS, RedHat, Debian, Ubuntu, SUSE. Reducing ARM64 scope to Ubuntu only.
Add function enforcing PMD requirements for netvsc/failsafe/mana etc.