### PR TITLE
add azure linux-specific fips tests

### DIFF
--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -92,6 +92,7 @@ class Sed(Tool):
             sudo=sudo,
             shell=True,
         )
+        result.assert_exit_code(message=result.stdout)
 
 
 class SedBSD(Sed):

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -79,6 +79,33 @@ class Sed(Tool):
         )
         result.assert_exit_code(message=result.stdout)
 
+    def raw(self, expression: str, file: str, sudo: bool = False) -> None:
+        """
+        Apply a raw sed expression to a file, as opposed to separating the expression into a pattern and replacement.
+        This allows for more advanced `sed` usage.
+        Args:
+            expression (str): The sed expression to apply.
+            file (str): The path to the file to modify.
+            sudo (bool, optional): Whether to execute the command with sudo. Defaults to False.
+        Returns:
+            None
+        """
+        self._log.debug(f"Applying raw sed expression '{expression}' to file '{file}' with sudo={sudo}")
+
+        # Escape special characters in the expression.
+        expression = expression.replace('"', r"\"").replace("$", r"\$")
+        self._log.debug(f"Escaped expression: '{expression}'")
+
+        cmd = f'-i.bak "{expression}" {file}'
+        result = self.run(
+            cmd,
+            force_run=True,
+            no_error_log=True,
+            no_info_log=True,
+            sudo=sudo,
+            shell=True,
+        )
+        result.assert_exit_code(message=result.stdout)
 
 class SedBSD(Sed):
     @property

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -79,19 +79,10 @@ class Sed(Tool):
         )
         result.assert_exit_code(message=result.stdout)
 
-    def raw(self, expression: str, file: str, sudo: bool = False) -> None:
-        """
-        Apply a raw sed expression to a file, as opposed to separating the expression into a pattern and replacement.
-        This allows for more advanced `sed` usage.
-        Args:
-            expression (str): The sed expression to apply.
-            file (str): The path to the file to modify.
-            sudo (bool, optional): Whether to execute the command with sudo. Defaults to False.
-        Returns:
-            None
-        """
-        # Escape special characters in the expression.
-        expression = expression.replace('"', r"\"").replace("$", r"\$")
+    def delete_line_substring(
+        self, match_line: str, regex_to_delete: str, file: PurePath, sudo: bool = False
+    ) -> None:
+        expression = f"/{match_line}/s/{regex_to_delete}//g"
         cmd = f'-i.bak "{expression}" {file}'
         result = self.run(
             cmd,
@@ -101,7 +92,7 @@ class Sed(Tool):
             sudo=sudo,
             shell=True,
         )
-        result.assert_exit_code(message=result.stdout)
+
 
 class SedBSD(Sed):
     @property

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -90,12 +90,8 @@ class Sed(Tool):
         Returns:
             None
         """
-        self._log.debug(f"Applying raw sed expression '{expression}' to file '{file}' with sudo={sudo}")
-
         # Escape special characters in the expression.
         expression = expression.replace('"', r"\"").replace("$", r"\$")
-        self._log.debug(f"Escaped expression: '{expression}'")
-
         cmd = f'-i.bak "{expression}" {file}'
         result = self.run(
             cmd,

--- a/lisa/features/disks.py
+++ b/lisa/features/disks.py
@@ -42,6 +42,17 @@ class Disk(Feature):
         else:
             return None
 
+    def get_partition_with_mount_point_or_raise(
+        self, mount_point: str
+    ) -> PartitionInfo:
+        """
+        Get partition with mount point or raise an exception if not found.
+        """
+        partition = self.get_partition_with_mount_point(mount_point)
+        if partition is None:
+            raise LisaException(f"Partition with mount point {mount_point} not found.")
+        return partition
+
     def check_resource_disk_mounted(self) -> bool:
         return False
 

--- a/lisa/features/disks.py
+++ b/lisa/features/disks.py
@@ -42,17 +42,6 @@ class Disk(Feature):
         else:
             return None
 
-    def get_partition_with_mount_point_or_raise(
-        self, mount_point: str
-    ) -> PartitionInfo:
-        """
-        Get partition with mount point or raise an exception if not found.
-        """
-        partition = self.get_partition_with_mount_point(mount_point)
-        if partition is None:
-            raise LisaException(f"Partition with mount point {mount_point} not found.")
-        return partition
-
     def check_resource_disk_mounted(self) -> bool:
         return False
 

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -407,13 +407,26 @@ class Posix(OperatingSystem, BaseClassMixin):
         package_names = self._get_package_list(packages)
         self._uninstall_packages(package_names, signed, timeout, extra_args)
 
-    def package_exists(self, package: Union[str, Tool, Type[Tool]]) -> bool:
+    def package_exists(
+        self,
+        package: Union[str, Tool, Type[Tool]],
+        assert_existance: Union[bool, None] = None,
+    ) -> bool:
         """
         Query if a package/tool is installed on the node.
+        If assert_existance is not None, it will be used to check the package
+        installation status, asserting that it is the same as the expected value.
         Return Value - bool
         """
         package_name = self.__resolve_package_name(package)
-        return self._package_exists(package_name)
+        exists = self._package_exists(package_name)
+
+        if assert_existance is not None:
+            assert_that(exists).described_as(
+                f"Package {package} installation status is unexpected."
+            ).is_equal_to(assert_existance)
+
+        return exists
 
     def is_package_in_repo(self, package: Union[str, Tool, Type[Tool]]) -> bool:
         """

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -40,12 +40,13 @@ from .fallocate import Fallocate
 from .fdisk import Fdisk
 from .find import Find
 from .fio import FIOMODES, Fio, FIOResult, IoEngine
-from .fips import Fips, Grub
+from .fips import Fips
 from .firewall import Firewall, Iptables
 from .free import Free
 from .gcc import Gcc
 from .gdb import Gdb
 from .git import Git
+from .grub_config import GrubConfig
 from .hibernation_setup import HibernationSetup
 from .hostname import Hostname
 from .hugepages import Hugepages
@@ -168,7 +169,7 @@ __all__ = [
     "Gcc",
     "Gdb",
     "Git",
-    "Grub",
+    "GrubConfig",
     "Ip",
     "IpInfo",
     "Iperf3",

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -40,6 +40,7 @@ from .fallocate import Fallocate
 from .fdisk import Fdisk
 from .find import Find
 from .fio import FIOMODES, Fio, FIOResult, IoEngine
+from .fips import Fips, Grub
 from .firewall import Firewall, Iptables
 from .free import Free
 from .gcc import Gcc
@@ -161,11 +162,13 @@ __all__ = [
     "FIOMODES",
     "Fio",
     "FIOResult",
+    "Fips",
     "Firewall",
     "Free",
     "Gcc",
     "Gdb",
     "Git",
+    "Grub",
     "Ip",
     "IpInfo",
     "Iperf3",

--- a/lisa/tools/blkid.py
+++ b/lisa/tools/blkid.py
@@ -44,7 +44,7 @@ class Blkid(Tool):
     def command(self) -> str:
         return "blkid"
 
-    def get_partition_information(self) -> List[PartitionInfo]:
+    def get_partition_information(self, force_run: bool = False) -> List[PartitionInfo]:
         """
         Get partition information from blkid output.
         Sample output :
@@ -54,7 +54,7 @@ class Blkid(Tool):
         /dev/loop0: TYPE="squashfs"
         /dev/sda3: UUID="5d1cdcfe-a342-4ce6-aec1-d6985fb9ceba" BLOCK_SIZE="4096" TYPE="ext4" PARTLABEL="primary" PARTUUID="3cdca255-3270-4cfb-84d4-e80a71677c7c" # noqa: E501
         """
-        output = self.run(sudo=True).stdout
+        output = self.run(sudo=True, force_run=force_run).stdout
         partition_info: List[PartitionInfo] = []
         for line in output.splitlines():
             # get partition info
@@ -75,11 +75,13 @@ class Blkid(Tool):
 
         return partition_info
 
-    def get_partition_info_by_name(self, partition_name: str) -> PartitionInfo:
+    def get_partition_info_by_name(
+        self, partition_name: str, force_run: bool = False
+    ) -> PartitionInfo:
         """
         Get partition information for partition name.
         """
-        partition_info = self.get_partition_information()
+        partition_info = self.get_partition_information(force_run=force_run)
         for partition in partition_info:
             if partition.name == partition_name:
                 return partition

--- a/lisa/tools/curl.py
+++ b/lisa/tools/curl.py
@@ -42,6 +42,7 @@ class Curl(Tool):
         sudo: bool = False,
         shell: bool = False,
         cwd: Optional[PurePath] = None,
+        expected_exit_code: Optional[int] = 0,
     ) -> ExecutableResult:
         err_msg = "curl fetch failed"
         cmd_arg = f" {arg} {url}"
@@ -49,7 +50,7 @@ class Curl(Tool):
             cmd_arg = f"{cmd_arg} | sh {execute_arg}"
         result = self.run(
             cmd_arg,
-            expected_exit_code=0,
+            expected_exit_code=expected_exit_code,
             expected_exit_code_failure_message=err_msg,
             sudo=sudo,
             cwd=cwd,

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -88,9 +88,6 @@ class Fips(Tool):
             boot_disk_part_uuid, boot_and_root_same
         )
 
-        # Update the grub configuration.
-        self.node.tools[GrubConfig].apply()
-
     def disable_fips(self) -> None:
         # dracut-fips provides FIPS support in the bootloader.
         self.node.os.uninstall_packages("dracut-fips")
@@ -103,9 +100,6 @@ class Fips(Tool):
         # Set the boot flag to the kernel command line.
         (boot_and_root_same, _) = self._get_boot_uuid()
         self.node.tools[GrubConfig].unset_boot_uuid(boot_and_root_same)
-
-        # Update the grub configuration.
-        self.node.tools[GrubConfig].apply()
 
     def _assert_kernel_fips_mode(self, expected: bool) -> None:
         """

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -2,177 +2,17 @@
 # Licensed under the MIT license.
 
 import re
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from assertpy import assert_that
 
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner
-from lisa.tools import Blkid, Cat, Sed
+from lisa.tools import Blkid, Cat
 from lisa.util import UnsupportedDistroException, get_matched_str
 
 if TYPE_CHECKING:
-    from lisa.operating_system import Posix
     from lisa.node import Node
-
-
-class Grub(Tool):
-    @classmethod
-    def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
-        """
-        Factory method to create an instance of the Grub tool.
-        """
-        if isinstance(node.os, CBLMariner):
-            if node.os.information.release == "2.0":
-                return GrubAzl2(node, args, kwargs)
-            if node.os.information.release == "3.0":
-                return GrubAzl3(node, args, kwargs)
-
-        raise UnsupportedDistroException(
-            os=node.os, message="Grub tool only supported on CBLMariner 2.0 and 3.0."
-        )
-
-    def __init__(
-        self, command: str, package: str, node: "Node", *args: Any, **kwargs: Any
-    ) -> None:
-        super().__init__(node, *args, **kwargs)
-        self._command = command
-        self._package = package
-
-    @property
-    def command(self) -> str:
-        return self._command
-
-    @property
-    def can_install(self) -> bool:
-        return True
-
-    def set_fips_mode(self, fips_mode: bool) -> None:
-        """
-        Set the FIPS mode to the specified value.
-        """
-        raise NotImplementedError("set_fips_mode is not implemented.")
-
-    def set_boot_uuid(self, uuid: str, same_as_root: bool) -> None:
-        """
-        Set the boot UUID to the specified value.
-        """
-        if same_as_root:
-            self.remove_kernel_cmdline_arg(r"boot")
-        else:
-            self.set_kernel_cmdline_arg(f"boot=UUID={uuid}")
-
-    def unset_boot_uuid(self, same_as_root: bool) -> None:
-        """
-        Unset the boot UUID.
-        """
-        raise NotImplementedError("unset_boot_uuid is not implemented.")
-
-    def remove_kernel_cmdline_arg(self, arg: str) -> None:
-        """
-        Remove the specified kernel command line argument from the grub configuration.
-        """
-        raise NotImplementedError("remove_kernel_cmdline_arg is not implemented.")
-
-    def set_kernel_cmdline_arg(self, arg: str) -> None:
-        """
-        Append the specified kernel command line argument to the grub configuration.
-        """
-        raise NotImplementedError("set_kernel_cmdline_arg is not implemented.")
-
-    def apply(self) -> None:
-        """
-        Reconfigure grub to apply the changes made to the kernel command line arguments.
-        """
-        raise NotImplementedError("apply is not implemented.")
-
-    def _install(self) -> bool:
-        posix_os: Posix = self.node.os  # type: ignore
-        posix_os.install_packages(self._package)
-        return self._check_exists()
-
-
-class GrubAzl2(Grub):
-    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
-        super().__init__("grubby", "grubby", node, *args, **kwargs)
-
-    def set_fips_mode(self, fips_mode: bool) -> None:
-        fips_flag = "fips=1" if fips_mode else "fips=0"
-        self.set_kernel_cmdline_arg(fips_flag)
-
-    def unset_boot_uuid(self, same_as_root: bool) -> None:
-        if same_as_root:
-            self.remove_kernel_cmdline_arg(r"boot")
-        else:
-            self.set_kernel_cmdline_arg("boot=")
-
-    def remove_kernel_cmdline_arg(self, arg: str) -> None:
-        self._run(f"--remove-args='{arg}'")
-
-    def set_kernel_cmdline_arg(self, arg: str) -> None:
-        self._run(f"--args='{arg}'")
-
-    def _run(self, added_arg: str) -> None:
-        """
-        Call grubby to update the kernel command line arguments.
-        """
-        self.run(
-            f"--update-kernel=ALL {added_arg}",
-            sudo=True,
-            force_run=True,
-            expected_exit_code=0,
-        )
-
-    def apply(self) -> None:
-        pass
-
-
-class GrubAzl3(Grub):
-    _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
-    _GRUB_DEFAULT_FILE = "/etc/default/grub"
-
-    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
-        super().__init__("grub2-mkconfig", "grub2-tools-minimal", node, *args, **kwargs)
-
-    def set_fips_mode(self, fips_mode: bool) -> None:
-        self.remove_kernel_cmdline_arg("fips")
-        if fips_mode:
-            self.set_kernel_cmdline_arg("fips=1")
-
-    def unset_boot_uuid(self, same_as_root: bool) -> None:
-        self.remove_kernel_cmdline_arg(r"boot")
-
-    def remove_kernel_cmdline_arg(self, arg: str) -> None:
-        self.node.tools[Sed].delete_line_substring(
-            match_line=self._GRUB_CMDLINE_LINE_REGEX,
-            regex_to_delete=(r"\s" + arg + r"[^\"\s]*"),
-            file=PurePosixPath(self._GRUB_DEFAULT_FILE),
-            sudo=True,
-        )
-
-    def set_kernel_cmdline_arg(self, arg: str) -> None:
-        """
-        Append the specified kernel command line argument to the grub configuration.
-        """
-        self.node.tools[Sed].substitute(
-            match_lines=self._GRUB_CMDLINE_LINE_REGEX,
-            regexp='"$',
-            replacement=f' {arg}"',
-            file=self._GRUB_DEFAULT_FILE,
-            sudo=True,
-        )
-
-    def apply(self) -> None:
-        """
-        Reconfigure grub to apply the changes made to the kernel command line arguments.
-        """
-        self.run(
-            "--output=/boot/grub2/grub.cfg",
-            sudo=True,
-            force_run=True,
-            expected_exit_code=0,
-        )
 
 
 class Fips(Tool):
@@ -236,30 +76,36 @@ class Fips(Tool):
         # dracut-fips provides FIPS support in the bootloader.
         self.node.os.install_packages("dracut-fips")
 
+        from lisa.tools import GrubConfig
+
         # Set the fips flag to the kernel command line.
-        self.node.tools[Grub].set_fips_mode(True)
+        self.node.tools[GrubConfig].set_fips_mode(True)
 
         # If the boot and root devices are different, add the boot uuid to the
         # kernel command line.
         (boot_and_root_same, boot_disk_part_uuid) = self._get_boot_uuid()
-        self.node.tools[Grub].set_boot_uuid(boot_disk_part_uuid, boot_and_root_same)
+        self.node.tools[GrubConfig].set_boot_uuid(
+            boot_disk_part_uuid, boot_and_root_same
+        )
 
         # Update the grub configuration.
-        self.node.tools[Grub].apply()
+        self.node.tools[GrubConfig].apply()
 
     def disable_fips(self) -> None:
         # dracut-fips provides FIPS support in the bootloader.
         self.node.os.uninstall_packages("dracut-fips")
 
+        from lisa.tools import GrubConfig
+
         # Set the fips flag to the kernel command line.
-        self.node.tools[Grub].set_fips_mode(False)
+        self.node.tools[GrubConfig].set_fips_mode(False)
 
         # Set the boot flag to the kernel command line.
         (boot_and_root_same, _) = self._get_boot_uuid()
-        self.node.tools[Grub].unset_boot_uuid(boot_and_root_same)
+        self.node.tools[GrubConfig].unset_boot_uuid(boot_and_root_same)
 
         # Update the grub configuration.
-        self.node.tools[Grub].apply()
+        self.node.tools[GrubConfig].apply()
 
     def _assert_kernel_fips_mode(self, expected: bool) -> None:
         """

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -10,7 +10,7 @@ from lisa.executable import Tool
 from lisa.operating_system import CBLMariner
 from lisa.tools import Blkid, Cat
 from .grub_config import GrubConfig
-from lisa.util import UnsupportedDistroException, get_matched_str, str_to_bool
+from lisa.util import UnsupportedDistroException, get_matched_str, to_bool
 
 if TYPE_CHECKING:
     from lisa.node import Node
@@ -95,7 +95,7 @@ class Fips(Tool):
             "/proc/sys/crypto/fips_enabled", force_run=True
         )
 
