### PR TITLE
Checking DMesg logs for Panics/Errors post test case execution

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -110,7 +110,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         self._support_sudo: Optional[bool] = None
         self._is_dirty: bool = False
         self.capture_boot_time: bool = False
-        self.assert_kernel_error: bool = False
+        self.assert_kernel_error_after_test: bool = False
         self.capture_azure_information: bool = False
         self.capture_kernel_config: bool = False
         self.has_checked_bash_prompt: bool = False
@@ -502,7 +502,8 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
 
         return final_information
 
-    def exec_check_dmesg_oops(self) -> None:
+    def check_kernel_error(self) -> None:
+        # Check if the kernel is in a healthy state without errors or panics.
         dmesg = self.tools[Dmesg]
         dmesg.check_kernel_errors(force_run=True, throw_error=True)
         self.check_kernel_panic()

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -502,18 +502,10 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
 
         return final_information
 
-    def exec_check_dmesg_oops(self) -> bool:
-        try:
-            dmesg = self.tools[Dmesg]
-            results = dmesg.check_kernel_errors(force_run=True, throw_error=False)
-            if results:
-                # If there are any results obtained from the Kernel Error Check, then return True
-                return True
-            else:
-                return False
-        except LisaException as ex:
-            self.log.error(f"Error: {ex}")
-            return True
+    def exec_check_dmesg_oops(self) -> None:
+        dmesg = self.tools[Dmesg]
+        dmesg.check_kernel_errors(force_run=True, throw_error=True)
+        self.check_kernel_panic()
 
     def expand_env_path(self, raw_path: str) -> str:
         echo = self.tools[Echo]

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -195,7 +195,7 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
                 node.features = Features(node, self)
             node.capture_azure_information = platform_runbook.capture_azure_information
             node.capture_boot_time = platform_runbook.capture_boot_time
-            node.assert_kernel_error = platform_runbook.assert_kernel_error
+            node.assert_kernel_error_after_test = platform_runbook.assert_kernel_error_after_test
             node.capture_kernel_config = (
                 platform_runbook.capture_kernel_config_information
             )

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -195,7 +195,9 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
                 node.features = Features(node, self)
             node.capture_azure_information = platform_runbook.capture_azure_information
             node.capture_boot_time = platform_runbook.capture_boot_time
-            node.assert_kernel_error_after_test = platform_runbook.assert_kernel_error_after_test
+            node.assert_kernel_error_after_test = (
+                platform_runbook.assert_kernel_error_after_test
+            )
             node.capture_kernel_config = (
                 platform_runbook.capture_kernel_config_information
             )

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -195,6 +195,7 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
                 node.features = Features(node, self)
             node.capture_azure_information = platform_runbook.capture_azure_information
             node.capture_boot_time = platform_runbook.capture_boot_time
+            node.assert_kernel_error = platform_runbook.assert_kernel_error
             node.capture_kernel_config = (
                 platform_runbook.capture_kernel_config_information
             )

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1444,6 +1444,8 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
     capture_azure_information: bool = False
     # capture boot time info or not
     capture_boot_time: bool = False
+    # to check if dmesg logs need to be analyzed after each test case
+    assert_kernel_error: bool
     # capture kernel config info or not
     capture_kernel_config_information: bool = False
     capture_vm_information: bool = True

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1445,7 +1445,7 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
     # capture boot time info or not
     capture_boot_time: bool = False
     # to check if dmesg logs need to be analyzed after each test case
-    assert_kernel_error: bool = False
+    assert_kernel_error_after_test: bool = False
     # capture kernel config info or not
     capture_kernel_config_information: bool = False
     capture_vm_information: bool = True

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1445,7 +1445,7 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
     # capture boot time info or not
     capture_boot_time: bool = False
     # to check if dmesg logs need to be analyzed after each test case
-    assert_kernel_error: bool
+    assert_kernel_error: bool = False
     # capture kernel config info or not
     capture_kernel_config_information: bool = False
     capture_vm_information: bool = True

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -856,12 +856,12 @@ class TestSuite:
                 timeout=timeout,
                 test_kwargs=test_kwargs,
             )
