### PR TITLE
DPDK: install path fixes for meson and Ubuntu 24.04

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2315,6 +2315,35 @@ class Suse(Linux):
                 "There are no enabled repositories defined in this image.",
             )
 
+    def _uninstall_packages(
+        self,
+        packages: List[str],
+        signed: bool = True,
+        timeout: int = 600,
+        extra_args: Optional[List[str]] = None,
+    ) -> None:
+        add_args = self._process_extra_package_args(extra_args)
+        command = f"zypper --non-interactive {add_args}"
+        if not signed:
+            command += " --no-gpg-checks "
+        command += f" rm {' '.join(packages)}"
+        self.wait_running_process("zypper")
+        install_result = self._node.execute(
+            command, shell=True, sudo=True, timeout=timeout
+        )
+        if install_result.exit_code in (1, 100):
+            raise LisaException(
+                f"Failed to install {packages}. exit_code: {install_result.exit_code}, "
+                f"stderr: {install_result.stderr}"
+            )
+        elif install_result.exit_code == 0:
+            self._log.debug(f"{packages} is/are installed successfully.")
+        else:
+            self._log.debug(
+                f"{packages} is/are installed."
+                " A system reboot or package manager restart might be required."
+            )
+
     def _install_packages(
         self,
         packages: List[str],

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2331,17 +2331,13 @@ class Suse(Linux):
         install_result = self._node.execute(
             command, shell=True, sudo=True, timeout=timeout
         )
-        if install_result.exit_code in (1, 100):
-            raise LisaException(
-                f"Failed to install {packages}. exit_code: {install_result.exit_code}, "
-                f"stderr: {install_result.stderr}"
-            )
-        elif install_result.exit_code == 0:
-            self._log.debug(f"{packages} is/are installed successfully.")
+
+        if install_result.exit_code == 0:
+            self._log.debug(f"{packages} is/are removed successfully.")
         else:
-            self._log.debug(
-                f"{packages} is/are installed."
-                " A system reboot or package manager restart might be required."
+            raise LisaException(
+                f"Failed to remove {packages}. exit_code: {install_result.exit_code}, "
+                f"stderr: {install_result.stderr}"
             )
 
     def _install_packages(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2341,13 +2341,14 @@ class Suse(Linux):
         command = f"zypper --non-interactive {add_args}"
         if not signed:
             command += " --no-gpg-checks "
-        command += f" rm {' '.join(packages)}"
+        remove_packages = " ".join(packages)
+        command += f" rm {remove_packages}"
         self.wait_running_process("zypper")
         install_result = self._node.execute(
             command, shell=True, sudo=True, timeout=timeout
         )
         assert_that(install_result.exit_code).described_as(
-            f"Failed to remove {packages}. "
+            f"Failed to remove {remove_packages}. "
             f"exit_code: {install_result.exit_code}, "
             f"stderr: {install_result.stderr}"
         ).is_equal_to(0)

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -418,6 +418,7 @@ class Posix(OperatingSystem, BaseClassMixin):
         self,
         package: Union[str, Tool, Type[Tool]],
         assert_existance: Union[bool, None] = None,
+        minimum_version: Optional[VersionInfo] = None,
     ) -> bool:
         """
         Query if a package/tool is installed on the node.
@@ -433,7 +434,13 @@ class Posix(OperatingSystem, BaseClassMixin):
                 f"Package {package} installation status is unexpected."
             ).is_equal_to(assert_existance)
 
-        return exists
+        if exists and minimum_version:
+            return (
+                self.get_package_information(package_name=package_name)
+                >= minimum_version
+            )
+        else:
+            return exists
 
     def is_package_in_repo(self, package: Union[str, Tool, Type[Tool]]) -> bool:
         """

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2346,14 +2346,12 @@ class Suse(Linux):
         install_result = self._node.execute(
             command, shell=True, sudo=True, timeout=timeout
         )
-
-        if install_result.exit_code == 0:
-            self._log.debug(f"{packages} is/are removed successfully.")
-        else:
-            raise LisaException(
-                f"Failed to remove {packages}. exit_code: {install_result.exit_code}, "
-                f"stderr: {install_result.stderr}"
-            )
+        assert_that(install_result.exit_code).described_as(
+            f"Failed to remove {packages}. "
+            f"exit_code: {install_result.exit_code}, "
+            f"stderr: {install_result.stderr}"
+        ).is_equal_to(0)
+        self._log.debug(f"{packages} is/are removed successfully.")
 
     def _install_packages(
         self,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -434,11 +434,19 @@ class Posix(OperatingSystem, BaseClassMixin):
                 f"Package {package} installation status is unexpected."
             ).is_equal_to(assert_existance)
 
-        if exists and minimum_version:
-            return (
+        if exists and minimum_version is not None:
+            acceptable = bool(
                 self.get_package_information(package_name=package_name)
                 >= minimum_version
             )
+            if not acceptable:
+                self._log.debug(
+                    (
+                        f"Minimum version of package {package_name} "
+                        f"did not meet minimum of {str(minimum_version)}."
+                    )
+                )
+            return acceptable
         else:
             return exists
 

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -434,21 +434,16 @@ class Posix(OperatingSystem, BaseClassMixin):
                 f"Package {package} installation status is unexpected."
             ).is_equal_to(assert_existance)
 
-        if exists and minimum_version is not None:
-            acceptable = bool(
-                self.get_package_information(package_name=package_name)
-                >= minimum_version
-            )
-            if not acceptable:
-                self._log.debug(
-                    (
-                        f"Minimum version of package {package_name} "
-                        f"did not meet minimum of {str(minimum_version)}."
-                    )
-                )
-            return acceptable
-        else:
+        self._log.debug(f"package '{package}' exists: {exists}")
+        if minimum_version is None or not exists:
             return exists
+
+        actual_version = self.get_package_information(package_name=package_name)
+        self._log.debug(
+            f"package '{package}' expected min version: "
+            f"{str(minimum_version)}, actual version: {str(actual_version)}"
+        )
+        return actual_version >= minimum_version
 
     def is_package_in_repo(self, package: Union[str, Tool, Type[Tool]]) -> bool:
         """

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -418,7 +418,6 @@ class Posix(OperatingSystem, BaseClassMixin):
         self,
         package: Union[str, Tool, Type[Tool]],
         assert_existance: Union[bool, None] = None,
-        minimum_version: Optional[VersionInfo] = None,
     ) -> bool:
         """
         Query if a package/tool is installed on the node.
@@ -435,15 +434,7 @@ class Posix(OperatingSystem, BaseClassMixin):
             ).is_equal_to(assert_existance)
 
         self._log.debug(f"package '{package}' exists: {exists}")
-        if minimum_version is None or not exists:
-            return exists
-
-        actual_version = self.get_package_information(package_name=package_name)
-        self._log.debug(
-            f"package '{package}' expected min version: "
-            f"{str(minimum_version)}, actual version: {str(actual_version)}"
-        )
-        return actual_version >= minimum_version
+        return exists
 
     def is_package_in_repo(self, package: Union[str, Tool, Type[Tool]]) -> bool:
         """
@@ -2339,14 +2330,14 @@ class Suse(Linux):
         remove_packages = " ".join(packages)
         command += f" rm {remove_packages}"
         self.wait_running_process("zypper")
-        install_result = self._node.execute(
+        uninstall_result = self._node.execute(
             command, shell=True, sudo=True, timeout=timeout
         )
-        assert_that(install_result.exit_code).described_as(
-            f"Failed to remove {remove_packages}. "
-            f"exit_code: {install_result.exit_code}, "
-            f"stderr: {install_result.stderr}"
-        ).is_equal_to(0)
+        uninstall_result.assert_exit_code(
+            expected_exit_code=0,
+            message=f"Could not uninstall package(s): {remove_packages}",
+            include_output=True,
+        )
         self._log.debug(f"{packages} is/are removed successfully.")
 
     def _install_packages(

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -15,7 +15,7 @@ from .whoami import Whoami
 
 
 class Meson(Tool):
-    _minimum_version = "0.52.0"
+    _minimum_version = VersionInfo(major=0, minor=52, patch=0)
 
     @property
     def command(self) -> str:
@@ -45,11 +45,7 @@ class Meson(Tool):
             "python3-meson",
             "meson",
         ]:
-            if (
-                posix_os.package_exists(pkg)
-                and posix_os.get_package_information(pkg, use_cached=False)
-                >= self._minimum_version
-            ):
+            if posix_os.package_exists(pkg, minimum_version=self._minimum_version):
                 package_installed = pkg
                 break
             elif posix_os.is_package_in_repo(pkg):
@@ -62,7 +58,7 @@ class Meson(Tool):
         if package_available:
             posix_os.install_packages(package_available)
             # verify version is correct if it's installed from pkg manager
-            if posix_os.get_package_information(pkg) < self._minimum_version:
+            if not posix_os.package_exists(pkg, minimum_version=self._minimum_version):
                 posix_os.uninstall_packages(pkg)
                 package_available = ""
 

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -8,14 +8,14 @@ from semver import VersionInfo
 
 from lisa.executable import Tool
 from lisa.operating_system import Posix
-
+from lisa.util import parse_version
 from .ln import Ln
 from .python import Pip
 from .whoami import Whoami
 
 
 class Meson(Tool):
-    _minimum_version = VersionInfo(major=0, minor=52, patch=0)
+    _minimum_version = parse_version("0.52.0")
 
     @property
     def command(self) -> str:

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -42,58 +42,71 @@ class Meson(Tool):
         # packaged as 'meson' on older systems and 'python3-meson' on newer ones,
         # since it's actually just a python package.
         # But now we have a bunch of annoying cases.
-        # 'meson' is installed but the wrong version
-        # meson is installed but the right version
-        # meson is not installed and it's the wrong version
-        # meson is not installed and it's the right version
+        # 1.  meson is installed and it's the right version
+        # 2. 'meson' is installed but the wrong version
+        # 3. meson is not installed and the right version is in the repo
+        # 4. meson is not installed and the wrong version is in the repo
+
         for pkg in [
             "python3-meson",
             "meson",
         ]:
             if posix_os.package_exists(pkg):
                 package_installed = pkg
-                break
-            elif posix_os.is_package_in_repo(pkg):
+            if posix_os.is_package_in_repo(pkg):
                 package_available = pkg
+            if package_installed or package_available:
                 break
 
-        # install the available package, if one was available and not installed
-        if package_available:
-            posix_os.install_packages(package_available)
-            package_installed = package_available
-
-        # now, if either previoulsy or newly installed package, check the version
         if package_installed:
+            # check the installed version before touching anything
             if (
                 posix_os.get_package_information(package_installed, use_cached=False)
-                < self._minimum_version
+                >= self._minimum_version
             ):
-                # and uninstall if the version is not recent enough
-                posix_os.uninstall_packages(package_installed)
-                package_installed = ""
-            else:
-                # otherwise, we're done.
+                # meson is installed and it's the right version
                 return self._check_exists()
 
-        # If we get here, we couldn't find a good version from the package manager
-        # so we will install with pip. This is least desirable since it introduces
+        # otherwise, install the available package from the repo
+        if package_available:
+            posix_os.install_packages(package_available)
+            # and update the cached version info
+            posix_os.get_package_information(package_available, use_cached=False)
+            package_installed = package_available
+
+        # check the version, return if it's good, remove if not
+        if package_installed:
+            if (
+                posix_os.get_package_information(package_installed)
+                >= self._minimum_version
+            ):
+                # the right version was in the repo
+                return self._check_exists()
+            else:
+                # the wrong version was in the repo
+                # (or wrong version installed and no update available from repo)
+                posix_os.uninstall_packages(package_installed)
+                package_installed = ""
+
+        # If we get here, we couldn't find a good version from the package manager.
+        # So we will install with pip. This is least desirable since it introduces
         # unpredictable behavior when running meson or ninja with sudo.
         # Like sudo ninja install, for example.
-        if not package_installed:
-            username = self.node.tools[Whoami].get_username()
-            self.node.tools[Pip].install_packages("meson", install_to_user=True)
-            self.node.tools[Ln].create_link(
-                f"/home/{username}/.local/bin/meson", "/usr/bin/meson", force=True
-            )
-            # ensure sudo has access as well
-            self.node.execute(
-                "pip3 install meson",
-                sudo=True,
-                shell=True,
-                no_debug_log=True,
-                no_info_log=True,
-                no_error_log=True,
-            )
+
+        username = self.node.tools[Whoami].get_username()
+        self.node.tools[Pip].install_packages("meson", install_to_user=True)
+        self.node.tools[Ln].create_link(
+            f"/home/{username}/.local/bin/meson", "/usr/bin/meson", force=True
+        )
+        # ensure sudo has access as well
+        self.node.execute(
+            "pip3 install meson",
+            sudo=True,
+            shell=True,
+            no_debug_log=True,
+            no_info_log=True,
+            no_error_log=True,
+        )
 
         return self._check_exists()
 

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -4,8 +4,6 @@
 from pathlib import PurePath
 from typing import cast
 
-from semver import VersionInfo
-
 from lisa.executable import Tool
 from lisa.operating_system import Posix
 from lisa.util import parse_version
@@ -26,7 +24,7 @@ class Meson(Tool):
         result = self.node.execute("meson --version", shell=True)
         return (
             result.exit_code == 0
-            and VersionInfo.parse(result.stdout) >= self._minimum_version
+            and parse_version(result.stdout) >= self._minimum_version
         )
 
     @property
@@ -61,7 +59,7 @@ class Meson(Tool):
         if package_installed:
             # check the installed version before touching anything
             if (
-                posix_os.get_package_information(package_installed, use_cached=False)
+                posix_os.get_package_information(pkg, use_cached=False)
                 >= self._minimum_version
             ):
                 # meson is installed and it's the right version
@@ -71,15 +69,12 @@ class Meson(Tool):
         if package_available:
             posix_os.install_packages(package_available)
             # and update the cached version info
-            posix_os.get_package_information(package_available, use_cached=False)
+            posix_os.get_package_information(pkg, use_cached=False)
             package_installed = package_available
 
         # check the version, return if it's good, remove if not
         if package_installed:
-            if (
-                posix_os.get_package_information(package_installed)
-                >= self._minimum_version
-            ):
+            if posix_os.get_package_information(pkg) >= self._minimum_version:
                 # the right version was in the repo
                 return self._check_exists()
             else:

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -41,6 +41,7 @@ class Meson(Tool):
         # since it's actually just a python package.
         # But now we have a bunch of annoying cases.
         # 1.  meson is installed and it's the right version
+        #     ^ covered by initial check_exists call before install()
         # 2. 'meson' is installed but the wrong version
         # 3. meson is not installed and the right version is in the repo
         # 4. meson is not installed and the wrong version is in the repo
@@ -56,14 +57,15 @@ class Meson(Tool):
             if package_installed or package_available:
                 break
 
-        # otherwise, install the available package from the repo
+        # if an update is available, install the available package from the repo
         if package_available:
             posix_os.install_packages(package_available)
             # and update the cached version info
             posix_os.get_package_information(pkg, use_cached=False)
             package_installed = package_available
 
-        # check the version, return if it's good, remove if not
+        # check the version, return if it's good, remove if not.
+        # we'll use pip as a fallback method to get a later version.
         if package_installed:
             if posix_os.get_package_information(pkg) >= self._minimum_version:
                 # the right version was in the repo

--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -56,15 +56,6 @@ class Meson(Tool):
             if package_installed or package_available:
                 break
 
-        if package_installed:
-            # check the installed version before touching anything
-            if (
-                posix_os.get_package_information(pkg, use_cached=False)
-                >= self._minimum_version
-            ):
-                # meson is installed and it's the right version
-                return self._check_exists()
-
         # otherwise, install the available package from the repo
         if package_available:
             posix_os.install_packages(package_available)
@@ -81,7 +72,6 @@ class Meson(Tool):
                 # the wrong version was in the repo
                 # (or wrong version installed and no update available from repo)
                 posix_os.uninstall_packages(package_installed)
-                package_installed = ""
 
         # If we get here, we couldn't find a good version from the package manager.
         # So we will install with pip. This is least desirable since it introduces

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -39,10 +39,12 @@ class OsPackageDependencies:
         matcher: Callable[[Posix], bool],
         packages: Optional[Sequence[Union[str, Tool, Type[Tool]]]] = None,
         stop_on_match: bool = False,
+        requires_reboot: bool = False,
     ) -> None:
         self.matcher = matcher
         self.packages = packages
         self.stop_on_match = stop_on_match
+        self.requires_reboot = requires_reboot
 
 
 class DependencyInstaller:
@@ -65,6 +67,10 @@ class DependencyInstaller:
         for requirement in self.requirements:
             if requirement.matcher(os) and requirement.packages:
                 packages += requirement.packages
+                if requirement.requires_reboot:
+                    os.install_packages(packages=packages, extra_args=extra_args)
+                    packages = []
+                    node.reboot()
                 if requirement.stop_on_match:
                     break
         os.install_packages(packages=packages, extra_args=extra_args)

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -224,9 +224,16 @@ class DpdkSourceInstall(Installer):
         # which breaks when another tool checks for it's existence before building...
         # like cmake, meson, make, autoconf, etc.
         self._node.tools[Ninja].install()
-        if not isinstance(self._os, Debian):
+        # try multiple avenues for installing pyelftools, preferring the
+        # more recent convention of prepending apt/dnf/etc python system packages
+        # with python3-...
+        if self._os.is_package_in_repo("python3-pyelftools"):
             self._os.install_packages("python3-pyelftools")
+        # then try the older package manager name if it's available
+        elif self._os.is_package_in_repo("pyelftools"):
+            self._os.install_packages("pyelftools")
         else:
+            # otherwise try pip. This can fail to install for the system on ubuntu 24.04
             self._node.tools[Pip].install_packages("pyelftools")
 
     def _uninstall(self) -> None:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -119,6 +119,7 @@ DPDK_SOURCE_INSTALL_PACKAGES = DependencyInstaller(
             and bool(x.get_kernel_information().version >= "5.15.0")
             and x.is_package_in_repo("linux-modules-extra-azure"),
             packages=["linux-modules-extra-azure"],
+            requires_reboot=True,
         ),
         OsPackageDependencies(
             matcher=lambda x: isinstance(x, Debian),

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -106,8 +106,6 @@ DPDK_SOURCE_INSTALL_PACKAGES = DependencyInstaller(
                 "dpkg-dev",
                 "pkg-config",
                 "python3-pip",
-                "python3-pyelftools",
-                "python-pyelftools",
                 # 18.04 doesn't need linux-modules-extra-azure
                 # since it will never have MANA support
             ],
@@ -128,7 +126,6 @@ DPDK_SOURCE_INSTALL_PACKAGES = DependencyInstaller(
                 "build-essential",
                 "libnuma-dev",
                 "libmnl-dev",
-                "python3-pyelftools",
                 "libelf-dev",
                 "pkg-config",
             ],
@@ -228,6 +225,8 @@ class DpdkSourceInstall(Installer):
         # like cmake, meson, make, autoconf, etc.
         self._node.tools[Ninja].install()
         if not isinstance(self._os, Debian):
+            self._os.install_packages("python3-pyelftools")
+        else:
             self._node.tools[Pip].install_packages("pyelftools")
 
     def _uninstall(self) -> None:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -63,6 +63,7 @@ DPDK_PACKAGE_MANAGER_PACKAGES = DependencyInstaller(
             and bool(x.get_kernel_information().version >= "5.15.0")
             and x.is_package_in_repo("linux-modules-extra-azure"),
             packages=["linux-modules-extra-azure"],
+            requires_reboot=True,
         ),
         OsPackageDependencies(
             matcher=lambda x: isinstance(x, Debian),
@@ -226,7 +227,8 @@ class DpdkSourceInstall(Installer):
         # which breaks when another tool checks for it's existence before building...
         # like cmake, meson, make, autoconf, etc.
         self._node.tools[Ninja].install()
-        self._node.tools[Pip].install_packages("pyelftools")
+        if not isinstance(self._os, Debian):
+            self._node.tools[Pip].install_packages("pyelftools")
 
     def _uninstall(self) -> None:
         # undo source installation (thanks ninja)

--- a/microsoft/testsuites/dpdk/rdmacore.py
+++ b/microsoft/testsuites/dpdk/rdmacore.py
@@ -149,7 +149,8 @@ class RdmaCoreSourceInstaller(Installer):
 
     def _setup_node(self) -> None:
         if isinstance(self._os, (Debian, Fedora, Suse)):
-            self._os.uninstall_packages("rdma-core")
+            if self._os.package_exists("rdma-core"):
+                self._os.uninstall_packages("rdma-core")
         if isinstance(self._os, Fedora):
             self._os.group_install_packages("Development Tools")
         super()._setup_node()


### PR DESCRIPTION
Fixing some bugs which were noted after testing on Ubuntu 24.04:

- 'meson' is occasionally packaged as 'meson' but it is being standardized as 'python3-meson' in future releases. This PR fixes the installation path for Meson to account for an prefer the packaged version if it's available and the correct version.
- linux-modules-extra-azure requires a restart, dependencies occasionally do. So add a 'needs_restart' parameter to the dependency installer to allow rebooting before continuing to install dependencies.