### PR TITLE
Fix test cases for Azure Linux

### DIFF
--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -262,8 +262,7 @@ class AzureImageStandard(TestSuite):
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
-            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]"
-            r" phys_seg 1 prio class 2\r)$",
+            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]+ phys_seg 1 prio class 2\r)$",  # noqa: E501
             re.M,
         ),
         # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -552,7 +552,7 @@ class AzureImageStandard(TestSuite):
             dhcp_file = node.tools[Cat].read(dhcp_file_path)
             assert_that(
                 dhcp_file,
-                'option host_name" should be present in '
+                "option host_name" should be present in "
                 f"file {dhcp_file_path}",
             ).contains(dhcp_file_content)
         else:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -254,18 +254,18 @@ class AzureImageStandard(TestSuite):
             r"^(.* ACPI: _OSC evaluation for CPUs failed, trying _PDC\r)$",
             re.M
         ),
-        #Buffer I/O error on dev sr0, logical block 1, async page read
+        # Buffer I/O error on dev sr0, logical block 1, async page read
         re.compile(
             r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$",
             re.M
         ),
-        #I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
-        #I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
+        # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
+        # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
             r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]+ phys_seg 1 prio class 2\r)$",
             re.M
         ),
-        #audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r', '2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r'
+        # audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r', '2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r'
         re.compile(
             r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
             r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -552,8 +552,7 @@ class AzureImageStandard(TestSuite):
             dhcp_file = node.tools[Cat].read(dhcp_file_path)
             assert_that(
                 dhcp_file,
-                "option host_name" should be present in "
-                f"file {dhcp_file_path}",
+                f"option host_name should be present in file {dhcp_file_path}",
             ).contains(dhcp_file_content)
         else:
             raise SkippedException(f"Unsupported distro type : {type(node.os)}")

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -276,7 +276,7 @@ class AzureImageStandard(TestSuite):
             r"msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct=\"(?P<acct>[a-zA-Z0-9\*\-]+)\""  # noqa: E501
             r"\s+exe=\"(?P<exe>[^\"]+)\"\s+hostname=\? addr=\? terminal=\? res="
             r"(?P<res>[a-zA-Z]+)\'\r"
-        ),# noqa: E501
+        ),
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -263,20 +263,20 @@ class AzureImageStandard(TestSuite):
             r"phys_seg 1 prio class 2\r)$",
             re.M,
         ),
-        # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 
-        # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 
-        # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" 
+        # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103
+        # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295
+        # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t"
         # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=?res=failed
         re.compile(
             r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
-            r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'
+            r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'  # noqa: E501
             r'(?:\s*)?audit:\s+type=(?P<type>\d+)\s+audit\((?P<audit_time>\d+\.\d+):'
             r'(?P<audit_id>\d+)\):\s+pid=(?P<pid>\d+)\s+uid=(?P<uid>\d+)\s+auid='
             r'(?P<auid>\d+)\s+ses=(?P<ses>\d+)\s+subj=(?P<subj>[a-zA-Z0-9\-]+)\s+'
-            r"msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct=\"(?P<acct>[a-zA-Z0-9\*\-]+)\""
+            r"msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct=\"(?P<acct>[a-zA-Z0-9\*\-]+)\""  # noqa: E501
             r"\s+exe=\"(?P<exe>[^\"]+)\"\s+hostname=\? addr=\? terminal=\? res="
             r"(?P<res>[a-zA-Z]+)\'\r"
-        ),
+        ),# noqa: E501
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -262,10 +262,20 @@ class AzureImageStandard(TestSuite):
         # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
         # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
-            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]+ phys_seg 1 prio class 2\r)$",
+                r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F] +"
+                r"phys_seg 1 prio class 2\r)$",
+                re.M
+        ),
+
+        re.compile(
+            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F] +"
+            r"phys_seg 1 prio class 2\r)$",
             re.M
         ),
