### PR TITLE
SharedImageGalleryTransformer: Take marketplace features

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2481,7 +2481,7 @@ def check_or_create_gallery_image(
     gallery_image_osstate: str,
     gallery_image_hyperv_generation: int,
     gallery_image_architecture: str,
-    gallery_image_securitytype: str,
+    gallery_image_features: Dict[str, Any],
 ) -> None:
     try:
         compute_client = get_compute_client(platform)
@@ -2513,12 +2513,13 @@ def check_or_create_gallery_image(
                 ],
             }
 
-            if gallery_image_securitytype:
+            if gallery_image_features:
                 image_post_body["features"] = [
                     {
-                        "name": "SecurityType",
-                        "value": gallery_image_securitytype,
+                        "name": key,
+                        "value": value,
                     }
+                    for (key, value) in gallery_image_features.items()
                 ]
             operation = compute_client.gallery_images.begin_create_or_update(
                 gallery_resource_group_name,


### PR DESCRIPTION
If a SIG is created from a marketplace image, you can provide the source image instead of specifying all of the features, hyper-v gen, and architecture individually.