### PR TITLE
Update xfstests version from master branch to specified version branch.

### DIFF
--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -41,7 +41,7 @@ class Xfstests(Tool):
     # This is the default repo and branch for xfstests.
     # Override this via _install method if needed.
     repo = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git"
-    branch = "master"
+    branch = "v2024.02.09"
     # these are dependencies for xfstests. Update on regular basis.
     common_dep = [
         "acl",


### PR DESCRIPTION
Roll back XFStest tag from master to v2024.02.09.
Will subsequently investigate stable tags that do not case tests to crash