-            case_result.set_status(TestStatus.PASSED, "")
             if case_result.environment is not None:
                 nodes = case_result.environment.nodes
                 for node in nodes.list():
-                    if node.assert_kernel_error:
-                        node.exec_check_dmesg_oops()
+                    if node.assert_kernel_error_after_test:
+                        node.check_kernel_error()
+            case_result.set_status(TestStatus.PASSED, "")
         except Exception as identifier:
             case_result.handle_exception(exception=identifier, log=log)
         log.debug(f"case end in {timer}")

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -857,9 +857,18 @@ class TestSuite:
                 test_kwargs=test_kwargs,
             )
             case_result.set_status(TestStatus.PASSED, "")
+            if node.assert_kernel_error:
+                nodes = case_result.environment.nodes
+                for node in nodes.list():
+                    self.__node_kernel_error_check(node, log)
         except Exception as identifier:
             case_result.handle_exception(exception=identifier, log=log)
         log.debug(f"case end in {timer}")
+
+    def __node_kernel_error_check(self, node: schema.NodeSpace, log: Logger) -> None:
+        dmesg_check_result = node.exec_check_dmesg_oops()[0]
+        if dmesg_check_result:
+            raise LisaException(f"failed. Kernel Errors found in the DMesg logs after test case execution. Please check the same!")
 
 
 def get_suites_metadata() -> Dict[str, TestSuiteMetadata]:

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -860,15 +860,10 @@ class TestSuite:
             nodes = case_result.environment.nodes
             for node in nodes.list():
                 if node.assert_kernel_error:
-                    self.__node_kernel_error_check(node, log)
+                    node.exec_check_dmesg_oops()
         except Exception as identifier:
             case_result.handle_exception(exception=identifier, log=log)
         log.debug(f"case end in {timer}")
-
-    def __node_kernel_error_check(self, node: schema.NodeSpace, log: Logger) -> None:
-        dmesg_check_result = node.exec_check_dmesg_oops()
-        if dmesg_check_result:
-            raise LisaException(f"failed. Kernel Errors found in the DMesg logs after test case execution. Please check the same!")
 
 
 def get_suites_metadata() -> Dict[str, TestSuiteMetadata]:

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -857,16 +857,16 @@ class TestSuite:
                 test_kwargs=test_kwargs,
             )
             case_result.set_status(TestStatus.PASSED, "")
-            if node.assert_kernel_error:
-                nodes = case_result.environment.nodes
-                for node in nodes.list():
+            nodes = case_result.environment.nodes
+            for node in nodes.list():
+                if node.assert_kernel_error:
                     self.__node_kernel_error_check(node, log)
         except Exception as identifier:
             case_result.handle_exception(exception=identifier, log=log)
         log.debug(f"case end in {timer}")
 
     def __node_kernel_error_check(self, node: schema.NodeSpace, log: Logger) -> None:
-        dmesg_check_result = node.exec_check_dmesg_oops()[0]
+        dmesg_check_result = node.exec_check_dmesg_oops()
         if dmesg_check_result:
             raise LisaException(f"failed. Kernel Errors found in the DMesg logs after test case execution. Please check the same!")
 

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -857,10 +857,11 @@ class TestSuite:
                 test_kwargs=test_kwargs,
             )
             case_result.set_status(TestStatus.PASSED, "")
-            nodes = case_result.environment.nodes
-            for node in nodes.list():
-                if node.assert_kernel_error:
-                    node.exec_check_dmesg_oops()
+            if case_result.environment is not None:
+                nodes = case_result.environment.nodes
+                for node in nodes.list():
+                    if node.assert_kernel_error:
+                        node.exec_check_dmesg_oops()
         except Exception as identifier:
             case_result.handle_exception(exception=identifier, log=log)
         log.debug(f"case end in {timer}")


### PR DESCRIPTION
- The purpose of this PR is to add code for checking the DMesg logs for any panics/exceptions once the test case execution is completed.
- The execution will be done based on a switch (_assert_kernel_error_) - the default value of which would be false - hence avoiding any unnecessary failures/noise.
- Thus, we aim to check both kernel errors and panics and fail the test in case either is found.