### PR TITLE
XFSTest tool hostfix - for Debian 12 and other distros

### DIFF
--- a/microsoft/testsuites/xfstests/xfstesting.py
+++ b/microsoft/testsuites/xfstests/xfstesting.py
@@ -73,8 +73,8 @@ _default_smb_testcases: str = (
     "generic/406 generic/412 generic/422 generic/428 generic/432 generic/433 "
     "generic/437 generic/443 generic/450 generic/451 generic/452 generic/460 "
     "generic/464 generic/465 generic/469 generic/524 generic/528 generic/538 "
-    "generic/565 generic/567 generic/568 generic/590 generic/591 generic/598"
-    "generic/599 generic/604 generic/609 generic/615 generic/632 generic/634"
+    "generic/565 generic/567 generic/568 generic/590 generic/591 generic/598 "
+    "generic/599 generic/604 generic/609 generic/615 generic/632 generic/634 "
     "generic/635 generic/637 generic/638 generic/639"
 )
 # Section : Global options

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -91,7 +91,7 @@ class Xfstests(Tool):
     ]
     debian_dep = [
         "exfatprogs",
-        "f2fs-tools", 
+        "f2fs-tools",
         "ocfs2-tools",
         "udftools",
         "xfsdump",
@@ -976,7 +976,7 @@ class Xfstests(Tool):
                     f"with status {test_status}"
                 )
         return result
-    
+
     def get_os_id_version(self) -> str:
         """
         Extracts OS information from node.os.information.
@@ -985,11 +985,22 @@ class Xfstests(Tool):
         """
         try:
             os_info = self.node.os.information
-            full_version = getattr(os_info, 'full_version', '')
-            major = getattr(os_info.version, 'major', 0) if hasattr(os_info, 'version') else 0
-            minor = getattr(os_info.version, 'minor', 0) if hasattr(os_info, 'version') else 0
-            patch = getattr(os_info.version, 'patch', 0) if hasattr(os_info, 'version') else 0
-
+            full_version = getattr(os_info, "full_version", "")
+            major = (
+                getattr(os_info.version, "major", 0)
+                if hasattr(os_info, "version")
+                else 0
+            )
+            minor = (
+                getattr(os_info.version, "minor", 0)
+                if hasattr(os_info, "version")
+                else 0
+            )
+            patch = (
+                getattr(os_info.version, "patch", 0)
+                if hasattr(os_info, "version")
+                else 0
+            )
             if not full_version:
                 return "unknown"
 

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -70,6 +70,7 @@ class Xfstests(Tool):
         "Debian GNU/Linux_12": "v2024.12.22",
         "Ubuntu_18": "v2024.12.22",
         "Ubuntu_20": "v2024.12.22",
+        "Ubuntu_22": "v2024.12.22",
         "Ubuntu_24": "v2024.12.22",
         "Red Hat_7": "v2024.02.09",
         "unknown": "v2024.02.09",  # Default tag for distros that cannot be identified

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -411,7 +411,6 @@ class Xfstests(Tool):
                          repo="https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git"
         )
         """
-        # Set branch to the recommended tag for the OS if not provided
         # Set the branch to the recommended tag for the OS if not provided
         if branch is None:
             os_id_version = self.get_os_id_version()

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -413,8 +413,8 @@ class Xfstests(Tool):
 
     def _install(
         self,
-        branch: Optional[str] = None,
-        repo: Optional[str] = None,
+        branch: str = "",
+        repo: str = "",
     ) -> bool:
         """
         About:This method will download and install XFSTest on a given node.
