### PR TITLE
Enable deploying Azure Storage account File shares with user specified storage quota.

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1986,7 +1986,7 @@ def get_or_create_file_share(
     resource_group_name: str,
     log: Logger,
     protocols: str = "SMB",
-    quota: int = 100,
+    quota_in_gb: int = 100,
 ) -> str:
     """
     Create an Azure Storage file share if it does not exist.
@@ -1999,10 +1999,10 @@ def get_or_create_file_share(
         resource_group_name,
     )
     all_shares = list(share_service_client.list_shares())
-    if file_share_name not in (x.name for x in all_shares):  # type: ignore
+    if file_share_name not in (x.name for x in all_shares):
         log.debug(f"creating file share {file_share_name} with protocols {protocols}")
         share_service_client.create_share(
-            file_share_name, protocols=protocols, quota=quota
+            file_share_name, protocols=protocols, quota=quota_in_gb
         )
     return str("//" + share_service_client.primary_hostname + "/" + file_share_name)
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1986,7 +1986,7 @@ def get_or_create_file_share(
     resource_group_name: str,
     log: Logger,
     protocols: str = "SMB",
-    quota: int = 107374182400,
+    quota: int = 100,
 ) -> str:
     """
     Create an Azure Storage file share if it does not exist.

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1975,6 +1975,8 @@ def get_share_service_client(
     return share_service_client
 
 
+# Update: Added quota to allow creation of variable sized file share volumes.
+# Default is 107374182400 bytes or 100GiB
 def get_or_create_file_share(
     credential: Any,
     subscription_id: str,
@@ -1984,9 +1986,10 @@ def get_or_create_file_share(
     resource_group_name: str,
     log: Logger,
     protocols: str = "SMB",
+    quota: int = 107374182400,
 ) -> str:
     """
-    Create a Azure Storage file share if it does not exist.
+    Create an Azure Storage file share if it does not exist.
     """
     share_service_client = get_share_service_client(
         credential,
@@ -1996,9 +1999,11 @@ def get_or_create_file_share(
         resource_group_name,
     )
     all_shares = list(share_service_client.list_shares())
-    if file_share_name not in (x.name for x in all_shares):
+    if file_share_name not in (x.name for x in all_shares):  # type: ignore
         log.debug(f"creating file share {file_share_name} with protocols {protocols}")
-        share_service_client.create_share(file_share_name, protocols=protocols)
+        share_service_client.create_share(
+            file_share_name, protocols=protocols, quota=quota
+        )
     return str("//" + share_service_client.primary_hostname + "/" + file_share_name)
 
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1976,7 +1976,7 @@ def get_share_service_client(
 
 
 # Update: Added quota to allow creation of variable sized file share volumes.
-# Default is 107374182400 bytes or 100GiB
+# Default is 100 GiB. All units are in GiB.
 def get_or_create_file_share(
     credential: Any,
     subscription_id: str,

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2002,7 +2002,9 @@ def get_or_create_file_share(
     if file_share_name not in (x.name for x in all_shares):
         log.debug(f"creating file share {file_share_name} with protocols {protocols}")
         share_service_client.create_share(
-            file_share_name, protocols=protocols, quota=quota_in_gb
+            file_share_name,
+            protocols=protocols,
+            quota=quota_in_gb,
         )
     return str("//" + share_service_client.primary_hostname + "/" + file_share_name)
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2912,7 +2912,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             resource_group_name=resource_group_name,
             protocols="NFS",
             log=self._log,
-            quota_in_gb=quota_in_gb
+            quota_in_gb=quota_in_gb,
         )
 
         storage_account_resource_id = (
@@ -3483,7 +3483,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 file_share_name=share_name,
                 resource_group_name=resource_group_name,
                 log=self._log,
-                quota_in_gb=quota_in_gb
+                quota_in_gb=quota_in_gb,
             )
         # Create file private endpoint, always after all shares have been created
         # There is a known issue in API preventing access to data plane

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2880,7 +2880,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
 
     def create_share(
         self,
-        quota: int = 100,
+        quota_in_gb: int = 100,
     ) -> None:
         platform: AzurePlatform = self._platform  # type: ignore
         node_context = self._node.capability.get_extended_runbook(AzureNodeSchema)
@@ -2912,7 +2912,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             resource_group_name=resource_group_name,
             protocols="NFS",
             log=self._log,
-            quota=quota,
+            quota_in_gb=quota_in_gb
         )
 
         storage_account_resource_id = (
@@ -3446,7 +3446,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         kind: str = "StorageV2",
         enable_https_traffic_only: bool = True,
         enable_private_endpoint: bool = False,
-        quota: int = 100,
+        quota_in_gb: int = 100,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3483,7 +3483,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 file_share_name=share_name,
                 resource_group_name=resource_group_name,
                 log=self._log,
-                quota=quota,
+                quota_in_gb=quota_in_gb
             )
         # Create file private endpoint, always after all shares have been created
         # There is a known issue in API preventing access to data plane

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2880,7 +2880,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
 
     def create_share(
         self,
-        quota: int = 107374182400,
+        quota: int = 100,
     ) -> None:
         platform: AzurePlatform = self._platform  # type: ignore
         node_context = self._node.capability.get_extended_runbook(AzureNodeSchema)
@@ -3446,7 +3446,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         kind: str = "StorageV2",
         enable_https_traffic_only: bool = True,
         enable_private_endpoint: bool = False,
-        quota: int = 107374182400,
+        quota: int = 100,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2878,7 +2878,10 @@ class Nfs(AzureFeatureMixin, features.Nfs):
         self.storage_account_name: str = ""
         self.file_share_name: str = ""
 
-    def create_share(self) -> None:
+    def create_share(
+        self,
+        quota: int = 107374182400,
+    ) -> None:
         platform: AzurePlatform = self._platform  # type: ignore
         node_context = self._node.capability.get_extended_runbook(AzureNodeSchema)
         location = node_context.location
@@ -2909,6 +2912,7 @@ class Nfs(AzureFeatureMixin, features.Nfs):
             resource_group_name=resource_group_name,
             protocols="NFS",
             log=self._log,
+            quota=quota,
         )
 
         storage_account_resource_id = (
@@ -3442,6 +3446,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         kind: str = "StorageV2",
         enable_https_traffic_only: bool = True,
         enable_private_endpoint: bool = False,
+        quota: int = 107374182400,
     ) -> Dict[str, str]:
         platform: AzurePlatform = self._platform  # type: ignore
         information = environment.get_information()
@@ -3467,6 +3472,8 @@ class AzureFileShare(AzureFeatureMixin, Feature):
         # If enable_private_endpoint is true, SMB share endpoint
         # will dns resolve to <share>.privatelink.file.core.windows.net
         # No changes need to be done in code calling function
+        # For Quota, currently all volumes will share same quota number.
+        # Ensure that you use the highest value applicable for your shares
         for share_name in file_share_names:
             fs_url_dict[share_name] = get_or_create_file_share(
                 credential=platform.credential,
@@ -3476,6 +3483,7 @@ class AzureFileShare(AzureFeatureMixin, Feature):
                 file_share_name=share_name,
                 resource_group_name=resource_group_name,
                 log=self._log,
+                quota=quota,
             )
         # Create file private endpoint, always after all shares have been created
         # There is a known issue in API preventing access to data plane


### PR DESCRIPTION
Changes done: Addition of "quota" int param to get_or_create_file_share() in commons.py and create_share() in features.py

Why? : Current code deploys a default 100GB volume when provisioning SMB/NFS shares using Azure Storage account. This may ( and in current scenario) cause tests such as XFSTest to fail for specific test cases ( FSStress, Zero fill perf, etc ).

Default Behavior: When called, get_or_create_file_share() will continue to deploy 100B shares unless param 'quota' is passed as an integer value corresponding to GiB of volume we want to provision. Existing extensions using this function will continue to behave as is without disruption.

Things to consider when using: Code currently does not check if quota > 100 is supplied as param. This will cause REST API to return with malformed header error for Storage_V2 and Premium types. Also, Azure Python API documentation states that quota is specified in Bytes, which is incorrect. All values passed should be in GiB ( 1000 MiB -> 1 GiB). This is done since we would eventually like to support PV2 billing model.
 
