### PR TITLE
Azure Update VM Capabilities: Add Location

### DIFF
--- a/lisa/sut_orchestrator/azure/hooks.py
+++ b/lisa/sut_orchestrator/azure/hooks.py
@@ -37,7 +37,7 @@ class AzureHookSpec:
 
     @hookspec
     def azure_update_vm_capabilities(
-        self, capabilities: Dict[str, AzureCapability]
+        self, location: str, capabilities: Dict[str, AzureCapability]
     ) -> None:
         """
         Implement it to update the vm capabilities.

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1111,7 +1111,9 @@ class AzurePlatform(Platform):
                     except Exception as e:
                         log.error(f"unknown sku: {sku_obj}")
                         raise e
-            plugin_manager.hook.azure_update_vm_capabilities(capabilities=all_skus)
+            plugin_manager.hook.azure_update_vm_capabilities(
+                location=location, capabilities=all_skus
+            )
             location_data = AzureLocation(location=location, capabilities=all_skus)
             log.debug(f"{location}: saving to disk")
             with open(cached_file_name, "w") as f:


### PR DESCRIPTION
If the capabilities dictionary is empty for any reason, the hook implementation would have no way to know which region is being queried.