### PR TITLE
Implement verify_mshv_secure_boot_succeeds

### DIFF
--- a/lisa/tools/journalctl.py
+++ b/lisa/tools/journalctl.py
@@ -15,6 +15,20 @@ class Journalctl(Tool):
     def _check_exists(self) -> bool:
         return True
 
+    def logs_for_kernel(self) -> str:
+        """
+        Get logs for the kernel.
+        """
+        result = self.run(
+            "--no-pager -k",
+            force_run=True,
+            sudo=True,
+            no_debug_log=True,  # don't flood LISA logs
+            expected_exit_code=0,
+        )
+
+        return result.stdout
+
     def logs_for_unit(self, unit_name: str, sudo: bool = True) -> str:
         result = self.run(
             f"--no-pager -u {unit_name}",

--- a/microsoft/testsuites/mshv/mshv_secure_boot.py
+++ b/microsoft/testsuites/mshv/mshv_secure_boot.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import Path
+from typing import Any, Dict, cast
+
+from lisa import (
+    Logger,
+    Node,
+    RemoteNode,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+)
+from lisa.features.security_profile import SecureBootEnabled
+from lisa.operating_system import CBLMariner
+from lisa.sut_orchestrator import AZURE
+from lisa.testsuite import simple_requirement
+from lisa.tools import Journalctl, Reboot
+from lisa.util import (
+    SkippedException,
+    TcpConnectionException,
+    UnsupportedDistroException,
+)
+from lisa.util.constants import (
+    ENVIRONMENTS_NODES_REMOTE_ADDRESS,
+    ENVIRONMENTS_NODES_REMOTE_PORT,
+)
+from lisa.util.shell import wait_tcp_port_ready
+
+
+@TestSuiteMetadata(
+    area="mshv",
+    category="functional",
+    description="""This test suite covers the secure boot flow for
+    Dom0 AzureLinux nodes.
+    """,
+)
+class Dom0SecureBootTestSuite(TestSuite):
+    def before_case(self, log: Logger, **kwargs: Any) -> None:
+        node: Node = kwargs["node"]
+        if not isinstance(node.os, CBLMariner):
+            raise SkippedException(
+                UnsupportedDistroException(
+                    node.os, "Dom0 secure boot test supports only Azure Linux."
+                )
+            )
+
+    @TestCaseMetadata(
+        description="""This test verifies secure boot succeeds
+        on an Azure Linux Dom0 node.
+
+        Steps:
+        1. On first boot, install the Dom0 components
+            (e.g. kernel-mshv, mshv, mshv-bootloader-lx, hvloader)
+        2. Reboot the VM (The Dom0 components should be loaded)
+        3. Await the VM to be ready by checking TCP port connectivity
+        4. Verify that secure boot is enabled by checking
+            journalctl for "Secure boot enabled"
+        5. Verify that the Dom0 stack is running by checking
+            journalctl for "Hyper-V: running as root partition"
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_features=[SecureBootEnabled()],
+            supported_platform_type=[AZURE],
+        ),
+    )
+    def verify_mshv_secure_boot_succeeds(
+        self,
+        log: Logger,
+        node: RemoteNode,
+        log_path: Path,
+        variables: Dict[str, Any],
+    ) -> None:
+        os: CBLMariner = cast(CBLMariner, node.os)
+
+        # 1. Install the Dom0 components
+        # Can provide: mshv, mshv-bootloader-lx
+        source_mshv_tarball = variables.get("mshv_rpm_tarball")
+        if source_mshv_tarball:
+            os.add_repository(source_mshv_tarball)
+
+        # Can provide: kernel-mshv, hvloader
+        source_base_tarball = variables.get("base_rpm_tarball")
+        if source_base_tarball:
+            os.add_repository(source_base_tarball)
+
+        components = ["kernel-mshv", "mshv", "mshv-bootloader-lx", "hvloader"]
+        os.install_packages(components)
+
+        # 2. Reboot the VM to load the Dom0 components
+        reboot_tool = node.tools[Reboot]
+        reboot_tool.reboot_and_check_panic(log_path)
+
+        # 3. Await the VM to be ready by checking TCP port connectivity
+        is_ready, tcp_error_code = wait_tcp_port_ready(
+            node.connection_info[ENVIRONMENTS_NODES_REMOTE_ADDRESS],
+            node.connection_info[ENVIRONMENTS_NODES_REMOTE_PORT],
+            log=log,
+        )
+
+        if is_ready:
+            journalctl = node.tools[Journalctl].logs_for_kernel()
+            # 4. Verify that secure boot is enabled
+            # 5. Verify that the Dom0 stack is running
+            assert (
+                "Secure boot enabled" in journalctl
+                and "Hyper-V: running as root partition" in journalctl
+            )
+        else:
+            raise TcpConnectionException(
+                node.connection_info[ENVIRONMENTS_NODES_REMOTE_ADDRESS],
+                node.connection_info[ENVIRONMENTS_NODES_REMOTE_PORT],
+                tcp_error_code,
+                "node failed to secure boot after dom0 components installed",
+            )

--- a/microsoft/testsuites/mshv/mshv_secure_boot.py
+++ b/microsoft/testsuites/mshv/mshv_secure_boot.py
@@ -103,12 +103,12 @@ class Dom0SecureBootTestSuite(TestSuite):
         )
 
         if is_ready:
-            journalctl = node.tools[Journalctl].logs_for_kernel()
+            kernel_logs = node.tools[Journalctl].logs_for_kernel()
             # 4. Verify that secure boot is enabled
             # 5. Verify that the Dom0 stack is **NOT** running under secure boot
             assert (
-                "Secure boot enabled" in journalctl
-                and "Hyper-V: running as root partition" not in journalctl
+                "Secure boot enabled" in kernel_logs
+                and "Hyper-V: running as root partition" not in kernel_logs
             )
         else:
             raise TcpConnectionException(

--- a/microsoft/testsuites/mshv/mshv_secure_boot.py
+++ b/microsoft/testsuites/mshv/mshv_secure_boot.py
@@ -57,8 +57,10 @@ class Dom0SecureBootTestSuite(TestSuite):
         3. Await the VM to be ready by checking TCP port connectivity
         4. Verify that secure boot is enabled by checking
             journalctl for "Secure boot enabled"
-        5. Verify that the Dom0 stack is running by checking
+        5. Verify that the Dom0 stack is **NOT** running by checking
             journalctl for "Hyper-V: running as root partition"
+            NOTE: The Dom0 stack is currently not secure boot signed,
+            so it will not run in secure boot mode.
         """,
         priority=2,
         requirement=simple_requirement(
@@ -103,10 +105,10 @@ class Dom0SecureBootTestSuite(TestSuite):
         if is_ready:
             journalctl = node.tools[Journalctl].logs_for_kernel()
             # 4. Verify that secure boot is enabled
-            # 5. Verify that the Dom0 stack is running
+            # 5. Verify that the Dom0 stack is **NOT** running under secure boot
             assert (
                 "Secure boot enabled" in journalctl
-                and "Hyper-V: running as root partition" in journalctl
+                and "Hyper-V: running as root partition" not in journalctl
             )
         else:
             raise TcpConnectionException(


### PR DESCRIPTION
Introduce a test which consumes mshv components "mshv_rpm_tarball" to stand up a Dom0 image. Checks:
    
    1. We come up with secure boot successfully
    2. The mshv driver is running

Also introduces Journalctl.logs_for_kernel() which retrieves kernel logs with journalctl -k.

Note: as no production-signed MSHV bits are published today, the test is expected to FAIL. 