@@ -431,7 +431,7 @@ class Xfstests(Tool):
         )
         """
         # Set the branch to the recommended tag for the OS if not provided
-        if branch is None:
+        if not branch:
             os_id_version = self.get_os_id_version()
             branch = self.os_recommended_tags.get(os_id_version, self.branch)
         repo = repo or self.repo

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -11,7 +11,6 @@ from lisa.executable import Tool
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.operating_system import (
     CBLMariner,
-    CentOs,
     Debian,
     Oracle,
     Posix,

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -41,25 +41,35 @@ class Xfstests(Tool):
     # This is the default repo and branch for xfstests.
     # Override this via _install method if needed.
     repo = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git"
-    # Branch default will be used when there are no match from the hash table below
     branch = "master"
-    # This hash table contains recommended tags for different OS versions.
+    # This hash table contains recommended tags for different OS versions
+    # based on our findings.
     # Since not all distros are updated to the latest build tools
-    # XFStests may not compile or run correctly.
-    # This is a workaround to ensure that the tests run on the recommended tag
-    # for the OS version.
-    # The format for key is "<OS full_version>_< major>_<minor>_<patch>"
+    # XFStests may not compile and/or run correctly.
+    # This is a workaround to ensure that the tests run on the maximum
+    # recommended tag for the OS version.
+    # The format for key is "<full_version>_< major>_<minor>_<patch>"
     # This information is derived from node.os.information
+    # Logic : the method "get_os_id_version" will return a string
+    # in the format "<full_version>_<major>_<minor>_<patch>"
+    # Example: "SUSE Linux Enterprise Server 15 SP5_15_5_0"
+    # This string is used to lookup the recommended key-value pair from
+    # the hash table. If a match is found, the value is used as the
+    # recommended tag for the OS version.
+    # If the OS Version is not detected, the method "get_os_id_version" will return
+    # "unknown" and a corresponding value will be used from the hash table.
+    # If the OS Version is not found in the hash table,
+    # the default branch will be used from line 45.
     os_recommended_tags: Dict[str, str] = {
         "SUSE Linux Enterprise Server 15 SP5_15_5_0": "v2025.04.27",
-        "SUSE Linux Enterprise Server 12 SP5_12_5_0": "v2025.12.22",
+        "SUSE Linux Enterprise Server 12 SP5_12_5_0": "v2024.12.22",
         "Debian GNU/Linux 11 (bullseye)_11_11_0": "v2024.12.22",
         "Ubuntu 18.04.6 LTS_18_4_0": "v2024.12.22",
         "Ubuntu 20.04.6 LTS_20_4_0": "v2024.12.22",
         "Red Hat Enterprise Linux Server release 7.8 (Maipo)_7_8_0": "v2024.02.09",
         "unknown": "v2024.02.09",  # Default tag for distros that cannot be identified
     }
-    # for all other distross not part of the above hash table,
+    # for all other distros not part of the above hash table,
     # the default branch will be used from line 45
     # these are dependencies for xfstests. Update on regular basis.
     common_dep = [

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -44,12 +44,16 @@ class Xfstests(Tool):
     branch = "master"
     # This hash table contains recommended tags for different OS versions
     # based on our findings that are known to build without issues.
-    # The format for key is "<vendor>_<release>"
-    # NOTE: The release and vendor information is case sensitive.
+    # The format for key is either "<vendor>_<release>" or "<vendor>_<major>
+    # NOTE: The vendor field is case sensitive.
     # This information is derived from node.os.information
     # Logic : the method "get_os_id_version" will return a string
     # in the format "<vendor>_<release>"
-    # Example: "SLES_15_5_0"
+    # Example: "SLES_15.5"
+    # Alternatively, a partial lookup for SLES_15.5 can be done against a key
+    # such as "SLES_15" which is used to encompass all SLES 15.x releases.
+    # If you have a specific version of OS with known major and minor version,
+    # please ensure it's added to the top of the hash table above partial match keys
     # This string is used to lookup the recommended key-value pair from
     # the hash table. If a match is found, the value is used as the
     # recommended tag for the OS version.
@@ -62,11 +66,12 @@ class Xfstests(Tool):
     os_recommended_tags: Dict[str, str] = {
         "SLES_15.5": "v2025.04.27",
         "SLES_12.5": "v2024.12.22",
-        "Debian GNU/Linux_11.11": "v2024.12.22",
-        "Ubuntu_18.04": "v2024.12.22",
-        "Ubuntu_20.04": "v2024.12.22",
-        "Ubuntu_24.10": "v2024.12.22",
-        "Red Hat_7.8": "v2024.02.09",
+        "Debian GNU/Linux_11": "v2024.12.22",
+        "Debian GNU/Linux_12": "v2024.12.22",
+        "Ubuntu_18": "v2024.12.22",
+        "Ubuntu_20": "v2024.12.22",
+        "Ubuntu_24": "v2024.12.22",
+        "Red Hat_7": "v2024.02.09",
         "unknown": "v2024.02.09",  # Default tag for distros that cannot be identified
     }
     # for all other distros not part of the above hash table,
@@ -433,7 +438,18 @@ class Xfstests(Tool):
         # Set the branch to the recommended tag for the OS if not provided
         if not branch:
             os_id_version = self.get_os_id_version()
-            branch = self.os_recommended_tags.get(os_id_version, self.branch)
+            # First try full match
+            if os_id_version in self.os_recommended_tags:
+                branch = self.os_recommended_tags[os_id_version]
+            else:
+                # Try partial match - check if any key is a prefix of os_id_version
+                # example: "Ubuntu_20.04" match with "Ubuntu_20" from hash table.
+                branch = self.branch  # default fallback
+                for key in self.os_recommended_tags:
+                    if os_id_version.startswith(key):
+                        branch = self.os_recommended_tags[key]
+                        # match found, break loop and exit conditional block
+                        break
         repo = repo or self.repo
         self._install_dep()
         self._add_test_users()

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -45,22 +45,22 @@ class Xfstests(Tool):
     # Dictionary mapping OS identifier (e.g., "ubuntu_18", "rhel_7")
     # to recommended xfstests-dev git tags.
     # This allows using specific xfstests versions for different OSes if needed.
-    # The key is typically constructed as f"{node.os.id}_{node.os.information.version.major}".
+    # The key is typically constructed as
+    # f"{node.os.id}_{node.os.information.version.major}".
     # The value is the git tag/branch to checkout.
     # The 'default' key is used if a specific OS version is not found.
     os_recommended_tags: Dict[str, str] = {
-        "ubuntu_18.04": "v2024.12.22",  # Ubuntu 18.04 LTS (ID: ubuntu, MajorVersion: 18)
-        "ubuntu_20.04": "v2024.12.22",  # Ubuntu 20.04 LTS (ID: ubuntu, MajorVersion: 20)
+        "ubuntu_18.04": "v2024.12.22",  # Ubuntu 18.04 LTS
+        "ubuntu_20.04": "v2024.12.22",  # Ubuntu 20.04 LTS
         "centos_7": "v2024.12.22",  # CentOS 7.x (ID: centos, MajorVersion: 7)
         "rhel_7.8": "v2024.12.22",  # RHEL 7.x (ID: rhel, MajorVersion: 7)
-        "sles_12.5": "v2024.12.22",  # SUSE Linux Enterprise Server 12 (ID: sles, MajorVersion: 12)
-        "debian_10": "v2024.12.22",  # Debian 10 (Buster) (ID: debian, MajorVersion: 10)
-        "debian_11": "v2024.12.22",  # Debian 11 (Bullseye) (ID: debian, MajorVersion: 11)
-        "cbl-mariner_1": "v2024.12.22",  # CBL-Mariner 1.0 (ID: cbl-mariner, MajorVersion: 1)
-        "cbl-mariner_2": "v2024.12.22",  # CBL-Mariner 2.0 (ID: cbl-mariner, MajorVersion: 2)
-        "default": "master",  # Default tag for other/unlisted OSes
+        "sles_12.5": "v2024.12.22",  # SUSE Linux Enterprise Server 12
+        "debian_10": "v2024.12.22",  # Debian 10 (Buster)
+        "debian_11": "v2024.12.22",  # Debian 11 (Bullseye)
+        "cbl-mariner_1": "v2024.12.22",  # CBL-Mariner 1.0
+        "cbl-mariner_2": "v2024.12.22",  # CBL-Mariner 2.0
+        "default": "v2024.02.09",  # Default tag for other/unlisted OSes
     }
-
     # these are dependencies for xfstests. Update on regular basis.
     common_dep = [
         "acl",
@@ -411,15 +411,13 @@ class Xfstests(Tool):
                          repo="https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git"
         )
         """
