### PR TITLE
Change/fix in the rg deletion condition

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -53,7 +53,8 @@ EnvironmentStatus = Enum(
         "Connected",
         # deleted by platform
         "Deleted",
-        # the environment is in a bad state, and need to be deleted.
+        # the environment is in a bad state, and need to be
+        # deleted or retained based on keep_environment value
         "Bad",
     ],
 )

--- a/lisa/platform_.py
+++ b/lisa/platform_.py
@@ -181,7 +181,11 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
         log.info(f"deploying environment: {environment.name}")
         timer = create_timer()
         environment.platform = self
-        self._deploy_environment(environment, log)
+        try:
+            self._deploy_environment(environment, log)
+        except Exception as identifier:
+            environment.status = EnvironmentStatus.Bad
+            raise identifier
         environment.status = EnvironmentStatus.Deployed
 
         # initialize features
@@ -210,29 +214,38 @@ class Platform(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
     def delete_environment(self, environment: Environment) -> None:
         log = get_logger(f"del[{environment.name}]", parent=self._log)
 
-        # mark environment is deleted firstly, if there is any error on
-        # deleting, it should be ignored.
-        environment.status = EnvironmentStatus.Deleted
-        environment.cleanup()
-        if self.runbook.keep_environment == constants.ENVIRONMENT_KEEP_ALWAYS:
-            log.info(
-                f"skipped to delete environment {environment.name}, "
-                f"as runbook set to keep environment."
-            )
+        try:
+            environment.cleanup()
+            if (self.runbook.keep_environment == constants.ENVIRONMENT_KEEP_ALWAYS) or (
+                self.runbook.keep_environment == constants.ENVIRONMENT_KEEP_FAILED
+                and environment.status == EnvironmentStatus.Bad
+            ):
+                log.info(
+                    f"skipped to delete environment {environment.name}, "
+                    "as on runbook, keep_environment value "
+                    f"is set to {self.runbook.keep_environment} "
+                    f"and env status is {environment.status}"
+                )
 
-            # output addresses for troubleshooting easier.
-            remote_addresses = [
-                x.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
-                for x in environment.nodes.list()
-                if isinstance(x, RemoteNode) and hasattr(x, "_connection_info")
-            ]
-            # if the connection info is not found, there is no ip address to
-            # output.
-            if remote_addresses:
-                log.info(f"node ip addresses: {remote_addresses}")
-        else:
-            log.debug("deleting")
-            self._delete_environment(environment, log)
+                # output addresses for troubleshooting easier.
+                remote_addresses = [
+                    x.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
+                    for x in environment.nodes.list()
+                    if isinstance(x, RemoteNode) and hasattr(x, "_connection_info")
+                ]
+                # if the connection info is not found, there is no ip address to
+                # output.
+                if remote_addresses:
+                    log.info(f"node ip addresses: {remote_addresses}")
+            else:
+                log.debug("deleting")
+                self._delete_environment(environment, log)
+                log.info("deleted")
+
+        finally:
+            # mark environment is deleted.
+            # if there is any error on deleting, it should be ignored.
+            environment.status = EnvironmentStatus.Deleted
 
     def cleanup(self) -> None:
         self._cleanup()

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -638,7 +638,6 @@ class AzurePlatform(Platform):
                 # Even skipped deploy, try best to initialize nodes
                 self.initialize_environment(environment, log)
             except Exception as e:
-                self._delete_environment(environment, log)
                 raise e
 
     def _delete_environment(self, environment: Environment, log: Logger) -> None:


### PR DESCRIPTION
At present, when there is a deployment failure, the environment gets deleted even if the keep_environment value is set to alway or failed. This PR is to change that and set the below expectations:
keep_environment: always
	Deployment failure - retain environment
	Test failure - retain environment
	Test Pass - retain environment

keep_environment: failed
	Deployment failure - retain environment
	Test failure - retain environment
	Test Pass - delete environment
	
keep_environment: no
	Deployment failure - delete environment
	Test failure - delete environment
	Test Pass - delete environment