### PR TITLE
Adding a Kself Lite Test Case

### DIFF
--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -18,6 +18,17 @@ class KselftestTestsuite(TestSuite):
     # timeout below is in seconds and set to 2 hours.
     _CASE_TIME_OUT = 7200
     _KSELF_TIMEOUT = 6700
+    # the default list of tests executed as part of kself lite
+    _KSELF_LITE_TESTS = [
+        "bpf",
+        "core",
+        "futex",
+        "ipc",
+        "kvm",
+        "mm",
+        "net",
+        "timers",
+    ]
 
     @TestCaseMetadata(
         description="""
@@ -57,5 +68,68 @@ class KselftestTestsuite(TestSuite):
                 file_path=file_path,
             )
             kselftest.run_all(result, log_path, self._KSELF_TIMEOUT, run_as_root)
+        except UnsupportedDistroException as identifier:
+            raise SkippedException(identifier)
+
+    @TestCaseMetadata(
+        description="""
+        This test case will run kself lite tests - a subset of kselftests.
+        Cases:
+        1. When a tarball is specified in .yml file, extract the tar and run kselftests.
+        Example:
+        - name: kselftest_file_path
+          value: <path_to_kselftests.tar.xz>
+          is_case_visible: true
+        2. When a tarball is not specified in .yml file, clone Mariner kernel,
+        copy current config to .config, build kselftests and generate a tar.
+        For both cases, verify that the kselftest tool extracts the tar, runs the script
+        run_kselftest.sh and redirects test results to a file kselftest-results.txt.
+        3. For this lite version, the list of collections to run and the list
+        of tests to skip can be specified in the .yml file.
+        Example:
+        - name: kself_skip_tests
+          value: <comma_separated_list_of_tests_to_skip - format: collection:test_name>
+          is_case_visible: true
+        - name: kself_test_collection
+          value: <comma_separated_list_of_collections_to_run - format: collection_name>
+          is_case_visible: true
+        """,
+        priority=3,
+        timeout=_CASE_TIME_OUT,
+        requirement=simple_requirement(
+            min_core_count=16,
+        ),
+    )
+    def verify_kself_lite(
+        self,
+        node: Node,
+        log_path: str,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        file_path = variables.get("kselftest_file_path", "")
+        skip_tests = variables.get("kself_skip_tests", "")
+        test_collection = variables.get("kself_test_collection", "")
+        # get comma separated list of tests
+        if test_collection:
+            test_collection_list = test_collection.split(",")
+        else:
+            test_collection_list = self._KSELF_LITE_TESTS
+        if skip_tests:
+            skip_tests_list = skip_tests.split(",")
+        else:
+            skip_tests_list = []
+        try:
+            kselftest: Kselftest = node.tools.get(
+                Kselftest,
+                kselftest_file_path=file_path,
+            )
+            kselftest.run_all(
+                test_result=result,
+                log_path=log_path,
+                timeout=self._KSELF_TIMEOUT,
+                run_collections=test_collection_list,
+                skip_tests=skip_tests_list,
+            )
         except UnsupportedDistroException as identifier:
             raise SkippedException(identifier)

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -71,28 +71,38 @@ class KselftestTestsuite(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case will run kself lite tests - a subset of kselftests.
-        A predefined list of tests is provided in _KSELF_LITE_TESTS,
-        though a custom value can be passed to the test case as well.
-        Cases:
-        1. When a tarball is specified in .yml file, extract the tar and run kselftests.
-        Example:
-        - name: kselftest_file_path
-          value: <path_to_kselftests.tar.xz>
-          is_case_visible: true
-        2. When a tarball is not specified in .yml file, clone Mariner kernel,
-        copy current config to .config, build kselftests and generate a tar.
-        For both cases, verify that the kselftest tool extracts the tar, runs the script
-        run_kselftest.sh and redirects test results to a file kselftest-results.txt.
-        3. For this lite version, the list of collections to run and the list
-        of tests to skip can be specified in the .yml file.
-        Example:
-        - name: kself_skip_tests
-          value: <comma_separated_list_of_tests_to_skip - format: collection:test_name>
-          is_case_visible: true
-        - name: kself_test_collection
-          value: <comma_separated_list_of_collections_to_run - format: collection_name>
-          is_case_visible: true
+        This test case will run a lighter version of kselftests, focusing on specific test suites
+        and skipping less critical and noisy tests. The default list of tests to run
+        is defined in the `_KSELF_LITE_TESTS` list, which includes collections such as "bpf",
+        "core", "futex", "ipc", "mm", "net", "timers", and "x86". These tests were
+        selected to cover critical kernel functionalities, such as memory management, inter-process
+        communication, and synchronization primitives, while reducing execution time and resource usage.
+
+        Purpose:
+        This "lite" version is designed for scenarios where running the full kselftest suite is
+        not feasible, such as environments with limited resources or during iterative development
+        where faster feedback is required. It ensures that critical kernel features are tested
+        without the overhead of running the entire suite. Also, ensuring that the user can avoid tests/
+        suites that are known to fail or are not relevant to their use case.
+        
+        Customization:
+        Users can customize the test by specifying the `kself_test_collection` and `kself_skip_tests`
+        variables in the runbook. For example:
+        - `kself_test_collection`: A comma-separated list of collections to run (e.g., "bpf,core,futex").
+        - `kself_skip_tests`: A comma-separated list of tests to skip (e.g., "cgroup:test_cpu,cgroup:test_freezer").
+        For both cases, the test extracts the tarball (if provided), runs the `run_kselftest.sh` script,
+        and redirects the test results to a file named `kselftest-results.txt`.
+        
+        Default Test Suites:
+        The `_KSELF_LITE_TESTS` list includes the following test suites:
+        - `bpf`: Tests related to the Berkeley Packet Filter (BPF) subsystem.
+        - `core`: Core kernel functionality tests.
+        - `futex`: Tests for fast user-space mutexes.
+        - `ipc`: Inter-process communication tests.
+        - `mm`: Memory management tests.
+        - `net`: Networking-related tests, including TCP, UDP, and other network protocols.
+        - `timers`: Tests for kernel timer functionality and timekeeping.
+        - `x86`: Architecture-specific tests for the x86 platform.
         """,
         priority=3,
         timeout=_CASE_TIME_OUT,
@@ -100,7 +110,7 @@ class KselftestTestsuite(TestSuite):
             min_core_count=16,
         ),
     )
