### PR TITLE
Kernel Source Installer Fixes

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -342,6 +342,7 @@ class SourceInstaller(BaseInstaller):
                     "git",
                     "build-essential",
                     "bison",
+                    "cpio",
                     "flex",
                     "libelf-dev",
                     "libncurses5-dev",
@@ -349,6 +350,7 @@ class SourceInstaller(BaseInstaller):
                     "libssl-dev",
                     "bc",
                     "ccache",
+                    "zstd",
                 ]
             )
         elif isinstance(os, CBLMariner):

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -14,7 +14,13 @@ from lisa.operating_system import CBLMariner, Redhat, Ubuntu
 from lisa.tools import Cp, Echo, Git, Make, Sed, Uname
 from lisa.tools.gcc import Gcc
 from lisa.tools.lscpu import Lscpu
-from lisa.util import LisaException, field_metadata, subclasses
+from lisa.util import (
+    LisaException,
+    VersionInfo,
+    field_metadata,
+    parse_version,
+    subclasses,
+)
 from lisa.util.logger import Logger, get_logger
 
 from .kernel_installer import BaseInstaller, BaseInstallerSchema
@@ -158,11 +164,24 @@ class SourceInstaller(BaseInstaller):
         # modify code
         self._modify_code(node=node, code_path=self._code_path)
 
+        result = node.execute(
+            "make kernelversion 2>/dev/null",
+            cwd=self._code_path,
+            shell=True,
+        )
+        result.assert_exit_code(
+            0,
+            f"failed on get kernel version: {result.stdout}",
+        )
+        build_kernel_version = parse_version(result.stdout)
+
         kconfig_file = runbook.kernel_config_file
         self._build_code(
-            node=node, code_path=self._code_path, kconfig_file=kconfig_file
+            node=node,
+            code_path=self._code_path,
+            kconfig_file=kconfig_file,
+            kernel_version=build_kernel_version,
         )
-
         self._install_build(node=node, code_path=self._code_path)
 
         result = node.execute(
@@ -170,22 +189,21 @@ class SourceInstaller(BaseInstaller):
             cwd=self._code_path,
             shell=True,
         )
-
-        kernel_version = result.stdout
         result.assert_exit_code(
             0,
-            f"failed on get kernel version: {kernel_version}",
+            f"failed on get kernel release: {result.stdout}",
         )
+        build_kernel_release = result.stdout
 
         # copy current config back to system folder.
         result = node.execute(
-            f"cp .config /boot/config-{kernel_version}",
+            f"cp .config /boot/config-{build_kernel_release}",
             cwd=self._code_path,
             sudo=True,
         )
         result.assert_exit_code()
 
-        return kernel_version
+        return build_kernel_release
 
     def _install_build(self, node: Node, code_path: PurePath) -> None:
         make = node.tools[Make]
@@ -227,7 +245,13 @@ class SourceInstaller(BaseInstaller):
             self._log.debug(f"modifying code by {modifier.type_name()}")
             modifier.modify()
 
-    def _build_code(self, node: Node, code_path: PurePath, kconfig_file: str) -> None:
+    def _build_code(
+        self,
+        node: Node,
+        code_path: PurePath,
+        kconfig_file: str,
+        kernel_version: VersionInfo,
+    ) -> None:
         self._log.info("building code...")
 
         uname = node.tools[Uname]
@@ -287,7 +311,12 @@ class SourceInstaller(BaseInstaller):
         result.assert_exit_code()
 
         # the gcc version of Redhat 7.x is too old. Upgrade it.
-        if isinstance(node.os, Redhat) and node.os.information.version < "8.0.0":
+        if (
+            kernel_version > "3.10.0"
+            and isinstance(node.os, Redhat)
+            and node.os.information.version < "8.0.0"
+        ):
+            node.os.install_packages(["centos-release-scl"])
             node.os.install_packages(["devtoolset-8"])
             node.tools[Mv].move("/bin/gcc", "/bin/gcc_back", overwrite=True, sudo=True)
             result.assert_exit_code()

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -302,9 +302,22 @@ class SourceInstaller(BaseInstaller):
         # set timeout to 2 hours
         make.make(arguments="", cwd=code_path, timeout=60 * 60 * 2)
 
+    def _fix_mirrorlist_to_vault(self, node: Node) -> None:
+        node.execute(
+            "sed -i '\
+                    s/^mirrorlist=/#mirrorlist=/;\
+                    s/^#baseurl=/baseurl=/;\
+                    /^baseurl=/ s/mirror/vault/\
+                ' /etc/yum.repos.d/CentOS-*.repo",
+            shell=True,
+            sudo=True,
+        )
+
     def _install_build_tools(self, node: Node) -> None:
         os = node.os
         self._log.info("installing build tools")
+        if isinstance(node.os, Redhat) and node.os.information.version < "8.0.0":
+            self._fix_mirrorlist_to_vault(node)
         if isinstance(os, Redhat):
             for package in list(
                 ["elfutils-libelf-devel", "openssl-devel", "dwarves", "bc"]

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -29,13 +29,13 @@ from .kernel_installer import BaseInstaller, BaseInstallerSchema
 @dataclass_json()
 @dataclass
 class BaseModifierSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
-    ...
+    pass
 
 
 @dataclass_json()
 @dataclass
 class BaseLocationSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
-    ...
+    pass
 
 
 @dataclass_json()


### PR DESCRIPTION
Fixes:
#. Old kernel versions build on modern distros.
#. devtoolset requirement for CentOS 7 for kernels <3.10
#. Mirror lists since CentOS7 is out of date.