### PR TITLE
DPDK: Raise and catch hugepage size err

### DIFF
--- a/lisa/tools/hugepages.py
+++ b/lisa/tools/hugepages.py
@@ -4,8 +4,6 @@ import re
 from enum import Enum
 from typing import Any, Set
 
-from assertpy import assert_that
-
 from lisa.executable import Tool
 from lisa.tools.echo import Echo
 from lisa.tools.free import Free
@@ -84,10 +82,12 @@ class Hugepages(Tool):
             )
         total_request_pages = request_space_kb // hugepage_size_kb.value
         pages_per_numa_node = total_request_pages // numa_nodes
-        assert_that(pages_per_numa_node).described_as(
-            "Must request huge page count > 0. Verify this system has enough "
-            "free memory to allocate ~2GB of hugepages"
-        ).is_greater_than(0)
+        if pages_per_numa_node <= 0:
+            raise NotEnoughMemoryException(
+                "Must request huge page count > 0. Verify this system has enough "
+                "free memory to allocate ~2GB of hugepages"
+            )
+
         for i in range(numa_nodes):
             # nr_hugepages will be written with the number calculated
             # based on 2MB hugepages if not specified, subject to change

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -346,7 +346,10 @@ def initialize_node_resources(
 
     # init and enable hugepages (required by dpdk)
     hugepages = node.tools[Hugepages]
-    hugepages.init_hugepages(hugepage_size, minimum_gb=4)
+    try:
+        hugepages.init_hugepages(hugepage_size, minimum_gb=4)
+    except NotEnoughMemoryException as err:
+        raise SkippedException(err)
 
     assert_that(len(node.nics)).described_as(
         "Test needs at least 1 NIC on the test node."


### PR DESCRIPTION
Previously we asserted, this scenario where you don't have enough memory to allocate a single gb hugepage per numa node is more common than I thought. So now we catch and skip, since we can't run the test on this system.