### PR TITLE
Allow user passed MTUs for ntttcp network perf tests.

### DIFF
--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -251,6 +251,8 @@ class NetworkTCPPerformanceMessage(PerfMessage):
     retransmitted_segments: Decimal = Decimal(0)
     congestion_windowsize_kb: Decimal = Decimal(0)
     protocol_type: Optional[str] = TransportProtocol.Tcp
+    client_mtu: int = -1
+    server_mtu: int = -1
 
 
 @dataclass
@@ -266,6 +268,8 @@ class NetworkUDPPerformanceMessage(PerfMessage):
     data_loss: Decimal = Decimal(0)
     packet_size_kbytes: Decimal = Decimal(0)
     protocol_type: Optional[str] = TransportProtocol.Udp
+    client_mtu: int = -1
+    server_mtu: int = -1
 
 
 @dataclass

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -220,6 +220,11 @@ class Ip(Tool):
         return int(cat.read(f"/sys/class/net/{nic_name}/mtu", force_run=True))
 
     def set_mtu(self, nic_name: str, mtu: int) -> None:
+        # Check if mtu is integer
+        try:
+            mtu = int(mtu)
+        except ValueError:
+            raise LisaException(f"MTU value is not an integer: {mtu}")
         self.run(f"link set dev {nic_name} mtu {mtu}", force_run=True, sudo=True)
         new_mtu = self.get_mtu(nic_name=nic_name)
         assert_that(new_mtu).described_as("set mtu failed").is_equal_to(mtu)

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -83,6 +83,7 @@ class NtttcpResult:
     rx_packets: Decimal = Decimal(0)
     pkts_interrupt: Decimal = Decimal(0)
     cycles_per_byte: Decimal = Decimal(0)
+    mtu: int = -1
 
 
 class Ntttcp(Tool):
@@ -389,10 +390,16 @@ class Ntttcp(Tool):
         buffer_size: int,
         test_case_name: str,
         test_result: "TestResult",
+        client_mtu: int = -1,
+        server_mtu: int = -1,
     ) -> NetworkTCPPerformanceMessage:
         other_fields: Dict[str, Any] = {}
         other_fields["tool"] = constants.NETWORK_PERFORMANCE_TOOL_NTTTCP
         other_fields["buffer_size"] = Decimal(buffer_size)
+        if client_mtu != -1:
+            other_fields["client_mtu"] = client_mtu
+        if server_mtu != -1:
+            other_fields["server_mtu"] = server_mtu
         other_fields["connections_created_time"] = int(
             client_result.connections_created_time
         )
@@ -415,6 +422,8 @@ class Ntttcp(Tool):
             buffer_size,
             test_case_name,
             test_result,
+            client_mtu,
+            server_mtu,
         )
 
         return create_perf_message(
@@ -433,10 +442,14 @@ class Ntttcp(Tool):
         buffer_size: int,
         test_case_name: str,
         test_result: "TestResult",
+        client_mtu: int = -1,
+        server_mtu: int = -1,
     ) -> NetworkUDPPerformanceMessage:
         other_fields: Dict[str, Any] = {}
         other_fields["tool"] = constants.NETWORK_PERFORMANCE_TOOL_NTTTCP
         other_fields["send_buffer_size"] = Decimal(buffer_size)
+        other_fields["client_mtu"] = client_mtu
+        other_fields["server_mtu"] = server_mtu
         other_fields["connections_created_time"] = int(
             client_result.connections_created_time
         )
@@ -458,6 +471,8 @@ class Ntttcp(Tool):
             buffer_size,
             test_case_name,
             test_result,
+            client_mtu,
+            server_mtu,
         )
 
         return create_perf_message(
@@ -500,6 +515,8 @@ class Ntttcp(Tool):
         buffer_size: int,
         test_case_name: str,
         test_result: "TestResult",
+        client_mtu: int,
+        server_mtu: int,
     ) -> None:
         """Send unified performance messages for TCP ntttcp metrics."""
         # Include connections_num in metric names to distinguish results
@@ -567,6 +584,25 @@ class Ntttcp(Tool):
                 "unit": "cycles/byte",
             },
         ]
+        # Only send MTU metrics if they are valid (not -1)
+        if client_mtu != -1:
+            metrics.append(
+                {
+                    "name": f"client_mtu{conn_suffix}",
+                    "value": int(client_mtu),
+                    "relativity": MetricRelativity.NA,
+                    "unit": "bytes",
+                }
+            )
+        if server_mtu != -1:
+            metrics.append(
+                {
+                    "name": f"server_mtu{conn_suffix}",
+                    "value": int(server_mtu),
+                    "relativity": MetricRelativity.NA,
+                    "unit": "bytes",
+                },
+            )
 
         self._send_unified_perf_metrics(
             metrics, test_case_name, test_result, TransportProtocol.Tcp
@@ -580,6 +616,8 @@ class Ntttcp(Tool):
         buffer_size: int,
         test_case_name: str,
         test_result: "TestResult",
+        client_mtu: int,
+        server_mtu: int,
     ) -> None:
         """Send unified performance messages for UDP ntttcp metrics."""
         # Include connections_num in metric names to distinguish results
@@ -630,6 +668,26 @@ class Ntttcp(Tool):
                 "unit": "cycles/byte",
             },
         ]
