### PR TITLE
Creating a plugin for DMesg log analysis post TC Execution

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -24,7 +24,7 @@ from lisa.feature import Features
 from lisa.nic import Nics, NicsBSD
 from lisa.operating_system import OperatingSystem
 from lisa.secret import add_secret
-from lisa.tools import Chmod, Df, Echo, Lsblk, Mkfs, Mount, Reboot, Uname, Wsl
+from lisa.tools import Chmod, Df, Dmesg, Echo, Lsblk, Mkfs, Mount, Reboot, Uname, Wsl
 from lisa.tools.mkfs import FileSystem
 from lisa.util import (
     ContextMixin,
@@ -110,6 +110,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         self._support_sudo: Optional[bool] = None
         self._is_dirty: bool = False
         self.capture_boot_time: bool = False
+        self.check_dmesg_after_case: bool = False
         self.capture_azure_information: bool = False
         self.capture_kernel_config: bool = False
         self.has_checked_bash_prompt: bool = False
@@ -500,6 +501,11 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
             final_information.update(current_information)
 
         return final_information
+
+    def exec_check_dmesg_oops(self) -> bool:
+        return plugin_manager.hook.check_dmesg_oops(
+            node=self
+        )
 
     def expand_env_path(self, raw_path: str) -> str:
         echo = self.tools[Echo]
@@ -1186,6 +1192,9 @@ class NodeHookSpec:
     def get_node_information(self, node: Node) -> Dict[str, str]:
         ...
 
+    @hookspec
+    def check_dmesg_oops(self, node: Node) -> bool:
+        """Hook for checking dmesg logs after each test case execution."""
 
 class NodeHookImpl:
     @hookimpl
@@ -1208,6 +1217,20 @@ class NodeHookImpl:
                 )
 
         return information
+    
+    @hookimpl
+    def check_dmesg_oops(self, node: Node) -> bool:
+        try:
+            dmesg = node.tools[Dmesg]
+            results = dmesg.check_kernel_errors(force_run=True, throw_error=False)
+            if results:
+                # If there are any results obtained from the Kernel Error Check, then return True
+                return True
+            else:
+                return False
+        except LisaException as ex:
+            node.log.error(f"Error: {ex}")
+            return True
 
 
 plugin_manager.add_hookspecs(NodeHookSpec)

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -195,6 +195,7 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
                 node.features = Features(node, self)
             node.capture_azure_information = platform_runbook.capture_azure_information
             node.capture_boot_time = platform_runbook.capture_boot_time
+            node.check_dmesg_after_case = platform_runbook.check_dmesg_after_case
             node.capture_kernel_config = (
                 platform_runbook.capture_kernel_config_information
             )

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1444,6 +1444,8 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
     capture_azure_information: bool = False
     # capture boot time info or not
     capture_boot_time: bool = False
+    # to check if dmesg logs need to be analyzed after each test case
+    check_dmesg_after_case: bool = False
     # capture kernel config info or not
     capture_kernel_config_information: bool = False
     capture_vm_information: bool = True

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -752,6 +752,16 @@ class TestSuite:
                     log=case_log,
                 )
 
+            nodes = environment.nodes
+            for node in nodes.list():
+                if node.check_dmesg_after_case:
+                    suite_log.info(f"Checking for Kernel Errors in DMesg logs after test case execution..")
+                    dmesg_check_result = node.exec_check_dmesg_oops()[0]
+                    if dmesg_check_result:
+                        case_result.set_status(TestStatus.FAILED, f"failed. Kernel Errors found in the DMesg logs after test case execution. Please check the same!")
+                        self.status = TestStatus.FAILED
+                        break
+
             self.__after_case(
                 case_result=case_result,
                 timeout=case_timeout,


### PR DESCRIPTION
- The purpose of this Draft PR is to create a code for checking the DMesg logs for any exceptions once the test case execution is completed.
- The execution will be done based on a switch - the default value of which would be false - hence avoiding any unnecessary failures/noise.
- This can be later on extended to also check panic patterns or increase the scope of the checks executed after the test case is completed.