-        # audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r', '2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r'
+        # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 
+        # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 
+        # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" 
+        # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r
         re.compile(
             r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
             r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -252,30 +252,21 @@ class AzureImageStandard(TestSuite):
         # ACPI failback to PDC
         re.compile(
             r"^(.* ACPI: _OSC evaluation for CPUs failed, trying _PDC\r)$",
-            re.M
+            re.M,
         ),
         # Buffer I/O error on dev sr0, logical block 1, async page read
+        # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
+        # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
-            r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$",
-            re.M
-        ),
-        # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
-        # I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
-        re.compile(
-                r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F] +"
-                r"phys_seg 1 prio class 2\r)$",
-                re.M
-        ),
-
-        re.compile(
-            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F] +"
+            r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r|"
+            r".*I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]* "
             r"phys_seg 1 prio class 2\r)$",
-            re.M
+            re.M,
         ),
         # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 
         # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 
         # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" 
-        # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r
+        # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=?res=failed
         re.compile(
             r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
             r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -250,10 +250,32 @@ class AzureImageStandard(TestSuite):
             re.M,
         ),
         # ACPI failback to PDC
-        re.compile(r"^(.* ACPI: _OSC evaluation for CPUs failed, trying _PDC\r)$", re.M),
-        re.compile(r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$", re.M),
-        re.compile(r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]+ phys_seg 1 prio class 2\r)$", re.M),
-        re.compile(r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\](?:\s*)?audit:\s+type=(?P<type>\d+)\s+audit\((?P<audit_time>\d+\.\d+):(?P<audit_id>\d+)\):\s+pid=(?P<pid>\d+)\s+uid=(?P<uid>\d+)\s+auid=(?P<auid>\d+)\s+ses=(?P<ses>\d+)\s+subj=(?P<subj>[a-zA-Z0-9\-]+)\s+msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct="(?P<acct>[a-zA-Z0-9\*\-]+)"\s+exe="(?P<exe>[^\"]+)"\s+hostname=\? addr=\? terminal=\? res=(?P<res>[a-zA-Z]+)\'\r'),
+        re.compile(
+            r"^(.* ACPI: _OSC evaluation for CPUs failed, trying _PDC\r)$",
+            re.M
+        ),
+        #Buffer I/O error on dev sr0, logical block 1, async page read
+        re.compile(
+            r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$",
+            re.M
+        ),
+        #I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
+        #I/O error, dev sr0, sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
+        re.compile(
+            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]+ phys_seg 1 prio class 2\r)$",
+            re.M
+        ),
+        #audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r', '2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103 audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295 subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t" exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=? res=failed\'\r'
+        re.compile(
+            r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
+            r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'
+            r'(?:\s*)?audit:\s+type=(?P<type>\d+)\s+audit\((?P<audit_time>\d+\.\d+):'
+            r'(?P<audit_id>\d+)\):\s+pid=(?P<pid>\d+)\s+uid=(?P<uid>\d+)\s+auid='
+            r'(?P<auid>\d+)\s+ses=(?P<ses>\d+)\s+subj=(?P<subj>[a-zA-Z0-9\-]+)\s+'
+            r"msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct=\"(?P<acct>[a-zA-Z0-9\*\-]+)\""
+            r"\s+exe=\"(?P<exe>[^\"]+)\"\s+hostname=\? addr=\? terminal=\? res="
+            r"(?P<res>[a-zA-Z]+)\'\r"
+        ),
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -257,14 +257,14 @@ class AzureImageStandard(TestSuite):
         # Buffer I/O error on dev sr0, logical block 1, async page read
         re.compile(
             r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$",
-            re.M
+            re.M,
         ),
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
-                r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]"
-                r" phys_seg 1 prio class 2\r)$",
-                re.M
+            r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]"
+            r" phys_seg 1 prio class 2\r)$",
+            re.M,
         ),
         # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103
         # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -255,18 +255,21 @@ class AzureImageStandard(TestSuite):
             re.M,
         ),
         # Buffer I/O error on dev sr0, logical block 1, async page read
