### PR TITLE
dom0_kernel_installer: generate initramfs and use PARTUUID

### DIFF
--- a/lisa/tools/lsblk.py
+++ b/lisa/tools/lsblk.py
@@ -35,6 +35,8 @@ class PartitionInfo(object):
     total_blocks: int = 0
     percentage_blocks_used: int = 0
     fstype: str = ""
+    uuid: str = ""
+    part_uuid: str = ""
 
     @property
     def is_mounted(self) -> bool:
@@ -59,6 +61,8 @@ class PartitionInfo(object):
         total_blocks: int = 0,
         percentage_blocks_used: int = 0,
         fstype: str = "",
+        uuid: str = "",
+        part_uuid: str = "",
     ):
         self.name = name
         self.mountpoint = mountpoint
@@ -69,6 +73,8 @@ class PartitionInfo(object):
         self.total_blocks = total_blocks
         self.percentage_blocks_used = percentage_blocks_used
         self.fstype = fstype
+        self.uuid = uuid
+        self.part_uuid = part_uuid
 
 
 @dataclass
@@ -79,6 +85,7 @@ class DiskInfo(object):
     type: str = ""
     fstype: str = ""
     partitions: List[PartitionInfo] = field(default_factory=list)
+    uuid: str = ""
 
     @property
     def is_os_disk(self) -> bool:
@@ -116,6 +123,7 @@ class DiskInfo(object):
         dev_type: str = "",
         fstype: str = "",
         partitions: Optional[List[PartitionInfo]] = None,
+        uuid: str = "",
     ):
         self.name = name
         self.mountpoint = mountpoint
@@ -123,6 +131,7 @@ class DiskInfo(object):
         self.type = dev_type
         self.fstype = fstype
         self.partitions = partitions if partitions else []
+        self.uuid = uuid
 
 
 class Lsblk(Tool):
@@ -175,6 +184,7 @@ class Lsblk(Tool):
                 size=int(lsblk_entry["size"]),
                 dev_type=lsblk_entry["type"],
                 fstype=lsblk_entry["fstype"],
+                uuid=lsblk_entry["uuid"],
             )
 
             for child in lsblk_entry.get("children", []):
@@ -185,6 +195,8 @@ class Lsblk(Tool):
                         size=int(child["size"]),
                         dev_type=child["type"],
                         fstype=child["fstype"],
+                        uuid=child["uuid"],
+                        part_uuid=child["partuuid"],
                     )
                 )
             # add disk to list of disks
@@ -222,6 +234,8 @@ class Lsblk(Tool):
                     dev_type=lsblk_entry["type"],
                     mountpoint=lsblk_entry["mountpoint"],
                     fstype=lsblk_entry["fstype"],
+                    uuid=lsblk_entry["uuid"],
+                    part_uuid=lsblk_entry["partuuid"],
                 )
             )
 
@@ -239,6 +253,7 @@ class Lsblk(Tool):
                     size=int(lsblk_entry["size"]),
                     dev_type=lsblk_entry["type"],
                     partitions=disk_partition_map.get(lsblk_entry["name"], []),
+                    uuid=lsblk_entry["uuid"],
                 )
             )
         return disks
@@ -252,7 +267,7 @@ class Lsblk(Tool):
         # -o list of columns to output
         # -e exclude devices by major number, '-e 7' excludes loop devices
         cmd_result = self.run(
-            "-e 7 -b -J -o NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE",
+            "-e 7 -b -J -o NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,UUID,PARTUUID",
             sudo=True,
             force_run=force_run,
         )
@@ -261,7 +276,7 @@ class Lsblk(Tool):
             self._INVAILD_JSON_OPTION_PATTERN, output
         ):
             output = self.run(
-                "-e 7 -b -P -o NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE",
+                "-e 7 -b -P -o NAME,SIZE,TYPE,MOUNTPOINT,FSTYPE,UUID,PARTUUID",
                 sudo=True,
                 force_run=force_run,
             ).stdout
@@ -289,6 +304,17 @@ class Lsblk(Tool):
                     return disk
 
         raise LisaException(f"Could not find disk with mountpoint {mountpoint}")
