### PR TITLE
DPDK: use multiple mbufs

### DIFF
--- a/lisa/tools/hugepages.py
+++ b/lisa/tools/hugepages.py
@@ -4,6 +4,8 @@ import re
 from enum import Enum
 from typing import Any, Set
 
+from assertpy import assert_that
+
 from lisa.executable import Tool
 from lisa.tools.echo import Echo
 from lisa.tools.free import Free
@@ -81,6 +83,10 @@ class Hugepages(Tool):
             )
 
         request_pages = request_space_kb // hugepage_size_kb.value
+        assert_that(request_pages).described_as(
+            "Must request huge page count > 0. Verify this system has enough "
+            "free memory to allocate ~2GB of hugepages"
+        ).is_greater_than(0)
         for i in range(numa_nodes):
             # nr_hugepages will be written with the number calculated
             # based on 2MB hugepages if not specified, subject to change

--- a/lisa/tools/hugepages.py
+++ b/lisa/tools/hugepages.py
@@ -65,13 +65,14 @@ class Hugepages(Tool):
             hugepage_sizes.add(int(matched_hugepage.group("hugepage_size_in_kb")))
         return hugepage_sizes
 
-    def _enable_hugepages(self, hugepage_size_kb: HugePageSize) -> None:
+    def _enable_hugepages(
+        self, hugepage_size_kb: HugePageSize, request_space_kb: int
+    ) -> None:
         echo = self.node.tools[Echo]
         meminfo = self.node.tools[Free]
-        nics_count = len(self.node.nics.get_nic_names())
         numa_nodes = self.node.tools[Lscpu].get_numa_node_count()
+        # ask for enough space, note that we enable pages per numa node
 
-        request_space_kb = (nics_count - 1) * 1024 * 1024 * numa_nodes * 2
         free_memory_kb = meminfo.get_free_memory_kb()
 
         if free_memory_kb < request_space_kb:
@@ -81,9 +82,9 @@ class Hugepages(Tool):
                 f"Requesting {request_space_kb} KB found {free_memory_kb} "
                 "KB free."
             )
-
-        request_pages = request_space_kb // hugepage_size_kb.value
-        assert_that(request_pages).described_as(
+        total_request_pages = request_space_kb // hugepage_size_kb.value
+        pages_per_numa_node = total_request_pages // numa_nodes
+        assert_that(pages_per_numa_node).described_as(
             "Must request huge page count > 0. Verify this system has enough "
             "free memory to allocate ~2GB of hugepages"
         ).is_greater_than(0)
@@ -92,7 +93,7 @@ class Hugepages(Tool):
             # based on 2MB hugepages if not specified, subject to change
             # this based on further discussion
             echo.write_to_file(
-                f"{request_pages}",
+                f"{pages_per_numa_node}",
                 self.node.get_pure_path(
                     f"/sys/devices/system/node/node{i}/hugepages/"
                     f"hugepages-{hugepage_size_kb.value}kB/nr_hugepages"
@@ -100,9 +101,10 @@ class Hugepages(Tool):
                 sudo=True,
             )
 
-    def init_hugepages(self, hugepage_size: HugePageSize) -> None:
+    def init_hugepages(self, hugepage_size: HugePageSize, minimum_gb: int = 2) -> None:
         mount = self.node.tools[Mount]
         hugepage_sizes = self.get_hugepage_sizes_in_kb()
+        minimum_kb = minimum_gb * 1024 * 1024
         if hugepage_size.value not in hugepage_sizes:
             raise UnsupportedOperationException(
                 f"Supported hugepage sizes in kB are: {hugepage_sizes}."
@@ -115,4 +117,6 @@ class Hugepages(Tool):
                 fs_type=FileSystem.hugetlbfs,
                 options=f"pagesize={hugepage_size.value}KB",
             )
-        self._enable_hugepages(hugepage_size_kb=hugepage_size)
+        self._enable_hugepages(
+            hugepage_size_kb=hugepage_size, request_space_kb=minimum_kb
+        )

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -565,6 +565,7 @@ class DpdkTestpmd(Tool):
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_include_info} -- --forward-mode={mode} "
             f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
+            "--mbuf-size=2048,4096"
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -565,7 +565,7 @@ class DpdkTestpmd(Tool):
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_include_info} -- --forward-mode={mode} "
             f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
-            "--mbuf-size=2048,4096"
+            "--mbuf-size=2048,8096"
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -346,7 +346,7 @@ def initialize_node_resources(
 
     # init and enable hugepages (required by dpdk)
     hugepages = node.tools[Hugepages]
-    hugepages.init_hugepages(hugepage_size)
+    hugepages.init_hugepages(hugepage_size, minimum_gb=4)
 
     assert_that(len(node.nics)).described_as(
         "Test needs at least 1 NIC on the test node."


### PR DESCRIPTION
Fufilling a request to excersize code where DPDK uses more than the default amount of memory pools. 
Testing showed this could cause DPDK to try to use more memory than our hugepage allocations allowed, so this PR also changes how hugepages are handled. Now there is an option to specify how much memory you want when initializing hugepages.