### PR TITLE
Updating Infiniband setup to support ARM64 

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -173,11 +173,7 @@ class Infiniband(Feature):
         return cat.read(f"/sys/class/infiniband/{ib_device_name}/ports/1/pkeys/0")
 
     def setup_rdma(self) -> None:
-        if self._node.tools[Ls].path_exists(
-            "/opt/azurehpc/component_versions.txt"
-        ) or self._node.tools[Ls].path_exists("/opt/azurehpc/component-versions"):
-            self.is_hpc_image = True
-        else:
+        if not self.is_hpc_image:
             self.install_ofed()
 
         node = self._node

--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -335,7 +335,7 @@ class Infiniband(Feature):
                 "python-dev",
             ]
             if arch == CpuArchitecture.ARM64:
-                check_package.append("lib32gcc-9-dev")
+                check_package.append("libgcc-9-dev")
                 check_package.append("libgcc-8-dev")
             else:
                 check_package.append("lib32gcc-9-dev")

--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -11,8 +11,8 @@ from retry import retry
 from lisa.base_tools import Cat, Sed, Uname, Wget
 from lisa.feature import Feature
 from lisa.features import Disk
-from lisa.operating_system import CBLMariner, Oracle, Redhat, Ubuntu
-from lisa.tools import Firewall, Ls, Lspci, Make, Service
+from lisa.operating_system import CBLMariner, CpuArchitecture, Oracle, Redhat, Ubuntu
+from lisa.tools import Firewall, Ls, Lscpu, Lspci, Make, Service
 from lisa.tools.tar import Tar
 from lisa.util import (
     LisaException,
@@ -173,7 +173,11 @@ class Infiniband(Feature):
         return cat.read(f"/sys/class/infiniband/{ib_device_name}/ports/1/pkeys/0")
 
     def setup_rdma(self) -> None:
-        if not self.is_hpc_image:
+        if self._node.tools[Ls].path_exists(
+            "/opt/azurehpc/component_versions.txt"
+        ) or self._node.tools[Ls].path_exists("/opt/azurehpc/component-versions"):
+            self.is_hpc_image = True
+        else:
             self.install_ofed()
 
         node = self._node
@@ -209,6 +213,8 @@ class Infiniband(Feature):
     def _install_dependencies(self) -> None:
         node = self._node
         os_version = node.os.information.release.split(".")
+        lscpu = node.tools[Lscpu]
+        arch = lscpu.get_architecture()
         # Dependencies
         kernel = node.tools[Uname].get_linux_information().kernel_version_raw
         ubuntu_required_packages = [
@@ -244,11 +250,14 @@ class Infiniband(Feature):
             "dkms",
             "python3-setuptools",
             "g++",
-            "libc6-i386",
             "cloud-init",
             "walinuxagent",
             "net-tools",
         ]
+        if arch == CpuArchitecture.ARM64:
+            ubuntu_required_packages.append("libc6-armhf-cross")
+        else:
+            ubuntu_required_packages.append("libc6-i386")
         redhat_required_packages = [
             "gtk2",
             "atk",
@@ -321,12 +330,17 @@ class Infiniband(Feature):
                     )
                     node.os.install_packages("kernel-devel")
         elif isinstance(node.os, Ubuntu) and node.os.information.version >= "18.4.0":
-            for package in [
-                "lib32gcc-9-dev",
+            check_package = [
                 "python3-dev",
-                "lib32gcc-8-dev",
                 "python-dev",
-            ]:
+            ]
+            if arch == CpuArchitecture.ARM64:
+                check_package.append("lib32gcc-9-dev")
+                check_package.append("libgcc-8-dev")
+            else:
+                check_package.append("lib32gcc-9-dev")
+                check_package.append("lib32gcc-8-dev")
+            for package in check_package:
                 if node.os.is_package_in_repo(package):
                     ubuntu_required_packages.append(package)
             node.os.install_packages(ubuntu_required_packages)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -707,10 +707,9 @@ class Infiniband(AzureFeatureMixin, features.Infiniband):
 
     def setup_rdma(self) -> None:
         ls = self._node.tools[Ls]
-        self.is_hpc_image = (
-            ls.path_exists("/opt/azurehpc/component_versions.txt")
-            or ls.path_exists("/opt/azurehpc/component-versions")
-        )
+        self.is_hpc_image = ls.path_exists(
+            "/opt/azurehpc/component_versions.txt"
+        ) or ls.path_exists("/opt/azurehpc/component-versions")
         super().setup_rdma()
         waagent = self._node.tools[Waagent]
         devices = self._get_ib_device_names()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -706,8 +706,11 @@ class Infiniband(AzureFeatureMixin, features.Infiniband):
         return "hvnd_try_bind_nic" in dmesg.get_output()
 
     def setup_rdma(self) -> None:
-        if self._node.tools[Ls].path_exists("/opt/azurehpc/component_versions.txt"):
-            self.is_hpc_image = True
+        ls = self._node.tools[Ls]
+        self.is_hpc_image = (
+            ls.path_exists("/opt/azurehpc/component_versions.txt")
+            or ls.path_exists("/opt/azurehpc/component-versions")
+        )
         super().setup_rdma()
         waagent = self._node.tools[Waagent]
         devices = self._get_ib_device_names()

--- a/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/microsoft/testsuites/hpc/infinibandsuite.py
@@ -50,7 +50,11 @@ class InfinibandSuite(TestSuite):
         ),
     )
     def verify_ib_naming(self, log: Logger, node: Node) -> None:
-        if node.tools[Ls].path_exists("/opt/azurehpc/component_versions.txt"):
+        if node.tools[Ls].path_exists(
+            path="/opt/azurehpc/component_versions.txt", sudo=True
+        ) or node.tools[Ls].path_exists(
+            path="/opt/azurehpc/component-versions", sudo=True
+        ):
             ib_interfaces = node.features[Infiniband].get_ib_interfaces()
             ib_first_device_name = [x.nic_name for x in ib_interfaces]
 


### PR DESCRIPTION
- Currently the packages installed as part of the Infiniband setup are for x86. Hence the setup is seen to fail for ARM64. Updating the packages as part of the PR and adding support to check the CPU Architecture before installing arch dependent packages.
- Adding appropriate checks for hpc image where missing.