### PR TITLE
DPDK: use multiple mempools, assert hugepage count is > 0

### DIFF
--- a/lisa/tools/hugepages.py
+++ b/lisa/tools/hugepages.py
@@ -4,6 +4,8 @@ import re
 from enum import Enum
 from typing import Any, Set
 
+from assertpy import assert_that
+
 from lisa.executable import Tool
 from lisa.tools.echo import Echo
 from lisa.tools.free import Free
@@ -81,6 +83,10 @@ class Hugepages(Tool):
             )
 
         request_pages = request_space_kb // hugepage_size_kb.value
+        assert_that(request_pages).described_as(
+            "Must request huge page count > 0. Verify this system has enough "
+            "free memory to allocate ~2GB of hugepages"
+        ).is_greater_than(0)
         for i in range(numa_nodes):
             # nr_hugepages will be written with the number calculated
             # based on 2MB hugepages if not specified, subject to change

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -565,6 +565,7 @@ class DpdkTestpmd(Tool):
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_include_info} -- --forward-mode={mode} "
             f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
+            "--mbuf-size=2048,4096"
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:


### PR DESCRIPTION
Fufilling a request to excersize code where DPDK uses more than the default amount of memory pools. Adds an option to testpmd to allocate multiple sizes. Includes a commit for the hugepages tool to assert the requested count is > 0.