+        re.compile(
+            r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r)$",
+            re.M
+        ),
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
         # I/O error,dev sr0,sector 8 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
         re.compile(
-            r"^(.*Buffer I/O error on dev sr0, logical block 1, async page read\r|"
-            r".*I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]* "
-            r"phys_seg 1 prio class 2\r)$",
-            re.M,
+                r"^(.* I/O error, dev sr0, sector 8 op 0x0:\(READ\) flags 0x[0-9a-fA-F]"
+                r" phys_seg 1 prio class 2\r)$",
+                re.M
         ),
         # 2025-01-16T08:51:16.449922+00:00 azurelinux kernel: audit: type=1103
         # audit(1737017476.442:257): pid=1296 uid=0 auid=4294967295 ses=4294967295
         # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t"
-        # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=? terminal=?res=failed
+        # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=?terminal=?res=failed
         re.compile(
             r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
             r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'  # noqa: E501

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -271,11 +271,11 @@ class AzureImageStandard(TestSuite):
         # subj=unconfined msg=\'op=PAM:setcred grantors=? acct="l****t"
         # exe="/usr/lib/systemd/systemd-executor" hostname=? addr=?terminal=?res=failed
         re.compile(
-            r'(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?'
-            r'(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]'  # noqa: E501
-            r'(?:\s*)?audit:\s+type=(?P<type>\d+)\s+audit\((?P<audit_time>\d+\.\d+):'
-            r'(?P<audit_id>\d+)\):\s+pid=(?P<pid>\d+)\s+uid=(?P<uid>\d+)\s+auid='
-            r'(?P<auid>\d+)\s+ses=(?P<ses>\d+)\s+subj=(?P<subj>[a-zA-Z0-9\-]+)\s+'
+            r"(?P<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00\s)?"
+            r"(?P<hostname>[a-zA-Z0-9\-]+)\s(kernel:\s)?\[\s*(?P<kernel_time>\d+\.\d+)\s*\]"  # noqa: E501
+            r"(?:\s*)?audit:\s+type=(?P<type>\d+)\s+audit\((?P<audit_time>\d+\.\d+):"
+            r"(?P<audit_id>\d+)\):\s+pid=(?P<pid>\d+)\s+uid=(?P<uid>\d+)\s+auid="
+            r"(?P<auid>\d+)\s+ses=(?P<ses>\d+)\s+subj=(?P<subj>[a-zA-Z0-9\-]+)\s+"
             r"msg=\'op=PAM:setcred\s+grantors=\?[\s\S]*?acct=\"(?P<acct>[a-zA-Z0-9\*\-]+)\""  # noqa: E501
             r"\s+exe=\"(?P<exe>[^\"]+)\"\s+hostname=\? addr=\? terminal=\? res="
             r"(?P<res>[a-zA-Z]+)\'\r"

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -538,10 +538,10 @@ class AzureImageStandard(TestSuite):
         elif isinstance(node.os, CBLMariner):
             if node.os.information.version.major == 3:
                 dhcp_file_path = "/etc/dhcpcd.conf"
-                dhcp_file_content = 'option host_name'
+                dhcp_file_content = "option host_name"
             else:
                 dhcp_file_path = "/etc/dhcp/dhclient.conf"
-                dhcp_file_content = 'host-name'
+                dhcp_file_content = "host-name"
             file_exists = node.shell.exists(PurePosixPath(dhcp_file_path))
 
             assert_that(


### PR DESCRIPTION
This PR fixes the following test cases for Azure Linux.
1. verify_boot_error_fail_warnings
2. verify_network_file_configuration
3. verify_udev_rules_moved
4. verify_dhcp_file_configuration

3.0 AMD - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=707340&view=results

3.0 ARM - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=715154&view=results

2.0 AMD - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=708163&view=results

2.0 ARM - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=708164&view=results