### PR TITLE
Support placement type for disks

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -98,7 +98,7 @@ func getEphemeralOSImage(node object) object => {
   name: '${node.name}-osDisk'
   diffDiskSettings: {
       option: 'local'
-      placement: 'CacheDisk'
+      placement: node.ephemeral_disk_placement_type
   }
   caching: 'ReadOnly'
   createOption: 'FromImage'
@@ -333,7 +333,7 @@ resource nodes_data_disks 'Microsoft.Compute/disks@2022-03-02' = [
   }
 ]
 
-resource nodes_vms 'Microsoft.Compute/virtualMachines@2022-08-01' = [for i in range(0, node_count): {
+resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in range(0, node_count): {
   name: nodes[i].name
   location: nodes[i].location
   tags: combined_vm_tags

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "17909783643222378721"
+      "version": "0.32.4.45862",
+      "templateHash": "16398577375970436728"
     }
   },
   "functions": [
@@ -113,7 +113,7 @@
               "name": "[format('{0}-osDisk', parameters('node').name)]",
               "diffDiskSettings": {
                 "option": "local",
-                "placement": "CacheDisk"
+                "placement": "[parameters('node').ephemeral_disk_placement_type]"
               },
               "caching": "ReadOnly",
               "createOption": "FromImage",
@@ -685,7 +685,7 @@
         "count": "[length(range(0, variables('node_count')))]"
       },
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2022-08-01",
+      "apiVersion": "2024-03-01",
       "name": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name]",
       "location": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].location]",
       "tags": "[variables('combined_vm_tags')]",
@@ -787,8 +787,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "12249187708601787514"
+              "version": "0.32.4.45862",
+              "templateHash": "7856159159103188049"
             }
           },
           "functions": [

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -9,6 +9,7 @@ import re
 import sys
 from dataclasses import InitVar, dataclass, field
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from functools import lru_cache, partial
 from pathlib import Path, PurePath
 from threading import Lock
@@ -1070,6 +1071,7 @@ class AzureNodeArmParameter(AzureNodeSchema):
     os_disk_type: str = ""
     data_disk_type: str = ""
     disk_controller_type: str = ""
+    ephemeral_disk_placement_type: str = ""
     security_profile: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -1104,6 +1106,25 @@ class DataDiskCreateOption:
             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_ATTACH,
         ]
+
+
+# EphemeralOSDiskPlacements
+# refer
+# https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks-faq
+class DiskPlacementType(str, Enum):
+    NONE = ""
+    RESOURCE = "ResourceDisk"
+    CACHE = "CacheDisk"
+    NVME = "NvmeDisk"
+
+
+def get_disk_placement_priority() -> List[DiskPlacementType]:
+    return [
+        DiskPlacementType.NVME,
+        DiskPlacementType.CACHE,
+        DiskPlacementType.RESOURCE,
+        DiskPlacementType.NONE,
+    ]
 
 
 @dataclass_json()


### PR DESCRIPTION
Currently, Ephemeral OS Disk placement value is hardcoded in LISA. This PR enables LISA to fetch the Ephemeral OS disk placement type value from the SKU capability in Azure VMs.
To allow this, DiskPlacementType setting and supported values are added to the AzureDiskOptionSettings.
LISA user can also pass the EphemeralDiskPlacementType from Runbook to deploy VM with specific supported placement type value.

For Ephemeral OS Disk placement types available, refer
 https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks-faq