### PR TITLE
Process: support kill process on Windows

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -347,7 +347,7 @@ class Process:
                     break
 
     def input(self, content: str) -> None:
-        assert self._process
+        assert self._process, "The process object is None, the process may end."
         self._log.debug(f"Inputting {len(content)} chars to process.")
         self._process.stdin_write(content)
 


### PR DESCRIPTION
Use taskkill process to kill process on Windows, and improved logging.
