### PR TITLE
Prevent duplicate plugin registrations

### DIFF
--- a/lisa/environment.py
+++ b/lisa/environment.py
@@ -583,4 +583,5 @@ class EnvironmentHookImpl:
 
 
 plugin_manager.add_hookspecs(EnvironmentHookSpec)
-plugin_manager.register(EnvironmentHookImpl())
+if not plugin_manager.is_registered(EnvironmentHookImpl):
+    plugin_manager.register(EnvironmentHookImpl())

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -1231,7 +1231,8 @@ class NodeHookImpl:
 
 
 plugin_manager.add_hookspecs(NodeHookSpec)
-plugin_manager.register(NodeHookImpl())
+if not plugin_manager.is_registered(NodeHookImpl):
+    plugin_manager.register(NodeHookImpl())
 
 
 def create_nics(node: Node) -> Nics:

--- a/lisa/sut_orchestrator/azure/hooks.py
+++ b/lisa/sut_orchestrator/azure/hooks.py
@@ -110,4 +110,5 @@ class AzureHookSpecDefaultImpl:
 
 
 plugin_manager.add_hookspecs(AzureHookSpec)
-plugin_manager.register(AzureHookSpecDefaultImpl())
+if not plugin_manager.is_registered(AzureHookSpecDefaultImpl):
+    plugin_manager.register(AzureHookSpecDefaultImpl())


### PR DESCRIPTION
Plugins were getting registered every time the file was being imported.