### PR TITLE
junit: add unique id in names.

### DIFF
--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -296,7 +296,7 @@ class JUnit(Notifier):
             raise LisaException("Test suite not started.")
 
         testcase = ET.SubElement(testsuite_info.xml, "testcase")
-        testcase.attrib["name"] = message.name
+        testcase.attrib["name"] = f"{message.name} ({message.id_})"
         testcase.attrib["classname"] = class_name
         testcase.attrib["time"] = self._get_elapsed_str(elapsed)
 


### PR DESCRIPTION
In some junit file consumers, the test name is
 considered as the key. If it's duplicated, it
 shows only one. This change use the test case id
 to make test name unique.