### PR TITLE
Fix version extract regex for arm64 and change menuentry extraction r…

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2107,7 +2107,7 @@ class CBLMariner(RPMDistro):
         # kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
         extracted_version = kernel_version
         rpm_version_pattern = re.compile(
-            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)\.x86_64$"
+            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)\.(x86_64|aarch64)$"
         )
         match_result = find_group_in_lines(
             kernel_version, rpm_version_pattern, single_line=True
@@ -2139,7 +2139,7 @@ class CBLMariner(RPMDistro):
             expected_exit_code_failure_message="Failed to read GRUB configuration",
         )
         menu_entry_pattern = re.compile(
-            rf"menuentry '(?P<entry>[^']*{re.escape(extracted_version)}[^']*)'",
+            rf"menuentry '(?P<entry>[^']*{re.escape(extracted_version)}\s*)'",
             re.IGNORECASE,
         )
         match_result = find_group_in_lines(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2105,6 +2105,7 @@ class CBLMariner(RPMDistro):
         # Examples:
         # kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
         # kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
+        # kernel-6.6.89-9.azl3.aarch64 -> 6.6.89-9.azl3
         extracted_version = kernel_version
         rpm_version_pattern = re.compile(
             r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)\.(x86_64|aarch64)$"
@@ -2138,6 +2139,9 @@ class CBLMariner(RPMDistro):
             expected_exit_code=0,
             expected_exit_code_failure_message="Failed to read GRUB configuration",
         )
+        # Examples of potential menu entries:
+        # For kernel-6.6.96-3.cm2.x86_64 => 6.6.96-3.cm2
+        # => menuentry 'AzureLinux GNU/Linux, with Linux 6.6.96-3.cm2'
         menu_entry_pattern = re.compile(
             rf"menuentry '(?P<entry>[^']*{re.escape(extracted_version)}\s*)'",
             re.IGNORECASE,


### PR DESCRIPTION
Related to: https://github.com/microsoft/lisa/pull/3925

The previous PR that adds the GRUB boot functionality doesn't properly extract the version for aarch64 rpms.
Additionally the menu entry regex is too unrestrictive, causing the menu entry match to sometimes match multiple entries (In the case where a recovery version of the kernel also exists as a menu entry).
Example: `[{'entry': 'AzureLinux GNU/Linux, with Linux 6.6.96-3.cm2'}, {'entry': 'AzureLinux GNU/Linux, with Linux 6.6.96-3.cm2 (recovery mode)'}]`

- Changed kernel version regex to match aarch64 rpm packages also
- Changed menu entry regex to be more restrictive