### PR TITLE
ch_tests: use different testcase var block size

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -205,11 +205,12 @@ class CloudHypervisorTestSuite(TestSuite):
         # with no disk caching and with direct mode. By Default, we
         # will not run it with data-disk and it would not add direct=on
         # if run_without_cache is not set to YES
-        use_datadisk = variables.get("use_datadisk", "")
+        use_datadisk = variables.get("ch_tests_use_datadisk", "")
         use_pmem = variables.get("ch_tests_use_pmem", "")
         pmem_config = variables.get("ch_tests_pmem_config", "")
-        disable_disk_cache = variables.get("disable_disk_cache", "")
-        block_size_kb = variables.get("block_size_kb", "")
+        disable_disk_cache = variables.get("ch_tests_disable_disk_cache", "")
+        mibps_block_size_kb = variables.get("ch_tests_mibps_block_size_kb", "")
+        iops_block_size_kb = variables.get("ch_tests_iops_block_size_kb", "")
 
         if not ms_access_token:
             raise SkippedException("Access Token is needed while using MS-CLH")
@@ -229,8 +230,10 @@ class CloudHypervisorTestSuite(TestSuite):
         if use_ms_bz_image == "YES":
             CloudHypervisorTests.use_ms_bz_image = use_ms_bz_image
 
-        if block_size_kb:
-            CloudHypervisorTests.block_size_kb = block_size_kb
+        if mibps_block_size_kb:
+            CloudHypervisorTests.mibps_block_size_kb = mibps_block_size_kb
+        if iops_block_size_kb:
+            CloudHypervisorTests.iops_block_size_kb = iops_block_size_kb
         if use_pmem:
             CloudHypervisorTests.use_pmem = use_pmem
             if pmem_config:


### PR DESCRIPTION
Use 'ch_tests_mibps_block_size_kb' and 'ch_tests_iops_block_size_kb' testcase variables for block size of MiBps and IOPS tests respectively. And set env variable accordingly.