### PR TITLE
Make encrypt_disk a SetSpace

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -311,6 +311,15 @@ class AzureImageSchema(schema.ImageSchema):
             )
         ),
     )
+    encrypt_disk: Union[search_space.SetSpace[bool], bool] = field(
+        default_factory=partial(
+            search_space.SetSpace[bool], is_allow_set=True, items=[False, True]
+        ),
+        metadata=field_metadata(
+            decoder=partial(search_space.decode_set_space_by_type, base_type=bool),
+            required=False,
+        ),
+    )
 
     def load_from_platform(self, platform: "AzurePlatform") -> None:
         """
@@ -379,21 +388,28 @@ class AzureImageSchema(schema.ImageSchema):
         self, raw_features: Dict[str, Any], log: Logger
     ) -> None:
         security_profile = raw_features.get("SecurityType")
-        capabilities: List[SecurityProfileType] = []
+        security_profile_capabilities: List[SecurityProfileType] = []
+        encrypt_capability: List[bool] = [False]
         if security_profile in ["TrustedLaunchSupported", "TrustedLaunch"]:
-            capabilities.append(SecurityProfileType.Standard)
-            capabilities.append(SecurityProfileType.SecureBoot)
+            security_profile_capabilities.extend(
+                [SecurityProfileType.Standard, SecurityProfileType.SecureBoot]
+            )
         elif security_profile in (
             "TrustedLaunchAndConfidentialVmSupported",
             "ConfidentialVmSupported",
             "ConfidentialVM",
         ):
-            capabilities.append(SecurityProfileType.CVM)
-            capabilities.append(SecurityProfileType.Stateless)
+            security_profile_capabilities.extend(
+                [SecurityProfileType.CVM, SecurityProfileType.Stateless]
+            )
+            encrypt_capability.append(True)
         else:
-            capabilities.append(SecurityProfileType.Standard)
+            security_profile_capabilities.append(SecurityProfileType.Standard)
 
-        self.security_profile = search_space.SetSpace(True, capabilities)
+        self.security_profile = search_space.SetSpace(
+            True, security_profile_capabilities
+        )
+        self.encrypt_disk = search_space.SetSpace(True, encrypt_capability)
 
 
 def _get_image_tags(image: Any) -> Dict[str, Any]:
@@ -538,6 +554,7 @@ class VhdSchema(AzureImageSchema):
                     SecurityProfileType.Stateless,
                 ],
             )
+            self.encrypt_disk = search_space.SetSpace(True, [True, False])
         else:
             self.security_profile = search_space.SetSpace(
                 True,
@@ -546,6 +563,7 @@ class VhdSchema(AzureImageSchema):
                     SecurityProfileType.SecureBoot,
                 ],
             )
+            self.encrypt_disk = search_space.SetSpace(True, [False])
 
 
 @dataclass_json()

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2564,7 +2564,10 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
         resource_sku: Any = kwargs.get("resource_sku")
-        capabilities: List[SecurityProfileType] = [SecurityProfileType.Standard]
+        security_profile_capabilities: List[SecurityProfileType] = [
+            SecurityProfileType.Standard
+        ]
+        encrypt_capability: List[bool] = [False]
 
         gen_value = raw_capabilities.get("HyperVGenerations", None)
         cvm_value = raw_capabilities.get("ConfidentialComputingType", None)
@@ -2581,17 +2584,18 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                 and ("V2" in str(gen_value))
                 and raw_capabilities.get("TrustedLaunchDisabled", "False") == "False"
             ):
-                capabilities.append(SecurityProfileType.SecureBoot)
+                security_profile_capabilities.append(SecurityProfileType.SecureBoot)
 
         if cvm_value and cvm_value.casefold() == "snp":
-            capabilities.append(SecurityProfileType.CVM)
-
+            security_profile_capabilities.append(SecurityProfileType.CVM)
+            encrypt_capability.append(True)
         if cvm_value and cvm_value.casefold() == "tdx":
-            capabilities.append(SecurityProfileType.CVM)
-            capabilities.append(SecurityProfileType.Stateless)
-
+            security_profile_capabilities.append(SecurityProfileType.CVM)
+            security_profile_capabilities.append(SecurityProfileType.Stateless)
+            encrypt_capability.append(True)
         return SecurityProfileSettings(
-            security_profile=search_space.SetSpace(True, capabilities)
+            security_profile=search_space.SetSpace(True, security_profile_capabilities),
+            encrypt_disk=search_space.SetSpace(True, encrypt_capability),
         )
 
     @classmethod
@@ -2618,6 +2622,7 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                 settings = security_profile[0]
                 assert isinstance(settings, SecurityProfileSettings)
                 assert isinstance(settings.security_profile, SecurityProfileType)
+                assert isinstance(settings.encrypt_disk, bool)
                 node_parameters.security_profile[
                     "security_type"
                 ] = cls._security_profile_mapping[settings.security_profile]

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -744,7 +744,10 @@ class AzurePlatform(Platform):
                 information[
                     "security_profile"
                 ] = security_profile.security_profile.value
-                if security_profile.security_profile == SecurityProfileType.CVM:
+                if (
+                    security_profile.security_profile == SecurityProfileType.CVM
+                    and isinstance(security_profile.encrypt_disk, bool)
+                ):
                     information["encrypt_disk"] = security_profile.encrypt_disk
 
             if node.capture_kernel_config:

--- a/microsoft/testsuites/cvm/cvm_boot.py
+++ b/microsoft/testsuites/cvm/cvm_boot.py
@@ -17,6 +17,7 @@ from lisa import (
 )
 from lisa.environment import EnvironmentStatus
 from lisa.features.security_profile import (
+    CvmDiskEncryptionEnabled,
     CvmEnabled,
     SecurityProfile,
     SecurityProfileSettings,
@@ -52,7 +53,7 @@ class CVMBootTestSuite(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
-            supported_features=[CvmEnabled()],
+            supported_features=[CvmDiskEncryptionEnabled()],
             supported_platform_type=[AZURE],
         ),
     )


### PR DESCRIPTION
Make encrypt_disk a SetSpace so that test cases can require an encrypt_disk value and it merges appropriately. The test case can only skip if there is an empty set value to represent the requirement not being met.

Co-authored-by: Kat Munson <katmunson@microsoft.com>
Co-authored-by: Kameron Carr <kameroncarr@microsoft.com>