-    def verify_kself_lite(
+    def verify_kselftest_lite(
         self,
         node: Node,
         log_path: str,

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -28,7 +28,7 @@ class KselftestTestsuite(TestSuite):
         "mm",
         "net",
         "timers",
-        "x86"
+        "x86",
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -87,11 +87,12 @@ class KselftestTestsuite(TestSuite):
         suites that are known to fail or are not relevant to their use case.
 
         Customization:
-        Users can customize the test by specifying the `kself_test_collection` and
-        `kself_skip_tests` variables in the runbook. For example:
-        - `kself_test_collection`: A comma-separated list of collections to run
-        (e.g., "bpf,net,timers").
-        - `kself_skip_tests`: A comma-separated list of tests to skip
+        Users can customize the test by specifying the
+        `kselftest_include_test_collections` and `kselftest_skip_tests` variables
+        in the runbook. For example:
+        - `kselftest_include_test_collections`: A comma-separated list of collections
+        to run (e.g., "bpf,net,timers").
+        - `kselftest_skip_tests`: A comma-separated list of tests to skip
         (e.g., "net:test_tcp,test_udp").
 
         For both cases, the test extracts the tarball (if provided), runs the
@@ -124,13 +125,13 @@ class KselftestTestsuite(TestSuite):
         result: TestResult,
     ) -> None:
         test_collection_list = (
-            variables.get("kself_test_collection", "").split(",")
-            if variables.get("kself_test_collection", "")
+            variables.get("kselftest_include_test_collections", "").split(",")
+            if variables.get("kselftest_include_test_collections", "")
             else self._KSELF_LITE_TESTS
         )
         skip_tests_list = (
-            variables.get("kself_skip_tests", "").split(",")
-            if variables.get("kself_skip_tests", "")
+            variables.get("kselftest_skip_tests", "").split(",")
+            if variables.get("kselftest_skip_tests", "")
             else []
         )
         try:

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -72,7 +72,7 @@ class KselftestTestsuite(TestSuite):
     @TestCaseMetadata(
         description="""
         This test case will run a lighter version of kselftests, focusing on specific
-        test suites and skipping less critical or resource-intensive tests. The default
+        test suites and skipping less critical and noisy tests. The default
         list of tests to run is defined in the `_KSELF_LITE_TESTS` list, which includes
         collections such as "bpf", "core", "futex", "ipc", "mm", "net", "timers", and
         "x86". These tests were selected to cover critical kernel functionalities, such
@@ -81,10 +81,10 @@ class KselftestTestsuite(TestSuite):
 
         Purpose:
         This "lite" version is designed for scenarios where running the full kselftest
-        suite is not feasible, such as environments with limited resources or during
-        iterative development where faster feedback is required. It ensures that
+        suite is not feasible or not required. It ensures that
         critical kernel features are tested without the overhead of running the entire
-        suite.
+        suite. Also, ensuring that the user can avoid tests/
+        suites that are known to fail or are not relevant to their use case.
 
         Customization:
         Users can customize the test by specifying the `kself_test_collection` and

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -71,28 +71,33 @@ class KselftestTestsuite(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case will run a lighter version of kselftests, focusing on specific test suites
-        and skipping less critical and noisy tests. The default list of tests to run
-        is defined in the `_KSELF_LITE_TESTS` list, which includes collections such as "bpf",
-        "core", "futex", "ipc", "mm", "net", "timers", and "x86". These tests were
-        selected to cover critical kernel functionalities, such as memory management, inter-process
-        communication, and synchronization primitives, while reducing execution time and resource usage.
+        This test case will run a lighter version of kselftests, focusing on specific
+        test suites and skipping less critical or resource-intensive tests. The default
+        list of tests to run is defined in the `_KSELF_LITE_TESTS` list, which includes
+        collections such as "bpf", "core", "futex", "ipc", "mm", "net", "timers", and
+        "x86". These tests were selected to cover critical kernel functionalities, such
+        as networking, timer management, and architecture-specific features, while
+        reducing execution time and resource usage.
 
         Purpose:
-        This "lite" version is designed for scenarios where running the full kselftest suite is
-        not feasible, such as environments with limited resources or during iterative development
-        where faster feedback is required. It ensures that critical kernel features are tested
-        without the overhead of running the entire suite. Also, ensuring that the user can avoid tests/
-        suites that are known to fail or are not relevant to their use case.
-        
+        This "lite" version is designed for scenarios where running the full kselftest
+        suite is not feasible, such as environments with limited resources or during
+        iterative development where faster feedback is required. It ensures that
+        critical kernel features are tested without the overhead of running the entire
+        suite.
+
         Customization:
-        Users can customize the test by specifying the `kself_test_collection` and `kself_skip_tests`
-        variables in the runbook. For example:
-        - `kself_test_collection`: A comma-separated list of collections to run (e.g., "bpf,core,futex").
-        - `kself_skip_tests`: A comma-separated list of tests to skip (e.g., "cgroup:test_cpu,cgroup:test_freezer").
-        For both cases, the test extracts the tarball (if provided), runs the `run_kselftest.sh` script,
-        and redirects the test results to a file named `kselftest-results.txt`.
-        
+        Users can customize the test by specifying the `kself_test_collection` and
+        `kself_skip_tests` variables in the runbook. For example:
+        - `kself_test_collection`: A comma-separated list of collections to run
+        (e.g., "bpf,net,timers").
+        - `kself_skip_tests`: A comma-separated list of tests to skip
+        (e.g., "net:test_tcp,test_udp").
+
+        For both cases, the test extracts the tarball (if provided), runs the
+        `run_kselftest.sh` script, and redirects the test results to a file named
+        `kselftest-results.txt`.
+
         Default Test Suites:
         The `_KSELF_LITE_TESTS` list includes the following test suites:
         - `bpf`: Tests related to the Berkeley Packet Filter (BPF) subsystem.
@@ -100,7 +105,8 @@ class KselftestTestsuite(TestSuite):
         - `futex`: Tests for fast user-space mutexes.
         - `ipc`: Inter-process communication tests.
         - `mm`: Memory management tests.
-        - `net`: Networking-related tests, including TCP, UDP, and other network protocols.
+        - `net`: Networking-related tests, including TCP, UDP, and other network
+        protocols.
         - `timers`: Tests for kernel timer functionality and timekeeping.
         - `x86`: Architecture-specific tests for the x86 platform.
         """,

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from lisa import Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.testsuite import TestResult, simple_requirement
@@ -59,22 +59,21 @@ class KselftestTestsuite(TestSuite):
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        file_path = variables.get("kselftest_file_path", "")
-        working_path = variables.get("kselftest_working_path", "")
-        run_as_root = variables.get("kselftest_run_as_root", False)
         try:
-            kselftest: Kselftest = node.tools.get(
-                Kselftest,
-                working_path=working_path,
-                file_path=file_path,
+            self._run_kselftest(
+                node,
+                log_path,
+                variables,
+                result,
             )
-            kselftest.run_all(result, log_path, self._KSELF_TIMEOUT, run_as_root)
         except UnsupportedDistroException as identifier:
             raise SkippedException(identifier)
 
     @TestCaseMetadata(
         description="""
         This test case will run kself lite tests - a subset of kselftests.
+        A predefined list of tests is provided in _KSELF_LITE_TESTS,
+        though a custom value can be passed to the test case as well.
         Cases:
         1. When a tarball is specified in .yml file, extract the tar and run kselftests.
         Example:
@@ -108,29 +107,52 @@ class KselftestTestsuite(TestSuite):
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        file_path = variables.get("kselftest_file_path", "")
-        skip_tests = variables.get("kself_skip_tests", "")
-        test_collection = variables.get("kself_test_collection", "")
-        # get comma separated list of tests
-        if test_collection:
-            test_collection_list = test_collection.split(",")
-        else:
-            test_collection_list = self._KSELF_LITE_TESTS
-        if skip_tests:
-            skip_tests_list = skip_tests.split(",")
-        else:
-            skip_tests_list = []
+        test_collection_list = (
+            variables.get("kself_test_collection", "").split(",")
+            if variables.get("kself_test_collection", "")
+            else self._KSELF_LITE_TESTS
+        )
+        skip_tests_list = (
+            variables.get("kself_skip_tests", "").split(",")
+            if variables.get("kself_skip_tests", "")
+            else []
+        )
         try:
-            kselftest: Kselftest = node.tools.get(
-                Kselftest,
-                kselftest_file_path=file_path,
-            )
-            kselftest.run_all(
-                test_result=result,
-                log_path=log_path,
-                timeout=self._KSELF_TIMEOUT,
-                run_collections=test_collection_list,
-                skip_tests=skip_tests_list,
+            self._run_kselftest(
+                node,
+                log_path,
+                variables,
+                result,
+                test_collection_list,
+                skip_tests_list,
             )
         except UnsupportedDistroException as identifier:
             raise SkippedException(identifier)
+
+    def _run_kselftest(
+        self,
+        node: Node,
+        log_path: str,
+        variables: Dict[str, Any],
+        result: TestResult,
+        run_collections: Optional[List[str]] = None,
+        skip_tests: Optional[List[str]] = None,
+    ) -> None:
+        run_collections = run_collections or []
+        skip_tests = skip_tests or []
+        file_path = variables.get("kselftest_file_path", "")
+        working_path = variables.get("kselftest_working_path", "")
+        run_as_root = variables.get("kselftest_run_as_root", False)
+        kselftest: Kselftest = node.tools.get(
+            Kselftest,
+            working_path=working_path,
+            file_path=file_path,
+        )
+        kselftest.run_all(
+            test_result=result,
+            log_path=log_path,
+            timeout=self._KSELF_TIMEOUT,
+            run_test_as_root=run_as_root,
+            run_collections=run_collections,
+            skip_tests=skip_tests,
+        )

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -24,10 +24,11 @@ class KselftestTestsuite(TestSuite):
         "core",
         "futex",
         "ipc",
-        "kvm",
+        "kexec",
         "mm",
         "net",
         "timers",
+        "x86"
     ]
 
     @TestCaseMetadata(

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -238,13 +238,21 @@ class Kselftest(Tool):
         if run_collections or skip_tests:
             # List all available tests
             list_result = self.run(" -l", shell=True)
-            list_result.assert_exit_code()
+            list_result.assert_exit_code(
+                message="failed to retrieve the list of available kself tests"
+            )
             all_tests = list_result.stdout.splitlines()
 
             # Filter tests based on run_collections if it exists
-            if not run_collections:
-                filtered_tests = all_tests
-            else:
+            # Example: if run_collections = ['uevent']
+            # all_tests will already have all tests in the format:
+            #   ['core:close_range_test', 'core:unshare_test',
+            #    'tty:tty_tstamp_update', 'uevent:uevent_filtering']
+            # The filtered_tests will then have the value:
+            #   ['uevent:uevent_filtering']
+            # This means all the tests that belong to the 'uevent'
+            #   collection are selected.
+            if run_collections:
                 filtered_tests = [
                     test
                     for test in all_tests
@@ -253,6 +261,8 @@ class Kselftest(Tool):
                         for collection in run_collections
                     )
                 ]
+            else:
+                filtered_tests = all_tests
 
             # Exclude tests based on skip_tests
             tests_to_run = [test for test in filtered_tests if test not in skip_tests]

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -257,7 +257,8 @@ class Kselftest(Tool):
                     test
                     for test in all_tests
                     if any(
-                        (match := re.match(r"^[^:/]+", test)) and collection == match.group(0)
+                        (match := re.match(r"^[^:/]+", test))
+                        and collection == match.group(0)
                         for collection in run_collections
                     )
                 ]

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -257,7 +257,7 @@ class Kselftest(Tool):
                     test
                     for test in all_tests
                     if any(
-                        collection == test.split(":")[0].split("/")[0]
+                        collection == re.match(r"^[^:/]+", test).group(0)
                         for collection in run_collections
                     )
                 ]

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -257,7 +257,7 @@ class Kselftest(Tool):
                     test
                     for test in all_tests
                     if any(
-                        collection == re.match(r"^[^:/]+", test).group(0)
+                        (match := re.match(r"^[^:/]+", test)) and collection == match.group(0)
                         for collection in run_collections
                     )
                 ]

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -257,10 +257,11 @@ class Kselftest(Tool):
             # Exclude tests based on skip_tests
             tests_to_run = [test for test in filtered_tests if test not in skip_tests]
 
-            for test in tests_to_run:
-                self._log.debug(f"Running test: {test}")
+            if tests_to_run:
+                tests_to_run_str = " ".join(f"-t {test}" for test in tests_to_run)
+                self._log.debug(f"Running tests: {tests_to_run}")
                 self.run(
-                    f" -t {test} 2>&1 | tee -a {result_file}",
+                    f" {tests_to_run_str} 2>&1 | tee -a {result_file}",
                     sudo=run_test_as_root,
                     force_run=True,
                     shell=True,


### PR DESCRIPTION
Currently the 'verify_kselftest' Test Case executes all the tests and test suites which are a part of the Linux KSelf tests.

Although we wanted to create a lighter version, where there would be a predefined list of the most critical test suites. Also, users would be able to pass the test suites they want to execute and the specific test cases that need to be skipped.