### PR TITLE
Dpdk: add annotations for multiqueue tests

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/microsoft/testsuites/dpdk/dpdkperf.py
@@ -286,6 +286,7 @@ class DpdkPerformance(TestSuite):
                     log,
                     variables,
                     pmd,
+                    result=test_result,
                 )
             else:
                 send_kit, receive_kit = verify_dpdk_send_receive(


### PR DESCRIPTION
Add missing line, enable test annotations for multi-queue perf tests.