### PR TITLE
Fix check error - install package libcairo2-dev

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,19 +36,22 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             nox-session: pylint
-            additional-sys-deps: libvirt-dev
+            additional-sys-deps: libvirt-dev libcairo2-dev
 
           - os: ubuntu-latest
             python-version: '3.8'
             nox-session: mypy
+            additional-sys-deps: libcairo2-dev
 
           - os: ubuntu-latest
             python-version: '3.8'
             nox-session: docs
+            additional-sys-deps: libcairo2-dev
 
           - os: ubuntu-latest
             python-version: '3.8'
             nox-session: coverage
+            additional-sys-deps: libcairo2-dev
 
     env:
       NOXSESSION: ${{ matrix.nox-session }}


### PR DESCRIPTION
Fix check error on latest ubuntu image - 24.04

```
 × Building wheel for pycairo (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [13 lines of output]
            running bdist_wheel
            running build
            running build_py
            creating build/lib.linux-x86_64-cpython-38/cairo
            copying cairo/__init__.py -> build/lib.linux-x86_64-cpython-38/cairo
            copying cairo/__init__.pyi -> build/lib.linux-x86_64-cpython-38/cairo
            copying cairo/py.typed -> build/lib.linux-x86_64-cpython-38/cairo
            running build_ext
            Package cairo was not found in the pkg-config search path.
            Perhaps you should add the directory containing `cairo.pc'
            to the PKG_CONFIG_PATH environment variable
            Package 'cairo', required by 'virtual:world', not found
            Command '['pkg-config', '--print-errors', '--exists', 'cairo >= 1.15.10']' returned non-zero exit status 1.
            [end of output]
```