### PR TITLE
Enable sl-micro detection

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2176,6 +2176,12 @@ class SLES(Suse):
         return re.compile("^SLES|sles|sle-hpc|sle_hpc$")
 
 
+class SlMicro(Suse):
+    @classmethod
+    def name_pattern(cls) -> Pattern[str]:
+        return re.compile(r"^sl-micro$", re.IGNORECASE)
+
+
 class NixOS(Linux):
     pass
 


### PR DESCRIPTION
This is the start of work to enable sl-micro detection.  More information on sl-micro can be found [here](https://www.suse.com/products/micro/)