### PR TITLE
dom0_kernel_installer: Add new menuentry for installed kernel

### DIFF
--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -70,6 +70,20 @@ class Sed(Tool):
         )
         result.assert_exit_code(message=result.stdout)
 
+    def insert_line_beginning(
+        self,
+        line: str,
+        file: str,
+        sudo: bool = False,
+    ) -> None:
+        result = self.run(
+            f"-i.bak '1i {line}' {file}",
+            force_run=True,
+            sudo=sudo,
+            shell=True,
+        )
+        result.assert_exit_code(message=result.stdout)
+
     def delete_lines(self, pattern: str, file: PurePath, sudo: bool = False) -> None:
         expression = f"/{pattern}/d"
         cmd = f'-i.bak "{expression}" {file}'


### PR DESCRIPTION
Writes to /boot/grub2/grub.cfg are not permanent and will be overriden when grub-update action is performed. Adding a new entry and making it the default will solve this problem. Introduce additional_grub_file, which acts as a template for the new menuentry with the installed kernel.