### PR TITLE
Dpdk: check for kernel dumps after tests

### DIFF
--- a/lisa/tools/dmesg.py
+++ b/lisa/tools/dmesg.py
@@ -20,13 +20,16 @@ class Dmesg(Tool):
         re.compile("BUG: soft lockup"),
         re.compile("Hibernate inconsistent memory map detected"),
         re.compile("check_flush_dependency"),
+        # Error messages related to memory corruption from fault.c for x86_64
         # https://github.com/torvalds/linux/blob/0de63bb7d91975e73338300a57c54b93d3cc151c/arch/x86/mm/fault.c#L543
         re.compile("BUG: kernel NULL pointer dereference"),
         re.compile("kernel tried to execute NX-protected page"),
         re.compile("unable to execute userspace code"),
         re.compile("BUG: unable to handle page fault for address:"),
+        # ex: PF: supervisor read access in kernel mode
         re.compile(
-            r"PF: (supervisor|user) (instruction fetch|read access|write access) "
+            r"PF: (supervisor|user) "
+            r"(instruction fetch|read access|write access) "
             r"in (user|kernel) mode"
         ),
     ]

--- a/lisa/tools/dmesg.py
+++ b/lisa/tools/dmesg.py
@@ -20,6 +20,15 @@ class Dmesg(Tool):
         re.compile("BUG: soft lockup"),
         re.compile("Hibernate inconsistent memory map detected"),
         re.compile("check_flush_dependency"),
+        # https://github.com/torvalds/linux/blob/0de63bb7d91975e73338300a57c54b93d3cc151c/arch/x86/mm/fault.c#L543
+        re.compile("BUG: kernel NULL pointer dereference"),
+        re.compile("kernel tried to execute NX-protected page"),
+        re.compile("unable to execute userspace code"),
+        re.compile("BUG: unable to handle page fault for address:"),
+        re.compile(
+            r"PF: (supervisor|user) (instruction fetch|read access|write access) "
+            r"in (user|kernel) mode"
+        ),
     ]
 
     # [   3.191822] hv_vmbus: Hyper-V Host Build:18362-10.0-3-0.3294; Vmbus version:3.0

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -531,10 +531,10 @@ def verify_dpdk_build(
         f"TX-PPS:{tx_pps} from {test_nic.name}/{test_nic.lower}:"
         + f"{test_nic.pci_slot}"
     )
+    node.tools[Dmesg].check_kernel_errors(force_run=True)
     assert_that(tx_pps).described_as(
         f"TX-PPS ({tx_pps}) should have been greater than 2^20 (~1m) PPS."
     ).is_greater_than(2**20)
-
     return test_kit
 
 
@@ -611,6 +611,8 @@ def verify_dpdk_send_receive(
     log.info(f"receiver rx-pps: {rcv_rx_pps}")
     log.info(f"sender tx-pps: {snd_tx_pps}")
 
+    sender.dmesg.check_kernel_errors(force_run=True)
+    receiver.dmesg.check_kernel_errors(force_run=True)
     # differences in NIC type throughput can lead to different snd/rcv counts
     assert_that(rcv_rx_pps).described_as(
         "Throughput for RECEIVE was below the correct order-of-magnitude"
@@ -1056,6 +1058,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     # NOTE: only checking 0 and < 1 now. Once we have more data
     # there should be more stringest checks for each NIC type.
     throughput = ntttcp_results[receiver].throughput_in_gbps
+    forwarder.tools[Dmesg].check_kernel_errors(force_run=True)
     assert_that(throughput).described_as(
         "l3fwd test found 0Gbps througput. "
         "Either the test or DPDK forwarding is broken."


### PR DESCRIPTION
Check for kernel errors before finishing the DPDK tests. This will reduce instances of silent bugs causing odd performance issues or strange behavior at the usermode level.

Dmesg: Adds kernel error messages from the Linux kernel fault.c file.