-        return str_to_bool(fips_enabled)
+        return to_bool(fips_enabled)
 
     def _enable_fips(self) -> None:
         # dracut-fips provides FIPS support in the bootloader.

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -139,10 +139,8 @@ class Fips(Tool):
         from lisa.features import Disk
 
         disk = self.node.features[Disk]
-        root_disk_partition = disk.get_partition_with_mount_point("/")
-        assert_that(root_disk_partition).is_not_none()
-        boot_disk_partition = disk.get_partition_with_mount_point("/boot")
-        assert_that(boot_disk_partition).is_not_none()
+        root_disk_partition = disk.get_partition_with_mount_point_or_raise("/")
+        boot_disk_partition = disk.get_partition_with_mount_point_or_raise("/boot")
 
         # If the boot and root devices are different, get the boot uuid it.
         if boot_disk_partition.name == root_disk_partition.name:

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -8,24 +8,13 @@ from typing import TYPE_CHECKING, Any
 from assertpy import assert_that
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, OperatingSystem
+from lisa.operating_system import CBLMariner
 from lisa.tools import Blkid, Cat, Sed
 from lisa.util import UnsupportedDistroException, get_matched_str
 
 if TYPE_CHECKING:
     from lisa.operating_system import Posix
     from lisa.node import Node
-
-
-def assert_package_existance(
-    os: OperatingSystem, package: str, should_exist: bool
-) -> None:
-    """
-    Assert that a package/tool is installed on the node.
-    """
-    assert_that(os.package_exists(package)).described_as(
-        f"Package {package} is installed."
-    ).is_equal_to(should_exist)
 
 
 class Grub(Tool):
@@ -238,7 +227,7 @@ class Fips(Tool):
         FIPS is enabled or disabled on the system.
         """
         # We rely on the dracut-fips package for bootloader FIPS support.
-        assert_package_existance(self.node.os, "dracut-fips", expect_fips_mode)
+        self.node.os.package_exists("dracut-fips", assert_existance=expect_fips_mode)
 
         # Kernel needs to be in the correct FIPS mode.
         self._assert_kernel_fips_mode(expect_fips_mode)
@@ -369,7 +358,7 @@ class AzlV3Fips(Fips):
         # when FIPS is disabled.
         if expect_fips_mode:
             for package in self._SYMCRYPT_PACKAGES:
-                assert_package_existance(self.node.os, package, True)
+                self.node.os.package_exists(package, assert_existance=True)
 
     def enable_fips(self) -> None:
         super().enable_fips()

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -9,8 +9,9 @@ from assertpy import assert_that
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner
 from lisa.tools import Blkid, Cat
-from .grub_config import GrubConfig
 from lisa.util import UnsupportedDistroException, get_matched_str, to_bool
+
+from .grub_config import GrubConfig
 
 if TYPE_CHECKING:
     from lisa.node import Node

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import re
-from abc import ABC, abstractmethod
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
@@ -29,7 +28,7 @@ def assert_package_existance(
     ).is_equal_to(should_exist)
 
 
-class Grub(Tool, ABC):
+class Grub(Tool):
     @classmethod
     def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
         """
@@ -60,11 +59,11 @@ class Grub(Tool, ABC):
     def can_install(self) -> bool:
         return True
 
-    @abstractmethod
     def set_fips_mode(self, fips_mode: bool) -> None:
         """
         Set the FIPS mode to the specified value.
         """
+        raise NotImplementedError("set_fips_mode is not implemented.")
 
     def set_boot_uuid(self, uuid: str, same_as_root: bool) -> None:
         """
@@ -75,29 +74,29 @@ class Grub(Tool, ABC):
         else:
             self.set_kernel_cmdline_arg(f"boot=UUID={uuid}")
 
-    @abstractmethod
     def unset_boot_uuid(self, same_as_root: bool) -> None:
         """
         Unset the boot UUID.
         """
+        raise NotImplementedError("unset_boot_uuid is not implemented.")
 
-    @abstractmethod
     def remove_kernel_cmdline_arg(self, arg: str) -> None:
         """
         Remove the specified kernel command line argument from the grub configuration.
         """
+        raise NotImplementedError("remove_kernel_cmdline_arg is not implemented.")
 
-    @abstractmethod
     def set_kernel_cmdline_arg(self, arg: str) -> None:
         """
         Append the specified kernel command line argument to the grub configuration.
         """
+        raise NotImplementedError("set_kernel_cmdline_arg is not implemented.")
 
-    @abstractmethod
     def apply(self) -> None:
         """
         Reconfigure grub to apply the changes made to the kernel command line arguments.
         """
+        raise NotImplementedError("apply is not implemented.")
 
     def _install(self) -> bool:
         posix_os: Posix = self.node.os  # type: ignore
@@ -187,7 +186,7 @@ class GrubAzl3(Grub):
         )
 
 
-class Fips(Tool, ABC):
+class Fips(Tool):
     """
     Base class for AZL FIPS tests. This class provides methods to check if
     FIPS is enabled or disabled, and to enable or disable FIPS.

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -139,8 +139,10 @@ class Fips(Tool):
         from lisa.features import Disk
 
         disk = self.node.features[Disk]
-        root_disk_partition = disk.get_partition_with_mount_point_or_raise("/")
-        boot_disk_partition = disk.get_partition_with_mount_point_or_raise("/boot")
+        root_disk_partition = disk.get_partition_with_mount_point("/")
+        assert root_disk_partition, "Root disk partition not found."
+        boot_disk_partition = disk.get_partition_with_mount_point("/boot")
+        assert boot_disk_partition, "Boot disk partition not found."
 
         # If the boot and root devices are different, get the boot uuid it.
         if boot_disk_partition.name == root_disk_partition.name:

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -9,6 +9,7 @@ from assertpy import assert_that
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner
 from lisa.tools import Blkid, Cat
+from .grub_config import GrubConfig
 from lisa.util import UnsupportedDistroException, get_matched_str
 
 if TYPE_CHECKING:
@@ -76,8 +77,6 @@ class Fips(Tool):
         # dracut-fips provides FIPS support in the bootloader.
         self.node.os.install_packages("dracut-fips")
 
-        from lisa.tools import GrubConfig
-
         # Set the fips flag to the kernel command line.
         self.node.tools[GrubConfig].set_fips_mode(True)
 
@@ -91,8 +90,6 @@ class Fips(Tool):
     def disable_fips(self) -> None:
         # dracut-fips provides FIPS support in the bootloader.
         self.node.os.uninstall_packages("dracut-fips")
-
-        from lisa.tools import GrubConfig
 
         # Set the fips flag to the kernel command line.
         self.node.tools[GrubConfig].set_fips_mode(False)

