### PR TITLE
Add check for BTF sysfs

### DIFF
--- a/lisa/tools/lsmod.py
+++ b/lisa/tools/lsmod.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import re
-from typing import Any, Tuple
+from typing import Any, List, Tuple
 
 from lisa.executable import Tool
 from lisa.util import find_patterns_groups_in_lines, find_patterns_in_lines
@@ -91,3 +91,19 @@ class Lsmod(Tool):
         usedby_modules = usedby_split[1] if len(usedby_split) > 1 else ""
 
         return usedby_count, usedby_modules
+
+    def list_modules(self) -> List[str]:
+        """
+        List all loaded kernel modules.
+        This method runs the `lsmod` command and parses its output to return
+        a list of module names.
+
+        It skips the header line and returns only the module names.
+        :return: A list of loaded kernel module names.
+        """
+        result = self.run(sudo=True, force_run=True)
+        module_info = find_patterns_in_lines(result.stdout, [self.__output_pattern])
+        if not module_info:
+            return []
+        module_info[0] = module_info[0][1:]  # Skip the header line
+        return [info[0] for sublist in module_info for info in sublist]

--- a/microsoft/testsuites/bpf/bpf_support.py
+++ b/microsoft/testsuites/bpf/bpf_support.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from assertpy.assertpy import assert_that
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.operating_system import CBLMariner
+from lisa.testsuite import simple_requirement
+from lisa.tools.ls import Ls
+from lisa.tools.lsmod import Lsmod
+
+
+@TestSuiteMetadata(
+    area="bpf",
+    category="functional",
+    description="""
+    This test suite is to confirm bpf support.
+    """,
+)
+class BpfSuite(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        This test case checks for the presences of the btf sysfs.
+        It checks if the /sys/kernel/btf/vmlinux file exists and if any loaded kernel
+        modules have corresponding entries in the /sys/kernel/btf directory.
+
+        If both conditions are met, it confirms that BTF (BPF Type Format) data is
+        available on the system.
+        """,
+        priority=3,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
+    )
+    def confirm_btf_sysfs(
+        self,
+        node: Node,
+        log: Logger,
+    ) -> None:
+        # Check if /sys/kernel/btf/vmlinux exists
+        ls = node.tools[Ls]
+        lsmod = node.tools[Lsmod]
+        result = ls.path_exists("/sys/kernel/btf/vmlinux", sudo=True)
+        assert_that(
+            result,
+            description="Check if /sys/kernel/btf/vmlinux exists",
+        ).is_equal_to(True)
+        log.info("BTF sysfs confirmed for /sys/kernel/btf/vmlinux.")
+
+        # Grab loaded modules
+        modules = lsmod.list_modules()
+
+        # Check if module is available in /sys/kernel/btf
+        for module in modules:
+            result = ls.path_exists(f"/sys/kernel/btf/{module}", sudo=True)
+            assert_that(
+                result,
+                description=f"Check if /sys/kernel/btf/{module} exists",
+            ).is_equal_to(True)
+
+        # If all checks passed, log success
+        log.info("BTF sysfs confirmed for all loaded modules.")

--- a/microsoft/testsuites/bpf/bpf_support.py
+++ b/microsoft/testsuites/bpf/bpf_support.py
@@ -57,13 +57,22 @@ class BpfSuite(TestSuite):
         # Grab loaded modules
         modules = lsmod.list_modules()
 
-        # Check if module is available in /sys/kernel/btf
+        missing_modules = []
+
         for module in modules:
             result = ls.path_exists(f"/sys/kernel/btf/{module}", sudo=True)
-            assert_that(
-                result,
-                description=f"Check if /sys/kernel/btf/{module} exists",
-            ).is_equal_to(True)
+            if not result:
+                missing_modules.append(module)
 
-        # If all checks passed, log success
+        if missing_modules:
+            log.error("BTF sysfs missing for modules: %s", ", ".join(missing_modules))
+
+        assert_that(
+            missing_modules,
+            description=(
+                "The following modules are missing /sys/kernel/btf entries: "
+                f"{', '.join(missing_modules)}"
+            ),
+        ).is_empty()
+
         log.info("BTF sysfs confirmed for all loaded modules.")

--- a/microsoft/testsuites/bpf/bpf_support.py
+++ b/microsoft/testsuites/bpf/bpf_support.py
@@ -39,7 +39,7 @@ class BpfSuite(TestSuite):
         """,
         priority=3,
     )
