### PR TITLE
Transformer Logs: Save to separate file

### DIFF
--- a/docs/run_test/runbook.rst
+++ b/docs/run_test/runbook.rst
@@ -524,6 +524,13 @@ its value will be overwritten by the transformer. For example,
 ``to_list_image`` to ``image``. The original variable name must exist in
 the output variables of the transformer.
 
+enable_file_logging
+^^^^^^^^^^^^^^^^^^^
+
+type: bool, optional, default is False.
+
+When set to True, the transformer will log the output to a file.
+
 .. _combinator:
 
 combinator

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -187,6 +187,8 @@ class Transformer(TypedSchema, ExtendableSchemaMixin):
     rename: Dict[str, str] = field(default_factory=dict)
     # enable this transformer or not, only enabled transformers run actually.
     enabled: bool = True
+    # write logs to file. set to false by default
+    enable_file_logging: bool = False
     # decide when the transformer run. The init means run at very beginning
     # phase, which is before the combinator. The expanded means run after
     # combinator expanded variables.


### PR DESCRIPTION
Set transformer property 'enable_file_logging' to True to save the transformer logs to separate file