### PR TITLE
Add credential support on Azure platform

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2300,7 +2300,7 @@ def find_storage_account(
 
 def get_token(platform: "AzurePlatform") -> str:
     token = platform.credential.get_token(platform.cloud.endpoints.resource_manager)
-    return token.token
+    return str(token.token)
 
 
 def _generate_sas_token_for_vhd(

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2782,12 +2782,17 @@ class StaticAccessTokenCredential(TokenCredential):
         return AccessToken(self._token, self._expires_on)
 
     def _get_exp(self) -> Any:
-        # The second part of the JWT is the payload
-        payload = self._token.split(".")[1]
-        # Add padding to ensure Base64 decoding works properly
-        padded_payload = payload + "=" * (4 - len(payload) % 4)
-        # Decode the Base64 URL-safe encoded payload
-        decoded_payload = base64.urlsafe_b64decode(padded_payload)
+        try:
+            # The second part of the JWT is the payload
+            payload = self._token.split(".")[1]
+            # Add padding to ensure Base64 decoding works properly
+            padded_payload = payload + "=" * (4 - len(payload) % 4)
+            # Decode the Base64 URL-safe encoded payload
+            decoded_payload = base64.urlsafe_b64decode(padded_payload)
+        except Exception as e:
+            raise LisaException(
+                f"Failed to decode JWT payload, maybe invalid token: {e}"
+            )
         # Convert the payload into a dictionary and get the expiration time
         # 'exp' is the UNIX timestamp for expiration
         return json.loads(decoded_payload).get("exp")

--- a/lisa/sut_orchestrator/azure/credential.py
+++ b/lisa/sut_orchestrator/azure/credential.py
@@ -12,7 +12,7 @@ from azure.identity import (
 )
 from dataclasses_json import dataclass_json
 
-from lisa import schema
+from lisa import schema, secret
 from lisa.util import constants, subclasses
 from lisa.util.logger import Logger
 
@@ -52,6 +52,9 @@ class ClientSecretCredentialSchema(AzureCredentialSchema):
     # for ClientSecretCredential, will be deprecated due to Security WAVE
     client_secret: str = ""
 
+    def __post_init__(self) -> None:
+        assert self.client_secret, "client_secret shouldn't be empty"
+        secret.add_secret(self.client_secret)
 
 class AzureCredential(subclasses.BaseClassWithRunbookMixin):
     """

--- a/lisa/sut_orchestrator/azure/credential.py
+++ b/lisa/sut_orchestrator/azure/credential.py
@@ -27,9 +27,9 @@ class AzureCredentialType(str, Enum):
 @dataclass_json()
 @dataclass
 class AzureCredentialSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
+    type: str = AzureCredentialType.DefaultAzureCredential
     tenant_id: str = ""
     client_id: str = ""
-    type: str = AzureCredentialType.DefaultAzureCredential
 
 
 @dataclass_json()
@@ -37,7 +37,6 @@ class AzureCredentialSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
 class CertCredentialSchema(AzureCredentialSchema):
     cert_path: str = ""
     client_send_cert_chain = "false"
-    type: str = AzureCredentialType.CertificateCredential
 
 
 @dataclass_json()
@@ -45,7 +44,6 @@ class CertCredentialSchema(AzureCredentialSchema):
 class ClientAssertionCredentialSchema(AzureCredentialSchema):
     msi_client_id: str = ""
     enterprise_app_client_id: str = ""
-    type: str = AzureCredentialType.ClientAssertionCredential
 
 
 @dataclass_json()
@@ -53,7 +51,6 @@ class ClientAssertionCredentialSchema(AzureCredentialSchema):
 class ClientSecretCredentialSchema(AzureCredentialSchema):
     # for ClientSecretCredential, will be deprecated due to Security WAVE
     client_secret: str = ""
-    type: str = AzureCredentialType.ClientSecretCredential
 
 
 class AzureCredential(subclasses.BaseClassWithRunbookMixin):

--- a/lisa/sut_orchestrator/azure/credential.py
+++ b/lisa/sut_orchestrator/azure/credential.py
@@ -108,7 +108,11 @@ class AzureCredential(subclasses.BaseClassWithRunbookMixin):
         assert runbook, "azure_credential shouldn't be empty"
         if runbook.tenant_id:
             self._tenant_id = runbook.tenant_id
+            self._log.debug(f"Use defined tenant id: {self._tenant_id}")
+            os.environ["AZURE_TENANT_ID"] = self._tenant_id
         if runbook.client_id:
+            self._client_id = runbook.client_id
+            self._log.debug(f"Use defined client id: {self._client_id}")
             os.environ["AZURE_CLIENT_ID"] = self._client_id
 
     def __hash__(self) -> int:
@@ -176,6 +180,8 @@ class AzureCertificateCredential(AzureCredential):
         self._credential_type = AzureCredentialType.CertificateCredential
         if runbook.cert_path:
             self._cert_path = runbook.cert_path
+            self._log.debug(f"Use defined cert path: {self._cert_path}")
+            os.environ["AZURE_CLIENT_CERTIFICATE_PATH"] = self._cert_path
         if runbook.client_send_cert_chain:
             self._client_send_cert_chain = runbook.client_send_cert_chain
 
@@ -282,12 +288,12 @@ class AzureClientSecretCredential(AzureCredential):
         self._client_secret = os.environ.get("AZURE_CLIENT_SECRET", "")
 
         runbook = cast(ClientSecretCredentialSchema, self.runbook)
-        if runbook.client_id:
-            self._client_id = runbook.client_id
-        if runbook.tenant_id:
-            self._tenant_id = runbook.tenant_id
         if runbook.client_secret:
             self._client_secret = runbook.client_secret
+            self._log.debug(
+                f"Use defined client secret: ({len(self._client_secret)} bytes)"
+            )
+            os.environ["AZURE_CLIENT_SECRET"] = self._client_secret
 
     def get_client_secret_credential(
         self, tenant_id: str, client_id: str, client_secret: str

--- a/lisa/sut_orchestrator/azure/credential.py
+++ b/lisa/sut_orchestrator/azure/credential.py
@@ -14,15 +14,15 @@ from dataclasses_json import dataclass_json
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD, Cloud  # type: ignore
 
 from lisa import schema, secret
-from lisa.util import constants, subclasses
+from lisa.util import subclasses
 from lisa.util.logger import Logger
 
 
 class AzureCredentialType(str, Enum):
-    DefaultAzureCredential = constants.DEFAULT_AZURE_CREDENTIAL
-    CertificateCredential = constants.CERTIFICATE_CREDENTIAL
-    ClientAssertionCredential = constants.CLIENT_ASSERTION_CREDENTIAL
-    ClientSecretCredential = constants.CLIENT_SECRET_CREDENTIAL
+    DefaultAzureCredential = "default"
+    CertificateCredential = "certificate"
+    ClientAssertionCredential = "assertion"
+    ClientSecretCredential = "secret"
 
 
 @dataclass_json()
@@ -188,7 +188,7 @@ class AzureClientAssertionCredential(AzureCredential):
 
     @classmethod
     def type_name(cls) -> str:
-        return constants.CLIENT_ASSERTION_CREDENTIAL
+        return AzureCredentialType.ClientAssertionCredential
 
     @classmethod
     def type_schema(cls) -> Type[schema.TypedSchema]:
@@ -252,7 +252,7 @@ class AzureClientSecretCredential(AzureCredential):
 
     @classmethod
     def type_name(cls) -> str:
-        return constants.CLIENT_SECRET_CREDENTIAL
+        return AzureCredentialType.ClientSecretCredential
 
     @classmethod
     def type_schema(cls) -> Type[schema.TypedSchema]:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -433,7 +433,7 @@ class SerialConsole(AzureFeatureMixin, features.SerialConsole):
             "https://management.core.windows.net/.default"
         ).token
 
-        return access_token
+        return str(access_token)
 
     def _get_console_log(self, saved_path: Optional[Path]) -> bytes:
         platform: AzurePlatform = self._platform  # type: ignore

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -62,7 +62,7 @@ from lisa.features import (
 from lisa.features.availability import AvailabilityType
 from lisa.node import Node, RemoteNode, local
 from lisa.platform_ import Platform
-from lisa.secret import PATTERN_GUID, add_secret
+from lisa.secret import add_secret
 from lisa.tools import Dmesg, Hostname, KernelConfig, Modinfo, Whoami
 from lisa.tools.lsinitrd import Lsinitrd
 from lisa.util import (
@@ -348,10 +348,6 @@ class AzurePlatformSchema:
             ],
         )
 
-        if self.service_principal_tenant_id:
-            add_secret(self.service_principal_tenant_id, mask=PATTERN_GUID)
-        if self.subscription_id:
-            add_secret(self.subscription_id, mask=PATTERN_GUID)
         if self.service_principal_key:
             add_secret(self.service_principal_key)
         if self.azure_arm_access_token:
@@ -362,8 +358,6 @@ class AzurePlatformSchema:
             add_secret(self.azure_keyvault_access_token)
         if self.azure_graph_access_token:
             add_secret(self.azure_graph_access_token)
-        if self.service_principal_client_id:
-            add_secret(self.service_principal_client_id, mask=PATTERN_GUID)
 
     @property
     def cloud(self) -> Cloud:

--- a/lisa/util/constants.py
+++ b/lisa/util/constants.py
@@ -53,12 +53,6 @@ NOTIFIER = "notifier"
 NOTIFIER_CONSOLE = "console"
 NOTIFIER_FILE = "file"
 
-# Azure Credential Type
-DEFAULT_AZURE_CREDENTIAL = "default"
-CERTIFICATE_CREDENTIAL = "certificate"
-CLIENT_ASSERTION_CREDENTIAL = "assertion"
-CLIENT_SECRET_CREDENTIAL = "secret"
-
 # common
 NODES = "nodes"
 NAME = "name"

--- a/microsoft/runbook/azure.yml
+++ b/microsoft/runbook/azure.yml
@@ -35,6 +35,8 @@ variable:
     is_secret: true
   - name: azcopy_path
     value: ""
+  - name: auth_type
+    value: "default"
 concurrency: $(concurrency)
 notifier:
   - type: html
@@ -45,11 +47,13 @@ platform:
     admin_password: $(admin_password)
     keep_environment: $(keep_environment)
     azure:
+      credential:
+        type: $(auth_type)
+        token: $(azure_arm_access_token)
       resource_group_name: $(resource_group_name)
       deploy: $(deploy)
       subscription_id: $(subscription_id)
       wait_delete: $(wait_delete)
-      azure_arm_access_token: $(azure_arm_access_token)
       azcopy_path: $(azcopy_path)
     requirement:
       core_count:


### PR DESCRIPTION
The credential supports many different auth types with a clear design. Enable it for more auth methods.

See details on commits.