### PR TITLE
Fixes for OpenSSL Speed test time out. 

### DIFF
--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -132,11 +132,11 @@ class OpenSSL(Tool):
         cmd = "speed"
         if sec is not None:
             cmd = f"{cmd} -seconds {sec}"
-        # 20 min timeout to complete all of the cryptographic operations
+        # 1 hour timeout to complete all of the cryptographic operations
         # that OpenSSL speed measures.
         return self.run(
             cmd,
-            timeout=1200,
+            timeout=3600,
             expected_exit_code=0,
             expected_exit_code_failure_message=("OpenSSL speed test failed."),
         )

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -95,7 +95,7 @@ class OpenSSLTestSuite(TestSuite):
         and test avoids timeout.
         """,
         priority=2,
-        timeout=1200,  # 20 minutes
+        timeout=3600,  # 1 hour
     )
     def verify_openssl_speed_test(self, node: Node) -> None:
         """This function runs OpenSSL speed test to measure the

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -14,6 +14,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
+from lisa.util import SkippedException
 from lisa.operating_system import CBLMariner, Posix
 from lisa.tools import OpenSSL
 
@@ -61,6 +62,11 @@ class OpenSSLTestSuite(TestSuite):
         This test sets up the dependencies to run the
         experimental Go system crypto tests and cleans go builds.
         """
+        if isinstance(node.os, CBLMariner):
+            if node.os.information.release != "3.0":
+                raise SkippedException(
+                    "Go system crypto tests are only supported on CBLMariner 3.0."
+                )
         # installs go dependencies for tests
         posix_os = cast(Posix, node.os)
         posix_os.install_packages(

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -62,11 +62,10 @@ class OpenSSLTestSuite(TestSuite):
         This test sets up the dependencies to run the
         experimental Go system crypto tests and cleans go builds.
         """
-        if isinstance(node.os, CBLMariner):
-            if node.os.information.release != "3.0":
-                raise SkippedException(
-                    "Go system crypto tests are only supported on CBLMariner 3.0."
-                )
+        if float(node.os.information.release) < 3.0:
+            raise SkippedException(
+                "Go system crypto tests are only supported on CBLMariner 3.0. or later"
+            )
         # installs go dependencies for tests
         posix_os = cast(Posix, node.os)
         posix_os.install_packages(

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -14,9 +14,9 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.util import SkippedException
 from lisa.operating_system import CBLMariner, Posix
 from lisa.tools import OpenSSL
+from lisa.util import SkippedException
 
 
 @TestSuiteMetadata(

--- a/microsoft/testsuites/security/openssl.py
+++ b/microsoft/testsuites/security/openssl.py
@@ -52,7 +52,7 @@ class OpenSSLTestSuite(TestSuite):
         description="""
         This test will use Go experimental system crypto tests
         """,
-        priority=2,
+        priority=3,
         requirement=simple_requirement(
             supported_os=[CBLMariner],
         ),


### PR DESCRIPTION
After tests were merged to pipelines tests on ARM64 took considerable more time to go through the entire cryptiographical suite and caused time out failures. These fixes will increase the time limit from 1200 to 3600. On average test runs were taking between 2300-2600 seconds on ARM 64. Also included fix to skip test for the Go Crypto System tests on 2.0  because they should only be ran for 3.0 and above. 