### PR TITLE
CVM: Add boot/reboot tests

### DIFF
--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -118,6 +118,7 @@ from .tee import Tee
 from .texinfo import Texinfo
 from .timedatectl import Timedatectl
 from .timeout import Timeout
+from .tpm2 import Tpm2
 from .unzip import Unzip
 from .uptime import Uptime
 from .usermod import Usermod
@@ -251,6 +252,7 @@ __all__ = [
     "TcpDump",
     "Timedatectl",
     "Timeout",
+    "Tpm2",
     "Uname",
     "Unzip",
     "Uptime",

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -18,6 +18,7 @@ from lisa.base_tools import (
 from .aria import Aria
 from .b4 import B4
 from .blkid import Blkid
+from .bootctl import BootCtl
 from .bzip2 import Bzip2
 from .cargo import Cargo
 from .chmod import Chmod
@@ -134,6 +135,7 @@ __all__ = [
     "Aria",
     "B4",
     "Blkid",
+    "BootCtl",
     "Bzip2",
     "Cargo",
     "Cat",

--- a/lisa/tools/bootctl.py
+++ b/lisa/tools/bootctl.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner
+from lisa.util import UnsupportedDistroException
+
+
+class BootCtl(Tool):
+    @property
+    def command(self) -> str:
+        return "bootctl"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def _install(self) -> bool:
+        if isinstance(self.node.os, CBLMariner):
+            self.node.os.install_packages("systemd-udev")
+        else:
+            raise UnsupportedDistroException(
+                self.node.os,
+                f"tool {self.command} can't be installed in {self.node.os.name}",
+            )
+        return self._check_exists()
+
+    def get_esp_path(self) -> str:
+        return self._get_cmd_output("--print-esp-path")
+
+    def get_boot_path(self) -> str:
+        return self._get_cmd_output("--print-boot-path")
+
+    def get_root_device(self) -> str:
+        return self._get_cmd_output("--print-root-device")
+
+    def _get_cmd_output(self, cmd: str) -> str:
+        cmd_result = self.run(
+            cmd,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="failed to get ESP path",
+            shell=True,
+            sudo=True,
+            force_run=True,
+        )
+        return cmd_result.stdout

--- a/lisa/tools/tpm2.py
+++ b/lisa/tools/tpm2.py
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+from typing import Dict, List, Match, Optional, Sequence, Union
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner
+from lisa.util import UnsupportedDistroException
+
+
+class Tpm2(Tool):
+    """tpm2 provides a toolset based on tpm2-tss to interact with TPM 2.0 devices"""
+
+    # example:
+    #   sha256:
+    #       4 : 0x0000000000000000000000000000000000000000000000000000000000000003
+    #       7 : 0x0000000000000000000000000000000000000000000000000000000000000003
+    _pcrread_split_hash_and_pcrs_regex = re.compile(
+        r"(?P<hash>sha\d+):\s*(?P<pcrs>(.*\s*)*)"
+    )
+    _pcrread_split_pcr_index_and_value_regex = re.compile(
+        r"(?P<pcr_index>\d+)\s*:\s*(?P<hash_value>0x[a-fA-F0-9]+)"
+    )
+
+    @property
+    def command(self) -> str:
+        return "tpm2"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def _install(self) -> bool:
+        if isinstance(self.node.os, CBLMariner):
+            self.node.os.install_packages("tpm2-tools")
+        else:
+            raise UnsupportedDistroException(
+                self.node.os,
+                f"tool {self.command} can't be installed in {self.node.os.name}.",
+            )
+        return self._check_exists()
+
+    def pcrread(
+        self, pcrs: Optional[Union[int, Sequence[int]]] = None
+    ) -> Dict[int, str]:
+        """List PCR values
+
+        A Platform Configuration Register (PCR) is a memory location in the TPM that
+        stores cryptographic measurements of a system's state.
+
+        Example command/output
+        $ tpm2 pcrread sha256:4,7
+          sha256:
+            4 : 0x0000000000000000000000000000000000000000000000000000000000000003
+            7 : 0x0000000000000000000000000000000000000000000000000000000000000003
+        """
+        alg = "sha256"
+        pcrs = self._get_pcr_list(pcrs)
+        if len(pcrs) == 0:
+            pcrs_arg = "all"
+        else:
+            pcrs_arg = ",".join(map(str, pcrs))
+        cmd = f"pcrread {alg}:{pcrs_arg}"
+        cmd_result = self.run(
+            cmd,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="failed to read PCR values",
+            shell=True,
+            sudo=True,
+            force_run=True,
+        )
+        output = cmd_result.stdout
+
+        m = self._pcrread_split_hash_and_pcrs_regex.search(output)
+        assert isinstance(m, Match)
+        hash_alg = m.group("hash")
+        pcrs_info = m.group("pcrs")
+
+        assert (
+            hash_alg == alg
+        ), "pcrread output does not contain the requested algorithm"
+
+        result = dict()
+        for m in self._pcrread_split_pcr_index_and_value_regex.finditer(pcrs_info):
+            pcr_index = int(m.group("pcr_index"))
+            hash_value = m.group("hash_value").lower()
+            result[pcr_index] = hash_value
+        self._log.debug(f"Parsed PCR values: {result}")
+        return result
+
+    def _get_pcr_list(self, pcrs: Optional[Union[int, Sequence[int]]]) -> List[int]:
+        if pcrs is None:
+            return []
+        if isinstance(pcrs, int):
+            return [pcrs]
+        return [pcr for pcr in pcrs]

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -418,6 +418,17 @@ class SwitchableMixin:
         self._switch(True)
 
 
+class LisaVersionInfo(VersionInfo):
+    def __init__(self, version_str: str, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.version_str = version_str
+
+    @classmethod
+    def parse(cls, version: str) -> "LisaVersionInfo":
+        version_info = VersionInfo.parse(version)
+        return LisaVersionInfo(version, *version_info.to_tuple())
+
+
 def get_date_str(current: Optional[datetime] = None) -> str:
     if current is None:
         current = datetime.now()
@@ -654,7 +665,7 @@ def dump_file(file_name: Path, content: Any) -> None:
         f.write(secret.mask(content))
 
 
-def parse_version(version: str) -> VersionInfo:
+def parse_version(version: str) -> LisaVersionInfo:
     """
     Convert an incomplete version string into a semver-compatible Version
     object
@@ -672,8 +683,8 @@ def parse_version(version: str) -> VersionInfo:
         belong to a basic version.
     :rtype: tuple(:class:`Version` | None, str)
     """
-    if VersionInfo.isvalid(version):
-        return VersionInfo.parse(version)
+    if LisaVersionInfo.isvalid(version):
+        return LisaVersionInfo.parse(version)
 
     match = __version_info_pattern.search(version)
     if not match:
@@ -685,9 +696,9 @@ def parse_version(version: str) -> VersionInfo:
         if key != "prerelease"
     }
     ver["prerelease"] = match["prerelease"]
-    rest = match.string[match.end() :]  # noqa:E203
+    rest = match.string[match.end() :]
     ver["build"] = rest
-    release_version = VersionInfo(**ver)
+    release_version = LisaVersionInfo(version, **ver)
 
     return release_version
 

--- a/microsoft/testsuites/cvm/cvm_boot.py
+++ b/microsoft/testsuites/cvm/cvm_boot.py
@@ -1,0 +1,147 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import itertools
+from pathlib import Path
+from typing import Any, Dict, cast
+
+from assertpy.assertpy import assert_that
+
+from lisa import (
+    Logger,
+    Node,
+    RemoteNode,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+)
+from lisa.environment import EnvironmentStatus
+from lisa.features.security_profile import (
+    CvmEnabled,
+    SecurityProfile,
+    SecurityProfileSettings,
+)
+from lisa.operating_system import CBLMariner, Posix
+from lisa.sut_orchestrator import AZURE
+from lisa.testsuite import simple_requirement
+from lisa.tools import BootCtl, Lsblk, Tpm2
+from lisa.tools.lsblk import PartitionInfo
+from lisa.util import SkippedException, UnsupportedDistroException
+
+
+@TestSuiteMetadata(
+    area="cvm",
+    category="functional",
+    description="""This test suite covers some common scenarios related to
+    CVM boot on Azure.
+    """,
+)
+class CVMBootTestSuite(TestSuite):
+    def before_case(self, log: Logger, **kwargs: Any) -> None:
+        node: Node = kwargs["node"]
+        if not isinstance(node.os, CBLMariner):
+            raise SkippedException(
+                UnsupportedDistroException(
+                    node.os, "CVM boot test supports only Azure Linux."
+                )
+            )
+
+    @TestCaseMetadata(
+        description="""This test verifies that TPM enrollment is done correctly on
+        a CVM with encrypted root partition
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_features=[CvmEnabled()],
+            supported_platform_type=[AZURE],
+        ),
+    )
+    def verify_encrypted_root_partition(self, node: RemoteNode) -> None:
+        security_profile_settings = cast(
+            SecurityProfileSettings, node.features[SecurityProfile].get_settings()
+        )
+        if not security_profile_settings.encrypt_disk:
+            raise SkippedException("This test requires disk encryption to be enabled")
+
+        disks = node.tools[Lsblk].get_disks(force_run=True)
+        root_device = node.tools[BootCtl].get_root_device()
+        partitions = itertools.chain.from_iterable(disk.partitions for disk in disks)
+        root_partition = next(
+            (p for p in partitions if p.device_name == root_device), None
+        )
+
+        assert_that(root_partition, "Cannot locate root partition").is_not_none()
+        assert isinstance(root_partition, PartitionInfo)
+        assert_that(root_partition.fstype).is_equal_to("crypto_LUKS")
+
+    @TestCaseMetadata(
+        description="""This test case verifies that a CVM can still boot if any boot
+        component is upgraded.
+
+        Steps:
+        1. On first boot, check current PCR values for PCR4 and PCR7
+        2. Get current boot components versions (e.g. shim, grub, systemd-boot, uki)
+        3. Run a package upgrade to update boot components
+        4. Get new boot components versions to see if anything has changed
+        5. Reboot the CVM, make sure the CVM can boot up again
+        6. PCR4 should change if any of the boot components is upgraded
+        7. PCR7 may change (for example, if a signing certificate is changed)
+        """,
+        priority=1,
+        requirement=simple_requirement(
+            environment_status=EnvironmentStatus.Connected,
+            supported_features=[CvmEnabled()],
+            supported_platform_type=[AZURE],
+        ),
+        use_new_environment=True,
+    )
+    def verify_boot_success_after_component_upgrade(
+        self, log: Logger, node: RemoteNode, log_path: Path
+    ) -> None:
+        posix_os: Posix = cast(Posix, node.os)
+        # First boot - no package upgrade has been performed
+        # Check PCR values (PCR4, PCR7)
+        pcrs_before_reboot = node.tools[Tpm2].pcrread(pcrs=[4, 7])
+
+        # - Get current boot components versions (shim, systemd-boot, kernel-uki)
+        boot_components = ["shim", "systemd-boot", "kernel-uki"]
+        boot_components_versions: Dict[str, str] = dict()
+        for pkg in boot_components:
+            pkg_version = posix_os.get_package_information(pkg, use_cached=False)
+            boot_components_versions[pkg] = pkg_version.version_str
+
+        # Upgrade boot components
+        posix_os.update_packages(boot_components)
+
+        # Get new boot components versions
+        boot_components_new_versions: Dict[str, str] = dict()
+        for pkg in boot_components:
+            pkg_version = posix_os.get_package_information(pkg, use_cached=False)
+            boot_components_new_versions[pkg] = pkg_version.version_str
+
+        # Reboot
+        node.reboot()
+
+        # VM is up again
+        pcrs_after_reboot = node.tools[Tpm2].pcrread(pcrs=[4, 7])
+        boot_component_changed = (
+            boot_components_versions != boot_components_new_versions
+        )
+
+        # - PCR4 should change if any of the boot components is upgraded
+        # - PCR7 may change if a signing cert is changed
+        if boot_component_changed:
+            assert_that(
+                pcrs_after_reboot[4],
+                "PCR4 value is still the same even though a boot component changed",
+            ).is_not_equal_to(pcrs_before_reboot[4])
+            if pcrs_after_reboot[7] != pcrs_before_reboot[7]:
+                log.info(
+                    "PCR7 changed after a boot component changed. This may happen if a "
+                    "signing certificate was updated"
+                )
+        else:
+            assert_that(
+                pcrs_after_reboot,
+                "PCR values changed even though no boot component was updated",
+            ).is_equal_to(pcrs_before_reboot)


### PR DESCRIPTION
- Tools:
  - Add tpm2 tool to support reading PCR values from the TPM
  - Add bootctl tool
- Tests: add boot tests for Azure Linux CVM:
  - verify_encrypted_root_partition: sanity check that the root partition on an Azure Linux CVM is encrypted when deployed with `DiskWithVMGuestState` encryption setting.
  - verify_boot_success_after_component_upgrade: check that a CVM can reboot after a boot component is upgraded. 
- Core: include raw version string in Posix.get_package_information return value in case the package does not follow semantic versioning (fixes #3625) 