### PR TITLE
Refactor _resource_sku_to_capability to classmethod

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1125,7 +1125,7 @@ class AzurePlatform(Platform):
                                 continue
                             resource_sku = sku_obj.as_dict()
                             capability = self._resource_sku_to_capability(
-                                location, sku_obj
+                                location, sku_obj, self._log
                             )
 
                             # estimate vm cost for priority
@@ -1794,8 +1794,9 @@ class AzurePlatform(Platform):
             ]
         )
 
+    @classmethod
     def _resource_sku_to_capability(  # noqa: C901
-        self, location: str, resource_sku: ResourceSku
+        cls, location: str, resource_sku: ResourceSku, log: Logger
     ) -> schema.NodeSpace:
         # fill in default values, in case no capability meet.
         node_space = schema.NodeSpace(
@@ -1923,7 +1924,7 @@ class AzurePlatform(Platform):
                         schema.DiskControllerType(allowed_type)
                     )
                 except ValueError:
-                    self._log.error(
+                    log.error(
                         f"'{allowed_type}' is not a known Disk Controller Type "
                         f"({[x for x in schema.DiskControllerType]})"
                     )
@@ -1947,7 +1948,7 @@ class AzurePlatform(Platform):
                             DiskPlacementType(allowed_type)
                         )
                     except ValueError:
-                        self._log.error(
+                        log.error(
                             f"'{allowed_type}' is not a known Ephemeral Disk Placement"
                             f" Type "
                             f"({[x for x in DiskPlacementType]})"
@@ -2052,7 +2053,7 @@ class AzurePlatform(Platform):
         else:
             node_space.disk.has_resource_disk = False
 
-        for supported_feature in self.supported_features():
+        for supported_feature in cls.supported_features():
             if supported_feature.name() in [
                 features.Disk.name(),
                 features.NetworkInterface.name(),

--- a/selftests/azure/test_prepare.py
+++ b/selftests/azure/test_prepare.py
@@ -64,7 +64,9 @@ class AzurePrepareTestCase(TestCase):
                 "restrictions": [],
             }
         )
-        node = self._platform._resource_sku_to_capability("eastus", resource_sku)
+        node = self._platform._resource_sku_to_capability(
+            "eastus", resource_sku, self._platform._log
+        )
         self.assertEqual(48, node.core_count)
         self.assertEqual(458752, node.memory_mb)
         assert node.network_interface


### PR DESCRIPTION
Changed _resource_sku_to_capability from an instance method to a classmethod in AzurePlatform. Updated references from 'self' to 'cls' and adjusted logging to use a class-level logger. This improves method usage flexibility and aligns with its stateless behavior.