### PR TITLE
Added setup commands for Chrony test on FreeBSD

### DIFF
--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -24,8 +24,10 @@ from lisa import (
 from lisa.operating_system import BSD, CpuArchitecture, Redhat, Suse, Windows
 from lisa.tools import (
     Cat,
+    Chmod,
     Chrony,
     Dmesg,
+    Echo,
     Hwclock,
     Ls,
     Lscpu,
@@ -417,8 +419,14 @@ class TimeSync(TestSuite):
         # On FreeBSD images, Chrony is not enabled by default after installation.
         # To enabled it the line chronyd_enable=YES must be added to /etc/rc.conf.
         if isinstance(node.os, BSD):
-            node.execute("chmod +x /etc/rc.conf", sudo=True)
-            node.execute("bash -c 'echo chronyd_enable=YES >> /etc/rc.conf'", sudo=True)
+            chmod = node.tools[Chmod]
+            echo = node.tools[Echo]
+            chmod.chmod("/etc/rc.conf", "+x", sudo=True)
+            echo.write_to_file(
+                value="chronyd_enable=YES",
+                file=PurePosixPath("/etc/rc.conf"),
+                sudo=True,
+            )
         chrony = node.tools[Chrony]
         # 1. Restart chrony service.
         chrony.restart()

--- a/microsoft/testsuites/core/timesync.py
+++ b/microsoft/testsuites/core/timesync.py
@@ -414,6 +414,11 @@ class TimeSync(TestSuite):
         priority=2,
     )
     def verify_timesync_chrony(self, node: Node) -> None:
+        # On FreeBSD images, Chrony is not enabled by default after installation.
+        # To enabled it the line chronyd_enable=YES must be added to /etc/rc.conf.
+        if isinstance(node.os, BSD):
+            node.execute("chmod +x /etc/rc.conf", sudo=True)
+            node.execute("bash -c 'echo chronyd_enable=YES >> /etc/rc.conf'", sudo=True)
         chrony = node.tools[Chrony]
         # 1. Restart chrony service.
         chrony.restart()


### PR DESCRIPTION
Added commands to enable chrony on freebsd into the chrony test case. Tested and passed on all 4 images.