### PR TITLE
Update to the list of suites executed as part of LTP Lite Test Case

### DIFF
--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -59,7 +59,6 @@ class Ltp(Tool):
     LTP_OUTPUT_PATH = "/opt/ltp/ltp-output.log"
     LTP_SKIP_FILE = "/opt/ltp/skipfile"
     COMPILE_TIMEOUT = 1800
-    RUN_TIMEOUT = 12000
 
     @property
     def command(self) -> str:
@@ -87,6 +86,7 @@ class Ltp(Tool):
         log_path: str,
         block_device: Optional[str] = None,
         temp_dir: str = "/tmp/",
+        ltp_run_timeout: int = 12000,
     ) -> List[LtpResult]:
         # tests cannot be empty
         assert_that(ltp_tests, "ltp_tests cannot be empty").is_not_empty()
@@ -144,7 +144,7 @@ class Ltp(Tool):
         )
 
         pgrep = self.node.tools[Pgrep]
-        pgrep.wait_processes("runltp", timeout=self.RUN_TIMEOUT)
+        pgrep.wait_processes("runltp", timeout=ltp_run_timeout)
 
         # to avoid no permission issue when copying back files
         self.node.tools[Chmod].update_folder("/opt", "a+rwX", sudo=True)

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -29,7 +29,18 @@ from microsoft.testsuites.ltp.ltp import Ltp
 )
 class LtpTestsuite(TestSuite):
     _TIME_OUT = 21000
-    LTP_LITE_TESTS = ["math", "ipc", "mm", "sched", "pty", "fs", "uevent", "syscalls", "hyperthreading", "irq"]
+    LTP_LITE_TESTS = [
+        "math",
+        "ipc",
+        "mm",
+        "sched",
+        "pty",
+        "fs",
+        "uevent",
+        "syscalls",
+        "hyperthreading",
+        "irq",
+    ]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -29,7 +29,7 @@ from microsoft.testsuites.ltp.ltp import Ltp
 )
 class LtpTestsuite(TestSuite):
     _TIME_OUT = 18000
-    LTP_LITE_TESTS = ["math", "fsx", "ipc", "mm", "sched", "pty", "fs"]
+    LTP_LITE_TESTS = ["math", "ipc", "mm", "sched", "pty", "fs", "uevent", "syscalls", "hyperthreading", "irq"]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -29,18 +29,7 @@ from microsoft.testsuites.ltp.ltp import Ltp
 )
 class LtpTestsuite(TestSuite):
     _TIME_OUT = 21000
-    LTP_LITE_TESTS = [
-        "math",
-        "ipc",
-        "mm",
-        "sched",
-        "pty",
-        "fs",
-        "uevent",
-        "syscalls",
-        "hyperthreading",
-        "irq",
-    ]
+    LTP_LITE_TESTS = ["math", "ipc", "mm", "sched", "pty", "fs"]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 
     @TestCaseMetadata(
@@ -77,7 +66,7 @@ class LtpTestsuite(TestSuite):
         tests = variables.get("ltp_test", "")
         skip_tests = variables.get("ltp_skip_test", "")
         ltp_tests_git_tag = variables.get("ltp_tests_git_tag", "")
-
+        ltp_run_timeout = variables.get("ltp_run_timeout", 12000)
         # block device is required for few ltp tests
         # If not provided, we will find a disk with enough space
         block_device = variables.get("ltp_block_device", None)
@@ -113,6 +102,7 @@ class LtpTestsuite(TestSuite):
             skip_test_list,
             log_path,
             block_device=block_device,
+            ltp_run_timeout=ltp_run_timeout,
         )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -28,7 +28,7 @@ from microsoft.testsuites.ltp.ltp import Ltp
     """,
 )
 class LtpTestsuite(TestSuite):
-    _TIME_OUT = 21000
+    _TIME_OUT = 18000
     LTP_LITE_TESTS = ["math", "ipc", "mm", "sched", "pty", "fs"]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 

--- a/microsoft/testsuites/ltp/ltpsuite.py
+++ b/microsoft/testsuites/ltp/ltpsuite.py
@@ -28,7 +28,7 @@ from microsoft.testsuites.ltp.ltp import Ltp
     """,
 )
 class LtpTestsuite(TestSuite):
-    _TIME_OUT = 18000
+    _TIME_OUT = 21000
     LTP_LITE_TESTS = ["math", "ipc", "mm", "sched", "pty", "fs", "uevent", "syscalls", "hyperthreading", "irq"]
     LTP_REQUIRED_DISK_SIZE_IN_GB = 2
 


### PR DESCRIPTION
- The list of tests that are available in the latest tag of LTP have been updated and 'fsx' is no longer available.
- Making LTP Run Timeout value configurable.