### PR TITLE
[dpdk] add symmetric_mp test

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -56,6 +56,7 @@ class NicInfo:
             f"pci_slot: {self.pci_slot}\n"
             f"ip_addr: {self.ip_addr}\n"
             f"mac_addr: {self.mac_addr}\n"
+            f"dev_uuid: {self.dev_uuid}\n"
         )
 
     @property

--- a/microsoft/testsuites/dpdk/devname/Makefile
+++ b/microsoft/testsuites/dpdk/devname/Makefile
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2010-2014 Intel Corporation
+
+# binary name
+APP = devname
+
+# all source are stored in SRCS-y
+SRCS-y := main.c
+
+PKGCONF ?= pkg-config
+
+# Build using pkg-config variables if possible
+ifneq ($(shell $(PKGCONF) --exists libdpdk && echo 0),0)
+$(error "no installation of DPDK found")
+endif
+
+all: shared
+.PHONY: shared static
+shared: build/$(APP)-shared
+	ln -sf $(APP)-shared build/$(APP)
+static: build/$(APP)-static
+	ln -sf $(APP)-static build/$(APP)
+
+PC_FILE := $(shell $(PKGCONF) --path libdpdk 2>/dev/null)
+CFLAGS += -O3 $(shell $(PKGCONF) --cflags libdpdk)
+LDFLAGS_SHARED = $(shell $(PKGCONF) --libs libdpdk)
+LDFLAGS_STATIC = $(shell $(PKGCONF) --static --libs libdpdk)
+
+ifeq ($(MAKECMDGOALS),static)
+# check for broken pkg-config
+ifeq ($(shell echo $(LDFLAGS_STATIC) | grep 'whole-archive.*l:lib.*no-whole-archive'),)
+$(warning "pkg-config output list does not contain drivers between 'whole-archive'/'no-whole-archive' flags.")
+$(error "Cannot generate statically-linked binaries with this version of pkg-config")
+endif
+endif
+
+CFLAGS += -DALLOW_EXPERIMENTAL_API
+
+build/$(APP)-shared: $(SRCS-y) Makefile $(PC_FILE) | build
+	$(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_SHARED)
+
+build/$(APP)-static: $(SRCS-y) Makefile $(PC_FILE) | build
+	$(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_STATIC)
+
+build:
+	@mkdir -p $@
+
+.PHONY: clean
+clean:
+	rm -f build/$(APP) build/$(APP)-static build/$(APP)-shared
+	test -d build && rmdir -p build || true

--- a/microsoft/testsuites/dpdk/devname/README.md
+++ b/microsoft/testsuites/dpdk/devname/README.md
@@ -1,0 +1,33 @@
+# dpdk-devname
+
+Print info about DPDK ports on a system.
+
+## NOTE: This is a frozen copy from https://www.github.com/mcgov/devname
+
+## build
+clone into dpdk/examples
+``` bash
+git clone https://www.github.com/DPDK/dpdk.git
+cd ./dpdk/examples
+git clone https://github.com/mcgov/devname.git
+cd ..
+meson setup -Dexamples=devname [other options] build
+cd build && ninja && ninja install
+```
+
+## usage:
+```
+$ ./build/examples/dpdk-devname
+EAL: Detected CPU lcores: 32
+EAL: Detected NUMA nodes: 1
+EAL: Detected static linkage of DPDK
+EAL: Multi-process socket /var/run/dpdk/rte/mp_socket
+EAL: Selected IOVA mode 'PA'
+EAL: Probe PCI driver: net_mana (1414:ba) device: 7870:00:00.0 (socket 0)
+mana_init_once(): MP INIT PRIMARY
+TELEMETRY: No legacy callbacks, legacy socket not created
+dpdk-devname found port=0 driver=net_mana eth_dev_info_name=7870:00:00.0 get_name_by_port_name=7870:00:00.0_port3 owner_id=0x0000000000000002 owner_name=f8615163-0002-1000-2000-6045bda6bbc0 macaddr=60:45:bd:a6:bb:c0
+dpdk-devname found port=1 driver=net_mana eth_dev_info_name=7870:00:00.0 get_name_by_port_name=7870:00:00.0_port2 owner_id=0x0000000000000001 owner_name=f8615163-0001-1000-2000-6045bda6bd76 macaddr=60:45:bd:a6:bd:76
+dpdk-devname found port=2 driver=net_netvsc eth_dev_info_name=f8615163-0001-1000-2000-6045bda6bd76 get_name_by_port_name=f8615163-0001-1000-2000-6045bda6bd76 owner_id=0x0000000000000000 owner_name=null macaddr=60:45:bd:a6:bd:76
+dpdk-devname found port=3 driver=net_netvsc eth_dev_info_name=f8615163-0002-1000-2000-6045bda6bbc0 get_name_by_port_name=f8615163-0002-1000-2000-6045bda6bbc0 owner_id=0x0000000000000000 owner_name=null macaddr=60:45:bd:a6:bb:c0
+```