-                # Set branch to the recommended tag for the OS if not provided
+        # Set branch to the recommended tag for the OS if not provided
         # Set the branch to the recommended tag for the OS if not provided
         if branch is None:
             os_id_version = self.get_os_id_version()
-            branch = self.os_recommended_tags.get(
-                os_id_version, self.os_recommended_tags["default"]
-            )
+            branch = self.os_recommended_tags.get(os_id_version, self.branch)
         else:
-            branch = self.branch
+            branch = branch
         repo = repo or self.repo
         self._install_dep()
         self._add_test_users()
@@ -977,11 +975,16 @@ class Xfstests(Tool):
         """
         Reads /etc/os-release and extracts ID and VERSION_ID.
         Returns a string in the format <ID>_<VERSION_ID>.
+        If /etc/os-release is not found, returns "default".
         """
         cat = self.node.tools[Cat]
-        os_release_content = cat.run(
-            "/etc/os-release", sudo=True, force_run=True
-        ).stdout
+        try:
+            os_release_content = cat.run(
+                "/etc/os-release", sudo=True, force_run=True
+            ).stdout
+        except Exception:
+            return "default"
+
         os_id = ""
         version_id = ""
         for line in os_release_content.splitlines():
@@ -989,8 +992,8 @@ class Xfstests(Tool):
                 os_id = line.split("=", 1)[1].strip().replace('"', "")
             elif line.startswith("VERSION_ID="):
                 version_id = line.split("=", 1)[1].strip().replace('"', "")
