### PR TITLE
hyperv: cleanup stale vm before raising exception

### DIFF
--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -131,9 +131,13 @@ class HyperV(Tool):
         if not self.exists_vm(name):
             return None
 
-        # delete port mapping for internal IP address of the VM
-        internal_ip = self.get_ip_address(name)
-        self.delete_nat_mapping(internal_ip=internal_ip)
+        if (
+            self._default_switch
+            and self._default_switch.type == HypervSwitchType.INTERNAL
+        ):
+            # delete port mapping for internal IP address of the VM
+            internal_ip = self.get_ip_address(name)
+            self.delete_nat_mapping(internal_ip=internal_ip)
 
         # stop and delete vm
         self.stop_vm(name=name)


### PR DESCRIPTION
If start_vm() fails due to unassigned IP address, an exception is thrown but it results in a stale VM on the HyperV host. This is inefficient as it continues to consume cpu, memory and storage resource of the host. Hence, cleanup the VM before raising the exception.