### PR TITLE
adds another cvm tag

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -385,6 +385,7 @@ class AzureImageSchema(schema.ImageSchema):
         elif security_profile in (
             "TrustedLaunchAndConfidentialVmSupported",
             "ConfidentialVmSupported",
+            "ConfidentialVM",
         ):
             capabilities.append(SecurityProfileType.CVM)
             capabilities.append(SecurityProfileType.Stateless)


### PR DESCRIPTION
This adds another way to detect CVM generalized image, created using cvm capture: https://learn.microsoft.com/en-us/azure/confidential-computing/create-confidential-vm-from-compute-gallery#create-a-confidential-vm-type-image-using-confidential-vm-capture