### PR TITLE
TestCase Logger: Add Case id to logger name

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -94,8 +94,7 @@ class TestResult:
         self._timer: Timer
 
         self._environment_information: Dict[str, Any] = {}
-        # parent_log = get_logger("suite", self.runtime_data.metadata.suite.name)
-        self.log = get_logger("case", self.name)
+        self.log = get_logger(f"case[{self.name}]", self.id_)
 
     @property
     def is_queued(self) -> bool:


### PR DESCRIPTION
When multiple tests of same name is run, the logger is shared between the multiple test instances. This causes incorrect logging in the test log file. The individual test log file contains logs from the concurrently executing test with same name.
Hence add case id to test case logger name.