### PR TITLE
Change the logic back for public ip address

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -269,11 +269,11 @@ resource nodes_public_ip 'Microsoft.Network/publicIPAddresses@2020-05-01' = [for
   tags: tags
   name: '${nodes[i].name}-public-ip'
   properties: {
-    publicIPAllocationMethod: 'Static'
+    publicIPAllocationMethod: ((is_ultradisk || use_availability_zones) ? 'Static' : 'Dynamic')
     ipTags: (empty(ip_tags) ? null : ip_tags)
   }
   sku: {
-    name: 'Standard'
+    name: ((is_ultradisk || use_availability_zones) ? 'Standard' : 'Basic')
   }
   zones: (use_availability_zones ? availability_zones : null)
 }]

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "9899340922005457447"
+      "version": "0.34.1.11899",
+      "templateHash": "3180323640814036703"
     }
   },
   "functions": [
@@ -600,11 +600,11 @@
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "properties": {
-        "publicIPAllocationMethod": "Static",
+        "publicIPAllocationMethod": "[if(or(parameters('is_ultradisk'), variables('use_availability_zones')), 'Static', 'Dynamic')]",
         "ipTags": "[if(empty(variables('ip_tags')), null(), variables('ip_tags'))]"
       },
       "sku": {
-        "name": "Standard"
+        "name": "[if(or(parameters('is_ultradisk'), variables('use_availability_zones')), 'Standard', 'Basic')]"
       },
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]"
     },
@@ -816,8 +816,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2335646842987786457"
+              "version": "0.34.1.11899",
+              "templateHash": "12853422832965079706"
             }
           },
           "functions": [


### PR DESCRIPTION
Revert the public IP from Standard to Basic to unblock some users. By default, Basic type PIP doesn't have restrictions for inbound and outbound ports and doesn't require additional NSG rules. 
However, please note that Basic type PIP rules will expire on September 30th. I will make changes soon to change the PIP type + nsg solutions for users.