### PR TITLE
junit: Add properties to the JUnit.xml file

### DIFF
--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -300,6 +300,18 @@ class JUnit(Notifier):
         testcase.attrib["classname"] = class_name
         testcase.attrib["time"] = self._get_elapsed_str(elapsed)
 
+        # Add a standard system-properties element for all test cases
+        if hasattr(message, 'information') and isinstance(message.information, dict):
+            # Create a system-properties element
+            system_props = ET.SubElement(testcase, "system-properties")
+            
+            # Add VM size and encrypt_disk if they exist
+            for key in ['vmsize', 'encrypt_disk']:
+                if key in message.information:
+                    prop = ET.SubElement(system_props, "property")
+                    prop.attrib["name"] = key
+                    prop.attrib["value"] = str(message.information[key])
+
         if message.status == TestStatus.FAILED:
             failure = ET.SubElement(testcase, "failure")
             failure.attrib["message"] = message.message

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -301,12 +301,12 @@ class JUnit(Notifier):
         testcase.attrib["time"] = self._get_elapsed_str(elapsed)
 
         # Add a standard system-properties element for all test cases
-        if hasattr(message, 'information') and isinstance(message.information, dict):
+        if hasattr(message, "information") and isinstance(message.information, dict):
             # Create a system-properties element
             system_props = ET.SubElement(testcase, "system-properties")
-            
+
             # Add VM size and encrypt_disk if they exist
-            for key in ['vmsize', 'encrypt_disk']:
+            for key in ["vmsize", "encrypt_disk"]:
                 if key in message.information:
                     prop = ET.SubElement(system_props, "property")
                     prop.attrib["name"] = key


### PR DESCRIPTION
- In case of CVM test cases, we need the information about `vmsize` and `disk_encryption` status in the JUnit.xml file for testing it on different combinations.
- This PR adds these values to the JUnit.xml file in the form of system properties by extracting it from the `information` in the `TestResultMessageBase` class. 
- In future, this method can also be used to add more properties to the Junit file if required 