--- a/microsoft/testsuites/dpdk/devname/main.c
+++ b/microsoft/testsuites/dpdk/devname/main.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2010-2014 Intel Corporation
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <sys/queue.h>
+#include <rte_memory.h>
+#include <rte_launch.h>
+#include <rte_eal.h>
+#include <rte_per_lcore.h>
+#include <rte_lcore.h>
+#include <rte_debug.h>
+#include <rte_ethdev.h>
+#include <rte_dev.h>
+
+const char usage_info[] = "usage: dpdk-devname\n";
+
+/*a tiny application to print dpdk device and port id info */
+int main(int argc, char **argv)
+{
+	int ret;
+	/* Initialization of Environment Abstraction Layer (EAL). */
+	ret = rte_eal_init(argc, argv);
+	if (ret < 0)
+		rte_panic("Cannot init EAL\n");
+	/* >8 End of initialization of Environment Abstraction Layer */
+
+	struct rte_eth_dev_info device_info;
+	char device_name_by_port[RTE_ETH_NAME_MAX_LEN] = {0};
+	for (uint16_t portid = 0; portid < RTE_MAX_ETHPORTS; portid++)
+	{
+		if (!rte_eth_dev_is_valid_port(portid))
+			continue;
+
+		ret = rte_eth_dev_info_get(portid, &device_info);
+		if (ret < 0)
+		{
+			fprintf(stderr,
+					"Invalid or no info for port %i, err: %s\n",
+					portid, rte_strerror(ret));
+			continue;
+		}
+		ret = rte_eth_dev_get_name_by_port(portid, device_name_by_port);
+		if (ret < 0)
+		{
+			fprintf(stderr,
+					"No name info returned for port %i, err: %s\n",
+					portid, rte_strerror(ret));
+			continue;
+		}
+		struct rte_eth_dev_owner device_owner;
+		ret = rte_eth_dev_owner_get(portid, &device_owner);
+		if (ret < 0)
+		{
+			fprintf(stderr, "Could not get ownership for port %i (%s)\n",
+					portid, device_name_by_port);
+			memset(&device_owner, 0, sizeof(struct rte_eth_dev_owner));
+		}
+		
+		if (!device_owner.name[0])
+			strcpy(device_owner.name, "null");
+		
+		struct rte_ether_addr macaddr;
+		ret = rte_eth_macaddr_get(portid, &macaddr);
+		if (ret < 0)
+		{
+			fprintf(stderr, "Could not get macaddr info for port %i (%s)\n",
+					portid, device_name_by_port);
+			memset(&macaddr, 0, sizeof(struct rte_ether_addr));
+		}
+		printf("dpdk-devname found port=%i "
+			   "driver=%s "
+			   "get_name_by_port_name=%s "
+			   "owner_id=0x%016lx "
+			   "owner_name=%s "
+			   "macaddr=%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx\n",
+			   portid,
+			   device_info.driver_name,
+			   device_name_by_port,
+			   device_owner.id,
+			   device_owner.name,
+			   macaddr.addr_bytes[0],
+			   macaddr.addr_bytes[1],
+			   macaddr.addr_bytes[2],
+			   macaddr.addr_bytes[3],
+			   macaddr.addr_bytes[4],
+			   macaddr.addr_bytes[5]
+		);
+	}
+
+	/* clean up the EAL */
+	rte_eal_cleanup();
+
+	return 0;
+}