-    def confirm_btf_sysfs(
+    def verify_btf_sysfs_exists(
         self,
         node: Node,
         log: Logger,


### PR DESCRIPTION
This PR adds a check for the presence of BTF data on the target system by verifying the existence of the /sys/kernel/btf/ directory with both kernel (vmlinux) and loaded module data

This directory indicates that BTF (BPF Type Format) data is available, which is crucial for certain BPF features and tools. BTF data is required for advanced BPF capabilities and observability on modern Linux kernels. Ensuring its presence helps validate system readiness for BPF workloads. Currently this test has been validated for AzureLinux scenarios.

Specifically this PR
- Updates lsmod to return the loaded modules
- Implements `verify_btf_sysfs_exists` to ensure /sys/kernel/btf/vmlinux and /sys/kernel/btf/<modules> are present.


**Testing**
Confirmed it will not run on a non AzL3 system (CBL-Mariner 2.0)
```
2025-06-11 16:10:44.366[135876417206080][INFO] lisa.RootRunner                   BpfSuite.verify_btf_sysfs_exists: SKIPPED  before_case skipped: Unsupported system: 'CBL-Mariner/Linux'. BPF support promised on AzureLinux 3.0 and later.
2025-06-11 16:10:44.366[135876417206080][INFO] lisa.RootRunner test result summary
2025-06-11 16:10:44.366[135876417206080][INFO] lisa.RootRunner     TOTAL    : 1
2025-06-11 16:10:44.366[135876417206080][INFO] lisa.RootRunner     QUEUED   : 0
2025-06-11 16:10:44.367[135876417206080][INFO] lisa.RootRunner     ASSIGNED : 0
2025-06-11 16:10:44.367[135876417206080][INFO] lisa.RootRunner     RUNNING  : 0
2025-06-11 16:10:44.367[135876417206080][INFO] lisa.RootRunner     FAILED   : 0
2025-06-11 16:10:44.367[135876417206080][INFO] lisa.RootRunner     PASSED   : 0
2025-06-11 16:10:44.367[135876417206080][INFO] lisa.RootRunner     SKIPPED  : 1
```

Confirm the check fails gracefully on systems without /sys/kernel/btf/<module>. 
```
2025-06-12 15:06:49.326[126099552990912][ERROR] lisa.case[verify_btf_sysfs_exists] BTF sysfs missing for modules: xt_owner, mlx5_ib, ib_uverbs, ib_core, mlx5_core, mlxfw, psample, tls, xt_tcpudp, xt_conntrack, nft_compat, nft_fib_ipv6, nft_masq, nft_nat, nft_fib_ipv4, nft_fib, nft_chain_nat, nf_tables, xt_LOG, nf_log_syslog, cfg80211, 8021q, garp, mrp, stp, llc, sm4_ce_cipher, sm4, sm3_ce, sm3, sha3_ce, sha512_ce, sha512_arm64, hyperv_fb, sch_fq_codel, fuse, efi_pstore, dmi_sysfs, hid_generic, crct10dif_ce, ghash_ce, hid_hyperv, gf128mul, hid, sha2_ce, sha256_arm64, sha1_ce, serio_raw, ebt_ip, ip6table_nat, ip6table_mangle, ip6table_filter, ip6_tables, iptable_security, iptable_nat, nf_nat, nf_conntrack, nf_defrag_ipv6, nf_defrag_ipv4, iptable_mangle, iptable_filter, ip_tables, x_tables, aes_ce_blk, aes_ce_cipher
2025-06-12 15:06:49.329[126099818538688][ERROR] lisa.case[verify_btf_sysfs_exists] case failed
...
2025-06-12 15:06:52.126[126100310230848][INFO] lisa.RootRunner                   BpfSuite.verify_btf_sysfs_exists: FAILED   failed. AssertionError: [The following modules are missing /sys/kernel/btf entries: xt_owner, mlx5_ib, ib_uverbs, ib_core, mlx5_core, mlxfw, psample, tls, xt_tcpudp, xt_conntrack, nft_compat, nft_fib_ipv6, nft_masq, nft_nat, nft_fib_ipv4, nft_fib, nft_chain_nat, nf_tables, xt_LOG, nf_log_syslog, cfg80211, 8021q, garp, mrp, stp, llc, sm4_ce_cipher, sm4, sm3_ce, sm3, sha3_ce, sha512_ce, sha512_arm64, hyperv_fb, sch_fq_codel, fuse, efi_pstore, dmi_sysfs, hid_generic, crct10dif_ce, ghash_ce, hid_hyperv, gf128mul, hid, sha2_ce, sha256_arm64, sha1_ce, serio_raw, ebt_ip, ip6table_nat, ip6table_mangle, ip6table_filter, ip6_tables, iptable_security, iptable_nat, nf_nat, nf_conntrack, nf_defrag_ipv6, nf_defrag_ipv4, iptable_mangle, iptable_filter, ip_tables, x_tables, aes_ce_blk, aes_ce_cipher] Expected <['xt_owner', 'mlx5_ib', 'ib_uverbs', 'ib_core', 'mlx5_core', 'mlxfw', 'psample', 'tls', 'xt_tcpudp', 'xt_conntrack', 'nft_compat', 'nft_fib_ipv6', 'nft_masq', 'nft_nat', 'nft_fib_ipv4', 'nft_fib', 'nft_chain_nat', 'nf_tables', 'xt_LOG', 'nf_log_syslog', 'cfg80211', '8021q', 'garp', 'mrp', 'stp', 'llc', 'sm4_ce_cipher', 'sm4', 'sm3_ce', 'sm3', 'sha3_ce', 'sha512_ce', 'sha512_arm64', 'hyperv_fb', 'sch_fq_codel', 'fuse', 'efi_pstore', 'dmi_sysfs', 'hid_generic', 'crct10dif_ce', 'ghash_ce', 'hid_hyperv', 'gf128mul', 'hid', 'sha2_ce', 'sha256_arm64', 'sha1_ce', 'serio_raw', 'ebt_ip', 'ip6table_nat', 'ip6table_mangle', 'ip6table_filter', 'ip6_tables', 'iptable_security', 'iptable_nat', 'nf_nat', 'nf_conntrack', 'nf_defrag_ipv6', 'nf_defrag_ipv4', 'iptable_mangle', 'iptable_filter', 'ip_tables', 'x_tables', 'aes_ce_blk', 'aes_ce_cipher']> to be empty, but was not.
2025-06-12 15:06:52.126[126100310230848][INFO] lisa.RootRunner test result summary
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     TOTAL    : 1
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     QUEUED   : 0
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     ASSIGNED : 0
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     RUNNING  : 0
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     FAILED   : 1
2025-06-12 15:06:52.127[126100310230848][INFO] lisa.RootRunner     PASSED   : 0
2025-06-12 15:06:52.128[126100310230848][INFO] lisa.RootRunner     SKIPPED  : 0
```
Run the new check on a target AZL3 VM system and verify it passes on systems with BTF support.

```
2025-06-11 15:56:02.480[125591412008640][INFO] lisa.case[verify_btf_sysfs_exists] test case 'BpfSuite.verify_btf_sysfs_exists' is running
2025-06-11 15:56:06.175[125591269398208][INFO] lisa.case[verify_btf_sysfs_exists] BTF sysfs confirmed for /sys/kernel/btf/vmlinux.
2025-06-11 15:56:14.481[125591269398208][INFO] lisa.case[verify_btf_sysfs_exists] BTF sysfs confirmed for all loaded modules.
2025-06-11 15:56:15.572[125591412008640][INFO] lisa.case[verify_btf_sysfs_exists] result: PASSED, elapsed: 13.091 sec
2025-06-11 15:56:16.289[125591412008640][INFO] lisa.[azure].del[generated_0] skipped to delete environment generated_0, as on runbook, keep_environment value is set to always and env status is EnvironmentStatus.Connected
2025-06-11 15:56:16.289[125591412008640][INFO] lisa.[azure].del[generated_0] node ip addresses: [...]
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner ________________________________________
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner                   BpfSuite.verify_btf_sysfs_exists: PASSED   
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner test result summary
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner     TOTAL    : 1
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner     QUEUED   : 0
2025-06-11 15:56:16.295[125591981520704][INFO] lisa.RootRunner     ASSIGNED : 0
2025-06-11 15:56:16.296[125591981520704][INFO] lisa.RootRunner     RUNNING  : 0
2025-06-11 15:56:16.296[125591981520704][INFO] lisa.RootRunner     FAILED   : 0
2025-06-11 15:56:16.296[125591981520704][INFO] lisa.RootRunner     PASSED   : 1
2025-06-11 15:56:16.296[125591981520704][INFO] lisa.RootRunner     SKIPPED  : 0
2025-06-11 15:56:16.300[125591981520704][INFO] lisa.notifier[Html] report: /home/mariner_user/repos/lisa/runtime/log/20250611/20250611-155106-264/lisa.html
```