+
+        # Only send MTU metrics if they are valid (not -1)
+        if client_mtu != -1:
+            metrics.append(
+                {
+                    "name": f"client_mtu{conn_suffix}",
+                    "value": int(client_mtu),
+                    "relativity": MetricRelativity.NA,
+                    "unit": "bytes",
+                }
+            )
+        if server_mtu != -1:
+            metrics.append(
+                {
+                    "name": f"server_mtu{conn_suffix}",
+                    "value": int(server_mtu),
+                    "relativity": MetricRelativity.NA,
+                    "unit": "bytes",
+                },
+            )
 
         self._send_unified_perf_metrics(
             metrics, test_case_name, test_result, TransportProtocol.Udp

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -47,6 +47,7 @@ from lisa.tools import (
     Sysctl,
 )
 from lisa.tools.fio import IoEngine
+from lisa.tools.ip import Ip
 from lisa.tools.ntttcp import (
     NTTTCP_TCP_CONCURRENCY,
     NTTTCP_TCP_CONCURRENCY_BSD,
@@ -309,6 +310,7 @@ def perf_ntttcp(  # noqa: C901
     lagscope_server_ip: Optional[str] = None,
     server_nic_name: Optional[str] = None,
     client_nic_name: Optional[str] = None,
+    variables: Optional[Dict[str, Any]] = None,
 ) -> List[Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]]:
     # Either server and client are set explicitly or we use the first two nodes
     # from the environment. We never combine the two options. We need to specify
@@ -364,6 +366,18 @@ def perf_ntttcp(  # noqa: C901
             ntttcp.setup_system(udp_mode, set_task_max)
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
+        client_nic = client.nics.default_nic
+        server_nic = server.nics.default_nic
+        client_ip = client.tools[Ip]
+        server_ip = server.tools[Ip]
+        mtu = variables.get("perf_ntttcp_mtu", 0) if variables is not None else 0
+        if mtu != 0:
+            # set mtu for default nics
+            client_ip.set_mtu(client_nic, mtu)
+            server_ip.set_mtu(server_nic, mtu)
+        client_mtu = client_ip.get_mtu(client_nic)
+        server_mtu = server_ip.get_mtu(server_nic)
+
         data_path = get_nic_datapath(client)
         if NetworkDataPath.Sriov.value == data_path:
             if need_reboot:
@@ -382,6 +396,10 @@ def perf_ntttcp(  # noqa: C901
                 else client.nics.get_primary_nic().pci_device_name
             )
             dev_differentiator = "mlx"
+            if mtu != 0:
+                # set mtu for AN nics, MTU needs to be set on both AN and non-AN nics
+                client_ip.set_mtu(client_nic_name, mtu)
+                server_ip.set_mtu(server_nic_name, mtu)
         else:
             server_nic_name = (
                 server_nic_name if server_nic_name else server.nics.default_nic
@@ -461,6 +479,8 @@ def perf_ntttcp(  # noqa: C901
                     buffer_size,
                     test_case_name,
                     test_result,
+                    client_mtu,
+                    server_mtu,
                 )
             else:
                 ntttcp_message = client_ntttcp.create_ntttcp_tcp_performance_message(
@@ -471,6 +491,8 @@ def perf_ntttcp(  # noqa: C901
                     buffer_size,
                     test_case_name,
                     test_result,
+                    client_mtu,
+                    server_mtu,
                 )
             notifier.notify(ntttcp_message)
             perf_ntttcp_message_list.append(ntttcp_message)

--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 from functools import partial
-from typing import Any
+from typing import Any, Dict
 
 from lisa import (
     Logger,
@@ -145,7 +145,9 @@ class NetworkPerformace(TestSuite):
             network_interface=Synthetic(),
         ),
     )
-    def perf_tcp_ntttcp_128_connections_synthetic(self, result: TestResult) -> None:
+    def perf_tcp_ntttcp_128_connections_synthetic(
+        self, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
         perf_ntttcp(result, connections=[128])
 
     @TestCaseMetadata(
@@ -162,8 +164,10 @@ class NetworkPerformace(TestSuite):
             )
         ),
     )
-    def perf_tcp_ntttcp_synthetic(self, result: TestResult) -> None:
-        perf_ntttcp(result)
+    def perf_tcp_ntttcp_synthetic(
+        self, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
+        perf_ntttcp(result, variables=variables)
 
     @TestCaseMetadata(
         description="""
@@ -179,8 +183,10 @@ class NetworkPerformace(TestSuite):
             )
         ),
     )
-    def perf_tcp_ntttcp_sriov(self, result: TestResult) -> None:
-        perf_ntttcp(result)
+    def perf_tcp_ntttcp_sriov(
+        self, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
+        perf_ntttcp(result, variables=variables)
 
     @TestCaseMetadata(
         description="""
@@ -194,8 +200,10 @@ class NetworkPerformace(TestSuite):
             unsupported_os=[BSD, Windows],
         ),
     )
-    def perf_udp_1k_ntttcp_synthetic(self, result: TestResult) -> None:
-        perf_ntttcp(result, udp_mode=True)
+    def perf_udp_1k_ntttcp_synthetic(
+        self, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
+        perf_ntttcp(result, udp_mode=True, variables=variables)
 
     @TestCaseMetadata(
         description="""
@@ -209,8 +217,10 @@ class NetworkPerformace(TestSuite):
             unsupported_os=[BSD, Windows],
         ),
     )
-    def perf_udp_1k_ntttcp_sriov(self, result: TestResult) -> None:
-        perf_ntttcp(result, udp_mode=True)
+    def perf_udp_1k_ntttcp_sriov(
+        self, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
+        perf_ntttcp(result, udp_mode=True, variables=variables)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
There is a need for testing network perf with different MTU sizes.
This change enables it.