### PR TITLE
Added properties to fdisk to prevent install issue.

### DIFF
--- a/lisa/tools/fdisk.py
+++ b/lisa/tools/fdisk.py
@@ -120,6 +120,13 @@ class Fdisk(Tool):
 class BSDFdisk(Fdisk):
     LIST_PARTITION_COMMAND = "sync; ls -lt /dev/da*; ls -lt /dev/nvd*"
 
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    def _check_exists(self) -> bool:
+        return True
+
     def _get_partition_pattern(self, disk_name: str) -> Pattern[str]:
         return re.compile(rf"({disk_name}p[0-9]+)")
 


### PR DESCRIPTION
To handle the issue that lists a failure to install fdisk on freebsd I have added the required properties to the bsdfdisk class that will prevent this. The affected tests will still fail due to other issues with storage management and a lack of tooling for setting up raid. That is an issue I am currently working on but it shouldn't prevent this fix from going in.