+
         if not os_id or not version_id:
-            raise LisaException(
-                "Could not extract ID or VERSION_ID from /etc/os-release"
-            )
+            return "default"
+
         return f"{os_id}_{version_id}"

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -413,8 +413,8 @@ class Xfstests(Tool):
 
     def _install(
         self,
-        branch: str = None,
-        repo: str = None,
+        branch: Optional[str] = None,
+        repo: Optional[str] = None,
     ) -> bool:
         """
         About:This method will download and install XFSTest on a given node.

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -413,8 +413,8 @@ class Xfstests(Tool):
 
     def _install(
         self,
-        branch: str | None = None,
-        repo: str | None = None,
+        branch: str = None,
+        repo: str = None,
     ) -> bool:
         """
         About:This method will download and install XFSTest on a given node.

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -415,8 +415,7 @@ class Xfstests(Tool):
         if branch is None:
             os_id_version = self.get_os_id_version()
             branch = self.os_recommended_tags.get(os_id_version, self.branch)
-        else:
-            branch = branch
+
         repo = repo or self.repo
         self._install_dep()
         self._add_test_users()

--- a/microsoft/testsuites/xfstests/xfstests.py
+++ b/microsoft/testsuites/xfstests/xfstests.py
@@ -11,6 +11,7 @@ from lisa.executable import Tool
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.operating_system import (
     CBLMariner,
+    CentOs,
     Debian,
     Oracle,
     Posix,
@@ -73,6 +74,7 @@ class Xfstests(Tool):
         "Ubuntu_22": "v2024.12.22",
         "Ubuntu_24": "v2024.12.22",
         "Red Hat_7": "v2024.02.09",
+        "CentOS_7": "v2024.02.09",
         "unknown": "v2024.02.09",  # Default tag for distros that cannot be identified
     }
     # for all other distros not part of the above hash table,
@@ -130,8 +132,10 @@ class Xfstests(Tool):
     ]
     fedora_dep = [
         "btrfs-progs",
+        "byacc",
         "exfatprogs",
         "f2fs-tools",
+        "gcc-c++",
         "gdbm-devel",
         "kernel-devel",
         "libacl-devel",
@@ -391,7 +395,7 @@ class Xfstests(Tool):
             )
             self.node.execute("rm -f /bin/gcc", sudo=True, shell=True)
             self.node.execute(
-                "ln -s /opt/rh/devtoolset-7/root/usr/bin/gcc /bin/gcc",
+                "ln -s /usr/bin/x86_64-redhat-linux-gcc /bin/gcc",
                 sudo=True,
                 shell=True,
             )


### PR DESCRIPTION
Added additional distros to the Hash table which are not able to build XFStests tool using master branch.
Added a simple logic to allow pattern based lookup to account for multiple minor build within a given major release.
Validated for RHEL 7,8, Ubuntu 18,20,24 , SLES 15,12 and Debian 11,12