### PR TITLE
Updating Kself Test Case to support custom collections and tests to be skipped

### DIFF
--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -33,6 +33,15 @@ class KselftestTestsuite(TestSuite):
 
         For both cases, verify that the kselftest tool extracts the tar, runs the script
         run_kselftest.sh and redirects test results to a file kselftest-results.txt.
+
+        Customization:
+        Users can customize the test by specifying the
+        `kselftest_include_test_collections` and `kselftest_skip_tests` variables
+        in the runbook. For example:
+        - `kselftest_include_test_collections`: A comma-separated list of collections
+        to run (e.g., "bpf,net,timers").
+        - `kselftest_skip_tests`: A comma-separated list of tests to skip
+        (e.g., "net:test_tcp,test_udp").
         """,
         priority=3,
         timeout=_CASE_TIME_OUT,

--- a/microsoft/testsuites/kselftest/kselftest-suite.py
+++ b/microsoft/testsuites/kselftest/kselftest-suite.py
@@ -50,12 +50,30 @@ class KselftestTestsuite(TestSuite):
         file_path = variables.get("kselftest_file_path", "")
         working_path = variables.get("kselftest_working_path", "")
         run_as_root = variables.get("kselftest_run_as_root", False)
+        test_collection_list = (
+            variables.get("kselftest_include_test_collections", "").split(",")
+            if variables.get("kselftest_include_test_collections", "")
+            else []
+        )
+        skip_tests_list = (
+            variables.get("kselftest_skip_tests", "").split(",")
+            if variables.get("kselftest_skip_tests", "")
+            else []
+        )
+
         try:
             kselftest: Kselftest = node.tools.get(
                 Kselftest,
                 working_path=working_path,
                 file_path=file_path,
             )
-            kselftest.run_all(result, log_path, self._KSELF_TIMEOUT, run_as_root)
+            kselftest.run_all(
+                test_result=result,
+                log_path=log_path,
+                timeout=self._KSELF_TIMEOUT,
+                run_test_as_root=run_as_root,
+                run_collections=test_collection_list,
+                skip_tests=skip_tests_list,
+            )
         except UnsupportedDistroException as identifier:
             raise SkippedException(identifier)

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -2,7 +2,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import PurePath, PurePosixPath
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 from assertpy import assert_that
 
@@ -233,7 +233,7 @@ class Kselftest(Tool):
             work_dir = PurePosixPath(self._installed_path)
         else:
             work_dir = None
-            
+
         if run_collections or skip_tests:
             # List all available tests
             list_result = self.run(" -l", shell=True)

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -2,7 +2,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import PurePath, PurePosixPath
-from typing import Any, Dict, List
+from typing import Any, Dict, Optional, List
 
 from assertpy import assert_that
 
@@ -214,8 +214,8 @@ class Kselftest(Tool):
         log_path: str,
         timeout: int = 5000,
         run_test_as_root: bool = False,
-        run_collections: list = None,
-        skip_tests: list = None,
+        run_collections: Optional[List[str]] = None,
+        skip_tests: Optional[List[str]] = None,
     ) -> List[KselftestResult]:
         # Executing kselftest as root may cause
         # VM to hang

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -264,6 +264,8 @@ class Kselftest(Tool):
             else:
                 filtered_tests = all_tests
 
+            # Ensure skip_tests is not None
+            skip_tests = skip_tests or []
             # Exclude tests based on skip_tests
             tests_to_run = [test for test in filtered_tests if test not in skip_tests]
 

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -230,7 +230,6 @@ class Kselftest(Tool):
 
         result_file_name = "kselftest-results.txt"
         result_file = f"{result_directory}/{result_file_name}"
-        
         # Initialize run_tests and skip_tests from kwargs if provided
         run_collections = kwargs.get("run_collections", [])
         skip_tests = kwargs.get("skip_tests", [])

--- a/microsoft/testsuites/kselftest/kselftest.py
+++ b/microsoft/testsuites/kselftest/kselftest.py
@@ -214,7 +214,8 @@ class Kselftest(Tool):
         log_path: str,
         timeout: int = 5000,
         run_test_as_root: bool = False,
-        **kwargs: Any,
+        run_collections: list = None,
+        skip_tests: list = None,
     ) -> List[KselftestResult]:
         # Executing kselftest as root may cause
         # VM to hang
@@ -230,9 +231,6 @@ class Kselftest(Tool):
 
         result_file_name = "kselftest-results.txt"
         result_file = f"{result_directory}/{result_file_name}"
-        # Initialize run_tests and skip_tests from kwargs if provided
-        run_collections = kwargs.get("run_collections", [])
-        skip_tests = kwargs.get("skip_tests", [])
 
         if run_collections or skip_tests:
             # List all available tests


### PR DESCRIPTION
Currently the 'verify_kselftest' Test Case executes all the tests and test suites which are a part of the Linux KSelf tests.

Although we wanted to add an option where the users can either provide the list of collections that should be executed, or a list of tests that should be skipped - possibly to avoid any noisy or known error-prone tests.

Hence, providing users more flexibility as to what gets executed from the broader Kself Test Collection.