### PR TITLE
Skip tests not supporting CVM

### DIFF
--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -32,6 +32,7 @@ from lisa.features import (
     StartStop,
     Synthetic,
 )
+from lisa.features.security_profile import CvmDisabled
 from lisa.tools import Lspci
 from lisa.util import constants
 from lisa.util.shell import wait_tcp_port_ready
@@ -122,7 +123,10 @@ class Provisioning(TestSuite):
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
             disk=DiskEphemeral(),
-            supported_features=[SerialConsole],
+            supported_features=[
+                SerialConsole,
+                CvmDisabled(),
+            ],  # TODO: Fix disk deployment for CVM
         ),
     )
     def verify_deployment_provision_ephemeral_managed_disk(

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -11,6 +11,7 @@ from azure.mgmt.keyvault.models import Sku as KeyVaultSku
 from azure.mgmt.keyvault.models import VaultProperties
 
 from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.features.security_profile import CvmDisabled
 from lisa.operating_system import CBLMariner, CentOs, Oracle, Redhat, Ubuntu
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
@@ -73,7 +74,7 @@ class AzureDiskEncryption(TestSuite):
         timeout=TIME_LIMIT,
         requirement=simple_requirement(
             min_memory_mb=MIN_REQUIRED_MEMORY_MB,
-            supported_features=[AzureExtension],
+            supported_features=[AzureExtension, CvmDisabled()],
             supported_platform_type=[AZURE],
             min_core_count=4,
         ),
@@ -136,6 +137,9 @@ class AzureDiskEncryption(TestSuite):
         provisioned successfully on the remote machine.
         """,
         priority=1,
+        requirement=simple_requirement(
+            supported_features=[CvmDisabled()],
+        ),
     )
     def verify_azure_disk_encryption_provisioned(
         self, log: Logger, node: Node, result: TestResult

--- a/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
+++ b/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
@@ -19,6 +19,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
+from lisa.features.security_profile import CvmDisabled
 from lisa.operating_system import BSD, Debian, Windows
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
@@ -41,7 +42,9 @@ from lisa.tools.whoami import Whoami
     area="vm_extension",
     category="functional",
     description="Test for VMSnapshot extension",
-    requirement=simple_requirement(unsupported_os=[]),
+    requirement=simple_requirement(
+        unsupported_os=[], supported_features=[CvmDisabled()]
+    ),
 )
 class VmSnapsotLinuxBVTExtension(TestSuite):
     @TestCaseMetadata(


### PR DESCRIPTION
Skip test cases which fail because of lack of support.

**VmSnapsotLinuxBVTExtension.verify_vmsnapshot_extension**
**VmSnapsotLinuxBVTExtension.verify_exclude_disk_support_restore_point**
&emsp;`This region does not support creation of Restore Points of a Virtual Machine with 'ConfidentialVM' security type.`
&emsp;`The VM size % is not supported for creation of VMs and Virtual Machine Scale Set with '<NULL>' security type.`
&emsp;[Azure Documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/concepts-restore-points#vm-restore-points-support-matrix) does not provide a list of supported regions, it simply says there is no support.

**AzureDiskEncryption.verify_azure_disk_encryption_provisioned**
&emsp;`'Pre-initialization check: ADE flow is blocked to volume-type:OS for confidential VMs.'`

**Provisioning.verify_deployment_provision_ephemeral_managed_disk**
&emsp;`BadRequest: Required parameter for Confidential VMs 'managedDisk.securityProfile.securityEncryptionType' is missing`