### PR TITLE
Added pre_command to bsdntttcp._initialize()

### DIFF
--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -555,6 +555,7 @@ class BSDNtttcp(Ntttcp):
     )
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        self.pre_command = ""
         firewall = self.node.tools[Firewall]
         firewall.stop()
 


### PR DESCRIPTION
added empty string assigned to the pre_command in the _initialize function of the bsdntttcp tool version. This based on the format of the original initialize command.