### PR TITLE
Openssl Go System crypto test

### DIFF
--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import json
-from pathlib import Path
 from typing import cast
 
 from assertpy import assert_that
@@ -57,7 +56,7 @@ class OpenSSLTestSuite(TestSuite):
             supported_os=[CBLMariner],
         ),
     )
-    def verify_golang_sys_crypto(self, log: Logger, node: Node) -> None:
+    def verify_golang_sys_crypto(self, node: Node) -> None:
         """
         This test sets up the dependencies to run the
         experimental Go system crypto tests and cleans go builds.
@@ -70,14 +69,14 @@ class OpenSSLTestSuite(TestSuite):
         # cleans up previous go builds
         node.execute(
             "go clean -testcache",
-            cwd=Path("/usr/lib/golang/src"),
+            cwd=node.get_pure_path("/usr/lib/golang/src"),
             expected_exit_code=0,
             expected_exit_code_failure_message=("Go clean up failed."),
             shell=True,
         )
         node.execute(
             "go test -short ./crypto/...",
-            cwd=Path("/usr/lib/golang/src"),
+            cwd=node.get_pure_path("/usr/lib/golang/src"),
             update_envs={
                 "GOEXPERIMENT": "systemcrypto",
             },

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -48,6 +48,20 @@ class OpenSSLTestSuite(TestSuite):
         self._openssl_test_encrypt_decrypt(log, node)
         self._openssl_test_sign_verify(log, node)
 
+    @TestCaseMetadata(
+        description="""
+        This test will use Go experimental system crypto tests
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_os=[CBLMariner],
+        ),
+    )
+    def verify_openssl_golang_sys_crypto_tests(self, log: Logger, node: Node) -> None:
+        """Verifies the Go experimental system crypto tests"""
+        self._run_go_crypto_tests(log, node)
+        return
+
     def _openssl_test_encrypt_decrypt(self, log: Logger, node: Node) -> None:
         """
         Tests OpenSSL encryption and decryption functionality.
@@ -96,20 +110,6 @@ class OpenSSLTestSuite(TestSuite):
         openssl.verify(plaintext, public_key, signature)
 
         log.debug("Successfully signed and verified a file.")
-
-    @TestCaseMetadata(
-        description="""
-        This test will use Go experimental system crypto tests
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            supported_os=[CBLMariner],
-        ),
-    )
-    def openssl_golang__sys_crypto_tests_verify(self, log: Logger, node: Node) -> None:
-        """Verifies the Go experimental system crypto tests"""
-        self._run_go_crypto_tests(log, node)
-        return
 
     def _run_go_crypto_tests(self, log: Logger, node: Node) -> None:
         """

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -3,6 +3,7 @@
 
 import json
 from pathlib import Path
+from typing import cast
 
 from assertpy import assert_that
 
@@ -116,7 +117,8 @@ class OpenSSLTestSuite(TestSuite):
         experimental Go system crypto tests and cleans go builds.
         """
         # installs go dependencies for tests
-        node.os.install_packages(
+        az_os = cast(CBLMariner, node.os)
+        az_os.install_packages(
             ["golang", "glibc-devel", "gcc", "binutils", "kernel-headers"]
         )
         # cleans up previous go builds


### PR DESCRIPTION
 This test runs the Go system crypto tests. It first installs dependencies needed, then clean go cache for accuracy then runs tests.

tested by running lisa with  -v "case:openssl_golang__sys_crypto_tests_verify" 