### PR TITLE
Fix ltp test fs_di failing on Mariner2

### DIFF
--- a/microsoft/testsuites/ltp/ltp.py
+++ b/microsoft/testsuites/ltp/ltp.py
@@ -281,6 +281,7 @@ class Ltp(Tool):
                 [
                     "kernel-headers",
                     "binutils",
+                    "diffutils",
                     "glibc-devel",
                     "zlib-devel",
                 ]


### PR DESCRIPTION
Currently, the fs_di LTP test fails on Mariner 2 VMs as it lacks one of the required packages. This PR fixes it by adding the missing package as a test requirement.

Note: Azure Linux 3 has this package installed by default.