### PR TITLE
Fix lisa test failures against latest Fedora(41+)

### DIFF
--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -144,10 +144,7 @@ class Docker(Tool):
                 )
         elif isinstance(self.node.os, CBLMariner):
             self.node.os.install_packages(["moby-engine", "moby-cli"])
-        elif isinstance(self.node.os, Fedora):
-            # Fedora supports Docker directly from their repositories
-            self.node.os.install_packages(["docker"])
-        elif isinstance(self.node.os, Suse):
+        elif isinstance(self.node.os, Suse) or isinstance(self.node.os, Fedora):
             self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, BSD):
             raise UnsupportedDistroException(

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -4,7 +4,7 @@ from retry import retry
 
 from lisa.base_tools import Service, Wget
 from lisa.executable import Tool
-from lisa.operating_system import BSD, CBLMariner, CentOs, Debian, Redhat, Suse
+from lisa.operating_system import BSD, CBLMariner, CentOs, Debian, Fedora, Redhat, Suse
 from lisa.util import (
     LisaException,
     ReleaseEndOfLifeException,
@@ -144,6 +144,9 @@ class Docker(Tool):
                 )
         elif isinstance(self.node.os, CBLMariner):
             self.node.os.install_packages(["moby-engine", "moby-cli"])
+        elif isinstance(self.node.os, Fedora):
+            # Fedora supports Docker directly from their repositories
+            self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, Suse):
             self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, BSD):

--- a/microsoft/testsuites/core/azure_image_standard.py
+++ b/microsoft/testsuites/core/azure_image_standard.py
@@ -55,6 +55,7 @@ from lisa.tools import (
     Stat,
     Swap,
 )
+from lisa.tools.lsblk import DiskInfo
 from lisa.util import (
     LisaException,
     PassedException,
@@ -916,7 +917,8 @@ class AzureImageStandard(TestSuite):
                 )
                 assert_that(
                     is_base_repository_present,
-                    f"Base repository should be present. Found repositories: {repo_ids}",
+                    f"Base repository should be present. Found repositories: "
+                    f"{repo_ids}",
                 ).is_true()
 
                 # Validate optional repositories (updates, extras, etc.)
@@ -1862,7 +1864,7 @@ class AzureImageStandard(TestSuite):
                 not_enabled_modules.append(module)
         return not_enabled_modules
 
