### PR TITLE
libvirt: Start default network and Capture libvirtd log

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -28,6 +28,7 @@ from lisa.operating_system import CBLMariner
 from lisa.platform_ import Platform
 from lisa.sut_orchestrator.libvirt.libvirt_device_pool import LibvirtDevicePool
 from lisa.tools import (
+    Cat,
     Chmod,
     Chown,
     Cp,
@@ -405,6 +406,12 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
                 == constants.ENVIRONMENT_KEEP_NO
             ):
                 self._delete_nodes(environment, log)
+
+            self._log.debug("Capturing libvirtd log from host...")
+            journalctl = self.host_node.tools[Journalctl]
+            journalctl.logs_for_unit(unit_name="libvirtd", sudo=True)
+            cat = self.host_node.tools[Cat]
+            cat.read(file="/var/log/libvirt/libvirtd.log", sudo=True)
 
             raise ex
 

--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -561,6 +561,18 @@ def _install_libvirt(runbook: schema.TypedSchema, node: Node, log: Logger) -> No
     log.info("Enabled libvirtd and virtnetworkd services")
     node.reboot(time_out=900)
     _wait_for_libvirtd(node)
+    if isinstance(node.os, CBLMariner):
+        # Some time we have seen 'default' nw of libvirt is not started
+        # start it in that case and mark it auto-start
+        node.execute(
+            cmd="virsh net-start default",
+            sudo=True,
+        )
+        node.execute(
+            cmd="virsh net-autostart default",
+            sudo=True,
+        )
+        log.info("Marked 'default' libvirt network as auto-start")
 
 
 def _wait_for_libvirtd(node: Node) -> None:


### PR DESCRIPTION
Capture journalctl log of libvirtd unit when libvirt domain creation fails.

Start the network using virsh cli before creating node