### PR TITLE
Use new environment for 'verify_gpu_rescind_validation' test case.

### DIFF
--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -217,6 +217,7 @@ class GpuTestSuite(TestSuite):
         requirement=simple_requirement(
             supported_features=[GpuEnabled()],
         ),
+        use_new_environment=True,
     )
     def verify_gpu_rescind_validation(
         self,


### PR DESCRIPTION
Most of the failures of 'verify_gpu_rescind_validation' are not reproducing when executed this test case in the new environment. 