--- a/lisa/tools/fips.py
+++ b/lisa/tools/fips.py
@@ -1,0 +1,379 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+from abc import ABC, abstractmethod
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from assertpy import assert_that
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner, OperatingSystem
+from lisa.tools import Blkid, Cat, Sed
+from lisa.util import UnsupportedDistroException, get_matched_str
+
+if TYPE_CHECKING:
+    from lisa.operating_system import Posix
+    from lisa.node import Node
+
+
+def assert_package_existance(
+    os: OperatingSystem, package: str, should_exist: bool
+) -> None:
+    """
+    Assert that a package/tool is installed on the node.
+    """
+    assert_that(os.package_exists(package)).described_as(
+        f"Package {package} is installed."
+    ).is_equal_to(should_exist)
+
+
+class Grub(Tool, ABC):
+    @classmethod
+    def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
+        """
+        Factory method to create an instance of the Grub tool.
+        """
+        if isinstance(node.os, CBLMariner):
+            if node.os.information.release == "2.0":
+                return GrubAzl2(node, args, kwargs)
+            if node.os.information.release == "3.0":
+                return GrubAzl3(node, args, kwargs)
+
+        raise UnsupportedDistroException(
+            os=node.os, message="Grub tool only supported on CBLMariner 2.0 and 3.0."
+        )
+
+    def __init__(
+        self, command: str, package: str, node: "Node", *args: Any, **kwargs: Any
+    ) -> None:
+        super().__init__(node, *args, **kwargs)
+        self._command = command
+        self._package = package
+
+    @property
+    def command(self) -> str:
+        return self._command
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    @abstractmethod
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        """
+        Set the FIPS mode to the specified value.
+        """
+
+    def set_boot_uuid(self, uuid: str, same_as_root: bool) -> None:
+        """
+        Set the boot UUID to the specified value.
+        """
+        if same_as_root:
+            self.remove_kernel_cmdline_arg(r"boot")
+        else:
+            self.set_kernel_cmdline_arg(f"boot=UUID={uuid}")
+
+    @abstractmethod
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        """
+        Unset the boot UUID.
+        """
+
+    @abstractmethod
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Remove the specified kernel command line argument from the grub configuration.
+        """
+
+    @abstractmethod
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Append the specified kernel command line argument to the grub configuration.
+        """
+
+    @abstractmethod
+    def apply(self) -> None:
+        """
+        Reconfigure grub to apply the changes made to the kernel command line arguments.
+        """
+
+    def _install(self) -> bool:
+        posix_os: Posix = self.node.os  # type: ignore
+        posix_os.install_packages(self._package)
+        return self._check_exists()
+
+
+class GrubAzl2(Grub):
+    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
+        super().__init__("grubby", "grubby", node, *args, **kwargs)
+
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        fips_flag = "fips=1" if fips_mode else "fips=0"
+        self.set_kernel_cmdline_arg(fips_flag)
+
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        if same_as_root:
+            self.remove_kernel_cmdline_arg(r"boot")
+        else:
+            self.set_kernel_cmdline_arg("boot=")
+
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        self._run(f"--remove-args='{arg}'")
+
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        self._run(f"--args='{arg}'")
+
+    def _run(self, added_arg: str) -> None:
+        """
+        Call grubby to update the kernel command line arguments.
+        """
+        self.run(
+            f"--update-kernel=ALL {added_arg}",
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
+    def apply(self) -> None:
+        pass
+
+
+class GrubAzl3(Grub):
+    _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
+    _GRUB_DEFAULT_FILE = "/etc/default/grub"
+
+    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
+        super().__init__("grub2-mkconfig", "grub2-tools-minimal", node, *args, **kwargs)
+
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        self.remove_kernel_cmdline_arg("fips")
+        if fips_mode:
+            self.set_kernel_cmdline_arg("fips=1")
+
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        self.remove_kernel_cmdline_arg(r"boot")
+
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        self.node.tools[Sed].delete_line_substring(
+            match_line=self._GRUB_CMDLINE_LINE_REGEX,
+            regex_to_delete=(r"\s" + arg + r"[^\"\s]*"),
+            file=PurePosixPath(self._GRUB_DEFAULT_FILE),
+            sudo=True,
+        )
+
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Append the specified kernel command line argument to the grub configuration.
+        """
+        self.node.tools[Sed].substitute(
+            match_lines=self._GRUB_CMDLINE_LINE_REGEX,
+            regexp='"$',
+            replacement=f' {arg}"',
+            file=self._GRUB_DEFAULT_FILE,
+            sudo=True,
+        )
+
+    def apply(self) -> None:
+        """
+        Reconfigure grub to apply the changes made to the kernel command line arguments.
+        """
+        self.run(
+            "--output=/boot/grub2/grub.cfg",
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
+
+class Fips(Tool, ABC):
+    """
+    Base class for AZL FIPS tests. This class provides methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    The derived classes (AzlV2Fips and AzlV3Fips) implement the specific
+    behavior for AZL2 and AZL3.
+    """
+
+    @classmethod
+    def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
+        """
+        Factory method to create an instance of the Fips tool.
+        """
+        if isinstance(node.os, CBLMariner):
+            if node.os.information.release == "2.0":
+                return AzlV2Fips(node, args, kwargs)
+            if node.os.information.release == "3.0":
+                return AzlV3Fips(node, args, kwargs)
+
+        raise UnsupportedDistroException(
+            os=node.os, message="FIPS tool only supported on CBLMariner 2.0 and 3.0."
+        )
+
+    @property
+    def command(self) -> str:
+        """
+        Returns the command to run the FIPS tool.
+        In this case, there is no direct command to run so we return an empty string.
+        """
+        return ""
+
+    @property
+    def can_install(self) -> bool:
+        """
+        Check if the tool can be installed.
+        In this case, we return False as the FIPS tool is not installable.
+        """
+        return False
+
+    def install(self) -> bool:
+        """
+        Installation method for the FIPS tool.
+        This method does nothing as the tool is not installable.
+        """
+        return False
+
+    def assert_fips_mode(self, expect_fips_mode: bool) -> None:
+        """
+        When implemented by the derived class, this method should assert that
+        FIPS is enabled or disabled on the system.
+        """
+        # We rely on the dracut-fips package for bootloader FIPS support.
+        assert_package_existance(self.node.os, "dracut-fips", expect_fips_mode)
+
+        # Kernel needs to be in the correct FIPS mode.
+        self._assert_kernel_fips_mode(expect_fips_mode)
+
+    def enable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        self.node.os.install_packages("dracut-fips")
+
+        # Set the fips flag to the kernel command line.
+        self.node.tools[Grub].set_fips_mode(True)
+
+        # If the boot and root devices are different, add the boot uuid to the
+        # kernel command line.
+        (boot_and_root_same, boot_disk_part_uuid) = self._get_boot_uuid()
+        self.node.tools[Grub].set_boot_uuid(boot_disk_part_uuid, boot_and_root_same)
+
+        # Update the grub configuration.
+        self.node.tools[Grub].apply()
+
+    def disable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        self.node.os.uninstall_packages("dracut-fips")
+
+        # Set the fips flag to the kernel command line.
+        self.node.tools[Grub].set_fips_mode(False)
+
+        # Set the boot flag to the kernel command line.
+        (boot_and_root_same, _) = self._get_boot_uuid()
+        self.node.tools[Grub].unset_boot_uuid(boot_and_root_same)
+
+        # Update the grub configuration.
+        self.node.tools[Grub].apply()
+
+    def _assert_kernel_fips_mode(self, expected: bool) -> None:
+        """
+        Assert that the kernel FIPS mode is set to the expected value.
+        """
+        fips_enabled = self.node.tools[Cat].read(
+            "/proc/sys/crypto/fips_enabled", force_run=True
+        )
+
+        expected_kernel_mode_value = "1" if expected else "0"
+        assert_that(fips_enabled).described_as("kernel fips mode").is_equal_to(
+            expected_kernel_mode_value
+        )
+
+    def _get_boot_uuid(self) -> tuple[bool, str]:
+        """
+        Get the UUID of the boot disk partition.
+        This method checks if the boot and root devices are different.
+        If the boot and root devices are different, return (True, boot uuid).
+        If they are the same, return (False, empty string).
+        """
+        boot_and_root_same = False
+        boot_disk_part_uuid = ""
+
+        # Get the boot and root devices.
+        from lisa.features import Disk
+
+        disk = self.node.features[Disk]
+        root_disk_partition = disk.get_partition_with_mount_point("/")
+        boot_disk_partition = disk.get_partition_with_mount_point("/boot")
+
+        # If the boot and root devices are different, get the boot uuid it.
+        if boot_disk_partition.name == root_disk_partition.name:
+            boot_and_root_same = True
+            boot_disk_part_uuid = ""
+        else:
+            boot_and_root_same = False
+            boot_disk_part_uuid = (
+                self.node.tools[Blkid]
+                .get_partition_info_by_name(boot_disk_partition.name, force_run=True)
+                .uuid
+            )
+
+        self._log.debug(
+            f"_get_boot_uuid: boot_and_root_same={boot_and_root_same}, "
+            f"boot_disk_part_uuid='{boot_disk_part_uuid}'"
+        )
+        return (boot_and_root_same, boot_disk_part_uuid)
+
+
+class AzlV2Fips(Fips):
+    """
+    FIPS test class for AZL2. This class implements the methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    """
+
+    # In AZL2, the command openssl md5 should fail with error messages like:
+    #   Error setting digest
+    #   131590634539840:error:060800C8:digital envelope routines:EVP_DigestInit_ex:disabled for FIPS:crypto/evp/digest.c:135: # noqa: E501
+    _md5_expected_failure_pattern = re.compile(
+        "Error setting digest\r\n.*EVP_DigestInit_ex:disabled for FIPS.*", re.M
+    )
+
+    def assert_fips_mode(self, expect_fips_mode: bool) -> None:
+        super().assert_fips_mode(expect_fips_mode)
+
+        # In AZL2, non-FIPS certified algorithms like MD5 will fail
+        # when FIPS is enabled.
+        result = self.node.execute(
+            "echo 'test' | openssl md5",
+            shell=True,
+            expected_exit_code=int(expect_fips_mode),
+        )
+        if expect_fips_mode:
+            assert_that(
+                get_matched_str(result.stdout, self._md5_expected_failure_pattern)
+            ).is_not_empty()
+
+
+class AzlV3Fips(Fips):
+    """
+    FIPS test class for AZL3. This class implements the methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    """
+
+    _SYMCRYPT_PACKAGES = [
+        "SymCrypt",
+        "SymCrypt-OpenSSL",
+    ]
+
+    def assert_fips_mode(self, expect_fips_mode: bool) -> None:
+        super().assert_fips_mode(expect_fips_mode)
+
+        # In AZL3, FIPS-compliant openssl is provided by the SymCrypt provider.
+        # They're also installed by default, so we don't want to check for them
+        # when FIPS is disabled.
+        if expect_fips_mode:
+            for package in self._SYMCRYPT_PACKAGES:
+                assert_package_existance(self.node.os, package, True)
+
+    def enable_fips(self) -> None:
+        super().enable_fips()
+
+        # AZL3 requres the SymCrypt provider for FIPS-compliant openssl.
+        self.node.os.install_packages(self._SYMCRYPT_PACKAGES)

--- a/lisa/tools/grub_config.py
+++ b/lisa/tools/grub_config.py
@@ -90,7 +90,7 @@ class GrubConfigAzl3(GrubConfig):
         # For simplicity, first remove the existing argument.
         self.node.tools[Sed].delete_line_substring(
             match_line=self._GRUB_CMDLINE_LINE_REGEX,
-            regex_to_delete=(r"\s" + arg + r"[^\"\s]*"),
+            regex_to_delete=(r"\s" + arg + r"[^\"[:space:]]*"),
             file=PurePosixPath(self._GRUB_DEFAULT_FILE),
             sudo=True,
         )

--- a/lisa/tools/grub_config.py
+++ b/lisa/tools/grub_config.py
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner
+from lisa.tools import Sed
+from lisa.util import UnsupportedDistroException
+
+if TYPE_CHECKING:
+    from lisa.node import Node
+    from lisa.operating_system import Posix
+
+
+class GrubConfig(Tool):
+    @classmethod
+    def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
+        """
+        Factory method to create an instance of the Grub tool.
+        """
+        if isinstance(node.os, CBLMariner):
+            if node.os.information.release == "2.0":
+                return GrubConfigAzl2(node, args, kwargs)
+            if node.os.information.release == "3.0":
+                return GrubConfigAzl3(node, args, kwargs)
+
+        raise UnsupportedDistroException(
+            os=node.os, message="Grub tool only supported on CBLMariner 2.0 and 3.0."
+        )
+
+    def __init__(
+        self, command: str, package: str, node: "Node", *args: Any, **kwargs: Any
+    ) -> None:
+        super().__init__(node, *args, **kwargs)
+        self._command = command
+        self._package = package
+
+    @property
+    def command(self) -> str:
+        return self._command
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        """
+        Set the FIPS mode to the specified value.
+        """
+        raise NotImplementedError("set_fips_mode is not implemented.")
+
+    def set_boot_uuid(self, uuid: str, same_as_root: bool) -> None:
+        """
+        Set the boot UUID to the specified value.
+        """
+        if same_as_root:
+            self.remove_kernel_cmdline_arg(r"boot")
+        else:
+            self.set_kernel_cmdline_arg(f"boot=UUID={uuid}")
+
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        """
+        Unset the boot UUID.
+        """
+        raise NotImplementedError("unset_boot_uuid is not implemented.")
+
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Remove the specified kernel command line argument from the grub configuration.
+        """
+        raise NotImplementedError("remove_kernel_cmdline_arg is not implemented.")
+
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Append the specified kernel command line argument to the grub configuration.
+        """
+        raise NotImplementedError("set_kernel_cmdline_arg is not implemented.")
+
+    def apply(self) -> None:
+        """
+        Reconfigure grub to apply the changes made to the kernel command line arguments.
+        """
+        raise NotImplementedError("apply is not implemented.")
+
+    def _install(self) -> bool:
+        posix_os: Posix = self.node.os  # type: ignore
+        posix_os.install_packages(self._package)
+        return self._check_exists()
+
+
+class GrubConfigAzl2(GrubConfig):
+    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
+        super().__init__("grubby", "grubby", node, *args, **kwargs)
+
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        fips_flag = "fips=1" if fips_mode else "fips=0"
+        self.set_kernel_cmdline_arg(fips_flag)
+
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        if same_as_root:
+            self.remove_kernel_cmdline_arg(r"boot")
+        else:
+            self.set_kernel_cmdline_arg("boot=")
+
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        self._run(f"--remove-args='{arg}'")
+
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        self._run(f"--args='{arg}'")
+
+    def _run(self, added_arg: str) -> None:
+        """
+        Call grubby to update the kernel command line arguments.
+        """
+        self.run(
+            f"--update-kernel=ALL {added_arg}",
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
+    def apply(self) -> None:
+        pass
+
+
+class GrubConfigAzl3(GrubConfig):
+    _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
+    _GRUB_DEFAULT_FILE = "/etc/default/grub"
+
+    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
+        super().__init__("grub2-mkconfig", "grub2-tools-minimal", node, *args, **kwargs)
+
+    def set_fips_mode(self, fips_mode: bool) -> None:
+        self.remove_kernel_cmdline_arg("fips")
+        if fips_mode:
+            self.set_kernel_cmdline_arg("fips=1")
+
+    def unset_boot_uuid(self, same_as_root: bool) -> None:
+        self.remove_kernel_cmdline_arg(r"boot")
+
+    def remove_kernel_cmdline_arg(self, arg: str) -> None:
+        self.node.tools[Sed].delete_line_substring(
+            match_line=self._GRUB_CMDLINE_LINE_REGEX,
+            regex_to_delete=(r"\s" + arg + r"[^\"\s]*"),
+            file=PurePosixPath(self._GRUB_DEFAULT_FILE),
+            sudo=True,
+        )
+
+    def set_kernel_cmdline_arg(self, arg: str) -> None:
+        """
+        Append the specified kernel command line argument to the grub configuration.
+        """
+        self.node.tools[Sed].substitute(
+            match_lines=self._GRUB_CMDLINE_LINE_REGEX,
+            regexp='"$',
+            replacement=f' {arg}"',
+            file=self._GRUB_DEFAULT_FILE,
+            sudo=True,
+        )
+
+    def apply(self) -> None:
+        """
+        Reconfigure grub to apply the changes made to the kernel command line arguments.
+        """
+        self.run(
+            "--output=/boot/grub2/grub.cfg",
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )

--- a/lisa/tools/grub_config.py
+++ b/lisa/tools/grub_config.py
@@ -78,12 +78,6 @@ class GrubConfig(Tool):
         """
         raise NotImplementedError("set_kernel_cmdline_arg is not implemented.")
 
-    def apply(self) -> None:
-        """
-        Reconfigure grub to apply the changes made to the kernel command line arguments.
-        """
-        raise NotImplementedError("apply is not implemented.")
-
     def _install(self) -> bool:
         posix_os: Posix = self.node.os  # type: ignore
         posix_os.install_packages(self._package)
@@ -121,9 +115,6 @@ class GrubConfigAzl2(GrubConfig):
             expected_exit_code=0,
         )
 
