### PR TITLE
Configure GRUB to boot into newly installed kernel

### DIFF
--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -29,7 +29,7 @@ class Sed(Tool):
             expression = f"/{match_lines}/s/{regexp}/{replacement}/g"
         else:
             expression = f"s/{regexp}/{replacement}/g"
-        expression = expression.replace('"', r"\"").replace("$", r"\$")
+        expression = expression.replace('"', r"\"").replace("$", r"\$").replace("'", r"\'")
 
         cmd = f'-i.bak "{expression}" {file}'
 

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -24,7 +24,8 @@ class Sed(Tool):
         match_lines: str = "",
         sudo: bool = False,
     ) -> None:
-        # Escape slashes (must be done before crafting sed expression, as we want to preserve slashes after)
+        # Escape slashes (must be done before crafting sed expression,
+        # as we want to preserve slashes after)
         regexp = regexp.replace("/", r"\/")
         replacement = replacement.replace("/", r"\/")
 

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -29,7 +29,7 @@ class Sed(Tool):
             expression = f"/{match_lines}/s/{regexp}/{replacement}/g"
         else:
             expression = f"s/{regexp}/{replacement}/g"
-        expression = expression.replace('"', r"\"").replace("$", r"\$").replace("'", r"\'")
+        expression = expression.replace('"', r"\"").replace("$", r"\$").replace("/", r"\/")
 
         cmd = f'-i.bak "{expression}" {file}'
 

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -27,8 +27,7 @@ class Sed(Tool):
         # Escape slashes (must be done before crafting sed expression, as we want to preserve slashes after)
         regexp = regexp.replace("/", r"\/")
         replacement = replacement.replace("/", r"\/")
-        
-        # always force run, make sure it happens every time.
+
         if match_lines != "":
             expression = f"/{match_lines}/s/{regexp}/{replacement}/g"
         else:

--- a/lisa/base_tools/sed.py
+++ b/lisa/base_tools/sed.py
@@ -24,12 +24,16 @@ class Sed(Tool):
         match_lines: str = "",
         sudo: bool = False,
     ) -> None:
+        # Escape slashes (must be done before crafting sed expression, as we want to preserve slashes after)
+        regexp = regexp.replace("/", r"\/")
+        replacement = replacement.replace("/", r"\/")
+        
         # always force run, make sure it happens every time.
         if match_lines != "":
             expression = f"/{match_lines}/s/{regexp}/{replacement}/g"
         else:
             expression = f"s/{regexp}/{replacement}/g"
-        expression = expression.replace('"', r"\"").replace("$", r"\$").replace("/", r"\/")
+        expression = expression.replace('"', r"\"").replace("$", r"\$")
 
         cmd = f'-i.bak "{expression}" {file}'
 

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2002,21 +2002,13 @@ class CBLMariner(RPMDistro):
         self._node.tools[Service].restart_service("systemd-logind")
 
     def replace_boot_kernel(self, kernel_version: str) -> None:
-        # Only configure Grub for Mariner 3.0+ (v6.6+)
-        # For Mariner 2.0, do nothing (no-op)
         kernel_info = self._node.tools[Uname].get_linux_information()
-        if kernel_info.kernel_version < "6.6":
-            self._log.debug(
-                f"Skipping Grub configuration for Mariner 2.0 "
-                f"(kernel version: {kernel_info.kernel_version})"
-            )
-            return
 
         self._log.info(
             f"Configuring Grub to boot into kernel version: {kernel_version}"
         )
 
