### PR TITLE
adding BSDTaskSet tool

### DIFF
--- a/lisa/tools/taskset.py
+++ b/lisa/tools/taskset.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from typing import Optional, Type
+
 from lisa.executable import Tool
 from lisa.util.process import Process
 
@@ -10,9 +12,22 @@ class TaskSet(Tool):
     def command(self) -> str:
         return "taskset"
 
+    @classmethod
+    def _freebsd_tool(cls) -> Optional[Type[Tool]]:
+        return BSDTaskSet
+
     @property
     def can_install(self) -> bool:
         return False
+
+    def run_on_specific_cpu(self, cpu_id: int) -> Process:
+        return self.run_async(f"-c {cpu_id} yes > /dev/null", shell=True)
+
+
+class BSDTaskSet(TaskSet):
+    @property
+    def command(self) -> str:
+        return "cpuset"
 
     def run_on_specific_cpu(self, cpu_id: int) -> Process:
         return self.run_async(f"-c {cpu_id} yes > /dev/null", shell=True)

--- a/lisa/tools/taskset.py
+++ b/lisa/tools/taskset.py
@@ -30,4 +30,4 @@ class BSDTaskSet(TaskSet):
         return "cpuset"
 
     def run_on_specific_cpu(self, cpu_id: int) -> Process:
-        return self.run_async(f"-c {cpu_id} yes > /dev/null", shell=True)
+        return self.run_async(f"-l {cpu_id} yes > /dev/null", shell=True)


### PR DESCRIPTION
created a BSDTaskSet tool to prevent task set issues on arm64 vms. The test case now fails with the interrupt inspector failure that the other images face.