### PR TITLE
Add test for Application Health Extension Linux

### DIFF
--- a/microsoft/testsuites/vm_extensions/applicationhealthextension.py
+++ b/microsoft/testsuites/vm_extensions/applicationhealthextension.py
@@ -97,7 +97,7 @@ class ApplicationHealthExtension(TestSuite):
         }
 
         for distro in supported_major_versions:
-            if isinstance(node.os, distro):
+            if type(node.os) == distro:
                 version_list = supported_major_versions.get(distro)
                 if version_list is not None and node.os.information.version.major in version_list:
                     return True

--- a/microsoft/testsuites/vm_extensions/applicationhealthextension.py
+++ b/microsoft/testsuites/vm_extensions/applicationhealthextension.py
@@ -50,22 +50,12 @@ class ApplicationHealthExtension(TestSuite):
     def verify_application_health_extension(self, log: Logger, node: Node) -> None:
         extension = node.features[AzureExtension]
 
-        settings = {
-            "protocol": "http",
-            "port": 8080,
-            "requestPath": "/health",
-            "intervalInSeconds": 5,
-            "numberOfProbes": 1,
-            "gracePeriod": 10,
-        }
-
         extension_result = extension.create_or_update(
             name="HealthExtension",
             publisher="Microsoft.ManagedServices.Edp",
             type_="ApplicationHealthLinux",
             type_handler_version="2.0",
             auto_upgrade_minor_version=True,
-            settings=settings,
         )
 
         assert_that(extension_result["provisioning_state"]).described_as(
@@ -75,7 +65,7 @@ class ApplicationHealthExtension(TestSuite):
         self._check_extension_logs(
             node=node,
             log_file="/var/log/azure/applicationhealth-extension/handler.log",
-            expected_app_health_message="AppHealthExtension is running",
+            expected_app_health_message="Committed health state is healthy",
         )
 
         extension.delete("HealthExtension")

--- a/microsoft/testsuites/vm_extensions/applicationhealthextension.py
+++ b/microsoft/testsuites/vm_extensions/applicationhealthextension.py
@@ -103,7 +103,7 @@ class ApplicationHealthExtension(TestSuite):
     @retry(tries=5, delay=60)
     def _check_extension_logs(
         self, node: Node, log_file: str, expected_app_health_message: str
-    ):
+    ) -> None:
         result = node.execute(
             f"grep '{expected_app_health_message}' {log_file}", sudo=True
         )

