### PR TITLE
Rabdulfaizy/stress reboot test 0602

### DIFF
--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -288,8 +288,10 @@ class Provisioning(TestSuite):
         try:
             for i in range(100):
                 elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
-                reboot_times.append((i + 1, elapsed))                
-                log.debug(f"Reboot stress iteration {i+1}/100 completed in {elapsed:.2f}s")
+                reboot_times.append((i + 1, elapsed)) 
+                log.debug(
+                    f"Reboot iterations {i+1}/100 completed in {elapsed:.2f}s"
+                )
         except PassedException as e:
             raise LisaException(f"{e}")
         finally:

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -2,9 +2,8 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
-
-from assertpy import assert_that
 from statistics import mean
+from assertpy import assert_that
 
 from lisa import (
     BadEnvironmentStateException,
@@ -291,7 +290,7 @@ class Provisioning(TestSuite):
                 elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
                 reboot_times.append((i + 1, elapsed))
         except PassedException as e:
-            raise LisaException(e.message)
+            raise LisaException(f"{e}")
         finally:
             times = [time for _, time in reboot_times if isinstance(time, (int, float))]
             log.info(f"completed {i+1}/100 iterations;summary:")

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 from assertpy import assert_that
+from statistics import mean
 
 from lisa import (
     BadEnvironmentStateException,
@@ -36,7 +37,7 @@ from lisa.features.security_profile import CvmDisabled
 from lisa.tools import Lspci
 from lisa.util import constants
 from lisa.util.shell import wait_tcp_port_ready
-
+from lisa.util import LisaException
 
 @TestSuiteMetadata(
     area="provisioning",
@@ -268,6 +269,36 @@ class Provisioning(TestSuite):
             is_restart=False,
         )
 
+    @TestCaseMetadata(
+        description="""
+        This case performs a reboot stress test on the node
+        and iterates smoke test 100 times.
+        The test steps are almost the same as `smoke_test`.
+        The reboot times is summarized after the test is run
+        """,
+        priority=3,
+        timeout=9000,
+        requirement=simple_requirement(
+            environment_status=EnvironmentStatus.Deployed,
+            supported_features=[SerialConsole],
+        ),
+    )
+    def stress_reboot(self, log: Logger, node: RemoteNode, log_path: Path) -> None:
+        reboot_times = []
+        try:
+            for i in range(100):
+                log.info(f"Reboot stress iteration {i+1}/100")
+                elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
+                reboot_times.append((i + 1, elapsed))
+        except PassedException as e:
+            raise LisaException(e.message)
+        finally:
+            times = [time for _, time in reboot_times if isinstance(time, (int, float))]
+            log.info(f"completed {i+1}/100 iterations;summary:")
+            log.info(f"Min reboot time: {min(times):.2f}s")
+            log.info(f"Max reboot time: {max(times):.2f}s")
+            log.info(f"Average reboot time: {mean(times):.2f}s")
+
     def _smoke_test(
         self,
         log: Logger,
@@ -277,7 +308,7 @@ class Provisioning(TestSuite):
         reboot_in_platform: bool = False,
         wait: bool = True,
         is_restart: bool = True,
-    ) -> None:
+    ) -> float:
         if not node.is_remote:
             raise SkippedException(f"smoke test: {case_name} cannot run on local node.")
 
@@ -344,6 +375,7 @@ class Provisioning(TestSuite):
             if isinstance(e, TcpConnectionException):
                 raise BadEnvironmentStateException(f"after reboot, {e}")
             raise PassedException(e)
+        return timer.elapsed()
 
     def is_mana_device_discovered(self, node: RemoteNode) -> bool:
         lspci = node.tools[Lspci]

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
-from statistics import mean
+from statistics import mean, median
 
 from assertpy import assert_that
 
@@ -35,9 +35,8 @@ from lisa.features import (
 )
 from lisa.features.security_profile import CvmDisabled
 from lisa.tools import Lspci
-from lisa.util import constants
+from lisa.util import LisaException, constants
 from lisa.util.shell import wait_tcp_port_ready
-from lisa.util import LisaException
 
 
 @TestSuiteMetadata(
@@ -278,7 +277,7 @@ class Provisioning(TestSuite):
         The reboot times is summarized after the test is run
         """,
         priority=3,
-        timeout=9000,
+        timeout=7200,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
             supported_features=[SerialConsole],
@@ -288,9 +287,9 @@ class Provisioning(TestSuite):
         reboot_times = []
         try:
             for i in range(100):
-                log.info(f"Reboot stress iteration {i+1}/100")
                 elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
-                reboot_times.append((i + 1, elapsed))
+                reboot_times.append((i + 1, elapsed))                
+                log.debug(f"Reboot stress iteration {i+1}/100 completed in {elapsed:.2f}s")
         except PassedException as e:
             raise LisaException(f"{e}")
         finally:
@@ -299,6 +298,7 @@ class Provisioning(TestSuite):
             log.info(f"Min reboot time: {min(times):.2f}s")
             log.info(f"Max reboot time: {max(times):.2f}s")
             log.info(f"Average reboot time: {mean(times):.2f}s")
+            log.info(f"Median reboot time: {median(times):.2f}s")
 
     def _smoke_test(
         self,

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -291,7 +291,7 @@ class Provisioning(TestSuite):
                 reboot_times.append((i + 1, elapsed))
                 log.debug(f"Reboot iterations {i+1}/100 completed in {elapsed:.2f}s")
         except PassedException as e:
-            raise LisaException(f"{e}")
+            raise LisaException(e)
         finally:
             times = [time for _, time in reboot_times if isinstance(time, (int, float))]
             log.info(f"completed {i+1}/100 iterations;summary:")

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -288,10 +288,8 @@ class Provisioning(TestSuite):
         try:
             for i in range(100):
                 elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
-                reboot_times.append((i + 1, elapsed)) 
-                log.debug(
-                    f"Reboot iterations {i+1}/100 completed in {elapsed:.2f}s"
-                )
+                reboot_times.append((i + 1, elapsed))
+                log.debug(f"Reboot iterations {i+1}/100 completed in {elapsed:.2f}s")
         except PassedException as e:
             raise LisaException(f"{e}")
         finally:

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from statistics import mean
+
 from assertpy import assert_that
 
 from lisa import (
@@ -37,6 +38,7 @@ from lisa.tools import Lspci
 from lisa.util import constants
 from lisa.util.shell import wait_tcp_port_ready
 from lisa.util import LisaException
+
 
 @TestSuiteMetadata(
     area="provisioning",


### PR DESCRIPTION
This case performs reboot stress test on the node and iterates smoke test 100 times. The reboot times is summarized after the test is run.

