### PR TITLE
ch_platform: Use sev-snp as the security type

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -139,7 +139,11 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         os_kernel.text = node_context.kernel_path
         if node_context.guest_vm_type is GuestVmType.ConfidentialVM:
             launch_sec = ET.SubElement(domain, "launchSecurity")
-            launch_sec.attrib["type"] = "sev"
+            if parse_version(libvirt_version) >= "10.5.0":
+                launch_sec.attrib["type"] = "sev-snp"
+            else:
+                launch_sec.attrib["type"] = "sev"
+
             cbitpos = ET.SubElement(launch_sec, "cbitpos")
             cbitpos.text = "0"
             reducedphysbits = ET.SubElement(launch_sec, "reducedPhysBits")


### PR DESCRIPTION
Starting with 10.5.0 version Libvirt introduced "sev-snp" LaunchSecurity type. Use the appropriate type after checking libvirt version.

https://github.com/libvirt/libvirt/commit/c65eba1f57ab1670f5bfc6bd178df1d5c3b09e2a