### PR TITLE
[Hyper-v platform] Use data disk as LISA working directory on Hyper-v host

### DIFF
--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -445,6 +445,71 @@ class HyperV(Tool):
         # Restart the DHCP server to apply the changes
         service.restart_service("dhcpserver")
 
+    # The default lisa working path is under 'C:/' which is not ideal for large data.
+    # This method initializes an attached disk, creates a partition, formats it,
+    # and mounts it to the lisa working directory
+    # This method expects an un-initialized (RAW) disk to be available on Hyper-V.
+    def configure_lisa_working_dir(self) -> None:
+        powershell = self.node.tools[PowerShell]
+
+        # Get the disk that is not initialized
+        disk_number = powershell.run_cmdlet(
+            "(Get-Disk | Where-Object PartitionStyle -Eq 'RAW').Number",
+            force_run=True,
+        )
+        # If no un-initialized disk is found, log a warning and return
+        if not disk_number:
+            self._log.warning("No un-initialized disk found.")
+            self._log.warning("Skipping lisa working dir setup on additional disk.")
+            return
+        # Initialize the disk
+        powershell.run_cmdlet(
+            f"Initialize-Disk -Number {disk_number}",
+            force_run=True,
+        )
+        # Create a new partition
+        powershell.run_cmdlet(
+            f"New-Partition -DiskNumber {disk_number}"
+            " -UseMaximumSize -AssignDriveLetter",
+            force_run=True,
+        )
+        # Get the drive letter
+        drive_letter = powershell.run_cmdlet(
+            f"(Get-Partition -DiskNumber {disk_number}"
+            " | Where-Object Type -Eq 'Basic').DriveLetter",
+            force_run=True,
+        )
+        # Format the partition
+        powershell.run_cmdlet(
+            f"Format-Volume -DriveLetter {drive_letter}"
+            " -FileSystem NTFS -NewFileSystemLabel 'DataDisk01'",
+            force_run=True,
+        )
+
+        # Get the partition number
+        partition_number = powershell.run_cmdlet(
+            f"(Get-Partition | Where-Object DriveLetter"
+            f" -Eq {drive_letter}).PartitionNumber",
+            force_run=True,
+        )
+
+        lisa_working_path = r"$([System.Environment]::GetFolderPath('UserProfile'))\AppData\Local\Temp\lisa_working"  # noqa: E501
+
+        # Create mount point if it doesn't exist
+        powershell.run_cmdlet(
+            f'if (-Not $(Test-Path -Path "{lisa_working_path}"))'
+            f' {{New-Item -ItemType Directory -Path "{lisa_working_path}"}}',
+            force_run=True,
+        )
+
+        # Mount the volume to the lisa working directory
+        powershell.run_cmdlet(
+            f"Add-PartitionAccessPath -DiskNumber {disk_number}"
+            f" -PartitionNumber {partition_number}"
+            f' -AccessPath "{lisa_working_path}"',
+            force_run=True,
+        )
+
     def _install(self) -> bool:
         assert isinstance(self.node.os, Windows)
 

--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -453,15 +453,20 @@ class HyperV(Tool):
         powershell = self.node.tools[PowerShell]
 
         # Get the first disk that is not initialized
-        disk_number = powershell.run_cmdlet(
-            "(Get-Disk | Where-Object PartitionStyle -Eq 'RAW').Number[0]",
+        raw_disks = powershell.run_cmdlet(
+            "Get-Disk | Where-Object PartitionStyle -Eq 'RAW'",
             force_run=True,
+            output_json=True,
         )
         # If no un-initialized disk is found, log a warning and return
-        if not disk_number:
+        if not raw_disks:
             self._log.warning("No un-initialized disk found.")
             self._log.warning("Skipping lisa working dir setup on additional disk.")
             return
+        if isinstance(raw_disks, list):
+            disk_number = raw_disks[0]["Number"]
+        else:
+            disk_number = raw_disks["Number"]
         # Initialize the disk
         powershell.run_cmdlet(
             f"Initialize-Disk -Number {disk_number}",

--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -448,13 +448,13 @@ class HyperV(Tool):
     # The default lisa working path is under 'C:/' which is not ideal for large data.
     # This method initializes an attached disk, creates a partition, formats it,
     # and mounts it to the lisa working directory
-    # This method expects an un-initialized (RAW) disk to be available on Hyper-V.
-    def configure_lisa_working_dir(self) -> None:
+    # This method expects an un-initialized (RAW) disk to be available on Hyper-V host.
+    def use_raw_disk_for_lisa_working_dir(self) -> None:
         powershell = self.node.tools[PowerShell]
 
-        # Get the disk that is not initialized
+        # Get the first disk that is not initialized
         disk_number = powershell.run_cmdlet(
-            "(Get-Disk | Where-Object PartitionStyle -Eq 'RAW').Number",
+            "(Get-Disk | Where-Object PartitionStyle -Eq 'RAW').Number[0]",
             force_run=True,
         )
         # If no un-initialized disk is found, log a warning and return

--- a/lisa/transformers/hyperv_preparation.py
+++ b/lisa/transformers/hyperv_preparation.py
@@ -33,6 +33,9 @@ class HyperVPreparationTransformer(DeploymentTransformer):
         # Enable Hyper-V
         hv = self._node.tools[HyperV]
 
+        # Configure lisa working path
+        hv.configure_lisa_working_dir()
+
         # Create an internal switch.
         hv.create_switch(name=switch_name)
 

--- a/lisa/transformers/hyperv_preparation.py
+++ b/lisa/transformers/hyperv_preparation.py
@@ -33,8 +33,8 @@ class HyperVPreparationTransformer(DeploymentTransformer):
         # Enable Hyper-V
         hv = self._node.tools[HyperV]
 
-        # Configure lisa working path
-        hv.configure_lisa_working_dir()
+        # Configure lisa working path to use free disk.
+        hv.use_raw_disk_for_lisa_working_dir()
 
         # Create an internal switch.
         hv.create_switch(name=switch_name)

--- a/lisa/transformers/hyperv_preparation.py
+++ b/lisa/transformers/hyperv_preparation.py
@@ -43,4 +43,7 @@ class HyperVPreparationTransformer(DeploymentTransformer):
 
         # Configure Internal DHCP
         hv.enable_internal_dhcp()
+
+        # Reboot the node to apply all the changes.
+        self._node.reboot()
         return {}


### PR DESCRIPTION
The default lisa working path on Hyper-v hosts is under 'C:/' which is not ideal for large data.
This change initializes an attached disk, creates a partition, formats it, and mounts it to the lisa working directory.
This change expects an un-initialized (RAW) disk to be available on Hyper-V.