### PR TITLE
Add required packages for installing stressng from source

### DIFF
--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -86,7 +86,9 @@ class StressNg(Tool):
 
     def _install_required_packages(self) -> None:
         if isinstance(self.node.os, CBLMariner):
-            self.node.os.install_packages(["glibc-devel", "kernel-headers", "binutils"])
+            self.node.os.install_packages(
+                ["gcc", "glibc-devel", "kernel-headers", "binutils", "make"]
+            )
 
     def _install_from_src(self) -> bool:
         tool_path = self.get_tool_path()


### PR DESCRIPTION
Add required packages for installing stressng from source on CBL mariner. need gcc and make so adding that. 