### PR TITLE
libvirt: Use 16/32 hex long host-data based on libvirt version

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -74,12 +74,14 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             node_context.kernel_path = node_runbook.kernel.path
         libvirt_version = self._get_libvirt_version()
         assert libvirt_version, "Can not get libvirt version"
-        token = secrets.token_hex(32)
+
         if parse_version(libvirt_version) >= "10.5.0":
             en = "utf-8"
+            token = secrets.token_hex(16)
             node_context.host_data = base64.b64encode(token.encode(en)).decode(en)
+            node_context.is_host_data_base64 = True
         else:
-            node_context.host_data = token
+            node_context.host_data = secrets.token_hex(32)
 
     def _create_node(
         self,

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -56,6 +56,7 @@ class NodeContext:
     kernel_source_path: str = ""
     kernel_path: str = ""
     host_data: str = ""
+    is_host_data_base64: bool = False
     guest_vm_type: GuestVmType = field(default_factory=lambda: GuestVmType.Standard)
     cloud_init_file_path: str = ""
     ignition_file_path: str = ""

--- a/microsoft/testsuites/cvm/cvm_attestation.py
+++ b/microsoft/testsuites/cvm/cvm_attestation.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import base64
-import binascii
 from pathlib import Path
 from typing import Any, Dict
 
@@ -16,6 +15,7 @@ from lisa import (
 from lisa.features.security_profile import CvmEnabled
 from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.sut_orchestrator import AZURE, CLOUD_HYPERVISOR
+from lisa.sut_orchestrator.libvirt.context import NodeContext
 from lisa.testsuite import TestResult, simple_requirement
 from lisa.tools import Ls, Lscpu
 from lisa.tools.lscpu import CpuType
@@ -126,7 +126,7 @@ class NestedCVMAttestationTestSuite(TestSuite):
         from lisa.sut_orchestrator.libvirt.context import get_node_context
 
         node_context = get_node_context(node)
-        host_data = self._get_host_data(node_context.host_data)
+        host_data = self._get_host_data(node_context)
         if not host_data:
             raise SkippedException("host_data is empty")
         node.tools[NestedCVMAttestationTests].run_cvm_attestation(
@@ -136,15 +136,14 @@ class NestedCVMAttestationTestSuite(TestSuite):
             host_data,
         )
 
-    def _get_host_data(self, host_data: str) -> str:
+    def _get_host_data(self, node_context: NodeContext) -> str:
         # Based on libvirt version our libvirt platform will set
         # either plain text or b64 encoded string as host data.
         # We need to decode it as this test would get host_data
         # from attestation tool as plain text
         # or
-        # Return original data if decoding fails considering
-        # this is non-encoded string
-        try:
-            return base64.b64decode(host_data).decode("utf-8")
-        except (binascii.Error, UnicodeDecodeError):
-            return host_data
+        # Return original data if not set as base64 encoded string
+        host_data = node_context.host_data
+        if node_context.is_host_data_base64:
+            host_data = base64.b64decode(host_data).hex()
+        return host_data


### PR DESCRIPTION
Use token_hex with 16/32 to generate hex string
for host data based on libvirt version.

Also use hex format in attestation tool to compare as libvirt convert host data in ASCII hex string. Based on node context, either decode or use plain string to compare as libvirt expect base64 encoded string for >=10.5.0 version