### PR TITLE
Fix verify_azure_disk_encryption_provisioned

### DIFF
--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -138,6 +138,7 @@ class AzureDiskEncryption(TestSuite):
         """,
         priority=1,
         requirement=simple_requirement(
+            min_memory_mb=MIN_REQUIRED_MEMORY_MB,
             supported_features=[CvmDisabled()],
         ),
     )

--- a/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -41,11 +41,6 @@ UnsupportedVersionInfo = List[Dict[str, int]]
     area="vm_extension",
     category="functional",
     description="Tests for the Azure Disk Encryption (ADE) extension",
-    requirement=simple_requirement(
-        min_memory_mb=MIN_REQUIRED_MEMORY_MB,
-        supported_features=[AzureExtension],
-        supported_platform_type=[AZURE],
-    ),
 )
 class AzureDiskEncryption(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
@@ -139,7 +134,8 @@ class AzureDiskEncryption(TestSuite):
         priority=1,
         requirement=simple_requirement(
             min_memory_mb=MIN_REQUIRED_MEMORY_MB,
-            supported_features=[CvmDisabled()],
+            supported_features=[AzureExtension, CvmDisabled()],
+            supported_platform_type=[AZURE],
         ),
     )
     def verify_azure_disk_encryption_provisioned(


### PR DESCRIPTION
Without fix - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=872064&view=results
With fix - https://dev.azure.com/mariner-org/mariner/_build/results?buildId=872059&view=results

This pull request resolves a test failure in Azure disk encryption by adding a minimum memory requirement parameter