### PR TITLE
New test cases added for performance validation of resource disks

### DIFF
--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -168,7 +168,9 @@ DiskType = Enum(
     [
         "unknown",
         "nvme",
+        "localnvme",
         "premiumssd",
+        "localssd",
         "premiumv2ssd",
         "ultradisk",
     ],

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1718,6 +1718,7 @@ class Disk(AzureFeatureMixin, features.Disk):
     LUN_PATTERN_BSD = re.compile(
         r"at\s+scbus\d+\s+target\s+\d+\s+lun\s+(\d+)\s+\(.*(da\d+)", re.M
     )
+    _resource_disk_type: Optional[schema.ResourceDiskType] = None
 
     @classmethod
     def settings_type(cls) -> Type[schema.FeatureSettings]:
@@ -2036,12 +2037,14 @@ class Disk(AzureFeatureMixin, features.Disk):
     # function returns the type of resource disk/disks available on the VM
     # raises exception if no resource disk is available
     def get_resource_disk_type(self) -> schema.ResourceDiskType:
-        resource_disks = self.get_resource_disks()
-        if not resource_disks:
-            raise LisaException("No Resource disks are available on VM")
-        return schema.ResourceDiskType(
-            self._node.features[Disk].get_disk_type(disk=resource_disks[0])
-        )
+        if self._resource_disk_type is None:
+            resource_disks = self.get_resource_disks()
+            if not resource_disks:
+                raise LisaException("No Resource disks are available on VM")
+            self._resource_disk_type = schema.ResourceDiskType(
+                self._node.features[Disk].get_disk_type(disk=resource_disks[0])
+            )
+        return self._resource_disk_type
 
     def get_resource_disks(self) -> List[str]:
         resource_disk_list = []

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -16,6 +16,7 @@ from lisa import (
     notifier,
     run_in_parallel,
 )
+from lisa.features import Nvme
 from lisa.messages import (
     DiskPerformanceMessage,
     DiskSetupType,
@@ -29,6 +30,7 @@ from lisa.schema import NetworkDataPath
 from lisa.testsuite import TestResult
 from lisa.tools import (
     FIOMODES,
+    Echo,
     Fdisk,
     Fio,
     FIOResult,
@@ -52,6 +54,55 @@ from lisa.tools.ntttcp import (
 )
 from lisa.util import LisaException
 from lisa.util.process import ExecutableResult, Process
+
+
+def perf_nvme(
+    node: Node,
+    result: TestResult,
+    test_name: str = "",
+    disk_type: DiskType = DiskType.nvme,
+    ioengine: IoEngine = IoEngine.LIBAIO,
+    max_iodepth: int = 256,
+) -> None:
+    nvme = node.features[Nvme]
+    nvme_namespaces = nvme.get_raw_nvme_disks()
+    disk_count = len(nvme_namespaces)
+    assert_that(disk_count).described_as(
+        "At least 1 NVMe disk for fio testing."
+    ).is_greater_than(0)
+    filename = ":".join(nvme_namespaces)
+    echo = node.tools[Echo]
+    # This will have kernel avoid sending IPI to finish I/O on the issuing CPUs
+    # if they are not on the same NUMA node of completion CPU.
+    # This setting will give a better and more stable IOPS.
+    for nvme_namespace in nvme_namespaces:
+        # /dev/nvme0n1 => nvme0n1
+        disk_name = nvme_namespace.split("/")[-1]
+        echo.write_to_file(
+            "0",
+            node.get_pure_path(f"/sys/block/{disk_name}/queue/rq_affinity"),
+            sudo=True,
+        )
+    cpu = node.tools[Lscpu]
+    core_count = cpu.get_core_count()
+    start_iodepth = 1
+    if test_name:
+        test_name = inspect.stack()[1][3]
+
+    perf_disk(
+        node,
+        start_iodepth,
+        max_iodepth,
+        filename,
+        core_count=core_count,
+        disk_count=disk_count,
+        numjob=core_count,
+        test_name=test_name,
+        disk_setup_type=DiskSetupType.raw,
+        disk_type=disk_type,
+        test_result=result,
+        ioengine=ioengine,
+    )
 
 
 def perf_disk(

--- a/microsoft/testsuites/performance/nvmeperf.py
+++ b/microsoft/testsuites/performance/nvmeperf.py
@@ -1,7 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-from assertpy import assert_that
-
 from lisa import (
     Node,
     TestCaseMetadata,
@@ -10,11 +8,9 @@ from lisa import (
     simple_requirement,
 )
 from lisa.features import Nvme, NvmeSettings
-from lisa.messages import DiskSetupType, DiskType
 from lisa.testsuite import TestResult
-from lisa.tools import Echo, Lscpu
 from lisa.tools.fio import IoEngine
-from microsoft.testsuites.performance.common import perf_disk
+from microsoft.testsuites.performance.common import perf_nvme
 
 
 @TestSuiteMetadata(
@@ -39,7 +35,7 @@ class NvmePerformace(TestSuite):
         ),
     )
     def perf_nvme(self, node: Node, result: TestResult) -> None:
-        self._perf_nvme(node, IoEngine.LIBAIO, result)
+        perf_nvme(node, result)
 
     @TestCaseMetadata(
         description="""
@@ -53,43 +49,4 @@ class NvmePerformace(TestSuite):
         ),
     )
     def perf_nvme_io_uring(self, node: Node, result: TestResult) -> None:
-        self._perf_nvme(node, IoEngine.IO_URING, result, max_iodepth=1024)
-
-    def _perf_nvme(
-        self, node: Node, ioengine: IoEngine, result: TestResult, max_iodepth: int = 256
-    ) -> None:
-        nvme = node.features[Nvme]
-        nvme_namespaces = nvme.get_raw_nvme_disks()
-        disk_count = len(nvme_namespaces)
-        assert_that(disk_count).described_as(
-            "At least 1 NVMe disk for fio testing."
-        ).is_greater_than(0)
-        filename = ":".join(nvme_namespaces)
-        echo = node.tools[Echo]
-        # This will have kernel avoid sending IPI to finish I/O on the issuing CPUs
-        # if they are not on the same NUMA node of completion CPU.
-        # This setting will give a better and more stable IOPS.
-        for nvme_namespace in nvme_namespaces:
-            # /dev/nvme0n1 => nvme0n1
-            disk_name = nvme_namespace.split("/")[-1]
-            echo.write_to_file(
-                "0",
-                node.get_pure_path(f"/sys/block/{disk_name}/queue/rq_affinity"),
-                sudo=True,
-            )
-        cpu = node.tools[Lscpu]
-        thread_count = cpu.get_thread_count()
-        start_iodepth = 1
-        perf_disk(
-            node,
-            start_iodepth,
-            max_iodepth,
-            filename,
-            core_count=thread_count,
-            disk_count=disk_count,
-            numjob=thread_count,
-            disk_setup_type=DiskSetupType.raw,
-            disk_type=DiskType.nvme,
-            test_result=result,
-            ioengine=ioengine,
-        )
+        perf_nvme(node, ioengine=IoEngine.IO_URING, result=result, max_iodepth=1024)

--- a/microsoft/testsuites/performance/storageperf.py
+++ b/microsoft/testsuites/performance/storageperf.py
@@ -4,7 +4,6 @@
 import inspect
 import uuid
 from pathlib import Path, PurePosixPath
-from time import sleep
 from typing import Any, Dict, List, cast
 
 from assertpy import assert_that
@@ -16,12 +15,11 @@ from lisa import (
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
-    create_timer,
     schema,
     search_space,
     simple_requirement,
 )
-from lisa.features import AvailabilityZoneEnabled, Disk, StartStop
+from lisa.features import AvailabilityZoneEnabled, Disk
 from lisa.features.network_interface import Sriov, Synthetic
 from lisa.messages import DiskSetupType, DiskType
 from lisa.node import RemoteNode


### PR DESCRIPTION
Added new test cases for performance validation of resource disks.
Testcases added: 
   1. perf_resource_disk_4k
   2. perf_resource_disk_1024k

These testcases support both SCSI and NVMe local/resource disks.