--- a/microsoft/testsuites/dpdk/devname/meson.build
+++ b/microsoft/testsuites/dpdk/devname/meson.build
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2017 Intel Corporation
+
+# meson file, for building this example as part of a main DPDK build.
+#
+# To build this example as a standalone application with an already-installed
+# DPDK instance, use 'make'
+
+allow_experimental_apis = true
+sources = files(
+        'main.c',
+)

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -24,19 +24,7 @@ from lisa import (
 from lisa.features import Gpu, Infiniband, IsolatedResource, Sriov
 from lisa.operating_system import BSD, CBLMariner, Ubuntu, Windows
 from lisa.testsuite import TestResult, simple_requirement
-from lisa.tools import (
-    Echo,
-    Git,
-    Hugepages,
-    Ip,
-    Kill,
-    Lscpu,
-    Lsmod,
-    Make,
-    Modprobe,
-    Ping,
-    Timeout,
-)
+from lisa.tools import Echo, Git, Hugepages, Ip, Kill, Lscpu, Lsmod, Make, Modprobe
 from lisa.tools.hugepages import HugePageSize
 from lisa.tools.lscpu import CpuArchitecture
 from lisa.util.constants import SIGINT
@@ -56,6 +44,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     generate_send_receive_run_info,
     init_nodes_concurrent,
     initialize_node_resources,
+    run_dpdk_symmetric_mp,
     run_testpmd_concurrent,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
@@ -139,98 +128,7 @@ class Dpdk(TestSuite):
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        # setup and unwrap the resources for this test
-        nics = [node.nics.get_nic("eth1"), node.nics.get_nic("eth2")]
-        test_nic = node.nics.get_secondary_nic()
-        extra_nics = [nic for nic in nics if nic.name != test_nic.name]
-        ping = node.tools[Ping]
-        ping.install()
-        try:
-            test_kit = initialize_node_resources(
-                node,
-                log,
-                variables,
-                "netvsc",
-                HugePageSize.HUGE_2MB,
-                extra_nics=extra_nics,
-            )
-        except (NotEnoughMemoryException, UnsupportedOperationException) as err:
-            raise SkippedException(err)
-        testpmd = test_kit.testpmd
-        if isinstance(testpmd.installer, PackageManagerInstall):
-            # The Testpmd tool doesn't get re-initialized
-            # even if you invoke it with new arguments.
-            raise SkippedException(
-                "DPDK symmetric_mp test is not implemented for "
-                " package manager installation."
-            )
-        symmetric_mp_path = testpmd.get_example_app_path("dpdk-symmetric_mp")
-        node.log.debug("\n".join([str(nic) for nic in nics]))
-        if node.nics.is_mana_device_present():
-            nic_args = (
-                f'--vdev="{test_nic.pci_slot},'
-                f"mac={test_nic.mac_addr},"
-                f'mac={extra_nics[0].mac_addr}"'
-            )
-        else:
-            nic_args = f"-b {node.nics.get_primary_nic().pci_slot}"
-
-        output = node.execute(
-            f"{str(testpmd.get_example_app_path('dpdk-devname'))} {nic_args}",
-            sudo=True,
-            shell=True,
-        ).stdout
-        port_mask = 0x0
-        port_regex = re.compile(
-            r"dpdk-devname found port=(?P<port_id>[0-9]+) driver=net_netvsc .*\n"
-        )
-        matches = port_regex.findall(output)
-        if not matches:
-            fail("could not find port ids")
-        for match in matches:
-            port_mask ^= 1 << (int(match))
-
-        node.log.debug(f"Port mask: {hex(port_mask)}")
-        # primary_nic = node.nics.get_primary_nic().pci_slot
-        symmetric_mp_args = (
-            f"{nic_args} --proc-type auto "
-            "--log-level netvsc,debug --log-level mana,debug --log-level eal,debug "
-            f"-- -p {hex(port_mask)[2:]} --num-procs 2"
-        )
-        primary = node.tools[Timeout].start_with_timeout(
-            command=f"{str(symmetric_mp_path)} -l 1 {symmetric_mp_args} --proc-id 0",
-            timeout=150,
-            signal=SIGINT,
-            kill_timeout=30,
-        )
-        primary.wait_output("APP: Finished Process Init")
-        secondary = node.tools[Timeout].start_with_timeout(
-            command=f"{str(symmetric_mp_path)} -l 2 {symmetric_mp_args} --proc-id 1",
-            timeout=120,
-            signal=SIGINT,
-            kill_timeout=35,
-        )
-        _ = ping.ping_async(
-            target=test_nic.ip_addr,
-            nic_name=node.nics.get_primary_nic().name,
-            count=100,
-        )
-        secondary_exit = secondary.wait_result()
-        assert_that(secondary_exit.exit_code).described_as(
-            f"Secondary process failure: {secondary_exit.stdout}"
-        ).is_zero()
-        process_result = primary.wait_result(
-            expected_exit_code=0,
-            expected_exit_code_failure_message="Primary process failed to exit with 0",
-        )
-        node.log.debug(
-            f"Primary process:\n\n{process_result.stdout}\n"
-            f"\nprimary stderr:\n{process_result.stderr}"
-        )
-        node.log.debug(
-            f"Secondary system:\n\n{secondary_exit.stdout}\n"
-            f"secondary stderr:\n{secondary_exit.stderr}"
-        )
+        run_dpdk_symmetric_mp(node, log, variables)
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -132,6 +132,32 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
+            netvsc pmd version.
+            This test case checks DPDK can be built and installed correctly.
+            Prerequisites, accelerated networking must be enabled.
+            The VM should have at least two network interfaces,
+             with one interface for management.
+            More details refer https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#prerequisites # noqa: E501
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+    )
+    def verify_dpdk_symmetric_mp_netvsc_rescind(
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        run_dpdk_symmetric_mp(node, log, variables, trigger_rescind=True)
+
+    @TestCaseMetadata(
+        description="""
             netvsc pmd version with 1GiB hugepages
             This test case checks DPDK can be built and installed correctly.
             Prerequisites, accelerated networking must be enabled.

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -132,32 +132,6 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            netvsc pmd version.
-            This test case checks DPDK can be built and installed correctly.
-            Prerequisites, accelerated networking must be enabled.
-            The VM should have at least two network interfaces,
-             with one interface for management.
-            More details refer https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#prerequisites # noqa: E501
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            min_core_count=8,
-            min_nic_count=3,
-            network_interface=Sriov(),
-            unsupported_features=[Gpu, Infiniband],
-        ),
-    )
-    def verify_dpdk_symmetric_mp_netvsc_rescind(
-        self,
-        node: Node,
-        log: Logger,
-        variables: Dict[str, Any],
-        result: TestResult,
-    ) -> None:
-        run_dpdk_symmetric_mp(node, log, variables, trigger_rescind=True)
-
-    @TestCaseMetadata(
-        description="""
             netvsc pmd version with 1GiB hugepages
             This test case checks DPDK can be built and installed correctly.
             Prerequisites, accelerated networking must be enabled.

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -199,6 +199,7 @@ class DpdkSourceInstall(Installer):
         "multi_process/client_server_mp/mp_server",
         "multi_process/client_server_mp/mp_client",
         "multi_process/symmetric_mp",
+        "devname",
     ]
 
     def _check_if_installed(self) -> bool:
@@ -256,14 +257,21 @@ class DpdkSourceInstall(Installer):
             "libdpdk", update_cached=True
         )
 
+    __devname_files = ["main.c", "Makefile", "meson.build"]
+
     def _install(self) -> None:
         super()._install()
-        _ = self._node.tools[Git].clone(
-            url="https://github.com/mcgov/devname.git",
-            cwd=self.asset_path.joinpath("examples"),
-            dir_name="devname",
+        # copy devname application into the examples directory
+        devname_local_folder = PurePath(__file__).parent.joinpath("devname")
+        self._node.shell.mkdir(
+            self.asset_path.joinpath("examples/devname"), parents=False, exist_ok=False
         )
-        self._sample_applications += ["devname"]
+        for file in self.__devname_files:
+            self._node.shell.copy(
+                devname_local_folder.joinpath(file),
+                self.asset_path.joinpath(f"examples/devname/{file}"),
+            )
+        # stringify the example app list
         if self._sample_applications:
             sample_apps = f"-Dexamples={','.join(self._sample_applications)}"
         else:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -198,6 +198,7 @@ class DpdkSourceInstall(Installer):
         "l3fwd",
         "multi_process/client_server_mp/mp_server",
         "multi_process/client_server_mp/mp_client",
+        "multi_process/symmetric_mp",
     ]
 
     def _check_if_installed(self) -> bool:
@@ -257,6 +258,12 @@ class DpdkSourceInstall(Installer):
 
     def _install(self) -> None:
         super()._install()
+        _ = self._node.tools[Git].clone(
+            url="https://github.com/mcgov/devname.git",
+            cwd=self.asset_path.joinpath("examples"),
+            dir_name="devname",
+        )
+        self._sample_applications += ["devname"]
         if self._sample_applications:
             sample_apps = f"-Dexamples={','.join(self._sample_applications)}"
         else:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -712,7 +712,7 @@ class DpdkTestpmd(Tool):
             "dpdk examples path does not exist, "
             f"cannot use requested dpdk example: {app_name}"
         ).is_true()
