### PR TITLE
UpgradeInstaller: Retry package installation

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1191,6 +1191,7 @@ class Debian(Linux):
         )
         if packages:
             command += " ".join(packages)
+        self.wait_running_package_process()
         self._node.execute(command, sudo=True, timeout=3600)
 
 

--- a/lisa/transformers/upgrade_packages.py
+++ b/lisa/transformers/upgrade_packages.py
@@ -188,6 +188,7 @@ class UnattendedUpgradeInstaller(UpgradeInstaller):
         )
         upgradable_before = [package.strip() for package in result.stdout.split("\n")]
 
+        node.os.wait_running_package_process()
         node.execute(
             "unattended-upgrade -d -v",
             sudo=True,
@@ -264,6 +265,7 @@ class FullUpgradeInstaller(UpgradeInstaller):
         node: Node = self._node
         assert isinstance(node.os, Debian)
 
+        node.os.wait_running_package_process()
         node.execute(
             "apt update",
             sudo=True,


### PR DESCRIPTION
VM extensions (or other causes) can result in the package manager lock being busy. Retrying the operation allows opportunities for other package manager operations to finish so the lock can be acquired.