-    def _find_os_disk_with_fallbacks(self, node: Node, lsblk):
+    def _find_os_disk_with_fallbacks(self, node: Node, lsblk: Lsblk) -> DiskInfo:
         """
         Helper method to find OS disk with multiple fallback strategies.
         Returns the identified OS disk or raises an exception if not found.
@@ -1898,7 +1900,8 @@ class AzureImageStandard(TestSuite):
             if disks:
                 largest_disk = max(disks, key=lambda d: d.size_in_gb)
                 node.log.warning(
-                    f"Could not definitively identify OS disk, using largest disk: {largest_disk.name}"
+                    f"Could not definitively identify OS disk, using largest disk: "
+                    f"{largest_disk.name}"
                 )
                 return largest_disk
 

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -80,7 +80,7 @@ class HvModule(TestSuite):
             unsupported_os=[BSD],
         ),
     )
-    def verify_initrd_modules(self, log: Logger, environment: Environment) -> None:
+    def verify_initrd_modules(self, environment: Environment) -> None:
         node = environment.nodes[0]
         # 1) Takes all of the necessary modules and removes
         #    those that are statically loaded into the kernel
@@ -117,20 +117,6 @@ class HvModule(TestSuite):
             and "hid_hyperv" in missing_modules
         ):
             missing_modules.remove("hid_hyperv")
-
-        # Fedora 41+ optimizes initrd by excluding non-essential modules like hv_netvsc
-        # Network drivers can be loaded later during network service initialization
-        node = environment.nodes[0]
-        if (
-            isinstance(node.os, Fedora)
-            and node.os.information.version.major >= 41
-            and "hv_netvsc" in missing_modules
-        ):
-            missing_modules.remove("hv_netvsc")
-            log.info(
-                "hv_netvsc excluded from initrd on Fedora 41+ - this is expected "
-                "behavior"
-            )
 
         assert_that(missing_modules).described_as(
             "Required Hyper-V modules are missing from initrd."

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -15,7 +15,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import BSD, Fedora, Redhat
+from lisa.operating_system import BSD, Redhat
 from lisa.sut_orchestrator import AZURE, HYPERV, READY
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.tools import KernelConfig, LisDriver, Lsinitrd, Lsmod, Modinfo, Modprobe

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -15,7 +15,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import BSD, Redhat
+from lisa.operating_system import BSD, Fedora, Redhat
 from lisa.sut_orchestrator import AZURE, HYPERV, READY
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.tools import KernelConfig, LisDriver, Lsinitrd, Lsmod, Modinfo, Modprobe
@@ -80,7 +80,7 @@ class HvModule(TestSuite):
             unsupported_os=[BSD],
         ),
     )
-    def verify_initrd_modules(self, environment: Environment) -> None:
+    def verify_initrd_modules(self, log: Logger, environment: Environment) -> None:
         node = environment.nodes[0]
         # 1) Takes all of the necessary modules and removes
         #    those that are statically loaded into the kernel
@@ -117,6 +117,19 @@ class HvModule(TestSuite):
             and "hid_hyperv" in missing_modules
         ):
             missing_modules.remove("hid_hyperv")
+
+        # Fedora 41+ optimizes initrd by excluding non-essential modules like hv_netvsc
+        # Network drivers can be loaded later during network service initialization
+        node = environment.nodes[0]
+        if (
+            isinstance(node.os, Fedora)
+            and node.os.information.version.major >= 41
+            and "hv_netvsc" in missing_modules
+        ):
+            missing_modules.remove("hv_netvsc")
+            log.info(
+                "hv_netvsc excluded from initrd on Fedora 41+ - this is expected behavior"
+            )
 
         assert_that(missing_modules).described_as(
             "Required Hyper-V modules are missing from initrd."

--- a/microsoft/testsuites/core/hv_module.py
+++ b/microsoft/testsuites/core/hv_module.py
@@ -128,7 +128,8 @@ class HvModule(TestSuite):
         ):
             missing_modules.remove("hv_netvsc")
             log.info(
-                "hv_netvsc excluded from initrd on Fedora 41+ - this is expected behavior"
+                "hv_netvsc excluded from initrd on Fedora 41+ - this is expected "
+                "behavior"
             )
 
         assert_that(missing_modules).described_as(

--- a/microsoft/testsuites/core/msr.py
+++ b/microsoft/testsuites/core/msr.py
@@ -122,7 +122,7 @@ class Msr(TestSuite):
     )
     def verify_hyperv_platform_id(self, node: RemoteNode) -> None:
         distro = node.os
-        if isinstance(distro, Redhat) and not isinstance(distro, Fedora):
+        if isinstance(distro, Redhat):
             # Install EPEL only for RHEL/CentOS, not Fedora
             # Fedora already has comprehensive package repositories
             distro.install_epel()

--- a/microsoft/testsuites/core/msr.py
+++ b/microsoft/testsuites/core/msr.py
@@ -18,6 +18,7 @@ from lisa.operating_system import (
     Debian,
     Fedora,
     Linux,
+    Redhat,
     Suse,
 )
 from lisa.sut_orchestrator import AZURE, HYPERV
@@ -121,9 +122,11 @@ class Msr(TestSuite):
     )
     def verify_hyperv_platform_id(self, node: RemoteNode) -> None:
         distro = node.os
-        if isinstance(distro, Fedora):
+        if isinstance(distro, Redhat) and not isinstance(distro, Fedora):
+            # Install EPEL only for RHEL/CentOS, not Fedora
+            # Fedora already has comprehensive package repositories
             distro.install_epel()
-        elif isinstance(distro, (Debian, Suse, CBLMariner)):
+        elif isinstance(distro, (Debian, Suse, CBLMariner, Fedora)):
             # no special setup, same package name
             pass
         else:


### PR DESCRIPTION
Below are the list of testcases that will be fixed with this patch 1.verify_repository_installed
2.verify_no_swap_on_osdisk
3.verify_docker_dotnet31_app
4.verify_initrd_modules
5.verify_hyperv_platform_id

The tests are passing with latest fedora in azure