### PR TITLE
add Openssl speed test case

### DIFF
--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT license.
 
 import shlex
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Optional
 
 from lisa.executable import Tool
+from lisa.util.process import ExecutableResult
 
 if TYPE_CHECKING:
     from lisa.operating_system import Posix
@@ -119,6 +120,21 @@ class OpenSSL(Tool):
             expected_exit_code_failure_message=(
                 "Failed to verify signature with OpenSSL."
             ),
+        )
+
+    def speed(self, sec: Optional[int] = None) -> ExecutableResult:
+        """
+        Run OpenSSL speed test to validate the performance
+        of cryptographic functions.
+        """
+        cmd = "speed"
+        if sec is not None:
+            cmd = f"{cmd} -seconds {sec}"
+        return self.run(
+            cmd,
+            timeout=3600,  # 1 hour
+            expected_exit_code=0,
+            expected_exit_code_failure_message=("OpenSSL speed test failed."),
         )
 
     def _run_with_piped_input(

--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import shlex
-from typing import TYPE_CHECKING, Tuple, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from lisa.executable import Tool
 from lisa.util.process import ExecutableResult

--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -124,19 +124,19 @@ class OpenSSL(Tool):
 
     def speed(self, sec: Optional[int] = None) -> ExecutableResult:
         """
-         Run OpenSSL speed test that measures the performance
-         of cryptographic functions.
+        Run OpenSSL speed test that measures the performance
+        of cryptographic functions."""
 
-        This breaks out the time input for the speed test
-         so it can be made to be a parameter in the future."""
+        # This breaks out the time input for the speed test
+        # so it can be made to be a parameter in the future.
         cmd = "speed"
         if sec is not None:
             cmd = f"{cmd} -seconds {sec}"
-        # 1 hour timeout to complete all of the cryptographic operations
+        # 20 min timeout to complete all of the cryptographic operations
         # that OpenSSL speed measures.
         return self.run(
             cmd,
-            timeout=3600,
+            timeout=1200,
             expected_exit_code=0,
             expected_exit_code_failure_message=("OpenSSL speed test failed."),
         )

--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -124,15 +124,19 @@ class OpenSSL(Tool):
 
     def speed(self, sec: Optional[int] = None) -> ExecutableResult:
         """
-        Run OpenSSL speed test to validate the performance
-        of cryptographic functions.
-        """
+         Run OpenSSL speed test that measures the performance
+         of cryptographic functions.
+
+        This breaks out the time input for the speed test
+         so it can be made to be a parameter in the future."""
         cmd = "speed"
         if sec is not None:
             cmd = f"{cmd} -seconds {sec}"
+        # 1 hour timeout to complete all of the cryptographic operations
+        # that OpenSSL speed measures.
         return self.run(
             cmd,
-            timeout=3600,  # 1 hour
+            timeout=3600,
             expected_exit_code=0,
             expected_exit_code_failure_message=("OpenSSL speed test failed."),
         )

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -86,6 +86,22 @@ class OpenSSLTestSuite(TestSuite):
             ),
         )
 
+    @TestCaseMetadata(
+        description="""
+        This test runs OpenSSL speed test this test will
+        run performance tests on OpenSSL cryptography tests,
+        not only giving us a performance baseline but also
+        testing to make sure crypto functions of openssl are working.
+        """,
+        priority=2,
+        timeout=3600,  # 1 hour
+    )
+    def verify_openssl_speed_test(self, node: Node) -> None:
+        """This function runs OpenSSL speed test to validate the
+        performance of cryptographic functions."""
+        openssl = node.tools[OpenSSL]
+        openssl.speed(sec=1)
+
     def _openssl_test_encrypt_decrypt(self, log: Logger, node: Node) -> None:
         """
         Tests OpenSSL encryption and decryption functionality.

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -88,19 +88,26 @@ class OpenSSLTestSuite(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test runs OpenSSL speed test this test will
-        run performance tests on OpenSSL cryptography tests,
-        not only giving us a performance baseline but also
-        testing to make sure crypto functions of openssl are working.
+        This test will first Run OpenSSL speed test
+        that measures the performance of cryptographic
+        functions. The parameter `sec` is set to 1 second
+        to ensure that the test runs for a short duration
+        and test avoids timeout.
         """,
         priority=2,
         timeout=3600,  # 1 hour
     )
     def verify_openssl_speed_test(self, node: Node) -> None:
-        """This function runs OpenSSL speed test to validate the
-        performance of cryptographic functions."""
-        openssl = node.tools[OpenSSL]
-        openssl.speed(sec=1)
+        """This function runs OpenSSL speed test to measure the
+        performance of cryptographic operations.
+
+        "sec=1" sets the duration of every
+        cryptographic operation to 1 second by default,
+        this ensures that the many operations that openssl
+        speed measures complete in a reasonable time frame.
+        """
+
+        node.tools[OpenSSL].speed(sec=1)
 
     def _openssl_test_encrypt_decrypt(self, log: Logger, node: Node) -> None:
         """

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -95,7 +95,7 @@ class OpenSSLTestSuite(TestSuite):
         and test avoids timeout.
         """,
         priority=2,
-        timeout=3600,  # 1 hour
+        timeout=1200,  # 20 minutes
     )
     def verify_openssl_speed_test(self, node: Node) -> None:
         """This function runs OpenSSL speed test to measure the


### PR DESCRIPTION
Adding a speed method to the openssl tool, this way well be able to use functionality to test openssl and perf test in the future. 