### PR TITLE
DPDK: Fix underallocation of hugepages for multiple numa nodes

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -346,8 +346,9 @@ def initialize_node_resources(
 
     # init and enable hugepages (required by dpdk)
     hugepages = node.tools[Hugepages]
+    numa_nodes = node.tools[Lscpu].get_numa_node_count()
     try:
-        hugepages.init_hugepages(hugepage_size, minimum_gb=4)
+        hugepages.init_hugepages(hugepage_size, minimum_gb=4 * numa_nodes)
     except NotEnoughMemoryException as err:
         raise SkippedException(err)
 


### PR DESCRIPTION
DPDK requires around 2-4 GB of memory, however when it's split across numa nodes it can end up being more like 2-4 per numa. Re-work the way we ask for hugepage memory to accommodate this. This commit fixes a bug when running on large sizes with multiple numa nodes (192 cores, v6 sku).