### PR TITLE
Add standard security profile in Baremetal platform

### DIFF
--- a/lisa/features/security_profile.py
+++ b/lisa/features/security_profile.py
@@ -102,20 +102,6 @@ class SecurityProfileSettings(schema.FeatureSettings):
         return value
 
     def check(self, capability: Any) -> search_space.ResultReason:
-        # Handle case when capability is a base FeatureSettings instead of SecurityProfileSettings
-        is_generic = isinstance(capability, schema.FeatureSettings)
-        is_specific = isinstance(capability, SecurityProfileSettings)
-        if is_generic and not is_specific:
-            # Convert the base FeatureSettings to SecurityProfileSettings
-            converted = SecurityProfileSettings()
-            # Copy any matching attributes
-            for attr in dir(capability):
-                if attr.startswith("_") or callable(getattr(capability, attr)):
-                    continue
-                if hasattr(converted, attr):
-                    setattr(converted, attr, getattr(capability, attr))
-            capability = converted
-
         assert isinstance(
             capability, SecurityProfileSettings
         ), f"actual: {type(capability)}"

--- a/lisa/features/security_profile.py
+++ b/lisa/features/security_profile.py
@@ -102,6 +102,20 @@ class SecurityProfileSettings(schema.FeatureSettings):
         return value
 
     def check(self, capability: Any) -> search_space.ResultReason:
+        # Handle case when capability is a base FeatureSettings instead of SecurityProfileSettings
+        is_generic = isinstance(capability, schema.FeatureSettings)
+        is_specific = isinstance(capability, SecurityProfileSettings)
+        if is_generic and not is_specific:
+            # Convert the base FeatureSettings to SecurityProfileSettings
+            converted = SecurityProfileSettings()
+            # Copy any matching attributes
+            for attr in dir(capability):
+                if attr.startswith("_") or callable(getattr(capability, attr)):
+                    continue
+                if hasattr(converted, attr):
+                    setattr(converted, attr, getattr(capability, attr))
+            capability = converted
+
         assert isinstance(
             capability, SecurityProfileSettings
         ), f"actual: {type(capability)}"

--- a/lisa/sut_orchestrator/baremetal/cluster/cluster.py
+++ b/lisa/sut_orchestrator/baremetal/cluster/cluster.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Type
 
-from lisa import features, schema, search_space
+from lisa import feature, features, schema, search_space
 from lisa.environment import Environment
 from lisa.util import InitializableMixin, subclasses
 from lisa.util.logger import Logger, get_logger
@@ -93,5 +93,14 @@ class Cluster(subclasses.BaseClassWithRunbookMixin, InitializableMixin):
             items=[
                 schema.FeatureSettings.create(features.SerialConsole.name()),
                 schema.FeatureSettings.create(features.StartStop.name()),
+                schema.FeatureSettings.create(features.SecurityProfile.name()),
             ],
+        )
+
+        # Convert generic FeatureSettings to baremetal-specific ones
+        from ..platform_ import BareMetalPlatform
+
+        feature.reload_platform_features(
+            node_capability,
+            BareMetalPlatform.supported_features(),
         )

--- a/lisa/sut_orchestrator/baremetal/features.py
+++ b/lisa/sut_orchestrator/baremetal/features.py
@@ -18,23 +18,8 @@ class ClusterFeature(Feature):
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         _feature_type = self._get_inner_type()
-
-        # Use the feature's own create_setting if available, otherwise default
-        # to the generic FeatureSettings.create. This allows platform-specific
-        # features to define their own default settings.
-        if hasattr(self, "create_setting"):
-            settings = self.create_setting()
-        else:
-            settings = schema.FeatureSettings.create(_feature_type.name())
-
-        # Ensure we always have a valid FeatureSettings object
-        if not settings:
-            settings = schema.FeatureSettings()
-            
-        settings.type = _feature_type.name()
-
         self._inner = _feature_type(
-            settings,
+            schema.FeatureSettings.create(_feature_type.name()),
             self._node,
             self._platform,
             *args,

--- a/lisa/sut_orchestrator/baremetal/platform_.py
+++ b/lisa/sut_orchestrator/baremetal/platform_.py
@@ -17,7 +17,7 @@ from .bootconfig import BootConfig
 from .build import Build
 from .cluster.cluster import Cluster
 from .context import get_build_context, get_node_context
-from .features import SerialConsole, StartStop
+from .features import SecurityProfile, SerialConsole, StartStop
 from .ip_getter import IpGetterChecker
 from .key_loader import KeyLoader
 from .readychecker import ReadyChecker
@@ -43,7 +43,7 @@ class BareMetalPlatform(Platform):
 
     @classmethod
     def supported_features(cls) -> List[Type[feature.Feature]]:
-        return [StartStop, SerialConsole]
+        return [StartStop, SerialConsole, SecurityProfile]
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         baremetal_runbook: BareMetalPlatformSchema = self.runbook.get_extended_runbook(


### PR DESCRIPTION
This commit introduces support for declaring security capabilities for baremetal nodes and includes a related bug fix.
The primary changes are:

1.  **Baremetal Security Profile Feature:**
    A new `SecurityProfile` class has been added to the baremetal orchestrator (`lisa/sut_orchestrator/baremetal/features.py`). This feature declares a fixed, non-configurable "Standard" security profile with disk encryption disabled for all baremetal nodes. It uses the `create_setting` method to programmatically provide these settings, ensuring that baremetal environments correctly report their capabilities to the LISA framework.

2.  **Bug Fix in Core Security Feature:**
    During development, an `AssertionError` was discovered in the core `SecurityProfileSettings.check` method in `lisa/features/security_profile.py`. The method would crash if it received a generic `FeatureSettings` object instead of the expected specific type. A type conversion handler has been added to gracefully handle this case by converting the object, making the feature more robust for all platforms.

This Changes were added to support running kdump tests on BM platform.