-    def apply(self) -> None:
-        pass
-
 
 class GrubConfigAzl3(GrubConfig):
     _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
@@ -147,6 +138,7 @@ class GrubConfigAzl3(GrubConfig):
             file=PurePosixPath(self._GRUB_DEFAULT_FILE),
             sudo=True,
         )
+        self._apply()
 
     def set_kernel_cmdline_arg(self, arg: str) -> None:
         """
@@ -159,8 +151,9 @@ class GrubConfigAzl3(GrubConfig):
             file=self._GRUB_DEFAULT_FILE,
             sudo=True,
         )
+        self._apply()
 
-    def apply(self) -> None:
+    def _apply(self) -> None:
         """
         Reconfigure grub to apply the changes made to the kernel command line arguments.
         """

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -910,7 +910,7 @@ def check_panic(content: str, stage: str, log: "Logger") -> None:
         raise KernelPanicException(stage, panics)
 
 
-def str_to_bool(value: str) -> Union[bool, None]:
+def str_to_bool(value: Union[str, bool, int]) -> bool:
     """
     Convert a string to a boolean value.
     returns True for "true", False for "false", and None for any other value.
@@ -919,8 +919,18 @@ def str_to_bool(value: str) -> Union[bool, None]:
     str_to_bool_map = {
         "true": True,
         "false": False,
+        "yes": True,
+        "no": False,
+        "1": True,
+        "0": False,
     }
 
+    # Handle boolean values directly
+    if isinstance(value, bool):
+        return value
+
+    # If the value is a string, convert it to lowercase and strip whitespace
+    # and look it up in the dictionary.
     value = value.lower().strip()
     bool_value = str_to_bool_map.get(value)
     if bool_value is None:

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -908,3 +908,21 @@ def check_panic(content: str, stage: str, log: "Logger") -> None:
 
     if panics:
         raise KernelPanicException(stage, panics)
+
+
+def str_to_bool(value: str) -> Union[bool, None]:
+    """
+    Convert a string to a boolean value.
+    returns True for "true", False for "false", and None for any other value.
+    Allows for casing and leading/trailing whitespace.
+    """
+    str_to_bool_map = {
+        "true": True,
+        "false": False,
+    }
+
+    value = value.lower().strip()
+    bool_value = str_to_bool_map.get(value)
+    if bool_value is None:
+        raise ValueError(f"Invalid boolean string: {value}")
+    return bool_value

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -910,10 +910,11 @@ def check_panic(content: str, stage: str, log: "Logger") -> None:
         raise KernelPanicException(stage, panics)
 
 
-def str_to_bool(value: Union[str, bool, int]) -> bool:
+def to_bool(value: Union[str, bool, int]) -> bool:
     """
     Convert a string to a boolean value.
-    returns True for "true", False for "false", and None for any other value.
+    Returns sensible "True/False" values for strings, bools and ints, failing
+    otherwise.
     Allows for casing and leading/trailing whitespace.
     """
     str_to_bool_map = {
@@ -929,10 +930,20 @@ def str_to_bool(value: Union[str, bool, int]) -> bool:
     if isinstance(value, bool):
         return value
 
+    # Handle integer values directly
+    if isinstance(value, int):
+        return bool(value)
+
     # If the value is a string, convert it to lowercase and strip whitespace
     # and look it up in the dictionary.
-    value = value.lower().strip()
-    bool_value = str_to_bool_map.get(value)
-    if bool_value is None:
-        raise ValueError(f"Invalid boolean string: {value}")
-    return bool_value
+    if isinstance(value, str):
+        value = value.lower().strip()
+        bool_value = str_to_bool_map.get(value)
+        if bool_value is None:
+            raise ValueError(f"Invalid boolean string: {value}")
+        return bool_value
+
+    # If the value is not a string, boolean, or integer, raise an error.
+    raise TypeError(
+        f"Unsupported type for conversion to boolean: {type(value).__name__}"
+    )

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -149,8 +149,8 @@ class FipsTests(TestSuite):
                 "get_expected_fips_mode: successfully fetched metadata; "
                 "checking image SKU."
             )