--- a/microsoft/testsuites/vm_extensions/applicationhealthextension.py
+++ b/microsoft/testsuites/vm_extensions/applicationhealthextension.py
@@ -1,0 +1,113 @@
+from typing import Any
+
+from assertpy import assert_that
+from retry import retry
+
+from lisa import (
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.operating_system import (
+    SLES,
+    CBLMariner,
+    CentOs,
+    Debian,
+    Oracle,
+    Redhat,
+    Suse,
+    Ubuntu,
+)
+from lisa.sut_orchestrator.azure.features import AzureExtension
+from lisa.util import SkippedException
+
+
+@TestSuiteMetadata(
+    area="vm_extension",
+    category="functional",
+    description="Tests for the Application Health Extension (AHE) on Linux",
+)
+class ApplicationHealthExtension(TestSuite):
+    def before_case(self, log: Logger, **kwargs: Any) -> None:
+        node = kwargs["node"]
+        if not self._is_supported_linux_distro(node):
+            raise SkippedException(f"{str(node.os.information.full_version)} is not supported.")
+
+    @TestCaseMetadata(
+        description="""
+        Installs and verifies the Application Health Extension (AHE).
+        Checks logs for expected message.
+        Deletes the VM Extension.
+        """,
+        priority=1,
+        requirement=simple_requirement(
+            supported_features=[AzureExtension],
+        ),
+    )
+    def verify_application_health_extension(self, log: Logger, node: Node) -> None:
+        extension = node.features[AzureExtension]
+
+        settings = {
+            "protocol": "http",
+            "port": 8080,
+            "requestPath": "/health",
+            "intervalInSeconds": 5,
+            "numberOfProbes": 1,
+            "gracePeriod": 10,
+        }
+
+        extension_result = extension.create_or_update(
+            name="HealthExtension",
+            publisher="Microsoft.ManagedServices.Edp",
+            type_="ApplicationHealthLinux",
+            type_handler_version="2.0",
+            auto_upgrade_minor_version=True,
+            settings=settings,
+        )
+
+        assert_that(extension_result["provisioning_state"]).described_as(
+            "Expected the extension to succeed"
+        ).is_equal_to("Succeeded")
+
+        self._check_extension_logs(
+            node=node,
+            log_file="/var/log/azure/applicationhealth-extension/handler.log",
+            expected_app_health_message="AppHealthExtension is running",
+        )
+
+        extension.delete("HealthExtension")
+
+        assert_that(extension.check_exist("HealthExtension")).described_as(
+            "Found the VM Extension still unexpectedly exists on the VM after deletion"
+        ).is_false()
+
+    def _is_supported_linux_distro(self, node: Node) -> bool:
+        supported_major_versions = {
+            Redhat: [7, 8],
+            CentOs: [6, 7],
+            Oracle: [6, 7],
+            Debian: [7, 8],
+            Ubuntu: [16, 18, 20, 22],
+            Suse: [12, 15],
+            SLES: [12, 15],
+            CBLMariner: [2, 3],
+        }
+
+        for distro in supported_major_versions:
+            if isinstance(node.os, distro):
+                version_list = supported_major_versions.get(distro)
+                if version_list is not None and node.os.information.version.major in version_list:
+                    return True
+                else:
+                    return False
+        return False
+
+    @retry(tries=5, delay=60)
+    def _check_extension_logs(self, node: Node, log_file: str, expected_app_health_message: str):
+        result = node.execute(f"grep '{expected_app_health_message}' {log_file}", sudo=True)
+        assert_that(result.exit_code).described_as(
+            f"Expected to find '{expected_app_health_message}' in {log_file}"
+        ).is_equal_to(0)

--- a/microsoft/testsuites/vm_extensions/applicationhealthextension.py
+++ b/microsoft/testsuites/vm_extensions/applicationhealthextension.py
@@ -34,7 +34,9 @@ class ApplicationHealthExtension(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
         if not self._is_supported_linux_distro(node):
-            raise SkippedException(f"{str(node.os.information.full_version)} is not supported.")
+            raise SkippedException(
+                f"{str(node.os.information.full_version)} is not supported."
+            )
 
     @TestCaseMetadata(
         description="""
@@ -89,15 +91,22 @@ class ApplicationHealthExtension(TestSuite):
         for distro in supported_major_versions:
             if type(node.os) == distro:
                 version_list = supported_major_versions.get(distro)
-                if version_list is not None and node.os.information.version.major in version_list:
+                if (
+                    version_list is not None
+                    and node.os.information.version.major in version_list
+                ):
                     return True
                 else:
                     return False
         return False
 
     @retry(tries=5, delay=60)
-    def _check_extension_logs(self, node: Node, log_file: str, expected_app_health_message: str):
-        result = node.execute(f"grep '{expected_app_health_message}' {log_file}", sudo=True)
+    def _check_extension_logs(
+        self, node: Node, log_file: str, expected_app_health_message: str
+    ):
+        result = node.execute(
+            f"grep '{expected_app_health_message}' {log_file}", sudo=True
+        )
         assert_that(result.exit_code).described_as(
             f"Expected to find '{expected_app_health_message}' in {log_file}"
         ).is_equal_to(0)


### PR DESCRIPTION
## Change summary ##

This PR introduces a test scenario for the Application Health Extension on Linux. The test performs the following validations:
- Ensure the extension is installed successfully
- Check the logs emitted by the Application Health Extension to assert that it is running
- Verify the extension is uninstalled successfully

## Test & Validation ##

- [X] Manual validation on dev machine

### Test & Validation details ###

I rebased my branch locally from [upstream/lildeng/fix_3_24_001](https://github.com/microsoft/lisa/tree/lildeng/fix_3_24_001) (thanks @LiliDeng) and ran the following command:
- `lisa run -r ./microsoft/runbook/azure.yml -v subscription_id:3f0e8d2d-2c35-4e12-9f17-e5458b2e9642 -v tier:0`

Note: I also modified the priority of my test case from 1 to 0 to receive timely feedback from the test engine.