-        # First, rebuild GRUB configuration to include the new kernel
+        # rebuild GRUB configuration to include the new kernel
         self._node.execute(
             "grub2-mkconfig -o /boot/grub2/grub.cfg",
             sudo=True,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -50,6 +50,7 @@ from lisa.util import (
     get_matched_str,
     parse_version,
     retry_without_exceptions,
+    extract_kernel_version_from_rpm,
 )
 from lisa.util.logger import get_logger
 from lisa.util.perf_timer import create_timer
@@ -2042,18 +2043,14 @@ class CBLMariner(RPMDistro):
         # Examples:
         # kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
         # kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
-        extracted_version = kernel_version
-        rpm_version_pattern = re.compile(
-            r"^kernel-(?:[^-]+-)*(\d+\.\d+\.\d+.*?)\.x86_64$"
-        )
-        match = rpm_version_pattern.match(kernel_version)
-        if match:
-            extracted_version = match.group(1)
+        extracted_version = extract_kernel_version_from_rpm(kernel_version)
+        if extracted_version is not None:
             self._log.info(
                 f"Extracted kernel version '{extracted_version}' "
                 f"from RPM package '{kernel_version}'"
             )
         else:
+            extracted_version = kernel_version
             self._log.debug(
                 f"Could not extract version from '{kernel_version}', using as-is"
             )

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2043,12 +2043,15 @@ class CBLMariner(RPMDistro):
         # kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
         # kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
         extracted_version = kernel_version
-        rpm_version_pattern = re.compile(r"^kernel-(?:[^-]+-)*(\d+\.\d+\.\d+.*?)\.x86_64$")
+        rpm_version_pattern = re.compile(
+            r"^kernel-(?:[^-]+-)*(\d+\.\d+\.\d+.*?)\.x86_64$"
+        )
         match = rpm_version_pattern.match(kernel_version)
         if match:
             extracted_version = match.group(1)
             self._log.info(
-                f"Extracted kernel version '{extracted_version}' from RPM package '{kernel_version}'"
+                f"Extracted kernel version '{extracted_version}' "
+                f"from RPM package '{kernel_version}'"
             )
         else:
             self._log.debug(
@@ -2063,7 +2066,7 @@ class CBLMariner(RPMDistro):
             expected_exit_code_failure_message="Failed to rebuild GRUB configuration",
         )
 
-        # Parse the GRUB configuration to find the correct menu entry name for the new kernel
+        # Parse the GRUB configuration to find the correct menu entry name
         grub_cfg_result = self._node.execute(
             "cat /boot/grub2/grub.cfg",
             sudo=True,
@@ -2083,8 +2086,9 @@ class CBLMariner(RPMDistro):
 
         if not menu_entry_name:
             self._log.warning(
-                f"Could not find GRUB menu entry for kernel version '{extracted_version}' "
-                f"(original: '{kernel_version}'). GRUB configuration may not be updated properly."
+                f"Could not find GRUB menu entry for kernel version "
+                f"'{extracted_version}' (original: '{kernel_version}'). "
+                f"GRUB configuration may not be updated properly."
             )
             return
 
@@ -2098,12 +2102,14 @@ class CBLMariner(RPMDistro):
             "grub2-mkconfig -o /boot/grub2/grub.cfg",
             sudo=True,
             expected_exit_code=0,
-            expected_exit_code_failure_message="Failed to rebuild GRUB configuration with new default",
+            expected_exit_code_failure_message=(
+                "Failed to rebuild GRUB configuration with new default"
+            ),
         )
 
         self._log.info(
-            f"Successfully configured GRUB to boot into kernel version '{extracted_version}' "
-            f"(from RPM package '{kernel_version}')"
+            f"Successfully configured GRUB to boot into kernel version "
+            f"'{extracted_version}' (from RPM package '{kernel_version}')"
         )
 
 

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2022,7 +2022,7 @@ class CBLMariner(RPMDistro):
             )
         else:
             self._node.execute(
-                f"echo 'GRUB_DEFAULT=\\'{entry}\\'' >> /etc/default/grub",
+                f"echo \"GRUB_DEFAULT='{entry}'\" >> /etc/default/grub",
                 sudo=True,
                 shell=True,
                 expected_exit_code=0,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2002,8 +2002,6 @@ class CBLMariner(RPMDistro):
         self._node.tools[Service].restart_service("systemd-logind")
 
     def replace_boot_kernel(self, kernel_version: str) -> None:
-        kernel_info = self._node.tools[Uname].get_linux_information()
-
         self._log.info(
             f"Configuring Grub to boot into kernel version: {kernel_version}"
         )

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -25,8 +25,7 @@ from lisa.util.logger import Logger, get_logger
 
 @dataclass_json()
 @dataclass
-class BaseInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
-    ...
+class BaseInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin): ...
 
 
 @dataclass_json()