-            response = json.loads(response.stdout)
-            return "fips" in response["compute"]["sku"]
+            json_response = json.loads(response.stdout)
+            return "fips" in json_response["compute"]["sku"]
 
         # If we couldn't determine the FIPS mode, return False as a default.
         log.debug(

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from assertpy import assert_that
 
@@ -30,190 +30,129 @@ from lisa.util import SkippedException, str_to_bool
 class FipsTests(TestSuite):
     @TestCaseMetadata(
         description="""
-            Ensures that an AZL machine is fips enabled.
-        """,
-        priority=1,
-        requirement=simple_requirement(
-            supported_os=[CBLMariner],
-        ),
-    )
-    def verify_azl_fips_is_enabled(
-        self, log: Logger, node: Node, variables: Dict[str, Any]
-    ) -> None:
-        # Skip the test if the image is not FIPS enabled.
-        self._ensure_fips_expectations(log, node, variables, should_be_fips=True)
-
-        # Ensure the system is FIPS enabled.
-        node.tools[Fips].assert_fips_mode(True)
-
-        log.info("FIPS is enabled and working correctly.")
-
-    @TestCaseMetadata(
-        description="""
-            Ensures that an AZL machine is not FIPS enabled.
+            Ensures that an AZL machine is in the correct FIPS mode.
         """,
         priority=3,
         requirement=simple_requirement(
             supported_os=[CBLMariner],
         ),
     )
-    def verify_azl_fips_is_disabled(
+    def verify_azl_fips_status(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
-        # Skip the test if the image is FIPS enabled.
-        self._ensure_fips_expectations(log, node, variables, should_be_fips=False)
+        # Get the expected FIPS mode based on the variables and the node's metadata.
+        expected_fips_mode = self._get_expected_fips_mode(log, node, variables)
+        if expected_fips_mode is None:
+            raise SkippedException(
+                "Could not determine the expected FIPS mode from variables or metadata."
+            )
 
         # Ensure the system is not FIPS enabled.
-        node.tools[Fips].assert_fips_mode(False)
+        log.info(f"Expected FIPS mode is '{expected_fips_mode}', checking.")
+        node.tools[Fips].assert_fips_mode(expected_fips_mode)
 
-        log.info("FIPS is disabled and properly.")
-
-    @TestCaseMetadata(
-        description="""
-            This test case will
-            1. Enable FIPS on the AZL machine
-            2. Restart the machine
-            3. Verify that FIPS was enabled properly
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            supported_os=[CBLMariner],
-        ),
-    )
-    def verify_azl_fips_enable(
-        self, log: Logger, node: Node, variables: Dict[str, Any]
-    ) -> None:
-        # Skip the test if the image is already FIPS enabled.
-        self._ensure_fips_expectations(log, node, variables, should_be_fips=False)
-
-        # Enable FIPS on the system and make sure it is worked.
-        azl_fips = node.tools[Fips]
-        azl_fips.enable_fips()
-        node.reboot()
-        azl_fips.assert_fips_mode(True)
-
-        log.info("Successfully enabled FIPS.")
-
-        # Re-disable FIPS to make sure the test can be run multiple times.
-        azl_fips.disable_fips()
-        node.reboot()
-
-    @TestCaseMetadata(
-        description="""
-            This test case will
-            1. Disable FIPS on the AZL machine
-            2. Restart the machine
-            3. Verify that FIPS is disabled
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            supported_os=[CBLMariner],
-        ),
-    )
-    def verify_azl_fips_disable(
-        self, log: Logger, node: Node, variables: Dict[str, Any]
-    ) -> None:
-        # Skip the test if the image is already not FIPS enabled.
-        self._ensure_fips_expectations(log, node, variables, should_be_fips=True)
-
-        # Disable FIPS on the system and make sure it is worked.
-        azl_fips = node.tools[Fips]
-        azl_fips.disable_fips()
-        node.reboot()
-        azl_fips.assert_fips_mode(False)
-
-        log.info("Successfully disabled FIPS.")
-
-        # Re-enable FIPS to make sure the test can be run multiple times.
-        azl_fips.enable_fips()
-        node.reboot()
+        log.info("FIPS mode is configured and properly.")
 
     @TestCaseMetadata(
         description="""
         This test case will
-        1. Check whether FIPS can be enabled on the VM
-        2. Enable FIPS
-        3. Restart the VM for the changes to take effect
-        4. Verify that FIPS was enabled properly
+        1. Check whether FIPS is currently enabled on the VM.
+        2. Switch FIPS mode (enabled-to-disabled or disabled-to-enabled).
+        3. Restart the VM for the changes to take effect.
+        4. Verify that FIPS was switched properly.
+        5. Revert the FIPS mode to its original state.
+        6. Restart the VM for the changes to take effect.
+        7. Verify that FIPS was reverted properly.
+
+        Note that for some platforms, we will only enable fips if it is disabled,
+        and then only if we have the proper tool to do so.
         """,
-        priority=3,
-        requirement=simple_requirement(
-            unsupported_os=[CBLMariner],
-        ),
+        priority=2,
     )
-    def verify_fips_enable(self, log: Logger, node: Node) -> None:
-        result = node.execute("command -v fips-mode-setup", shell=True)
-        if result.exit_code != 0:
-            raise SkippedException(
-                "Command not found: fips-mode-setup. "
-                f"Please ensure {node.os.name} supports fips mode."
-            )
+    def verify_fips_enablement(self, log: Logger, node: Node) -> None:
+        if isinstance(node.os, CBLMariner):
+            fips = node.tools[Fips]
+            starting_fips_mode = fips.is_kernel_fips_mode()
 
-        node.execute("fips-mode-setup --enable", sudo=True)
+            # Swap the FIPS mode.
+            log.info(f"Starting FIPS mode is '{starting_fips_mode}', switching.")
+            fips.set_fips_mode(not starting_fips_mode)
+            node.reboot()
+            fips.assert_fips_mode(not starting_fips_mode)
 
-        log.info("FIPS mode set to enable. Attempting reboot.")
-        node.reboot()
+            # Revert the FIPS mode to its original state.
+            log.info(f"Reverting FIPS mode to '{starting_fips_mode}'.")
+            fips.set_fips_mode(starting_fips_mode)
+            node.reboot()
+            fips.assert_fips_mode(starting_fips_mode)
+        else:
+            result = node.execute("command -v fips-mode-setup", shell=True)
+            if result.exit_code != 0:
+                raise SkippedException(
+                    "Command not found: fips-mode-setup. "
+                    f"Please ensure {node.os.name} supports fips mode."
+                )
 
-        result = node.execute("fips-mode-setup --check")
+            node.execute("fips-mode-setup --enable", sudo=True)
 
-        assert_that(result.stdout).described_as(
-            "FIPS was not properly enabled."
-        ).contains("is enabled")
+            log.info("FIPS mode set to enable. Attempting reboot.")
+            node.reboot()
 
-    def _ensure_fips_expectations(
-        self, log: Logger, node: Node, variables: Dict[str, Any], should_be_fips: bool
-    ):
+            result = node.execute("fips-mode-setup --check")
+
+            assert_that(result.stdout).described_as(
+                "FIPS was not properly enabled."
+            ).contains("is enabled")
+
+    def _get_expected_fips_mode(
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> Union[None, bool]:
         """
-        Ensures that the expectations about the node's FIPS status are correct
-        for the test.
-        The argument `should_be_fips` indicates whether the test should be run on a
-        FIPS vs. non-FIPS image.
-        To determine whether the image is FIPS or not, the function first checks
-        the `testing_fips_image` variable in the `variables` dictionary.
-        If it can't determine the image type from the variable, it falls back to checking
-        the image SKU from the azure metadata endpoint.
-        If this does not match the expectation, a SkippedException is raised.
+        Get the expected FIPS mode based on the variables and the node's metadata.
 
         Args:
             log (Logger): The logger instance for logging messages.
             node (Node): The node object representing the target machine.
-            should_be_fips (bool): A flag indicating whether the test should be
-                                run on a FIPS vs. non-FIPS image.
             variables (Dict[str, Any]): A dictionary of variables containing the
-                                    'testing_fips_image' key.
-        Raises:
-            SkippedException: If the FIPS image expectation does not match the actual image SKU.
+                                        'testing_fips_image' key.
+
+        Returns:
+            bool: The expected FIPS mode (True for enabled,
+                  False for disabled or None if we can't determine.).
         """
-        log.debug(f"ensure_fips_expectations: should_be_fips is '{should_be_fips}'")
-        log.debug(f"ensure_fips_expectations: variables is '{variables}'")
+        log.debug(f"get_expected_fips_mode: variables is '{variables}'")
 
-        # First, try to deduce the FIPS image type from the variables dictionary.
+        # First, see if the test runner specified the FIPS image type in the variables.
         testing_fips_image = variables.get("testing_fips_image", None)
-        is_fips_image = str_to_bool(testing_fips_image) if testing_fips_image else None
-
-        # If the variable is not set or not in the expected format, fall back to
-        # checking the image SKU from the azure metadata endpoint.
-        if is_fips_image is None:
+        if testing_fips_image is not None:
             log.debug(
-                f"ensure_fips_expectations: testing_fips_image '{testing_fips_image}' "
-                "is not a bool; falling back to marketplace image sku"
+                f"get_expected_fips_mode: testing_fips_image '{testing_fips_image}' "
+                "is set in the variables; using it to determine the expected FIPS mode."
             )
-            response = node.tools[Curl].fetch(
-                arg="--max-time 2 --header Metadata:true --silent",
-                execute_arg="",
-                expected_exit_code=None,
-                url=METADATA_ENDPOINT,
-            )
+            return str_to_bool(testing_fips_image)
 
-            # If we successfully fetched the metadata, check the image SKU.
-            if response.exit_code == 0:
-                response = json.loads(response.stdout)
-                is_fips_image = "fips" in response["compute"]["sku"]
+        # Fall back to checking the image SKU from the azure metadata endpoint.
+        log.debug(
+            "get_expected_fips_mode: testing_fips_image is not set; falling back to "
+            "marketplace image sku."
+        )
+        response = node.tools[Curl].fetch(
+            arg="--max-time 2 --header Metadata:true --silent",
+            execute_arg="",
+            expected_exit_code=None,
+            url=METADATA_ENDPOINT,
+        )
 
-        # If the image type does not match the expectation, raise a SkippedException.
-        # This includes the case where we could not determine the image type.
-        if is_fips_image != should_be_fips:
-            raise SkippedException(
-                f"FIPS image expectation does not match actual image SKU. "
-                f"Expected: {should_be_fips}, Actual: {is_fips_image}"
+        # If we successfully fetched the metadata, check the image SKU.
+        if response.exit_code == 0:
+            log.debug(
+                "get_expected_fips_mode: successfully fetched metadata; checking image SKU."
             )
+            response = json.loads(response.stdout)
+            return "fips" in response["compute"]["sku"]
+
+        # If we couldn't determine the FIPS mode, return False as a default.
+        log.debug(
+            "get_expected_fips_mode: could not determine the FIPS mode; returning None."
+        )
+        return None

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 
 import json
-import re
-from abc import ABC, abstractmethod
 from typing import Any, Dict
 
 from assertpy import assert_that
@@ -16,342 +14,10 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.features import Disk
-from lisa.operating_system import CBLMariner, OperatingSystem
+from lisa.operating_system import CBLMariner
 from lisa.sut_orchestrator.azure.common import METADATA_ENDPOINT
-from lisa.tools import Blkid, Cat, Curl, Sed
-from lisa.util import SkippedException, get_matched_str
-
-
-def assert_package_exists(os: OperatingSystem, package: str) -> None:
-    """
-    Assert that a package/tool is installed on the node.
-    """
-    assert_that(os.package_exists(package)).described_as(
-        f"Package {package} is not installed."
-    ).is_true()
-
-
-def assert_package_not_exists(os: OperatingSystem, package: str) -> None:
-    """
-    Assert that a package/tool is not installed on the node.
-    """
-    assert_that(os.package_exists(package)).described_as(
-        f"Package {package} is installed."
-    ).is_false()
-
-
-class AzlFips(ABC):
-    '''
-    Base class for AZL FIPS tests. This class provides methods to check if
-    FIPS is enabled or disabled, and to enable or disable FIPS.
-    The derived classes (AzlV2Fips and AzlV3Fips) implement the specific
-    behavior for AZL2 and AZL3.
-    '''
-    @staticmethod
-    def create_instance(log: Logger, node: Node) -> "AzlFips":
-        '''
-        Factory method to create an instance of AzlFips based
-        on the OS release.
-        '''
-        release_to_class = {
-            "2.0": AzlV2Fips,
-            "3.0": AzlV3Fips,
-        }
-
-        assert_that(node.os.information.release).described_as(
-            "Test only works on currently supported Azure Linux releases."
-        ).is_in(*release_to_class.keys())
-
-        klass = release_to_class[node.os.information.release]
-        log.debug(
-            f"Creating '{klass.__name__}' instance for release "
-            f"{node.os.information.release}.")
-        return klass(log, node)
-
-    def __init__(self, log: Logger, node: Node):
-        self.log = log
-        self.node = node
-
-    @abstractmethod
-    def assert_fips_enabled(self) -> None:
-        '''
-        When implemented by the derived class, this method should assert that
-        FIPS is enabled on the system.
-        '''
-
-    @abstractmethod
-    def assert_fips_disabled(self) -> None:
-        '''
-        When implemented by the derived class, this method should assert that
-        FIPS is disabled on the system.
-        '''
-
-    @abstractmethod
-    def enable_fips(self) -> None:
-        '''
-        When implemented by the derived class, this method should enable FIPS
-        on the system.
-        '''
-
-    @abstractmethod
-    def disable_fips(self) -> None:
-        '''
-        When implemented by the derived class, this method should disable FIPS
-        on the system.
-        '''
-        pass
-
-    def _assert_kernel_fips_mode(self, expected: str) -> None:
-        '''
-        Assert that the kernel FIPS mode is set to the expected value.
-        '''
-        fips_enabled = self.node.tools[Cat].read(
-            "/proc/sys/crypto/fips_enabled",
-            force_run=True)
-
-        assert_that(
-            fips_enabled
-        ).described_as(
-            "kernel fips mode"
-        ).is_equal_to(expected)
-
-    def _azl_get_boot_uuid(self) -> str:
-        '''
-        Get the UUID of the boot disk partition.
-        '''
-        boot_disk_part_uuid = ""
-
-        # Get the boot and root devices.
-        disk = self.node.features[Disk]
-        root_disk_partition = disk.get_partition_with_mount_point("/")
-        boot_disk_partition = disk.get_partition_with_mount_point("/boot")
-
-        # If the boot and root devices are different, add the boot block id to
-        # the kernel command line.
-        if boot_disk_partition.name == root_disk_partition.name:
-            self.log.info("Boot and root partitions are the same; returning empty string.")
-        else:
-            boot_disk_part_uuid = self.node.tools[Blkid].get_partition_info_by_name(boot_disk_partition.name).uuid
-            self.log.info(
-                "Boot and root partitions are different; "
-                f"boot disk UUID is '{boot_disk_part_uuid}'.")
-
-        return boot_disk_part_uuid
-
-
-class AzlV2Fips(AzlFips):
-    '''
-    FIPS test class for AZL2. This class implements the methods to check if
-    FIPS is enabled or disabled, and to enable or disable FIPS.
-    '''
-    # In AZL2, the command openssl md5 should fail with error messages like:
-    #   Error setting digest
-    #   131590634539840:error:060800C8:digital envelope routines:EVP_DigestInit_ex:disabled for FIPS:crypto/evp/digest.c:135: # noqa: E501
-    _md5_expected_failure_pattern = re.compile(
-        "Error setting digest\r\n.*EVP_DigestInit_ex:disabled for FIPS.*", re.M
-    )
-
-    def assert_fips_enabled(self) -> None:
-        # We rely on the dracut-fips package for bootloader FIPS support.
-        assert_package_exists(self.node.os, "dracut-fips")
-
-        # Check if fips is enabled in the kernel
-        self._assert_kernel_fips_mode("1")
-
-        # In AZL2, non-FIPS certified algorithms like MD5 will fail
-        # when FIPS is enabled.
-        result = self.node.execute("echo 'test' | openssl md5", shell=True)
-        result.assert_exit_code(1, "openssl md5 should fail on AZL2 in FIPS mode")
-        assert_that(get_matched_str(
-            result.stdout,
-            self._md5_expected_failure_pattern)
-        ).is_not_empty()
-
-    def assert_fips_disabled(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        assert_package_not_exists(self.node.os, "dracut-fips")
-
-        # FIPS should be disabled in the kernel.
-        self._assert_kernel_fips_mode("0")
-
-        # In AZL2, non-FIPS certified algorithms like MD5 will fail when FIPS is enabled
-        # so we make sure that it works when FIPS is disabled.
-        result = self.node.execute("echo 'test' | openssl md5", shell=True)
-        result.assert_exit_code(0, "openssl md5 should work on AZL2 when FIPS is disabled")
-
-    def enable_fips(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        self.node.os.install_packages("dracut-fips")
-
-        # In AZL2, grubby is used to modify kernel parameters.
-        self.node.os.install_packages("grubby")
-
-        # In AZL2, we use grubby to modify the kernel command line.
-        # We need to add `fips=1` and `boot=UUID=<boot_disk_part_uuid>`
-        # to the kernel command line.
-        boot_disk_part_uuid = self._azl_get_boot_uuid()
-        result = self.node.execute(
-            "grub2-editenv - list | grep 'kernelopts'",
-            sudo=True,
-            shell=True)
-        if result.exit_code == 0:
-            self.log.info("Found kernelopts in grub2-editenv; editing with grub2-editenv")
-            self.node.execute(
-                f'sudo grub2-editenv - set "{result.stdout} fips=1 boot=UUID={boot_disk_part_uuid}"',
-                sudo=True)
-        else:
-            self.log.info("Did not find kernelopts in grub2-editenv; adding with grubby")
-            self.node.execute(
-                f'sudo grubby --update-kernel=ALL --args="fips=1 boot=UUID={boot_disk_part_uuid}"',
-                sudo=True)
-
-    def disable_fips(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        self.node.os.uninstall_packages("dracut-fips")
-
-        # In AZL2, grubby is used to modify kernel parameters.
-        self.node.os.install_packages("grubby")
-
-        # If FIPS is set in the kernel command line, we need to change it.
-        self.node.tools[Sed].raw(
-            r's/ fips=1//g',
-            "/boot/grub2/grub.cfg",
-            sudo=True
-        )
-
-        # Remove the boot UUID from the kernel command line.
-        self.node.tools[Sed].raw(
-            r's/ boot=UUID=[^ ]*//g',
-            "/boot/grub2/grub.cfg",
-            sudo=True
-        )
-
-class AzlV3Fips(AzlFips):
-    '''
-    FIPS test class for AZL3. This class implements the methods to check if
-    FIPS is enabled or disabled, and to enable or disable FIPS.
-    '''
-    def assert_fips_enabled(self) -> None:
-        # We rely on the dracut-fips package for bootloader FIPS support.
-        assert_package_exists(self.node.os, "dracut-fips")
-
-        # Check if fips is enabled in the kernel
-        self._assert_kernel_fips_mode("1")
-
-        # In AZL3, FIPS-compliant openssl is provided by the SymCrypt provider.
-        assert_package_exists(self.node.os, "SymCrypt")
-        assert_package_exists(self.node.os, "SymCrypt-OpenSSL")
-
-    def assert_fips_disabled(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        assert_package_not_exists(self.node.os, "dracut-fips")
-
-        # FIPS should be disabled in the kernel.
-        self._assert_kernel_fips_mode("0")
-
-    def enable_fips(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        # AZL3 requres the SymCrypt provider for FIPS-compliant openssl.
-        self.node.os.install_packages("dracut-fips SymCrypt SymCrypt-OpenSSL")
-
-        # Update the kernel command line to enable FIPS.
-        # This sed expression looks for the GRUB_CMDLINE_LINUX line an
-        # appends `fips=1` to the end of the line or changes `fips=0` to `fips=1`.
-        self.node.tools[Sed].raw(
-            r'/^GRUB_CMDLINE_LINUX=/ { /fips=/! s/"$/ fips=1"/; s/fips=0/fips=1/ }',
-            "/etc/default/grub",
-            sudo=True
-        )
-
-        # Add the boot UUID to the kernel command line.
-        # This sed expressions looks for the end of the GRUB_CMDLINE_LINUX
-        # line and appends `boot=UUID=<boot_disk_part_uuid>` to the end of the
-        # line, but only if it doesn't already contain `boot=UUID=`.
-        self.node.tools[Sed].raw(
-            f'/^GRUB_CMDLINE_LINUX=/ {{ /boot=UUID/! s/"$/ boot=UUID={self._azl_get_boot_uuid()}"/ }}',
-            "/etc/default/grub",
-            sudo=True
-        )
-
-        # Update the grub configuration.
-        self.node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
-
-    def disable_fips(self) -> None:
-        # dracut-fips provides FIPS support in the bootloader.
-        self.node.os.uninstall_packages("dracut-fips")
-
-        # This sed expression looks for the GRUB_CMDLINE_LINUX line and
-        # removes `fips=1` from it.
-        self.node.tools[Sed].raw(
-            r'/^GRUB_CMDLINE_LINUX=/ s/ fips=1//',
-            "/etc/default/grub",
-            sudo=True
-        )
-
-        # Update the grub configuration.
-        self.node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
-
-
-def ensure_fips_expectations(
-        log: Logger,
-        node: Node,
-        variables: Dict[str, Any],
-        should_be_fips: bool):
-    """
-    Ensures that the expectations about the node's FIPS status are correct
-    for the test.
-    The argument `should_be_fips` indicates whether the test should be run on a
-    FIPS vs. non-FIPS image.
-    To determine whether the image is FIPS or not, the function first checks
-    the `testing_fips_image` variable in the `variables` dictionary.
-    If it can't determine the image type from the variable, it falls back to checking
-    the image SKU from the azure metadata endpoint.
-    If this does not match the expectation, a SkippedException is raised.
-
-    Args:
-        log (Logger): The logger instance for logging messages.
-        node (Node): The node object representing the target machine.
-        should_be_fips (bool): A flag indicating whether the test should be
-                               run on a FIPS vs. non-FIPS image.
-        variables (Dict[str, Any]): A dictionary of variables containing the
-                                   'testing_fips_image' key.
-    Raises:
-        SkippedException: If the FIPS image expectation does not match the actual image SKU.
-    """
-    log.debug(f"ensure_fips_expectations: should_be_fips is '{should_be_fips}'")
-    log.debug(f"ensure_fips_expectations: variables is '{variables}'")
-
-    # First, try to deduce the FIPS image type from the variables dictionary.
-    fips_image_map = {"yes": True, "no": False}
-    testing_fips_image = variables.get("testing_fips_image", None)
-    is_fips_image = fips_image_map.get(testing_fips_image, None)
-
-    # If the variable is not set or not in the expected format, fall back to
-    # checking the image SKU from the azure metadata endpoint.
-    if is_fips_image is None:
-        log.debug(
-            f"ensure_fips_expectations: testing_fips_image not in '{list(fips_image_map.keys())}'; "
-            "falling back to marketplace image sku")
-        response = node.tools[Curl].fetch(
-            arg="--max-time 2 --header Metadata:true --silent",
-            execute_arg="",
-            expected_exit_code=None,
-            url=METADATA_ENDPOINT
-        )
-
-        # If we successfully fetched the metadata, check the image SKU.
-        if response.exit_code == 0:
-            response = json.loads(response.stdout)
-            is_fips_image = "fips" in response["compute"]["sku"]
-
-    # If the image type does not match the expectation, raise a SkippedException.
-    # This includes the case where we could not determine the image type.
-    if is_fips_image != should_be_fips:
-        raise SkippedException(
-            f"FIPS image expectation does not match actual image SKU. "
-            f"Expected: {should_be_fips}, Actual: {is_fips_image}"
-        )
+from lisa.tools import Curl, Fips
+from lisa.util import SkippedException
 
 
 @TestSuiteMetadata(
@@ -361,7 +27,7 @@ def ensure_fips_expectations(
     Tests the functionality of FIPS enable
     """,
 )
-class Fips(TestSuite):
+class FipsTests(TestSuite):
     @TestCaseMetadata(
         description="""
             Ensures that an AZL machine is fips enabled.
@@ -372,17 +38,13 @@ class Fips(TestSuite):
         ),
     )
     def verify_fips_is_enabled_azl(
-        self,
-        log: Logger,
-        node: Node,
-        variables: Dict[str, Any]
+        self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is not FIPS enabled.
-        ensure_fips_expectations(log, node, variables, should_be_fips=True)
+        self._ensure_fips_expectations(log, node, variables, should_be_fips=True)
 
         # Ensure the system is FIPS enabled.
-        azl_fips = AzlFips.create_instance(log, node)
-        azl_fips.assert_fips_enabled()
+        node.tools[Fips].assert_fips_mode(True)
 
         log.info("FIPS is enabled and working correctly.")
 
@@ -396,17 +58,13 @@ class Fips(TestSuite):
         ),
     )
     def verify_fips_is_disabled_azl(
-        self,
-        log: Logger,
-        node: Node,
-        variables: Dict[str, Any]
+        self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is FIPS enabled.
-        ensure_fips_expectations(log, node, variables, should_be_fips=False)
+        self._ensure_fips_expectations(log, node, variables, should_be_fips=False)
 
         # Ensure the system is not FIPS enabled.
-        azl_fips = AzlFips.create_instance(log, node)
-        azl_fips.assert_fips_disabled()
+        node.tools[Fips].assert_fips_mode(False)
 
         log.info("FIPS is disabled and properly.")
 
@@ -423,19 +81,16 @@ class Fips(TestSuite):
         ),
     )
     def verify_fips_enable_azl(
-        self,
-        log: Logger,
-        node: Node,
-        variables: Dict[str, Any]
+        self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is already FIPS enabled.
-        ensure_fips_expectations(log, node, variables, should_be_fips=False)
+        self._ensure_fips_expectations(log, node, variables, should_be_fips=False)
 
         # Enable FIPS on the system and make sure it is worked.
-        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips = node.tools[Fips]
         azl_fips.enable_fips()
         node.reboot()
-        azl_fips.assert_fips_enabled()
+        azl_fips.assert_fips_mode(True)
 
         log.info("Successfully enabled FIPS.")
 
@@ -456,19 +111,16 @@ class Fips(TestSuite):
         ),
     )
     def verify_fips_disable_azl(
-        self,
-        log: Logger,
-        node: Node,
-        variables: Dict[str, Any]
+        self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is already not FIPS enabled.
-        ensure_fips_expectations(log, node, variables, should_be_fips=True)
+        self._ensure_fips_expectations(log, node, variables, should_be_fips=True)
 
         # Disable FIPS on the system and make sure it is worked.
-        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips = node.tools[Fips]
         azl_fips.disable_fips()
         node.reboot()
-        azl_fips.assert_fips_disabled()
+        azl_fips.assert_fips_mode(False)
 
         log.info("Successfully disabled FIPS.")
 
@@ -487,7 +139,7 @@ class Fips(TestSuite):
         priority=3,
         requirement=simple_requirement(
             unsupported_os=[CBLMariner],
-        )
+        ),
     )
     def verify_fips_enable(self, log: Logger, node: Node) -> None:
         result = node.execute("command -v fips-mode-setup", shell=True)
@@ -507,3 +159,62 @@ class Fips(TestSuite):
         assert_that(result.stdout).described_as(
             "FIPS was not properly enabled."
         ).contains("is enabled")
+
+    def _ensure_fips_expectations(
+        self, log: Logger, node: Node, variables: Dict[str, Any], should_be_fips: bool
+    ):
+        """
+        Ensures that the expectations about the node's FIPS status are correct
+        for the test.
+        The argument `should_be_fips` indicates whether the test should be run on a
+        FIPS vs. non-FIPS image.
+        To determine whether the image is FIPS or not, the function first checks
+        the `testing_fips_image` variable in the `variables` dictionary.
+        If it can't determine the image type from the variable, it falls back to checking
+        the image SKU from the azure metadata endpoint.
+        If this does not match the expectation, a SkippedException is raised.
+
+        Args:
+            log (Logger): The logger instance for logging messages.
+            node (Node): The node object representing the target machine.
+            should_be_fips (bool): A flag indicating whether the test should be
+                                run on a FIPS vs. non-FIPS image.
+            variables (Dict[str, Any]): A dictionary of variables containing the
+                                    'testing_fips_image' key.
+        Raises:
+            SkippedException: If the FIPS image expectation does not match the actual image SKU.
+        """
+        log.debug(f"ensure_fips_expectations: should_be_fips is '{should_be_fips}'")
+        log.debug(f"ensure_fips_expectations: variables is '{variables}'")
+
+        # First, try to deduce the FIPS image type from the variables dictionary.
+        fips_image_map = {"yes": True, "no": False}
+        testing_fips_image = variables.get("testing_fips_image", None)
+        is_fips_image = fips_image_map.get(testing_fips_image, None)
+
+        # If the variable is not set or not in the expected format, fall back to
+        # checking the image SKU from the azure metadata endpoint.
+        if is_fips_image is None:
+            log.debug(
+                f"ensure_fips_expectations: testing_fips_image not in '{list(fips_image_map.keys())}'"
+                "falling back to marketplace image sku"
+            )
+            response = node.tools[Curl].fetch(
+                arg="--max-time 2 --header Metadata:true --silent",
+                execute_arg="",
+                expected_exit_code=None,
+                url=METADATA_ENDPOINT,
+            )
+
+            # If we successfully fetched the metadata, check the image SKU.
+            if response.exit_code == 0:
+                response = json.loads(response.stdout)
+                is_fips_image = "fips" in response["compute"]["sku"]
+
+        # If the image type does not match the expectation, raise a SkippedException.
+        # This includes the case where we could not determine the image type.
+        if is_fips_image != should_be_fips:
+            raise SkippedException(
+                f"FIPS image expectation does not match actual image SKU. "
+                f"Expected: {should_be_fips}, Actual: {is_fips_image}"
+            )

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -466,7 +466,7 @@ class Fips(TestSuite):
         node.reboot()
         azl_fips.assert_fips_disabled()
 
-        log.debug("Successfully disabled FIPS.")
+        log.info("Successfully disabled FIPS.")
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -146,7 +146,8 @@ class FipsTests(TestSuite):
         # If we successfully fetched the metadata, check the image SKU.
         if response.exit_code == 0:
             log.debug(
-                "get_expected_fips_mode: successfully fetched metadata; checking image SKU."
+                "get_expected_fips_mode: successfully fetched metadata; "
+                "checking image SKU."
             )
             response = json.loads(response.stdout)
             return "fips" in response["compute"]["sku"]

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -1,14 +1,357 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import json
 import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 from assertpy import assert_that
 
-from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
-from lisa.operating_system import CBLMariner
-from lisa.tools import Cat
-from lisa.util import LisaException, SkippedException, get_matched_str
+from lisa import (
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.features import Disk
+from lisa.operating_system import CBLMariner, OperatingSystem
+from lisa.sut_orchestrator.azure.common import METADATA_ENDPOINT
+from lisa.tools import Blkid, Cat, Curl, Sed
+from lisa.util import SkippedException, get_matched_str
+
+
+def assert_package_exists(os: OperatingSystem, package: str) -> None:
+    """
+    Assert that a package/tool is installed on the node.
+    """
+    assert_that(os.package_exists(package)).described_as(
+        f"Package {package} is not installed."
+    ).is_true()
+
+
+def assert_package_not_exists(os: OperatingSystem, package: str) -> None:
+    """
+    Assert that a package/tool is not installed on the node.
+    """
+    assert_that(os.package_exists(package)).described_as(
+        f"Package {package} is installed."
+    ).is_false()
+
+
+class AzlFips(ABC):
+    '''
+    Base class for AZL FIPS tests. This class provides methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    The derived classes (AzlV2Fips and AzlV3Fips) implement the specific
+    behavior for AZL2 and AZL3.
+    '''
+    @staticmethod
+    def create_instance(log: Logger, node: Node) -> "AzlFips":
+        '''
+        Factory method to create an instance of AzlFips based
+        on the OS release.
+        '''
+        release_to_class = {
+            "2.0": AzlV2Fips,
+            "3.0": AzlV3Fips,
+        }
+
+        assert_that(node.os.information.release).described_as(
+            "Test only works on currently supported Azure Linux releases."
+        ).is_in(*release_to_class.keys())
+
+        klass = release_to_class[node.os.information.release]
+        log.debug(
+            f"Creating '{klass.__name__}' instance for release "
+            f"{node.os.information.release}.")
+        return klass(log, node)
+
+    def __init__(self, log: Logger, node: Node):
+        self.log = log
+        self.node = node
+
+    @abstractmethod
+    def assert_fips_enabled(self) -> None:
+        '''
+        When implemented by the derived class, this method should assert that
+        FIPS is enabled on the system.
+        '''
+
+    @abstractmethod
+    def assert_fips_disabled(self) -> None:
+        '''
+        When implemented by the derived class, this method should assert that
+        FIPS is disabled on the system.
+        '''
+
+    @abstractmethod
+    def enable_fips(self) -> None:
+        '''
+        When implemented by the derived class, this method should enable FIPS
+        on the system.
+        '''
+
+    @abstractmethod
+    def disable_fips(self) -> None:
+        '''
+        When implemented by the derived class, this method should disable FIPS
+        on the system.
+        '''
+        pass
+
+    def _assert_kernel_fips_mode(self, expected: str) -> None:
+        '''
+        Assert that the kernel FIPS mode is set to the expected value.
+        '''
+        fips_enabled = self.node.tools[Cat].read(
+            "/proc/sys/crypto/fips_enabled",
+            force_run=True)
+
+        assert_that(
+            fips_enabled
+        ).described_as(
+            "kernel fips mode"
+        ).is_equal_to(expected)
+
+    def _azl_get_boot_uuid(self) -> str:
+        '''
+        Get the UUID of the boot disk partition.
+        '''
+        boot_disk_part_uuid = ""
+
+        # Get the boot and root devices.
+        disk = self.node.features[Disk]
+        root_disk_partition = disk.get_partition_with_mount_point("/")
+        boot_disk_partition = disk.get_partition_with_mount_point("/boot")
+
+        # If the boot and root devices are different, add the boot block id to
+        # the kernel command line.
+        if boot_disk_partition.name == root_disk_partition.name:
+            self.log.info("Boot and root partitions are the same; returning empty string.")
+        else:
+            boot_disk_part_uuid = self.node.tools[Blkid].get_partition_info_by_name(boot_disk_partition.name).uuid
+            self.log.info(
+                "Boot and root partitions are different; "
+                f"boot disk UUID is '{boot_disk_part_uuid}'.")
+
+        return boot_disk_part_uuid
+
+
+class AzlV2Fips(AzlFips):
+    '''
+    FIPS test class for AZL2. This class implements the methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    '''
+    # In AZL2, the command openssl md5 should fail with error messages like:
+    #   Error setting digest
+    #   131590634539840:error:060800C8:digital envelope routines:EVP_DigestInit_ex:disabled for FIPS:crypto/evp/digest.c:135: # noqa: E501
+    _md5_expected_failure_pattern = re.compile(
+        "Error setting digest\r\n.*EVP_DigestInit_ex:disabled for FIPS.*", re.M
+    )
+
+    def assert_fips_enabled(self) -> None:
+        # We rely on the dracut-fips package for bootloader FIPS support.
+        assert_package_exists(self.node.os, "dracut-fips")
+
+        # Check if fips is enabled in the kernel
+        self._assert_kernel_fips_mode("1")
+
+        # In AZL2, non-FIPS certified algorithms like MD5 will fail
+        # when FIPS is enabled.
+        result = self.node.execute("echo 'test' | openssl md5", shell=True)
+        result.assert_exit_code(1, "openssl md5 should fail on AZL2 in FIPS mode")
+        assert_that(get_matched_str(
+            result.stdout,
+            self._md5_expected_failure_pattern)
+        ).is_not_empty()
+
+    def assert_fips_disabled(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        assert_package_not_exists(self.node.os, "dracut-fips")
+
+        # FIPS should be disabled in the kernel.
+        self._assert_kernel_fips_mode("0")
+
+        # In AZL2, non-FIPS certified algorithms like MD5 will fail when FIPS is enabled
+        # so we make sure that it works when FIPS is disabled.
+        result = self.node.execute("echo 'test' | openssl md5", shell=True)
+        result.assert_exit_code(0, "openssl md5 should work on AZL2 when FIPS is disabled")
+
+    def enable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        self.node.os.install_packages("dracut-fips")
+
+        # In AZL2, grubby is used to modify kernel parameters.
+        self.node.os.install_packages("grubby")
+
+        # In AZL2, we use grubby to modify the kernel command line.
+        # We need to add `fips=1` and `boot=UUID=<boot_disk_part_uuid>`
+        # to the kernel command line.
+        boot_disk_part_uuid = self._azl_get_boot_uuid()
+        result = self.node.execute(
+            "grub2-editenv - list | grep 'kernelopts'",
+            sudo=True,
+            shell=True)
+        if result.exit_code == 0:
+            self.log.info("Found kernelopts in grub2-editenv; editing with grub2-editenv")
+            self.node.execute(
+                f'sudo grub2-editenv - set "{result.stdout} fips=1 boot=UUID={boot_disk_part_uuid}"',
+                sudo=True)
+        else:
+            self.log.info("Did not find kernelopts in grub2-editenv; adding with grubby")
+            self.node.execute(
+                f'sudo grubby --update-kernel=ALL --args="fips=1 boot=UUID={boot_disk_part_uuid}"',
+                sudo=True)
+
+    def disable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        self.node.os.uninstall_packages("dracut-fips")
+
+        # In AZL2, grubby is used to modify kernel parameters.
+        self.node.os.install_packages("grubby")
+
+        # If FIPS is set in the kernel command line, we need to change it.
+        self.node.tools[Sed].raw(
+            r's/ fips=1//g',
+            "/boot/grub2/grub.cfg",
+            sudo=True
+        )
+
+        # Remove the boot UUID from the kernel command line.
+        self.node.tools[Sed].raw(
+            r's/ boot=UUID=[^ ]*//g',
+            "/boot/grub2/grub.cfg",
+            sudo=True
+        )
+
+class AzlV3Fips(AzlFips):
+    '''
+    FIPS test class for AZL3. This class implements the methods to check if
+    FIPS is enabled or disabled, and to enable or disable FIPS.
+    '''
+    def assert_fips_enabled(self) -> None:
+        # We rely on the dracut-fips package for bootloader FIPS support.
+        assert_package_exists(self.node.os, "dracut-fips")
+
+        # Check if fips is enabled in the kernel
+        self._assert_kernel_fips_mode("1")
+
+        # In AZL3, FIPS-compliant openssl is provided by the SymCrypt provider.
+        assert_package_exists(self.node.os, "SymCrypt")
+        assert_package_exists(self.node.os, "SymCrypt-OpenSSL")
+
+    def assert_fips_disabled(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        assert_package_not_exists(self.node.os, "dracut-fips")
+
+        # FIPS should be disabled in the kernel.
+        self._assert_kernel_fips_mode("0")
+
+    def enable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        # AZL3 requres the SymCrypt provider for FIPS-compliant openssl.
+        self.node.os.install_packages("dracut-fips SymCrypt SymCrypt-OpenSSL")
+
+        # Update the kernel command line to enable FIPS.
+        # This sed expression looks for the GRUB_CMDLINE_LINUX line an
+        # appends `fips=1` to the end of the line or changes `fips=0` to `fips=1`.
+        self.node.tools[Sed].raw(
+            r'/^GRUB_CMDLINE_LINUX=/ { /fips=/! s/"$/ fips=1"/; s/fips=0/fips=1/ }',
+            "/etc/default/grub",
+            sudo=True
+        )
+
+        # Add the boot UUID to the kernel command line.
+        # This sed expressions looks for the end of the GRUB_CMDLINE_LINUX
+        # line and appends `boot=UUID=<boot_disk_part_uuid>` to the end of the
+        # line, but only if it doesn't already contain `boot=UUID=`.
+        self.node.tools[Sed].raw(
+            f'/^GRUB_CMDLINE_LINUX=/ {{ /boot=UUID/! s/"$/ boot=UUID={self._azl_get_boot_uuid()}"/ }}',
+            "/etc/default/grub",
+            sudo=True
+        )
+
+        # Update the grub configuration.
+        self.node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
+
+    def disable_fips(self) -> None:
+        # dracut-fips provides FIPS support in the bootloader.
+        self.node.os.uninstall_packages("dracut-fips")
+
+        # This sed expression looks for the GRUB_CMDLINE_LINUX line and
+        # removes `fips=1` from it.
+        self.node.tools[Sed].raw(
+            r'/^GRUB_CMDLINE_LINUX=/ s/ fips=1//',
+            "/etc/default/grub",
+            sudo=True
+        )
+
+        # Update the grub configuration.
+        self.node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
+
+
+def ensure_fips_expectations(
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any],
+        should_be_fips: bool):
+    """
+    Ensures that the expectations about the node's FIPS status are correct
+    for the test.
+    The argument `should_be_fips` indicates whether the test should be run on a
+    FIPS vs. non-FIPS image.
+    To determine whether the image is FIPS or not, the function first checks
+    the `testing_fips_image` variable in the `variables` dictionary.
+    If it can't determine the image type from the variable, it falls back to checking
+    the image SKU from the azure metadata endpoint.
+    If this does not match the expectation, a SkippedException is raised.
+
+    Args:
+        log (Logger): The logger instance for logging messages.
+        node (Node): The node object representing the target machine.
+        should_be_fips (bool): A flag indicating whether the test should be
+                               run on a FIPS vs. non-FIPS image.
+        variables (Dict[str, Any]): A dictionary of variables containing the
+                                   'testing_fips_image' key.
+    Raises:
+        SkippedException: If the FIPS image expectation does not match the actual image SKU.
+    """
+    log.debug(f"ensure_fips_expectations: should_be_fips is '{should_be_fips}'")
+    log.debug(f"ensure_fips_expectations: variables is '{variables}'")
+
+    # First, try to deduce the FIPS image type from the variables dictionary.
+    fips_image_map = {"yes": True, "no": False}
+    testing_fips_image = variables.get("testing_fips_image", None)
+    is_fips_image = fips_image_map.get(testing_fips_image, None)
+
+    # If the variable is not set or not in the expected format, fall back to
+    # checking the image SKU from the azure metadata endpoint.
+    if is_fips_image is None:
+        log.debug(
+            f"ensure_fips_expectations: testing_fips_image not in '{list(fips_image_map.keys())}'; "
+            "falling back to marketplace image sku")
+        response = node.tools[Curl].fetch(
+            arg="--max-time 2 --header Metadata:true --silent",
+            execute_arg="",
+            expected_exit_code=None,
+            url=METADATA_ENDPOINT
+        )
+
+        # If we successfully fetched the metadata, check the image SKU.
+        if response.exit_code == 0:
+            response = json.loads(response.stdout)
+            is_fips_image = "fips" in response["compute"]["sku"]
+
+    # If the image type does not match the expectation, raise a SkippedException.
+    # This includes the case where we could not determine the image type.
+    if is_fips_image != should_be_fips:
+        raise SkippedException(
+            f"FIPS image expectation does not match actual image SKU. "
+            f"Expected: {should_be_fips}, Actual: {is_fips_image}"
+        )
 
 
 @TestSuiteMetadata(
@@ -19,9 +362,111 @@ from lisa.util import LisaException, SkippedException, get_matched_str
     """,
 )
 class Fips(TestSuite):
-    _expected_failure_pattern = re.compile(
-        "Error setting digest\r\n.*EVP_DigestInit_ex:disabled for FIPS.*", re.M
+    @TestCaseMetadata(
+        description="""
+            Ensures that an AZL machine is fips enabled.
+        """,
+        priority=1,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
     )
+    def verify_fips_is_enabled_azl(
+        self,
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any]
+    ) -> None:
+        # Skip the test if the image is not FIPS enabled.
+        ensure_fips_expectations(log, node, variables, should_be_fips=True)
+
+        # Ensure the system is FIPS enabled.
+        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips.assert_fips_enabled()
+
+        log.info("FIPS is enabled and working correctly.")
+
+    @TestCaseMetadata(
+        description="""
+            Ensures that an AZL machine is not FIPS enabled.
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
+    )
+    def verify_fips_is_disabled_azl(
+        self,
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any]
+    ) -> None:
+        # Skip the test if the image is FIPS enabled.
+        ensure_fips_expectations(log, node, variables, should_be_fips=False)
+
+        # Ensure the system is not FIPS enabled.
+        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips.assert_fips_disabled()
+
+        log.info("FIPS is disabled and properly.")
+
+    @TestCaseMetadata(
+        description="""
+            This test case will
+            1. Enable FIPS on the AZL machine
+            2. Restart the machine
+            3. Verify that FIPS was enabled properly
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
+    )
+    def verify_fips_enable_azl(
+        self,
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any]
+    ) -> None:
+        # Skip the test if the image is already FIPS enabled.
+        ensure_fips_expectations(log, node, variables, should_be_fips=False)
+
+        # Enable FIPS on the system and make sure it is worked.
+        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips.enable_fips()
+        node.reboot()
+        azl_fips.assert_fips_enabled()
+
+        log.info("Successfully enabled FIPS.")
+
+    @TestCaseMetadata(
+        description="""
+            This test case will
+            1. Disable FIPS on the AZL machine
+            2. Restart the machine
+            3. Verify that FIPS is disabled
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
+    )
+    def verify_fips_disable_azl(
+        self,
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any]
+    ) -> None:
+        # Skip the test if the image is already not FIPS enabled.
+        ensure_fips_expectations(log, node, variables, should_be_fips=True)
+
+        # Disable FIPS on the system and make sure it is worked.
+        azl_fips = AzlFips.create_instance(log, node)
+        azl_fips.disable_fips()
+        node.reboot()
+        azl_fips.assert_fips_disabled()
+
+        log.debug("Successfully disabled FIPS.")
 
     @TestCaseMetadata(
         description="""
@@ -32,61 +477,25 @@ class Fips(TestSuite):
         4. Verify that FIPS was enabled properly
         """,
         priority=3,
+        requirement=simple_requirement(
+            unsupported_os=[CBLMariner],
+        )
     )
     def verify_fips_enable(self, log: Logger, node: Node) -> None:
-        if isinstance(node.os, CBLMariner):
-            # check If It is a non-FIPS image
-            if node.execute("rpm -qa | grep dracut-fips", shell=True).exit_code != 0:
-                raise SkippedException("Not a fips enabled image.")
-            else:
-                # FIPS image
-                result = node.tools[Cat].run(
-                    "/proc/sys/crypto/fips_enabled", sudo=True, force_run=True
-                )
+        result = node.execute("command -v fips-mode-setup", shell=True)
+        if result.exit_code != 0:
+            raise SkippedException(
+                "Command not found: fips-mode-setup. "
+                f"Please ensure {node.os.name} supports fips mode."
+            )
 
-                if result.exit_code != 0:
-                    raise LisaException(
-                        "fips_enabled file is not found in proc file system."
-                    )
+        node.execute("fips-mode-setup --enable", sudo=True)
 
-                if "1" != result.stdout:
-                    raise LisaException(
-                        "fips is not enabled properly. "
-                        f"Please ensure {node.os.name} has fips turned on by default."
-                    )
+        log.info("FIPS mode set to enable. Attempting reboot.")
+        node.reboot()
 
-                result = node.execute("openssl md5")
-                # md5 should not work If It is a FIPS image
-                # Following the output of the above command
-                # Error setting digest
-                # 131590634539840:error:060800C8:digital envelope routines:EVP_DigestInit_ex:disabled for FIPS:crypto/evp/digest.c:135: # noqa: E501
-                if result.exit_code != 0:
-                    if get_matched_str(result.stdout, self._expected_failure_pattern):
-                        log.info("FIPS is enabled properly.")
-                    else:
-                        raise LisaException(
-                            "md5 alogrithm should not work in FIPS mode."
-                        )
-                else:
-                    raise LisaException(
-                        "md5 algorithm should not work in FIPS mode. "
-                        f"Please ensure {node.os.name} has fips turned on."
-                    )
-        else:
-            result = node.execute("command -v fips-mode-setup", shell=True)
-            if result.exit_code != 0:
-                raise SkippedException(
-                    "Command not found: fips-mode-setup. "
-                    f"Please ensure {node.os.name} supports fips mode."
-                )
+        result = node.execute("fips-mode-setup --check")
 
-            node.execute("fips-mode-setup --enable", sudo=True)
-
-            log.info("FIPS mode set to enable. Attempting reboot.")
-            node.reboot()
-
-            result = node.execute("fips-mode-setup --check")
-
-            assert_that(result.stdout).described_as(
-                "FIPS was not properly enabled."
-            ).contains("is enabled")
+        assert_that(result.stdout).described_as(
+            "FIPS was not properly enabled."
+        ).contains("is enabled")

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -37,7 +37,7 @@ class FipsTests(TestSuite):
             supported_os=[CBLMariner],
         ),
     )
-    def verify_fips_is_enabled_azl(
+    def verify_azl_fips_is_enabled(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is not FIPS enabled.
@@ -57,7 +57,7 @@ class FipsTests(TestSuite):
             supported_os=[CBLMariner],
         ),
     )
-    def verify_fips_is_disabled_azl(
+    def verify_azl_fips_is_disabled(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is FIPS enabled.
@@ -80,7 +80,7 @@ class FipsTests(TestSuite):
             supported_os=[CBLMariner],
         ),
     )
-    def verify_fips_enable_azl(
+    def verify_azl_fips_enable(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is already FIPS enabled.
@@ -110,7 +110,7 @@ class FipsTests(TestSuite):
             supported_os=[CBLMariner],
         ),
     )
-    def verify_fips_disable_azl(
+    def verify_azl_fips_disable(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         # Skip the test if the image is already not FIPS enabled.

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -17,7 +17,7 @@ from lisa import (
 from lisa.operating_system import CBLMariner
 from lisa.sut_orchestrator.azure.common import METADATA_ENDPOINT
 from lisa.tools import Curl, Fips
-from lisa.util import SkippedException
+from lisa.util import SkippedException, str_to_bool
 
 
 @TestSuiteMetadata(
@@ -188,16 +188,15 @@ class FipsTests(TestSuite):
         log.debug(f"ensure_fips_expectations: variables is '{variables}'")
 
         # First, try to deduce the FIPS image type from the variables dictionary.
-        fips_image_map = {"yes": True, "no": False}
         testing_fips_image = variables.get("testing_fips_image", None)
-        is_fips_image = fips_image_map.get(testing_fips_image, None)
+        is_fips_image = str_to_bool(testing_fips_image) if testing_fips_image else None
 
         # If the variable is not set or not in the expected format, fall back to
         # checking the image SKU from the azure metadata endpoint.
         if is_fips_image is None:
             log.debug(
-                f"ensure_fips_expectations: testing_fips_image not in '{list(fips_image_map.keys())}'"
-                "falling back to marketplace image sku"
+                f"ensure_fips_expectations: testing_fips_image '{testing_fips_image}' "
+                "is not a bool; falling back to marketplace image sku"
             )
             response = node.tools[Curl].fetch(
                 arg="--max-time 2 --header Metadata:true --silent",

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -439,6 +439,10 @@ class Fips(TestSuite):
 
         log.info("Successfully enabled FIPS.")
 
+        # Re-disable FIPS to make sure the test can be run multiple times.
+        azl_fips.disable_fips()
+        node.reboot()
+
     @TestCaseMetadata(
         description="""
             This test case will
@@ -467,6 +471,10 @@ class Fips(TestSuite):
         azl_fips.assert_fips_disabled()
 
         log.info("Successfully disabled FIPS.")
+
+        # Re-enable FIPS to make sure the test can be run multiple times.
+        azl_fips.enable_fips()
+        node.reboot()
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/security/fips.py
+++ b/microsoft/testsuites/security/fips.py
@@ -17,7 +17,7 @@ from lisa import (
 from lisa.operating_system import CBLMariner
 from lisa.sut_orchestrator.azure.common import METADATA_ENDPOINT
 from lisa.tools import Curl, Fips
-from lisa.util import SkippedException, str_to_bool
+from lisa.util import SkippedException, to_bool
 
 
 @TestSuiteMetadata(
@@ -129,7 +129,7 @@ class FipsTests(TestSuite):
                 f"get_expected_fips_mode: testing_fips_image '{testing_fips_image}' "
                 "is set in the variables; using it to determine the expected FIPS mode."
             )
-            return str_to_bool(testing_fips_image)
+            return to_bool(testing_fips_image)
 
         # Fall back to checking the image SKU from the azure metadata endpoint.
         log.debug(

--- a/selftests/test_utils.py
+++ b/selftests/test_utils.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from assertpy import assert_that
 
-from lisa.util import get_first_combination, str_to_bool
+from lisa.util import get_first_combination, to_bool
 
 
 class UtilsTestCase(TestCase):
@@ -49,7 +49,7 @@ class UtilsTestCase(TestCase):
         )
         assert_that(results).described_as("unexpected results").is_equal_to([])
 
-    def test_str_to_bool_positive(self):
+    def test_to_bool_positive(self):
         test_cases = [
             # Basic tests.
             ("True", True),
@@ -71,34 +71,39 @@ class UtilsTestCase(TestCase):
             # Bools are the identity function.
             (True, True),
             (False, False),
+            # Ints are converted to bools.
+            # 0 is false, everything else is true.
+            (-1, True),
+            (0, False),
+            (1, True),
+            (2, True),
         ]
 
         for input_str, expected in test_cases:
-            result = str_to_bool(input_str)
+            result = to_bool(input_str)
             assert_that(result).described_as(
                 f"Failed for input: {input_str}"
             ).is_equal_to(expected)
 
-    def test_str_to_bool_negative(self):
+    def test_to_bool_negative(self):
         test_cases = [
-            "invalid",
-            "10",
-            "2",
-            "yesyes",
-            "no no",
-            "yes no",
-            "no yes",
-            "one",
+            ("invalid", ValueError),
+            ("10", ValueError),
+            ("2", ValueError),
+            ("yesyes", ValueError),
+            ("no no", ValueError),
+            ("yes no", ValueError),
+            ("no yes", ValueError),
+            ("one", ValueError),
+            (None, TypeError),
+            (1.5, TypeError),
+            (object(), TypeError),
+            ([], TypeError),
+            ({}, TypeError),
         ]
-
-        for input_str in test_cases:
-            try:
-                str_to_bool(input_str)
-                assert_that(False).described_as(
-                    f"Input '{input_str}' should raise an error"
-                ).is_true()
-            except ValueError:
-                continue
+        for input_value, expected_exception in test_cases:
+            with self.assertRaises(expected_exception):
+                to_bool(input_value)
 
     def _check(self, values: List[Any]) -> Any:
         print(f"checked results: {values}")

--- a/selftests/test_utils.py
+++ b/selftests/test_utils.py
@@ -54,16 +54,23 @@ class UtilsTestCase(TestCase):
             # Basic tests.
             ("True", True),
             ("False", False),
+            ("yes", True),
+            ("no", False),
+            ("1", True),
+            ("0", False),
             # Should also work with different casing and whitepace.
             # Rather than doing this exhaustively, we just test
             # some random cases.
             ("true", True),
             ("FALSE", False),
-            ("TrUe", True),
+            (" 1", True),
             ("faLse", False),
-            ("  True  ", True),
+            ("  yes  ", True),
             ("  false", False),
             ("faLsE ", False),
+            # Bools are the identity function.
+            (True, True),
+            (False, False),
         ]
 
         for input_str, expected in test_cases:
@@ -73,11 +80,25 @@ class UtilsTestCase(TestCase):
             ).is_equal_to(expected)
 
     def test_str_to_bool_negative(self):
-        test_cases = ["invalid", "1", "0", "yes", "no"]
+        test_cases = [
+            "invalid",
+            "10",
+            "2",
+            "yesyes",
+            "no no",
+            "yes no",
+            "no yes",
+            "one",
+        ]
 
         for input_str in test_cases:
-            result = str_to_bool(input_str)
-            assert_that(result).described_as(f"Failed for input: {input_str}").is_none()
+            try:
+                str_to_bool(input_str)
+                assert_that(False).described_as(
+                    f"Input '{input_str}' should raise an error"
+                ).is_true()
+            except ValueError:
+                continue
 
     def _check(self, values: List[Any]) -> Any:
         print(f"checked results: {values}")

--- a/selftests/test_utils.py
+++ b/selftests/test_utils.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 from assertpy import assert_that
 
-from lisa.util import get_first_combination
+from lisa.util import get_first_combination, str_to_bool
 
 
 class UtilsTestCase(TestCase):
@@ -48,6 +48,36 @@ class UtilsTestCase(TestCase):
             False
         )
         assert_that(results).described_as("unexpected results").is_equal_to([])
+
+    def test_str_to_bool_positive(self):
+        test_cases = [
+            # Basic tests.
+            ("True", True),
+            ("False", False),
+            # Should also work with different casing and whitepace.
+            # Rather than doing this exhaustively, we just test
+            # some random cases.
+            ("true", True),
+            ("FALSE", False),
+            ("TrUe", True),
+            ("faLse", False),
+            ("  True  ", True),
+            ("  false", False),
+            ("faLsE ", False),
+        ]
+
+        for input_str, expected in test_cases:
+            result = str_to_bool(input_str)
+            assert_that(result).described_as(
+                f"Failed for input: {input_str}"
+            ).is_equal_to(expected)
+
+    def test_str_to_bool_negative(self):
+        test_cases = ["invalid", "1", "0", "yes", "no"]
+
+        for input_str in test_cases:
+            result = str_to_bool(input_str)
+            assert_that(result).described_as(f"Failed for input: {input_str}").is_none()
 
     def _check(self, values: List[Any]) -> Any:
         print(f"checked results: {values}")


### PR DESCRIPTION
Add Azure Linux-specific tests around FIPS compliance. Specifically, this change adds:

`verify_fips_is_enabled_azl`: Verifies that an AZL system is in FIPS mode.
`verify_fips_is_disabled_azl`: Verifies that an AZL system is not in FIPS mode.
`verify_fips_enable_azl`: Verifies that an AZL system can be put into FIPS mode.
`verify_fips_disable_azl`: Verifies that an AZL system can be taken out of FIPS mode.

It also removes the AZL code from `verify_fips_enable`.

Due to the nature of these tests, they only make sense to run if we believe a machine is already in the correct mode. For example, `verify_fips_is_enabled_azl` would make sense on the marketplace image `MicrosoftCBLMariner:azure-linux-3:azure-linux-3-fips:latest` but not on `MicrosoftCBLMariner:azure-linux-3:azure-linux-3:latest`.

To accomplish this, we look at two things (see function `ensure_fips_expectations`).
First, we see if a variable `testing_fips_image` was provided to the test case. If so, and if it is `yes` or `no`, we respect that.
Second, we try to hit the azure metadata endpoint to get the image sku name. If that is a FIPS sku, we consider it to be a FIPS machine.
If neither exist, we skip the test.