### PR TITLE
Add retry logic for install packages, kselftest redirect TMPDIR if /tmp/ free space < 2GB

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1562,6 +1562,7 @@ class RPMDistro(Linux):
         )
         return self._cache_and_return_version_info(package_name, version_info)
 
+    @retry(tries=3, delay=1)
     def _install_packages(
         self,
         packages: List[str],


### PR DESCRIPTION
add retry logic for install packages
kselftest redirect TMPDIR if /tmp/ free space < 2GB