### PR TITLE
[Hyper-v platform] Delete disks on deletion of VM

### DIFF
--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
-
 from assertpy import assert_that
 from dataclasses_json import dataclass_json
 

--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -5,7 +5,8 @@ import re
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set
+
 
 from assertpy import assert_that
 from dataclasses_json import dataclass_json
@@ -14,6 +15,7 @@ from lisa.base_tools import Service
 from lisa.executable import Tool
 from lisa.operating_system import Windows
 from lisa.tools.powershell import PowerShell
+from lisa.tools.rm import Rm
 from lisa.tools.windows_feature import WindowsFeatureManagement
 from lisa.util import LisaException
 from lisa.util.process import Process
@@ -29,6 +31,25 @@ class HypervSwitchType(Enum):
 class VMSwitch:
     name: str = ""
     type: HypervSwitchType = HypervSwitchType.EXTERNAL
+
+
+class ControllerType(Enum):
+    IDE = 0
+    SCSI = 1
+
+
+@dataclass
+class VMDisk:
+    # The unique identifier of the virtual hard disk.
+    id: str = ""
+    # The file path of the virtual hard disk (VHDX) file.
+    path: str = ""
+    # The type of the controller (IDE or SCSI).
+    controller_type: ControllerType = ControllerType.IDE
+    # The number of the controller to which the virtual hard disk is attached.
+    controller_number: int = 0
+    # The location of the controller to which the virtual hard disk is attached.
+    controller_location: int = 0
 
 
 class HyperV(Tool):
@@ -62,8 +83,52 @@ class HyperV(Tool):
 
         return bool(output.strip() != "")
 
+    def get_vm_disks(self, name: str) -> List[VMDisk]:
+        vm_disks: List[VMDisk] = []
+        output = self.node.tools[PowerShell].run_cmdlet(
+            f"Get-VMHardDiskDrive -VMName {name} ",
+            force_run=True,
+            output_json=True,
+        )
+        if not output:
+            return []
+        # above command returns a list of disks if there are multiple disks.
+        # if there is only one disk, it returns a single disk but not a list.
+        # so convert the output to a list if it is not already a list
+        if not isinstance(output, list):
+            output = [output]
+        for disk in output:
+            vm_disks.append(
+                VMDisk(
+                    id=disk["Id"],
+                    path=disk["Path"],
+                    controller_type=disk["ControllerType"],
+                    controller_number=disk["ControllerNumber"],
+                    controller_location=disk["ControllerLocation"],
+                )
+            )
+        return vm_disks
+
+    def delete_vm_disks(self, name: str) -> None:
+        # get vm disks
+        vm_disks = self.get_vm_disks(name)
+
+        # delete vm disks
+        for disk in vm_disks:
+            self.node.tools[PowerShell].run_cmdlet(
+                f"Remove-VMHardDiskDrive -VMName {name} "
+                f"-ControllerType {disk.controller_type} "
+                f"-ControllerNumber {disk.controller_number} "
+                f"-ControllerLocation {disk.controller_location}",
+                force_run=True,
+            )
+            self.node.tools[Rm].remove_file(
+                disk.path,
+                sudo=True,
+            )
+
     def delete_vm_async(self, name: str) -> Optional[Process]:
-        # check if vm is present
+        # check if VM is present
         if not self.exists_vm(name):
             return None
 
@@ -73,8 +138,12 @@ class HyperV(Tool):
 
         # stop and delete vm
         self.stop_vm(name=name)
-        powershell = self.node.tools[PowerShell]
-        return powershell.run_cmdlet_async(
+
+        # delete VM disks before deleting vm
+        self.delete_vm_disks(name)
+
+        # delete vm
+        return self.node.tools[PowerShell].run_cmdlet_async(
             f"Remove-VM -Name {name} -Force",
             force_run=True,
         )

--- a/lisa/tools/ls.py
+++ b/lisa/tools/ls.py
@@ -92,7 +92,7 @@ class WindowsLs(Ls):
 
     def path_exists(self, path: str, sudo: bool = False) -> bool:
         output = self.node.tools[PowerShell].run_cmdlet(
-            f"Test-Path {path}",
+            f"Test-Path '{path}'",
             force_run=True,
             sudo=sudo,
         )


### PR DESCRIPTION
When a VM is deleted, its attached disks are not automatically removed, which can lead to disk space issues. This change will address the problem by ensuring that both the OS and data disks attached to the VM are deleted across all storage controllers on VM deletion.