### PR TITLE
Fix script file transformer command generation for interpreter

### DIFF
--- a/lisa/transformers/script_file_transformer.py
+++ b/lisa/transformers/script_file_transformer.py
@@ -81,7 +81,7 @@ class ScriptFileTransformer(DeploymentTransformer):
         failed_scripts = []
 
         for item in runbook.scripts:
-            command = f"{item.interpreter} {item.script} {item.args}"
+            command = f"{item.interpreter.value} {item.script} {item.args}"
             execution_result = self._node.execute(command, sudo=True, shell=True)
             results[item.script] = execution_result
             if item.expected_exit_code is not None:


### PR DESCRIPTION
When generating the command to run a script, script_file_transformer.py currently uses "item.interpreter" whereas "item.interpreter.value" is more explicit to what it is trying to do and does not rely on python automatically getting the value as that does not work.

To fix the command generation so that is uses the command generated uses string "bash" as intended instead of the enum "ScriptInterpreter.BASH" which is not valid, you would need to use the value field instead for the ScriptInterpreter enum object.

Example screenshot from printing out "item.interpreter" and "item.interpreter.value" within a LISA pipeline run:

print("danny test", item.interpreter, item.interpreter.value, item.script, item.args)
<img width="978" height="56" alt="lisa bug screenshot" src="https://github.com/user-attachments/assets/72114646-eceb-40ce-bb3f-41d26f56d497" />