-        # if the application has not been built; check if there is a rep
+        # if the application has not been built; check if there is a build directory and build the application if necessary
         if not shell.exists(source_path.joinpath("build")):
             self.node.tools[Make].make("static", cwd=source_path, sudo=True)
         return source_path.joinpath(f"build/{source_path.name}")

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -712,7 +712,9 @@ class DpdkTestpmd(Tool):
             "dpdk examples path does not exist, "
             f"cannot use requested dpdk example: {app_name}"
         ).is_true()
-        # if the application has not been built; check if there is a build directory and build the application if necessary
+        # if the application has not been built;
+        # check if there is a build directory and build the application
+        # (if necessary)
         if not shell.exists(source_path.joinpath("build")):
             self.node.tools[Make].make("static", cwd=source_path, sudo=True)
         return source_path.joinpath(f"build/{source_path.name}")

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import re
-from pathlib import PurePath, PurePosixPath, Path
+from pathlib import PurePath, PurePosixPath
 from typing import Any, List, Tuple, Type
 
 from assertpy import assert_that, fail
@@ -18,6 +18,7 @@ from lisa.tools import (
     Kill,
     Lscpu,
     Lspci,
+    Make,
     Meson,
     Modprobe,
     Ninja,
@@ -27,7 +28,6 @@ from lisa.tools import (
     Python,
     Timeout,
     Wget,
-    Make,
 )
 from lisa.util import (
     LisaException,

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -712,23 +712,8 @@ class DpdkTestpmd(Tool):
             "dpdk examples path does not exist, "
             f"cannot use requested dpdk example: {app_name}"
         ).is_true()
+        # if the application has not been built; check if there is a rep
         if not shell.exists(source_path.joinpath("build")):
-            local_path = Path(__file__).parent.joinpath(source_path.name)
-            if local_path.exists():
-                remote_tmp_path=self.node.working_path.joinpath(f"{source_path.name}_main.c")
-                self.node.shell.copy(
-                    local_path=PurePath(__file__).parent.joinpath(
-                        f"{local_path}/main.c"
-                    ),
-                    node_path=remote_tmp_path,
-                )
-                self.node.execute(
-                    f"cp {str(remote_tmp_path)} {str(source_path.joinpath("main.c"))}",
-                    sudo=True,
-                    shell=True,
-                    expected_exit_code=0,
-                    expected_exit_code_failure_message="could not copy patched main.c"
-                )
             self.node.tools[Make].make("static", cwd=source_path, sudo=True)
         return source_path.joinpath(f"build/{source_path.name}")
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1543,8 +1543,6 @@ def run_dpdk_symmetric_mp(
     all_matches = [
         result_regex.finditer(secondary_result.stdout),
         result_regex.finditer(primary_result.stdout),
-        # result_regex.search(secondary_result.stdout),
-        # result_regex.search(primary_result.stdout),
     ]
     match_count = 0
     process_data: List[Dict[str, int]] = []

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1302,7 +1302,7 @@ def _apply_workaround_for_symmetric_mp_main(node: Node) -> None:
     symmetric_mp_patched_main_c = "symmetric-mp-patched-main.c"
     node.shell.copy(
         symmetric_mp_local_dir.joinpath(symmetric_mp_patched_main_c),
-        node.working_path,
+        node.working_path.joinpath(symmetric_mp_patched_main_c),
     )
     symmetric_mp_remote = (
         "/usr/local/share/dpdk/examples/multi_process/symmetric_mp/main.c"

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1506,3 +1506,10 @@ def run_dpdk_symmetric_mp(
                 match_data = {"rx": int(rx_count), "tx": int(tx_count)}
                 process_data += [match_data]
     print(repr(process_data))
+
+    assert_that(process_data[0]["rx"]).described_as(
+        "process 0 port 0 tx and port 1 rx should match"
+    ).is_equal_to(process_data[1]["tx"])
+    assert_that(process_data[2]["rx"]).described_as(
+        "process 1 port_0_tx and port_1_rx should match"
+    ).is_equal_to(process_data[3]["tx"])

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1530,7 +1530,7 @@ def run_dpdk_symmetric_mp(
                 )
                 match_data = {"rx": int(rx_count), "tx": int(tx_count)}
                 process_data += [match_data]
-    print(repr(process_data))
+    node.log.debug(repr(process_data))
 
     assert_that(process_data[0]["rx"]).described_as(
         "process 0 port 0 tx and port 1 rx should match"

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1405,10 +1405,10 @@ def run_dpdk_symmetric_mp(
         while rescind_times > 0:
             rescind_times -= 1
             # turn SRIOV off
-            for index in [1, 2]:
-                node.features[NetworkInterface].switch_sriov(
-                    enable=False, wait=False, reset_connections=False, index=index
-                )
+
+            node.features[NetworkInterface].switch_sriov(
+                enable=False, wait=False, reset_connections=False
+            )
 
             # wait for the RTE_DEV_EVENT_REMOVE message
             primary.wait_output(
@@ -1418,12 +1418,13 @@ def run_dpdk_symmetric_mp(
             )  # relying on compiler defaults here, not great.
 
             # turn SRIOV on
-            for index in [1, 2]:
-                node.features[NetworkInterface].switch_sriov(
-                    enable=True, wait=False, reset_connections=False, index=index
-                )
+            node.features[NetworkInterface].switch_sriov(
+                enable=True, wait=False, reset_connections=False
+            )
+
             primary.wait_output(
-                "mana_dev_start(): TX/RX queues have started", delta_only=True
+                "HN_DRIVER: netvsc_hotadd_callback(): Device notification type=0",
+                delta_only=True,
             )
             ping.ping_async(
                 target=test_nics[0].ip_addr,

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -229,7 +229,7 @@ UIO_HV_GENERIC_SYSFS_PATH = "/sys/bus/vmbus/drivers/uio_hv_generic"
 HV_NETVSC_SYSFS_PATH = "/sys/bus/vmbus/drivers/hv_netvsc"
 
 
-def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
+def enable_uio_hv_generic(node: Node) -> None:
     # hv_uio_generic driver uuid, a constant value used by vmbus.
     # https://doc.dpdk.org/guides/nics/netvsc.html#installation
     hv_uio_generic_uuid = "f8615163-df3e-46c5-913f-f2d2f965ed0e"
@@ -267,21 +267,29 @@ def enable_uio_hv_generic_for_nic(node: Node, nic: NicInfo) -> None:
 
 
 def do_pmd_driver_setup(
-    node: Node, test_nic: NicInfo, testpmd: DpdkTestpmd, pmd: str = "failsafe"
+    node: Node, test_nics: List[NicInfo], testpmd: DpdkTestpmd, pmd: str = "failsafe"
 ) -> None:
     if pmd == "netvsc":
         # setup system for netvsc pmd
         # https://doc.dpdk.org/guides/nics/netvsc.html
-        enable_uio_hv_generic_for_nic(node, test_nic)
-        node.nics.unbind(test_nic)
-        node.nics.bind(test_nic, UIO_HV_GENERIC_SYSFS_PATH)
+        enable_uio_hv_generic(node)
+        # bound vmbus device may be the same when using vports
+        # ie... MANA. So track which devices we've already unbound to avoid
+        # doing things twice.
+        bound: List[str] = []
+        for nic in test_nics:
+            if nic.dev_uuid not in bound:
+                node.nics.unbind(nic)
+                node.nics.bind(nic, UIO_HV_GENERIC_SYSFS_PATH)
+                bound.append(nic.dev_uuid)
 
     # if mana is present, set VF interface down.
     # FIXME: add mana dpdk docs link when it's available.
     if testpmd.is_mana:
         ip = node.tools[Ip]
-        if test_nic.lower and ip.is_device_up(test_nic.lower):
-            ip.down(test_nic.lower)
+        for test_nic in test_nics:
+            if test_nic.lower and ip.is_device_up(test_nic.lower):
+                ip.down(test_nic.lower)
 
 
 def initialize_node_resources(
@@ -372,10 +380,11 @@ def initialize_node_resources(
     ).is_equal_to("hv_netvsc")
 
     # netvsc pmd requires uio_hv_generic to be loaded before use
-    do_pmd_driver_setup(node=node, test_nic=test_nic, testpmd=testpmd, pmd=pmd)
-    if extra_nics:
-        for extra_nic in extra_nics:
-            do_pmd_driver_setup(node=node, test_nic=extra_nic, testpmd=testpmd, pmd=pmd)
+    test_nics = [test_nic]
+    if extra_nics is not None:
+        test_nics += extra_nics
+
+    do_pmd_driver_setup(node=node, test_nics=test_nics, testpmd=testpmd, pmd=pmd)
 
     return DpdkTestResources(_node=node, _testpmd=testpmd, _rdma_core=rdma_core)
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1410,7 +1410,6 @@ def run_dpdk_symmetric_mp(
     symmetric_mp_args = (
         f"{nic_args} -n 2 "
         "--log-level netvsc,debug --log-level mana,debug "
-        # "--log-level eal,debug --log-level mbuf,debug "
         "--log-level ethdev,debug --log-level pci,debug "
         "--log-level port,debug "
         "--log-level vmbus,debug "

--- a/microsoft/testsuites/dpdk/symmetric_mp/README.md
+++ b/microsoft/testsuites/dpdk/symmetric_mp/README.md
@@ -1,0 +1,9 @@
+# patched symmetric_mp example app
+
+The main.c file in this directory is a patched version of the multi_process/symmetric_mp example application from the DPDK project.
+
+https://git.dpdk.org/dpdk/tree/examples/multi_process/symmetric_mp
+
+This change in this main.c is under review, but not merged. This cached version of the main.c file for this app is a workaround for older versions of DPDK. It should build for most if not all recent versions of the project.
+
+https://patches.dpdk.org/project/dpdk/list/?series=36143

--- a/microsoft/testsuites/dpdk/symmetric_mp/symmetric-mp-patched-main.c
+++ b/microsoft/testsuites/dpdk/symmetric_mp/symmetric-mp-patched-main.c
@@ -1,0 +1,495 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2010-2014 Intel Corporation
+ */
+
+/*
+ * Sample application demonstrating how to do packet I/O in a multi-process
+ * environment. The same code can be run as a primary process and as a
+ * secondary process, just with a different proc-id parameter in each case
+ * (apart from the EAL flag to indicate a secondary process).
+ *
+ * Each process will read from the same ports, given by the port-mask
+ * parameter, which should be the same in each case, just using a different
+ * queue per port as determined by the proc-id parameter.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <sys/queue.h>
+#include <getopt.h>
+#include <signal.h>
+#include <inttypes.h>
+
+#include <rte_common.h>
+#include <rte_log.h>
+#include <rte_memory.h>
+#include <rte_launch.h>
+#include <rte_eal.h>
+#include <rte_per_lcore.h>
+#include <rte_lcore.h>
+#include <rte_branch_prediction.h>
+#include <rte_debug.h>
+#include <rte_interrupts.h>
+#include <rte_ether.h>
+#include <rte_ethdev.h>
+#include <rte_mempool.h>
+#include <rte_memcpy.h>
+#include <rte_mbuf.h>
+#include <rte_string_fns.h>
+#include <rte_cycles.h>
+
+#define RTE_LOGTYPE_APP RTE_LOGTYPE_USER1
+
+#define NB_MBUFS 64*1024 /* use 64k mbufs */
+#define MBUF_CACHE_SIZE 256
+#define PKT_BURST 32
+#define RX_RING_SIZE 1024
+#define TX_RING_SIZE 1024
+
+#define PARAM_PROC_ID "proc-id"
+#define PARAM_NUM_PROCS "num-procs"
+
+/* for each lcore, record the elements of the ports array to use */
+struct lcore_ports{
+	unsigned start_port;
+	unsigned num_ports;
+};
+
+/* structure to record the rx and tx packets. Put two per cache line as ports
+ * used in pairs */
+struct __rte_aligned(RTE_CACHE_LINE_SIZE / 2) port_stats{
+	unsigned rx;
+	unsigned tx;
+	unsigned drop;
+};
+
+static int proc_id = -1;
+static unsigned num_procs = 0;
+
+static uint16_t ports[RTE_MAX_ETHPORTS];
+static unsigned num_ports = 0;
+
+static struct lcore_ports lcore_ports[RTE_MAX_LCORE];
+static struct port_stats pstats[RTE_MAX_ETHPORTS];
+
+/* prints the usage statement and quits with an error message */
+static void
+smp_usage(const char *prgname, const char *errmsg)
+{
+	printf("\nError: %s\n",errmsg);
+	printf("\n%s [EAL options] -- -p <port mask> "
+			"--"PARAM_NUM_PROCS" <n>"
+			" --"PARAM_PROC_ID" <id>\n"
+			"-p         : a hex bitmask indicating what ports are to be used\n"
+			"--num-procs: the number of processes which will be used\n"
+			"--proc-id  : the id of the current process (id < num-procs)\n"
+			"\n",
+			prgname);
+	exit(1);
+}
+
+
+/* signal handler configured for SIGTERM and SIGINT to print stats on exit */
+static void
+print_stats(int signum)
+{
+	unsigned i;
+	printf("\nExiting on signal %d\n\n", signum);
+	for (i = 0; i < num_ports; i++){
+		const uint8_t p_num = ports[i];
+		printf("Port %u: RX - %u, TX - %u, Drop - %u\n", (unsigned)p_num,
+				pstats[p_num].rx, pstats[p_num].tx, pstats[p_num].drop);
+	}
+	exit(0);
+}
+
+/* Parse the argument given in the command line of the application */
+static int
+smp_parse_args(int argc, char **argv)
+{
+	int opt, ret;
+	char **argvopt;
+	int option_index;
+	uint16_t i, port_mask = 0;
+	char *prgname = argv[0];
+	static struct option lgopts[] = {
+			{PARAM_NUM_PROCS, 1, 0, 0},
+			{PARAM_PROC_ID, 1, 0, 0},
+			{NULL, 0, 0, 0}
+	};
+
+	argvopt = argv;
+
+	while ((opt = getopt_long(argc, argvopt, "p:", \
+			lgopts, &option_index)) != EOF) {
+
+		switch (opt) {
+		case 'p':
+			port_mask = strtoull(optarg, NULL, 16);
+			break;
+			/* long options */
+		case 0:
+			if (strncmp(lgopts[option_index].name, PARAM_NUM_PROCS, 8) == 0)
+				num_procs = atoi(optarg);
+			else if (strncmp(lgopts[option_index].name, PARAM_PROC_ID, 7) == 0)
+				proc_id = atoi(optarg);
+			break;
+
+		default:
+			smp_usage(prgname, "Cannot parse all command-line arguments\n");
+		}
+	}
+
+	if (optind >= 0)
+		argv[optind-1] = prgname;
+
+	if (proc_id < 0)
+		smp_usage(prgname, "Invalid or missing proc-id parameter\n");
+	if (rte_eal_process_type() == RTE_PROC_PRIMARY && num_procs == 0)
+		smp_usage(prgname, "Invalid or missing num-procs parameter\n");
+	if (port_mask == 0)
+		smp_usage(prgname, "Invalid or missing port mask\n");
+
+	/* get the port numbers from the port mask */
+	RTE_ETH_FOREACH_DEV(i)
+		if(port_mask & (1 << i))
+			ports[num_ports++] = (uint8_t)i;
+
+	ret = optind-1;
+	optind = 1; /* reset getopt lib */
+
+	return ret;
+}
+
+/*
+ * Initialises a given port using global settings and with the rx buffers
+ * coming from the mbuf_pool passed as parameter
+ */
+static inline int
+smp_port_init(uint16_t port, struct rte_mempool *mbuf_pool,
+	       uint16_t num_queues)
+{
+	struct rte_eth_conf port_conf = {
+			.rxmode = {
+				.mq_mode	= RTE_ETH_MQ_RX_RSS,
+				.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM,
+			},
+			.rx_adv_conf = {
+				.rss_conf = {
+					.rss_key = NULL,
+					.rss_hf = RTE_ETH_RSS_IP,
+				},
+			},
+			.txmode = {
+				.mq_mode = RTE_ETH_MQ_TX_NONE,
+			}
+	};
+	const uint16_t rx_rings = num_queues, tx_rings = num_queues;
+	struct rte_eth_dev_info info;
+	struct rte_eth_rxconf rxq_conf;
+	struct rte_eth_txconf txq_conf;
+	int retval;
+	uint16_t q;
+	uint16_t nb_rxd = RX_RING_SIZE;
+	uint16_t nb_txd = TX_RING_SIZE;
+	uint64_t rss_hf_tmp;
+
+	if (rte_eal_process_type() == RTE_PROC_SECONDARY)
+		return 0;
+
+	if (!rte_eth_dev_is_valid_port(port))
+		return -1;
+
+	printf("# Initialising port %u... ", port);
+	fflush(stdout);
+
+	retval = rte_eth_dev_info_get(port, &info);
+	if (retval != 0) {
+		printf("Error during getting device (port %u) info: %s\n",
+				port, strerror(-retval));
+		return retval;
+	}
+
+	info.default_rxconf.rx_drop_en = 1;
+
+	if (info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE)
+		port_conf.txmode.offloads |=
+			RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE;
+
+	rss_hf_tmp = port_conf.rx_adv_conf.rss_conf.rss_hf;
+	port_conf.rx_adv_conf.rss_conf.rss_hf &= info.flow_type_rss_offloads;
+	if (port_conf.rx_adv_conf.rss_conf.rss_hf != rss_hf_tmp) {
+		printf("Port %u modified RSS hash function based on hardware support,"
+			"requested:%#"PRIx64" configured:%#"PRIx64"\n",
+			port,
+			rss_hf_tmp,
+			port_conf.rx_adv_conf.rss_conf.rss_hf);
+	}
+
+	retval = rte_eth_dev_configure(port, rx_rings, tx_rings, &port_conf);
+	if (retval == -EINVAL) {
+		printf("Port %u configuration failed. Re-attempting with HW checksum disabled.\n",
+			port);
+		port_conf.rxmode.offloads &= ~(RTE_ETH_RX_OFFLOAD_CHECKSUM);
+		retval = rte_eth_dev_configure(port, rx_rings, tx_rings, &port_conf);
+	}
+
+	if (retval == -ENOTSUP) {
+		printf("Port %u configuration failed. Re-attempting with HW RSS disabled.\n",
+			port);
+		port_conf.rxmode.mq_mode &= ~(RTE_ETH_MQ_RX_RSS);
+		retval = rte_eth_dev_configure(port, rx_rings, tx_rings, &port_conf);
+	}
+
+	if (retval < 0)
+		return retval;
+
+	retval = rte_eth_dev_adjust_nb_rx_tx_desc(port, &nb_rxd, &nb_txd);
+	if (retval < 0)
+		return retval;
+
+	rxq_conf = info.default_rxconf;
+	rxq_conf.offloads = port_conf.rxmode.offloads;
+	for (q = 0; q < rx_rings; q ++) {
+		retval = rte_eth_rx_queue_setup(port, q, nb_rxd,
+				rte_eth_dev_socket_id(port),
+				&rxq_conf,
+				mbuf_pool);
+		if (retval < 0)
+			return retval;
+	}
+
+	txq_conf = info.default_txconf;
+	txq_conf.offloads = port_conf.txmode.offloads;
+	for (q = 0; q < tx_rings; q ++) {
+		retval = rte_eth_tx_queue_setup(port, q, nb_txd,
+				rte_eth_dev_socket_id(port),
+				&txq_conf);
+		if (retval < 0)
+			return retval;
+	}
+
+	retval = rte_eth_promiscuous_enable(port);
+	if (retval != 0)
+		fprintf(stderr,
+			"Error during enabling promiscuous mode for port %u: %s - ignore\n",
+			retval, rte_strerror(-retval));
+
+	retval  = rte_eth_dev_start(port);
+	if (retval < 0)
+		return retval;
+
+	return 0;
+}
+
+/* Goes through each of the lcores and calculates what ports should
+ * be used by that core. Fills in the global lcore_ports[] array.
+ */
+static void
+assign_ports_to_cores(void)
+{
+
+	const unsigned int lcores = rte_lcore_count();
+	const unsigned port_pairs = num_ports / 2;
+	const unsigned pairs_per_lcore = port_pairs / lcores;
+	unsigned extra_pairs = port_pairs % lcores;
+	unsigned ports_assigned = 0;
+	unsigned i;
+
+	RTE_LCORE_FOREACH(i) {
+		lcore_ports[i].start_port = ports_assigned;
+		lcore_ports[i].num_ports = pairs_per_lcore * 2;
+		if (extra_pairs > 0) {
+			lcore_ports[i].num_ports += 2;
+			extra_pairs--;
+		}
+		ports_assigned += lcore_ports[i].num_ports;
+	}
+}
+
+/* Main function used by the processing threads.
+ * Prints out some configuration details for the thread and then begins
+ * performing packet RX and TX.
+ */
+static int
+lcore_main(void *arg __rte_unused)
+{
+	const unsigned id = rte_lcore_id();
+	const unsigned start_port = lcore_ports[id].start_port;
+	const unsigned end_port = start_port + lcore_ports[id].num_ports;
+	const uint16_t q_id = (uint16_t)proc_id;
+	unsigned p, i;
+	char msgbuf[256];
+	int msgbufpos = 0;
+
+	if (start_port == end_port){
+		printf("Lcore %u has nothing to do\n", id);
+		return 0;
+	}
+
+	/* build up message in msgbuf before printing to decrease likelihood
+	 * of multi-core message interleaving.
+	 */
+	msgbufpos += snprintf(msgbuf, sizeof(msgbuf) - msgbufpos,
+			"Lcore %u using ports ", id);
+	for (p = start_port; p < end_port; p++){
+		msgbufpos += snprintf(msgbuf + msgbufpos, sizeof(msgbuf) - msgbufpos,
+				"%u ", (unsigned)ports[p]);
+	}
+	printf("%s\n", msgbuf);
+	printf("lcore %u using queue %u of each port\n", id, (unsigned)q_id);
+
+	/* handle packet I/O from the ports, reading and writing to the
+	 * queue number corresponding to our process number (not lcore id)
+	 */
+
+	for (;;) {
+		struct rte_mbuf *buf[PKT_BURST];
+
+		for (p = start_port; p < end_port; p++) {
+			const uint8_t src = ports[p];
+			const uint8_t dst = ports[p ^ 1]; /* 0 <-> 1, 2 <-> 3 etc */
+			const uint16_t rx_c = rte_eth_rx_burst(src, q_id, buf, PKT_BURST);
+			if (rx_c == 0)
+				continue;
+			pstats[src].rx += rx_c;
+
+			const uint16_t tx_c = rte_eth_tx_burst(dst, q_id, buf, rx_c);
+			pstats[dst].tx += tx_c;
+			if (tx_c != rx_c) {
+				pstats[dst].drop += (rx_c - tx_c);
+				for (i = tx_c; i < rx_c; i++)
+					rte_pktmbuf_free(buf[i]);
+			}
+		}
+	}
+}
+
+/* Check the link status of all ports in up to 9s, and print them finally */
+static void
+check_all_ports_link_status(uint16_t port_num, uint32_t port_mask)
+{
+#define CHECK_INTERVAL 100 /* 100ms */
+#define MAX_CHECK_TIME 90 /* 9s (90 * 100ms) in total */
+	uint16_t portid;
+	uint8_t count, all_ports_up, print_flag = 0;
+	struct rte_eth_link link;
+	int ret;
+	char link_status_text[RTE_ETH_LINK_MAX_STR_LEN];
+
+	printf("\nChecking link status");
+	fflush(stdout);
+	for (count = 0; count <= MAX_CHECK_TIME; count++) {
+		all_ports_up = 1;
+		for (portid = 0; portid < port_num; portid++) {
+			if ((port_mask & (1 << portid)) == 0)
+				continue;
+			memset(&link, 0, sizeof(link));
+			ret = rte_eth_link_get_nowait(portid, &link);
+			if (ret < 0) {
+				all_ports_up = 0;
+				if (print_flag == 1)
+					printf("Port %u link get failed: %s\n",
+						portid, rte_strerror(-ret));
+				continue;
+			}
+			/* print link status if flag set */
+			if (print_flag == 1) {
+				rte_eth_link_to_str(link_status_text,
+					sizeof(link_status_text), &link);
+				printf("Port %d %s\n", portid,
+				       link_status_text);
+				continue;
+			}
+			/* clear all_ports_up flag if any link down */
+			if (link.link_status == RTE_ETH_LINK_DOWN) {
+				all_ports_up = 0;
+				break;
+			}
+		}
+		/* after finally printing all link status, get out */
+		if (print_flag == 1)
+			break;
+
+		if (all_ports_up == 0) {
+			printf(".");
+			fflush(stdout);
+			rte_delay_ms(CHECK_INTERVAL);
+		}
+
+		/* set the print_flag if all ports up or timeout */
+		if (all_ports_up == 1 || count == (MAX_CHECK_TIME - 1)) {
+			print_flag = 1;
+			printf("done\n");
+		}
+	}
+}
+
+/* Main function.
+ * Performs initialisation and then calls the lcore_main on each core
+ * to do the packet-processing work.
+ */
+int
+main(int argc, char **argv)
+{
+	static const char *_SMP_MBUF_POOL = "SMP_MBUF_POOL";
+	int ret;
+	unsigned i;
+	enum rte_proc_type_t proc_type;
+	struct rte_mempool *mp;
+
+	/* set up signal handlers to print stats on exit */
+	signal(SIGINT, print_stats);
+	signal(SIGTERM, print_stats);
+
+	/* initialise the EAL for all */
+	ret = rte_eal_init(argc, argv);
+	if (ret < 0)
+		rte_exit(EXIT_FAILURE, "Cannot init EAL\n");
+	argc -= ret;
+	argv += ret;
+
+	/* determine the NIC devices available */
+	if (rte_eth_dev_count_avail() == 0)
+		rte_exit(EXIT_FAILURE, "No Ethernet ports - bye\n");
+
+	/* parse application arguments (those after the EAL ones) */
+	smp_parse_args(argc, argv);
+
+	proc_type = rte_eal_process_type();
+	mp = (proc_type == RTE_PROC_SECONDARY) ?
+			rte_mempool_lookup(_SMP_MBUF_POOL) :
+			rte_pktmbuf_pool_create(_SMP_MBUF_POOL, NB_MBUFS,
+				MBUF_CACHE_SIZE, 0, RTE_MBUF_DEFAULT_BUF_SIZE,
+				rte_socket_id());
+	if (mp == NULL)
+		rte_exit(EXIT_FAILURE, "Cannot get memory pool for buffers\n");
+
+	/* Primary instance initialized. 8< */
+	if (num_ports & 1)
+		rte_exit(EXIT_FAILURE, "Application must use an even number of ports\n");
+	for(i = 0; i < num_ports; i++){
+		if(proc_type == RTE_PROC_PRIMARY)
+			if (smp_port_init(ports[i], mp, (uint16_t)num_procs) < 0)
+				rte_exit(EXIT_FAILURE, "Error initialising ports\n");
+	}
+	/* >8 End of primary instance initialization. */
+
+	if (proc_type == RTE_PROC_PRIMARY)
+		check_all_ports_link_status((uint8_t)num_ports, (~0x0));
+
+	assign_ports_to_cores();
+
+	RTE_LOG(INFO, APP, "Finished Process Init.\n");
+
+	rte_eal_mp_remote_launch(lcore_main, NULL, CALL_MAIN);
+
+	/* clean up the EAL */
+	rte_eal_cleanup();
+
+	return 0;
+}


### PR DESCRIPTION
Adding a runner for the DPDK example app `multiprocessing/symmetric_mp`. This is another flavor of the multiprocessing test which can scale to a larger number of ports and processes than 'multiprocessing/client_server_mp'.

Adding this test required a few smaller changes (and one refactor):
- Allow an arbitrary number of nics to be passed to initialize_node_resources (refactor)
- Use dpdk-devname app to select the correct DPDK port ID when building a port mask

With these changes, the test itself is straightforward. We build and start the application; then use enable debug logging and check for the important DPDK netvsc PMD events that show the example app is working as expected.