### PR TITLE
Rydailey/devicestatistics

### DIFF
--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -1128,7 +1128,8 @@ class EthtoolFreebsd(Ethtool):
         if not force_run and device.device_statistics:
             return device.device_statistics
 
-        result = self.run(f"netstat -i | grep {interface}", force_run=True, shell=True)
+        result = self.run(f"ifconfig {interface}", force_run=True, shell=True)
+        self.node.log.info(f"ifconfig {interface} result: {result.stdout}")
         if (result.exit_code != 0) and (
             "Operation not supported" in result.stdout
             or "no stats available" in result.stdout

--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -1140,6 +1140,10 @@ class EthtoolFreebsd(Ethtool):
         if not force_run and device.device_statistics:
             return device.device_statistics
 
+        # Example Matches
+        # hn0
+        # mce0
+        # da0
         match = re.match(r"^(\w+)(\d+)$", interface)
         if not match:
             raise LisaException(f"Invalid interface name: {interface}")

--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -438,9 +438,13 @@ class DeviceStatistics:
     # dev.hn.0.rx.0.packets: 0
     # dev.mce.0.txstat0tc0.packets: 0
     # dev.mce.0.rxstat0.packets: 0
-    _bsd_statistics_pattern = re.compile(r"^dev\.\w+\.\d+.(?P<name>.*?)\: +?(?P<value>\d+?)\r?$")
+    _bsd_statistics_pattern = re.compile(
+        r"^dev\.\w+\.\d+.(?P<name>.*?)\: +?(?P<value>\d+?)\r?$"
+    )
 
-    def __init__(self, interface: str, device_statistics_raw: str, bsd: bool = False) -> None:
+    def __init__(
+        self, interface: str, device_statistics_raw: str, bsd: bool = False
+    ) -> None:
         self._parse_statistics_info(interface, device_statistics_raw, bsd)
 
     def _parse_statistics_info(self, interface: str, raw_str: str, bsd: bool) -> None:
@@ -1141,7 +1145,9 @@ class EthtoolFreebsd(Ethtool):
             raise LisaException(f"Invalid interface name: {interface}")
         device_name = match.group(1)
         number = match.group(2)
-        result = self.run(f"sysctl dev.{device_name}.{number}", force_run=True, shell=True)
+        result = self.run(
+            f"sysctl dev.{device_name}.{number}", force_run=True, shell=True
+        )
         if (result.exit_code != 0) and (
             "Operation not supported" in result.stdout
             or "no stats available" in result.stdout

--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -1128,7 +1128,7 @@ class EthtoolFreebsd(Ethtool):
         if not force_run and device.device_statistics:
             return device.device_statistics
 
-        result = self.run(f"FREEBSD COMMAND to acquire stats for {interface}", force_run=True, shell=True)
+        result = self.run(f"netstat -i | grep {interface}", force_run=True, shell=True)
         if (result.exit_code != 0) and (
             "Operation not supported" in result.stdout
             or "no stats available" in result.stdout

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -768,6 +768,7 @@ class NetworkSettings(TestSuite):
         per_vf_queue_stats = 0
         for device_stats in devices_statistics:
             nic = client_node.nics.get_nic(device_stats.interface)
+            client_node.log.info(f"Checking device stats for {device_stats.interface}: {device_stats.counters.keys()}")
             if nic.lower:
                 try:
                     device_stats = ethtool.get_device_statistics(nic.lower, True)

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -772,8 +772,8 @@ class NetworkSettings(TestSuite):
             "netvsc_set_msglevel" not in msg_level_symbols
         ):
             raise SkippedException(
-                f"Get/Set message level not supported on {kernel_version},"
-                " Skipping test."
+                f"Get/Set message level not supported on {kernel_version}, "
+                "Skipping test."
             )
 
     def _verify_stats_exists(
@@ -791,7 +791,6 @@ class NetworkSettings(TestSuite):
         per_vf_queue_stats = 0
         for device_stats in devices_statistics:
             nic = client_node.nics.get_nic(device_stats.interface)
-            client_node.log.info(f"Checking device stats for {device_stats.interface}: {device_stats.counters.keys()}")
             if nic.lower:
                 try:
                     device_stats = ethtool.get_device_statistics(nic.lower, True)

--- a/microsoft/testsuites/network/networksettings.py
+++ b/microsoft/testsuites/network/networksettings.py
@@ -57,25 +57,7 @@ class NetworkSettings(TestSuite):
     _vf_queue_stats_regex = re.compile(r"[tr]x[_]?(?P<name>[\d]+)_packets")
 
     # regex for filtering vf queue stats on FreeBSD
-    # dev.mce.0.rxstat3.decrypted_error_packets: 0
-    # dev.mce.0.rxstat3.decrypted_ok_packets: 0
-    # dev.mce.0.rxstat3.wqe_err: 0
-    # dev.mce.0.rxstat3.sw_lro_flushed: 2171
-    # dev.mce.0.rxstat3.sw_lro_queued: 2900
-    # dev.mce.0.rxstat3.lro_bytes: 0
-    # dev.mce.0.rxstat3.lro_packets: 0
-    # dev.mce.0.rxstat3.csum_none: 0
-    # dev.mce.0.rxstat3.bytes: 1470978
     # dev.mce.0.rxstat3.packets: 2901
-    # dev.mce.0.txstat3tc0.nop: 3
-    # dev.mce.0.txstat3tc0.cqe_err: 0
-    # dev.mce.0.txstat3tc0.enobuf: 0
-    # dev.mce.0.txstat3tc0.dropped: 0
-    # dev.mce.0.txstat3tc0.defragged: 0
-    # dev.mce.0.txstat3tc0.csum_offload_none: 0
-    # dev.mce.0.txstat3tc0.tso_bytes: 331660
-    # dev.mce.0.txstat3tc0.tso_packets: 125
-    # dev.mce.0.txstat3tc0.bytes: 857284
     # dev.mce.0.txstat3tc0.packets: 3287
     _bsd_vf_queue_stats_regex = re.compile(r"[tr]xstat(?P<name>[\d]+)\S*\.packets")
 


### PR DESCRIPTION
Updated BSD Ethtool and the verify_device_settings test case. Ethtool get_device_statistics() now works on BSD and added new regex filters and conditionals to the test case to work with the BSD statistics format.