### PR TITLE
Marked all sockperf tests to skip

### DIFF
--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -294,6 +294,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_tcp_sriov(self, result: TestResult) -> None:
@@ -307,6 +308,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_udp_sriov(self, result: TestResult) -> None:
@@ -320,6 +322,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Synthetic(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_udp_synthetic(self, result: TestResult) -> None:
@@ -333,6 +336,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Synthetic(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_tcp_synthetic(self, result: TestResult) -> None:
@@ -346,6 +350,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_tcp_sriov_busy_poll(self, result: TestResult) -> None:
@@ -364,6 +369,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Sriov(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_udp_sriov_busy_poll(self, result: TestResult) -> None:
@@ -382,6 +388,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Synthetic(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_udp_synthetic_busy_poll(self, result: TestResult) -> None:
@@ -400,6 +407,7 @@ class NetworkPerformace(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=Synthetic(),
+            unsupported_os=[BSD, Windows],
         ),
     )
     def perf_sockperf_latency_tcp_synthetic_busy_poll(self, result: TestResult) -> None:

--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -286,6 +286,8 @@ class NetworkPerformace(TestSuite):
             udp_mode=True,
         )
 
+    # Marked all following tests to skip on BSD since
+    # sockperf compilation is not natively supported at this time
     @TestCaseMetadata(
         description="""
         This test case uses sockperf to test sriov network latency.

--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -288,6 +288,10 @@ class NetworkPerformace(TestSuite):
 
     # Marked all following tests to skip on BSD since
     # sockperf compilation is not natively supported at this time
+    # This is due to the default compiler on freebsd being c++17
+    # and sockperf is designed to compile on c+11 which is no longer available
+    # This is a way to compile it but it requires adding a patch file
+    # to the sockperf repo to remove references to std::unary and std::binary
     @TestCaseMetadata(
         description="""
         This test case uses sockperf to test sriov network latency.


### PR DESCRIPTION
Since sockperf compilation is not possible without changes to the sockperf tool or the compiler these tests are to be skipped until sockperf can be compiled natively.