### PR TITLE
VhdTransformer: use vhd_path

### DIFF
--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -246,7 +246,7 @@ class VhdTransformer(Transformer):
         )
 
         if vmgs_sas_url:
-            vmgs_path = runbook.custom_blob_name.replace(".vhd", "_vmgs.vhd")
+            vmgs_path = vhd_path.replace(".vhd", "_vmgs.vhd")
             assert vmgs_path != vhd_path, (
                 "vmgs url path is the same as vhd url path. "
                 "Make sure the custom_blob_name ends in .vhd"


### PR DESCRIPTION
use vhd_path instead of custom_blob_name because the custom blob name is not always provided.