### PR TITLE
Fix verify_timedrift_corrected testcase for fedora

### DIFF
--- a/lisa/tools/chrony.py
+++ b/lisa/tools/chrony.py
@@ -13,10 +13,10 @@ from lisa.operating_system import (
     Cat,
     CBLMariner,
     Debian,
+    Fedora,
     Posix,
     Redhat,
     Suse,
-    Fedora,
 )
 from lisa.tools.ls import Ls
 from lisa.util import LisaException

--- a/lisa/tools/chrony.py
+++ b/lisa/tools/chrony.py
@@ -8,7 +8,16 @@ from retry import retry
 
 from lisa.base_tools import Service
 from lisa.executable import Tool
-from lisa.operating_system import BSD, Cat, CBLMariner, Debian, Posix, Redhat, Suse
+from lisa.operating_system import (
+    BSD,
+    Cat,
+    CBLMariner,
+    Debian,
+    Posix,
+    Redhat,
+    Suse,
+    Fedora,
+)
 from lisa.tools.ls import Ls
 from lisa.util import LisaException
 
@@ -44,6 +53,7 @@ class Chrony(Tool):
             or isinstance(self.node.os, Suse)
             or isinstance(self.node.os, CBLMariner)
             or isinstance(self.node.os, BSD)
+            or isinstance(self.node.os, Fedora)
         ):
             service_name = "chronyd"
         else:


### PR DESCRIPTION
Just added Fedora to restart chronyd service section The testcase is passing on azure for latest fedora