### PR TITLE
Upgrade "azure-mgmt-compute" to "30.5.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ aws = [
 
 azure = [
     "azure-identity ~= 1.17.0b1",
-    "azure-mgmt-compute ~= 30.3.0",
+    "azure-mgmt-compute ~= 30.5.0",
     "azure-mgmt-keyvault ~= 10.2.3",
     "azure-mgmt-marketplaceordering ~= 1.1.0",
     "azure-mgmt-msi ~= 7.0.0",


### PR DESCRIPTION
IntelTDX CVM OS disk captures are failing with below error:

azure.core.exceptions.HttpResponseError: (BadRequest) Minimum api-version of 2023-10-02 required to use ReadSecure or WriteSecure SAS access.
Code: BadRequest
Message: Minimum api-version of 2023-10-02 required to use ReadSecure or WriteSecure SAS access.

Upgrading "azure-mgmt-compute" to "30.5.0" fixed this issue.