### PR TITLE
tool: set snpguest version to v0.8.3

### DIFF
--- a/microsoft/testsuites/cvm/cvm_attestation_tool.py
+++ b/microsoft/testsuites/cvm/cvm_attestation_tool.py
@@ -126,6 +126,7 @@ class SnpGuest(Tool):
     _snpguest_repo = "https://github.com/virtee/snpguest"
     cmd_path: PurePath
     repo_root: PurePath
+    branch = "v0.8.3"
 
     @property
     def command(self) -> str:
@@ -150,7 +151,7 @@ class SnpGuest(Tool):
             self.node.os.install_packages(["perl", "tpm2-tss-devel"])
         tool_path = self.get_tool_path(use_global=True)
         git = self.node.tools[Git]
-        git.clone(self._snpguest_repo, tool_path)
+        git.clone(self._snpguest_repo, tool_path, ref=self.branch)
 
         cargo = self.node.tools[Cargo]
         cargo.build(release=True, features="hyperv", sudo=False, cwd=self.repo_root)


### PR DESCRIPTION
Commit https://github.com/virtee/snpguest/commit/ffb099067fd27824ad875fc46bf34bc4f27a16de breaks `verify_azure_cvm_attestation_report` test case on Azure CVM, so we need to lock the version at v0.8.3 to stabilize the tool.