### PR TITLE
Enable setting "tags" in test case metadata

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -928,8 +928,8 @@ def _add_case_to_suite(
     test_case.suite = test_suite
     test_case.full_name = f"{test_suite.name}.{test_case.name}"
     # Append tags from test_suite if exists to test_case tags and remove duplicates
-    suite_tags = getattr(test_suite, "tags", None)
-    case_tags = getattr(test_case, "tags", None)
+    suite_tags = getattr(test_suite, "tags", []) or []
+    case_tags = getattr(test_case, "tags", []) or []
     test_case.tags = list(dict.fromkeys(case_tags + suite_tags))
     test_suite.cases.append(test_case)
 

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -930,11 +930,7 @@ def _add_case_to_suite(
     # Append tags from test_suite if exists to test_case tags and remove duplicates
     suite_tags = getattr(test_suite, "tags", None)
     case_tags = getattr(test_case, "tags", None)
-    if suite_tags:
-        if case_tags is None:
-            test_case.tags = list(dict.fromkeys(suite_tags))
-        else:
-            test_case.tags = list(dict.fromkeys(case_tags + suite_tags))
+    test_case.tags = list(dict.fromkeys(case_tags + suite_tags))
     test_suite.cases.append(test_case)
 
 

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -927,6 +927,14 @@ def _add_case_to_suite(
 ) -> None:
     test_case.suite = test_suite
     test_case.full_name = f"{test_suite.name}.{test_case.name}"
+    # Append tags from test_suite if exists to test_case tags and remove duplicates
+    suite_tags = getattr(test_suite, "tags", None)
+    case_tags = getattr(test_case, "tags", None)
+    if suite_tags:
+        if case_tags is None:
+            test_case.tags = list(dict.fromkeys(suite_tags))
+        else:
+            test_case.tags = list(dict.fromkeys(case_tags + suite_tags))
     test_suite.cases.append(test_case)
 
 

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -566,6 +566,7 @@ class TestCaseMetadata:
         use_new_environment: bool = False,
         owner: str = "",
         requirement: Optional[TestCaseRequirement] = None,
+        tags: Optional[List[str]] = None,
     ) -> None:
         self.suite: TestSuiteMetadata
 
@@ -575,7 +576,8 @@ class TestCaseMetadata:
         self.use_new_environment = use_new_environment
         if requirement:
             self.requirement = requirement
-
+        if tags:
+            self.tags = tags
         self._owner = owner
 
     def __getattr__(self, key: str) -> Any:


### PR DESCRIPTION
Enable setting "tags" in test case metadata to allow grouping and execution of tests based on tags.

This makes it possible to run a customized set of tests spanning different areas and priorities.