### PR TITLE
Dpdk Build: Fix builds running out of space because of partition selection

### DIFF
--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -99,9 +99,10 @@ class GitDownloader(Downloader):
         # NOTE: fail on exists is set to True.
         # The expectation is that the parent Installer class should
         # remove any lingering installations
+        work_path = self._node.get_working_path_with_required_space(5)
         self.asset_path = self._node.tools[Git].clone(
             self._git_repo,
-            cwd=self._node.get_working_path(),
+            cwd=self._node.get_pure_path(work_path),
             ref=self._git_ref,
             fail_on_exists=False,
         )
@@ -123,7 +124,9 @@ class TarDownloader(Downloader):
     # then extract it
     def download(self) -> PurePath:
         node = self._node
-        work_path = self._node.get_working_path()
+        work_path = self._node.get_pure_path(
+            self._node.get_working_path_with_required_space(5)
+        )
         is_tarball = False
         for suffix in [".tar.gz", ".tar.bz2", ".tar"]:
             if self._tar_url.endswith(suffix):
@@ -137,7 +140,9 @@ class TarDownloader(Downloader):
         ).is_true()
         if self._is_remote_tarball:
             tarfile = node.tools[Wget].get(
-                self._tar_url, overwrite=False, file_path=str(node.get_working_path())
+                self._tar_url,
+                overwrite=False,
+                file_path=str(work_path),
             )
             remote_path = node.get_pure_path(tarfile)
             self.tar_filename = remote_path.name


### PR DESCRIPTION
Fixing a build issue where some systems (RHEL and SUSE) have small-ish /home directories by default. To fix this, ask specifically for a working path with some space when proceeding with the source builds of DPDK.

This also adds a function to raise more specific error messages if a known issue is seen in build output. The original error message is kept for when a known issue is not noted.