### PR TITLE
fix deepcopy handle SetSpace incorrectly.

### DIFF
--- a/lisa/search_space.py
+++ b/lisa/search_space.py
@@ -287,6 +287,10 @@ class SetSpace(RequirementMixin, Set[T]):
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         self.update(self.items)
 
+    def __deepcopy__(self, memo: Any) -> Any:
+        # Deepcopy is not supported for SetSpace, so we need to implement it manually.
+        return SetSpace(is_allow_set=self.is_allow_set, items=copy.deepcopy(self.items))
+
     def check(self, capability: Any) -> ResultReason:
         result = ResultReason()
         if self.is_allow_set and len(self) > 0 and not capability:


### PR DESCRIPTION
The items are set to is_allowed_set incorrectly, so the req check failed. Overwrite the __deepcopy__ to force it runs correctly.