@@ -164,12 +163,16 @@ class KernelInstallerTransformer(DeploymentTransformer):
             from lisa.transformers.rpm_kernel_installer import RPMInstaller
 
             if (
-                isinstance(installer, RepoInstaller)
-                and "fde" not in installer.runbook.source
-            ) or (
-                isinstance(installer, SourceInstaller)
-                and not isinstance(installer, Dom0Installer)
-            ) or isinstance(installer, RPMInstaller):
+                (
+                    isinstance(installer, RepoInstaller)
+                    and "fde" not in installer.runbook.source
+                )
+                or (
+                    isinstance(installer, SourceInstaller)
+                    and not isinstance(installer, Dom0Installer)
+                )
+                or isinstance(installer, RPMInstaller)
+            ):
                 posix = cast(Posix, node.os)
                 posix.replace_boot_kernel(installed_kernel_version)
             elif (

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -25,7 +25,8 @@ from lisa.util.logger import Logger, get_logger
 
 @dataclass_json()
 @dataclass
-class BaseInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin): ...
+class BaseInstallerSchema(schema.TypedSchema, schema.ExtendableSchemaMixin):
+    ...
 
 
 @dataclass_json()

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -161,6 +161,7 @@ class KernelInstallerTransformer(DeploymentTransformer):
             # the installed kernel version is lower than current kernel version.
             from lisa.transformers.dom0_kernel_installer import Dom0Installer
             from lisa.transformers.kernel_source_installer import SourceInstaller
+            from lisa.transformers.rpm_kernel_installer import RPMInstaller
 
             if (
                 isinstance(installer, RepoInstaller)
@@ -168,7 +169,7 @@ class KernelInstallerTransformer(DeploymentTransformer):
             ) or (
                 isinstance(installer, SourceInstaller)
                 and not isinstance(installer, Dom0Installer)
-            ):
+            ) or isinstance(installer, RPMInstaller):
                 posix = cast(Posix, node.os)
                 posix.replace_boot_kernel(installed_kernel_version)
             elif (

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -80,12 +80,6 @@ __version_info_pattern = re.compile(
     re.VERBOSE,
 )
 
-# kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
-# kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
-__rpm_version_pattern = re.compile(
-    r"^kernel-(?:[^-]+-)*(\d+\.\d+\.\d+.*?)\.x86_64$"
-)
-
 # hooks manager helper, they must be same name.
 _NAME_LISA = "lisa"
 plugin_manager = pluggy.PluginManager(_NAME_LISA)
@@ -663,13 +657,6 @@ def is_valid_url(url: str, raise_error: bool = True) -> bool:
 
 def filter_ansi_escape(content: str) -> str:
     return __ansi_escape.sub("", content)
-
-
-def extract_kernel_version_from_rpm(rpm_pkg_name: str) -> str | None:
-    match = __rpm_version_pattern.match(rpm_pkg_name)
-    if match:
-        return match.group(1)
-    return None
 
 
 def dump_file(file_name: Path, content: Any) -> None:

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -80,6 +80,12 @@ __version_info_pattern = re.compile(
     re.VERBOSE,
 )
 
+# kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
+# kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
+__rpm_version_pattern = re.compile(
+    r"^kernel-(?:[^-]+-)*(\d+\.\d+\.\d+.*?)\.x86_64$"
+)
+
 # hooks manager helper, they must be same name.
 _NAME_LISA = "lisa"
 plugin_manager = pluggy.PluginManager(_NAME_LISA)
@@ -657,6 +663,13 @@ def is_valid_url(url: str, raise_error: bool = True) -> bool:
 
 def filter_ansi_escape(content: str) -> str:
     return __ansi_escape.sub("", content)
+
+
+def extract_kernel_version_from_rpm(rpm_pkg_name: str) -> str | None:
+    match = __rpm_version_pattern.match(rpm_pkg_name)
+    if match:
+        return match.group(1)
+    return None
 
 
 def dump_file(file_name: Path, content: Any) -> None:

--- a/microsoft/testsuites/display/drm.py
+++ b/microsoft/testsuites/display/drm.py
@@ -155,7 +155,7 @@ class Drm(TestSuite):
                     grub_content,
                     GRUB_CMDLINE_LINUX_DEFAULT_PATTERN,
                     first_match=False,
-                ).replace("/", r"\/")
+                )
 
                 sed = node.tools[Sed]
 


### PR DESCRIPTION
Original Issue: lisa/transformers/kernel_installer.py doesn't properly replace the boot kernel for Azure Linux hosts.

- Implemented replace_boot_kernel for CBLMariner class to properly replace and set the default kernel to boot into.
- Call replace_boot_kernel within kernel_installer.py
- Small changes to Sed utility

Example installation run (LKT Validation Pipeline Run): https://msazure.visualstudio.com/LSG-linux/_build/results?buildId=129894806&view=logs&j=63569f4e-8888-5ebe-983d-7fd6eeda134b&t=affdd524-60b2-5ab3-272b-88799b6aee80&l=2263