### PR TITLE
powershell - ouput as json

### DIFF
--- a/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
+++ b/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
@@ -104,7 +104,7 @@ class HypervAssignableDevices:
             sudo=True,
             force_run=True,
         )
-        return output.strip()
+        return str(output.strip())
 
     def __load_pnp_allocated_resources(self) -> List[Dict[str, str]]:
         # Command output result (just 2 device properties)

--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -41,7 +41,7 @@ class HyperV(Tool):
             force_run=True,
         )
 
-        return output.strip() != ""
+        return bool(output.strip() != "")
 
     def delete_vm_async(self, name: str) -> Optional[Process]:
         # check if vm is present
@@ -219,7 +219,7 @@ class HyperV(Tool):
             fail_on_error=False,
             force_run=True,
         )
-        return output.strip() != ""
+        return bool(output.strip() != "")
 
     def delete_switch(self, name: str) -> None:
         if self.exists_switch(name):
@@ -251,7 +251,7 @@ class HyperV(Tool):
             fail_on_error=False,
             force_run=True,
         )
-        return output.strip() != ""
+        return bool(output.strip() != "")
 
     def delete_nat(self, name: str) -> None:
         if self.exists_nat(name):
@@ -317,7 +317,7 @@ class HyperV(Tool):
         if not ip_address:
             raise LisaException(f"Could not find IP address for VM {name}")
 
-        return ip_address
+        return str(ip_address)
 
     def exist_port_forwarding(
         self,
@@ -328,7 +328,7 @@ class HyperV(Tool):
             fail_on_error=False,
             force_run=True,
         )
-        return output.strip() != ""
+        return bool(output.strip() != "")
 
     def delete_port_forwarding(self, nat_name: str) -> None:
         if self.exist_port_forwarding(nat_name):
@@ -359,7 +359,7 @@ class HyperV(Tool):
             fail_on_error=False,
             force_run=True,
         )
-        return output.strip() != ""
+        return  bool(output.strip() != "")
 
     def delete_virtual_disk(self, name: str) -> None:
         if self.exists_virtual_disk(name):
@@ -417,6 +417,8 @@ class HyperV(Tool):
         pwsh = self.node.tools[PowerShell]
         if not extra_args:
             extra_args = {}
-        return pwsh.run_cmdlet(
-            f"{cmd} {args} {extra_args.get(cmd.lower(), '')}", force_run=force_run
+        return str(
+            pwsh.run_cmdlet(
+                f"{cmd} {args} {extra_args.get(cmd.lower(), '')}", force_run=force_run
+            )
         )

--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -359,7 +359,7 @@ class HyperV(Tool):
             fail_on_error=False,
             force_run=True,
         )
-        return  bool(output.strip() != "")
+        return bool(output.strip() != "")
 
     def delete_virtual_disk(self, name: str) -> None:
         if self.exists_virtual_disk(name):

--- a/lisa/tools/ls.py
+++ b/lisa/tools/ls.py
@@ -88,7 +88,7 @@ class WindowsLs(Ls):
             sudo=sudo,
         )
 
-        return output.strip() == "True"
+        return bool(output.strip() == "True")
 
     def path_exists(self, path: str, sudo: bool = False) -> bool:
         output = self.node.tools[PowerShell].run_cmdlet(
@@ -96,7 +96,7 @@ class WindowsLs(Ls):
             force_run=True,
             sudo=sudo,
         )
-        return output.strip() == "True"
+        return bool(output.strip() == "True")
 
     def list(self, path: str, sudo: bool = False) -> List[str]:
         command = f'Get-ChildItem -Path "{path}" | Select-Object -ExpandProperty Name'
@@ -106,7 +106,7 @@ class WindowsLs(Ls):
             sudo=sudo,
         )
         if output:
-            return output.split()
+            return List(output.split())
         else:
             return []
 

--- a/lisa/tools/mdadm.py
+++ b/lisa/tools/mdadm.py
@@ -171,7 +171,7 @@ class WindowsMdadm(Mdadm):
             fail_on_error=False,
             force_run=True,
         )
-        return output.strip() != ""
+        return bool(output.strip() != "")
 
     def _delete_pool(self, pool_name: str) -> None:
         if self._exists_pool(pool_name):

--- a/lisa/tools/powershell.py
+++ b/lisa/tools/powershell.py
@@ -3,6 +3,7 @@
 
 import base64
 from typing import Any
+import json
 from xml.etree import ElementTree
 
 from lisa.executable import Tool
@@ -48,6 +49,7 @@ class PowerShell(Tool):
     def run_cmdlet(
         self,
         cmdlet: str,
+        output_json: bool = False,
         force_run: bool = False,
         sudo: bool = False,
         fail_on_error: bool = True,
@@ -55,7 +57,9 @@ class PowerShell(Tool):
         # Powershell error log is the xml format, it needs extra decoding. But
         # for long running script, it needs to look real time results.
         no_debug_log: bool = True,
-    ) -> str:
+    ) -> Any:
+        if output_json:
+            cmdlet = f"{cmdlet} | ConvertTo-Json"
         process = self.run_cmdlet_async(
             cmdlet=cmdlet, force_run=force_run, sudo=sudo, no_debug_log=no_debug_log
         )
@@ -68,7 +72,8 @@ class PowerShell(Tool):
             # if stdout is output already, it doesn't need to output again.
             no_debug_log=not no_debug_log,
         )
-
+        if output_json and result.stdout:
+            return json.loads(result.stdout)
         return result.stdout
 
     def wait_result(

--- a/lisa/tools/powershell.py
+++ b/lisa/tools/powershell.py
@@ -1,9 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-
 import base64
-from typing import Any
 import json
+from typing import Any
 from xml.etree import ElementTree
 
 from lisa.executable import Tool


### PR DESCRIPTION
This patch enables the `run_cmdlet` method in `lisa/tools/powershell.py` to output the result as JSON when the `output_json` parameter is set to `True`.

Getting Powershell output as JSON is beneficial because it allows for easier parsing and processing of the output data.
