### PR TITLE
tools: make expected exit code optional for cargo test

### DIFF
--- a/lisa/tools/cargo.py
+++ b/lisa/tools/cargo.py
@@ -154,6 +154,7 @@ class Cargo(Tool):
         self,
         sudo: bool = False,
         cwd: Optional[PurePath] = None,
+        expected_exit_code: Optional[int] = None,
     ) -> ExecutableResult:
         echo = self.node.tools[Echo]
         path = echo.run(
@@ -172,7 +173,7 @@ class Cargo(Tool):
             cwd=cwd,
             update_envs={"PATH": path},
             shell=True,
-            expected_exit_code=0,
+            expected_exit_code=expected_exit_code,
             expected_exit_code_failure_message="cargo test failed",
         )
         return result


### PR DESCRIPTION
Subtest failure of `verify_rust_vmm_mshv_tests` results in an assertion error for the entire test case. The cargo tool implementation for executing the test itself asserts a non zero exit code & results in cargo test failure which hides the subtest failure.

To control whether the test should assert on command exit code, make the exit code params optional. This ensures that the subtests are individually reported as failed instead of throwing an assert error on the entire test case.