+
+    def find_partition_by_mountpoint(
+        self, mountpoint: str, force_run: bool = False
+    ) -> PartitionInfo:
+        disk = self.find_disk_by_mountpoint(mountpoint, force_run=force_run)
+
+        for partition in disk.partitions:
+            if partition.mountpoint == mountpoint:
+                return partition
+
+        raise LisaException(f"Could not find partition with mountpoint {mountpoint}")
 
     def find_mountpoint_by_volume_name(
         self, volume_name: str, force_run: bool = False

--- a/lisa/transformers/dom0_kernel_installer.py
+++ b/lisa/transformers/dom0_kernel_installer.py
@@ -10,8 +10,8 @@ from dataclasses_json import dataclass_json
 from lisa import schema
 from lisa.node import Node
 from lisa.operating_system import CBLMariner
-from lisa.tools import Cp, Echo, Ln, Ls, Sed, Tar, Uname
-from lisa.util import field_metadata
+from lisa.tools import Cat, Cp, Echo, Ln, Ls, Lsblk, Sed, Tar, Uname
+from lisa.util import UnsupportedDistroException, field_metadata
 
 from .kernel_installer import BaseInstaller, BaseInstallerSchema
 from .kernel_source_installer import SourceInstaller, SourceInstallerSchema
@@ -67,8 +67,11 @@ class BinaryInstaller(BaseInstaller):
         return []
 
     def validate(self) -> None:
-        # nothing to validate before source installer started.
-        ...
+        if not isinstance(self._node.os, CBLMariner):
+            raise UnsupportedDistroException(
+                self._node.os,
+                f"The '{self.type_name()}' installer only support Mariner distro",
+            )
 
     def install(self) -> str:
         node = self._node
@@ -127,20 +130,21 @@ class BinaryInstaller(BaseInstaller):
                 node.get_pure_path(f"/boot/initrd.img-{new_kernel}"),
             )
         else:
-            # Mariner 3.0 initrd
-            target = f"/boot/initramfs-{current_kernel}.img"
-            link = f"/boot/initramfs-{new_kernel}.img"
-
-            if isinstance(node.os, CBLMariner) and mariner_version == 2:
+            if mariner_version == 2:
                 # Mariner 2.0 initrd
                 target = f"/boot/initrd.img-{current_kernel}"
                 link = f"/boot/initrd.img-{new_kernel}"
 
-            ln = node.tools[Ln]
-            ln.create_link(
-                target=target,
-                link=link,
-            )
+                ln = node.tools[Ln]
+                ln.create_link(
+                    target=target,
+                    link=link,
+                )
+            else:
+                # Mariner 3.0 and above
+                initramfs = f"/boot/initramfs-{new_kernel}.img"
+                dracut_cmd = f"dracut --force {initramfs} {new_kernel}"
+                node.execute(dracut_cmd, sudo=True, shell=True)
 
         if kernel_config_path:
             # Copy kernel config
@@ -228,6 +232,7 @@ def _update_mariner_config(
     new_kernel: str,
     mariner_version: int,
 ) -> None:
+    cat = node.tools[Cat]
     sed = node.tools[Sed]
 
     # Param for Dom0 3.0 kernel installation
@@ -242,6 +247,8 @@ def _update_mariner_config(
         mariner_config = "/boot/mariner-mshv.cfg"
         initrd_regexp = f"mariner_initrd_mshv=initrd.img-{current_kernel}"
         initrd_replacement = f"mariner_initrd_mshv=initrd.img-{new_kernel}"
+
+    cat.read(mariner_config, sudo=True, force_run=True)
 
     # Modify file to point new kernel binary
     sed.substitute(
@@ -258,3 +265,15 @@ def _update_mariner_config(
         file=mariner_config,
         sudo=True,
     )
+
+    lsblk = node.tools[Lsblk]
+    root_partition = lsblk.find_partition_by_mountpoint("/", force_run=True)
+
+    # initramfs can only understand PARTUUID
+    sed.substitute(
+        regexp=f"root=UUID={root_partition.uuid}",
+        replacement=f"root=PARTUUID={root_partition.part_uuid}",
+        file=mariner_config,
+        sudo=True,
+    )
+    cat.read(mariner_config, sudo=True, force_run=True)


### PR DESCRIPTION
Using older initramfs does not work anymore as there are some kernel module dependencies. Hence, generate a new one. Also, replace UUID with PARTUUID since initramfs fails to understand the UUID.

While at it, update validate() method to check if node's os is Mariner.