### PR TITLE
Add parse for logical devices of 'lsblk' and changes for swap check

### DIFF
--- a/lisa/tools/swap.py
+++ b/lisa/tools/swap.py
@@ -70,6 +70,9 @@ class Swap(Tool):
         # run 'cat /proc/swaps' or 'swapon -s' and parse the output
         # The output is in the following format:
         # <Filename> <Type> <Size> <Used> <Priority>
+        # Filename       Type       Size     Used     Priority
+        # /dev/dm-5      partition  3891196  1820932  -2
+        # /mnt/swapfile  file       4194300  0        -3
         cat = self.node.tools[Cat]
         swap_result = cat.run("/proc/swaps", shell=True, sudo=True)
         if swap_result.exit_code != 0:

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -1475,11 +1475,16 @@ class AzureImageStandard(TestSuite):
         also has IO issues.
 
         Steps:
-        1. Use 'cat /proc/swaps' or 'swapon -s' list all swap devices
+        1. Use 'cat /proc/swaps' or 'swapon -s' to list all swap devices
             Note: For FreeBSD, use 'swapinfo -k'.
-        2. Use 'lsblk' to identify the OS disk and get all the partitions
+        2. Use 'lsblk <swap_part> -P -o NAME' to get the real block device name for
+           each swap partition. If there is no swap partition, pass the case.
+        3. Use 'lsblk' to identify the OS disk and get all its partitions and logical
+           devices through matching the mount point '/'.
             Note: For FreeBSD, if there is no lsblk, install it and run the command
-        3. Verify that no swap partition exists on the OS disk
+        4. Compare if the device name of each swap partition is the same as the device
+           name of one OS disk partition or logical device. If yes, fail the case.
+        5. Pass the case if no swap partition is found on the OS disk.
         """,
         priority=1,
         requirement=simple_requirement(supported_platform_type=[AZURE]),
@@ -1491,23 +1496,32 @@ class AzureImageStandard(TestSuite):
             return
         node.log.info(f"Swap partitions: {swap_parts}")
 
+        # For some images like audiocodes audcovoc acovoce4azure 8.4.591, the swap
+        # partition is created on a logical device, such as /dev/dm-5. In this case,
+        # we need to get the real block device name.
         lsblk = node.tools[Lsblk]
         os_disk = lsblk.find_disk_by_mountpoint("/")
-        # e.g. os_disk_partitions: ['sda1', 'sda2']
-        os_disk_partitions = [part.name for part in os_disk.partitions]
-        node.log.info(f"OS disk partitions: {os_disk_partitions}")
-
         for swap_part in swap_parts:
-            for os_part in os_disk_partitions:
-                if os_part in swap_part:
-                    raise LisaException(
-                        f"Swap partition '{swap_part}' found on OS disk. There should"
-                        "  be no Swap Partition on OS Disk. OS disk has IOPS limit. "
-                        "When memory pressure causes swapping, IOPS limit may be "
-                        "reached easily and cause VM performance to go down "
-                        "disastrously, because aside from memory issues in now also "
-                        "has IO issues."
-                    )
+            block_name = lsblk.get_block_name(swap_part)
+            if block_name == "":
+                raise LisaException(
+                    f"Failed to get the device name for swap partition '{swap_part}'."
+                )
+            node.log.info(f"Swap partition '{swap_part}' is on device '{block_name}'.")
+            for part in os_disk.partitions:
+                # e.g. 'sda1', 'vg-root', 'vg-home'
+                parts = [part] + part.logical_devices
+                for p in parts:
+                    node.log.info(f"OS disk partition or logical device: {p.name}")
+                    if p.name == block_name:
+                        raise LisaException(
+                            f"Swap partition '{swap_part}' found on OS disk partition "
+                            f"or logical device '{p.name}'. There should be no Swap "
+                            "Partition on OS Disk. OS disk has IOPS limit. When memory"
+                            " pressure causes swapping, IOPS limit may be reached "
+                            "easily and cause VM performance to go down disastrously, "
+                            "as aside from memory issues in now also has IO issues."
+                        )
 
     def _verify_version_by_pattern_value(
         self,


### PR DESCRIPTION
Some images have logical devices on the disk partition. This PR adds parse for logical devices of 'lsblk' and adds some changes for swap partition verification.

This PR fix the following scenario:
Image: audiocodes audcovoc acovoce4azure 8.4.591

$ lsblk
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sda           8:0    0  320G  0 disk
├─sda1        8:1    0    5G  0 part
└─sda2        8:2    0  315G  0 part
  ├─vg-data 253:0    0  238G  0 lvm  /data
  ├─vg-meta 253:1    0  128M  0 lvm  /meta
  ├─vg-opt  253:2    0   10G  0 lvm  /opt
  ├─vg-var  253:3    0   33G  0 lvm  /var
  ├─vg-home 253:4    0   20G  0 lvm  /home
  ├─vg-swap 253:5    0  3.7G  0 lvm  [SWAP]
  └─vg-root 253:6    0   10G  0 lvm  /
sdb           8:16   0   14G  0 disk
└─sdb1        8:17   0   14G  0 part /mnt
sr0          11:0    1  628K  0 rom

$ swapon
NAME          TYPE      SIZE USED PRIO
/dev/dm-5     partition 3.7G 1.8G   -2

$ lsblk /dev/dm-5
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
vg-swap 253:5    0  3.7G  0 lvm  [SWAP]

The kernel block name of the logical device `vg-swap` is `dm-5.` The swap partition is created on it. We need to find the real device name to compare with the partitions and logical devices on OS disk.

We have run the following images for tests:
thefreebsdfoundation freebsd-14_0 14_0-release 14.0.0
suse sles-sap-15-sp6 gen2 2025.01.30
audiocodes audcovoc acovoce4azure 8.4.591
maplelabsinc1623932715330 sfpoller sfpoller 4.2.154
firemon lumeta-scout4-2 lumeta-community-edition-scout 4.2.0
newnetcommunicationtechnologies1589991852134 secure_transaction_cloud stc_byol_plan1 8.0.0

The last four images all have swap partitions on the logical devices of OS disk.

