### PR TITLE
[Hyper-v platform] Enabling port forwarding when switch type is Internal

### DIFF
--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -559,4 +559,4 @@ class HyperV(Tool):
         if port in self._assigned_nat_ports:
             self._assigned_nat_ports.remove(port)
         else:
-            print(f"Port {port} was not assigned.")
+            self._log.debug(f"Port {port} was not assigned.")


### PR DESCRIPTION
Virtual machines with an internal switch type cannot be accessed from outside the host. To enable external access, you need to use NAT and port mapping.