### PR TITLE
Changes to verify_l3_cache TC to handle shared L3 Cache scenarios

### DIFF
--- a/microsoft/testsuites/core/cpu.py
+++ b/microsoft/testsuites/core/cpu.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from typing import Any
 
 from assertpy.assertpy import assert_that
 
@@ -322,7 +323,7 @@ class CPU(TestSuite):
 
         return all_numa_nodes == all_l3_caches
 
-    def _verify_one_to_one_mapping(self, cpu_info: list, log: Logger) -> None:
+    def _verify_one_to_one_mapping(self, cpu_info: list[Any], log: Logger) -> None:
         """Verify traditional 1:1 mapping between NUMA nodes and L3 caches."""
         log.debug("Detected 1:1 mapping between NUMA nodes and L3 caches")
         for cpu in cpu_info:
@@ -334,7 +335,7 @@ class CPU(TestSuite):
 
     def _verify_socket_aware_mapping(
         self,
-        cpu_info: list,
+        cpu_info: list[Any],
         socket_to_numa_nodes: dict[int, set[int]],
         socket_to_l3_caches: dict[int, set[int]],
         log: Logger,
@@ -348,7 +349,7 @@ class CPU(TestSuite):
         # Verify isolation: L3 caches should not be shared across sockets
         self._verify_socket_isolation(socket_to_numa_nodes, socket_to_l3_caches, log)
 
-    def _verify_numa_consistency(self, cpu_info: list) -> None:
+    def _verify_numa_consistency(self, cpu_info: list[Any]) -> None:
         """Verify all CPUs in the same NUMA node have the same L3 cache."""
         numa_to_l3_mapping = {}
         for cpu in cpu_info:

--- a/microsoft/testsuites/core/cpu.py
+++ b/microsoft/testsuites/core/cpu.py
@@ -117,13 +117,85 @@ class CPU(TestSuite):
                 self._verify_node_mapping(node, effective_numa_node_size)
                 return
 
+        # For all other cases, check L3 cache mapping with socket awareness
         cpu_info = lscpu.get_cpu_info()
+        
+        # Build a mapping of socket -> NUMA nodes and socket -> L3 caches
+        socket_to_numa_nodes = {}
+        socket_to_l3_caches = {}
+        
         for cpu in cpu_info:
-            assert_that(
-                cpu.l3_cache,
-                "L3 cache of each core must be mapped to the NUMA node "
-                "associated with the core.",
-            ).is_equal_to(cpu.numa_node)
+            socket = cpu.socket
+            numa_node = cpu.numa_node
+            l3_cache = cpu.l3_cache
+            
+            # Track NUMA nodes per socket
+            if socket not in socket_to_numa_nodes:
+                socket_to_numa_nodes[socket] = set()
+            socket_to_numa_nodes[socket].add(numa_node)
+            
+            # Track L3 caches per socket
+            if socket not in socket_to_l3_caches:
+                socket_to_l3_caches[socket] = set()
+            socket_to_l3_caches[socket].add(l3_cache)
+        
+        # Check if this is a simple 1:1 mapping (traditional case)
+        all_numa_nodes = set()
+        all_l3_caches = set()
+        for numa_nodes in socket_to_numa_nodes.values():
+            all_numa_nodes.update(numa_nodes)
+        for l3_caches in socket_to_l3_caches.values():
+            all_l3_caches.update(l3_caches)
+        
+        # If NUMA nodes and L3 caches are identical sets, use simple verification
+        if all_numa_nodes == all_l3_caches:
+            log.debug("Detected 1:1 mapping between NUMA nodes and L3 caches")
+            for cpu in cpu_info:
+                assert_that(
+                    cpu.l3_cache,
+                    "L3 cache of each core must be mapped to the NUMA node "
+                    "associated with the core.",
+                ).is_equal_to(cpu.numa_node)
+        else:
+            # Otherwise, verify socket-aware mapping
+            log.debug("Detected shared L3 cache within sockets")
+            
+            # For each socket, all CPUs in the same NUMA node should have same L3 cache
+            numa_to_l3_mapping = {}
+            for cpu in cpu_info:
+                if cpu.numa_node not in numa_to_l3_mapping:
+                    numa_to_l3_mapping[cpu.numa_node] = cpu.l3_cache
+                else:
+                    # Verify consistency: all CPUs in same NUMA node should have same L3
+                    assert_that(
+                        cpu.l3_cache,
+                        f"All CPUs in NUMA node {cpu.numa_node} should have the same "
+                        f"L3 cache mapping, expected {numa_to_l3_mapping[cpu.numa_node]} "
+                        f"but found {cpu.l3_cache} for CPU {cpu.cpu}",
+                    ).is_equal_to(numa_to_l3_mapping[cpu.numa_node])
+            
+            # For each socket, verify L3 caches are only shared within the socket
+            for socket, numa_nodes in socket_to_numa_nodes.items():
+                l3_caches_in_socket = socket_to_l3_caches[socket]
+                
+                # Get L3 caches used by other sockets
+                other_socket_l3_caches = set()
+                for other_socket, other_l3_caches in socket_to_l3_caches.items():
+                    if other_socket != socket:
+                        other_socket_l3_caches.update(other_l3_caches)
+                
+                # Verify no L3 cache is shared across sockets
+                shared_l3_caches = l3_caches_in_socket.intersection(other_socket_l3_caches)
+                assert_that(
+                    len(shared_l3_caches),
+                    f"L3 caches should not be shared across sockets. "
+                    f"Socket {socket} shares L3 cache(s) {shared_l3_caches} with other sockets",
+                ).is_equal_to(0)
+                
+                log.debug(
+                    f"Socket {socket}: NUMA nodes {sorted(numa_nodes)} use "
+                    f"L3 cache(s) {sorted(l3_caches_in_socket)}"
+                )
 
     @TestCaseMetadata(
         description="""

--- a/microsoft/testsuites/core/cpu.py
+++ b/microsoft/testsuites/core/cpu.py
@@ -121,8 +121,8 @@ class CPU(TestSuite):
         cpu_info = lscpu.get_cpu_info()
 
         # Build a mapping of socket -> NUMA nodes and socket -> L3 caches
-        socket_to_numa_nodes = {}
-        socket_to_l3_caches = {}
+        socket_to_numa_nodes: dict[int, set[int]] = {}
+        socket_to_l3_caches: dict[int, set[int]] = {}
 
         for cpu in cpu_info:
             socket = cpu.socket
@@ -147,59 +147,14 @@ class CPU(TestSuite):
         for l3_caches in socket_to_l3_caches.values():
             all_l3_caches.update(l3_caches)
 
+        # Check if this is a simple 1:1 mapping or socket-aware mapping
         # If NUMA nodes and L3 caches are identical sets, use simple verification
-        if all_numa_nodes == all_l3_caches:
-            log.debug("Detected 1:1 mapping between NUMA nodes and L3 caches")
-            for cpu in cpu_info:
-                assert_that(
-                    cpu.l3_cache,
-                    "L3 cache of each core must be mapped to the NUMA node "
-                    "associated with the core.",
-                ).is_equal_to(cpu.numa_node)
+        if self._is_one_to_one_mapping(socket_to_numa_nodes, socket_to_l3_caches):
+            self._verify_one_to_one_mapping(cpu_info, log)
         else:
-            # Otherwise, verify socket-aware mapping
-            log.debug("Detected shared L3 cache within sockets")
-
-            # For each socket, all CPUs in the same NUMA node should have same L3 cache
-            numa_to_l3_mapping = {}
-            for cpu in cpu_info:
-                if cpu.numa_node not in numa_to_l3_mapping:
-                    numa_to_l3_mapping[cpu.numa_node] = cpu.l3_cache
-                else:
-                    # Verify consistency: all CPUs in same NUMA node should have same L3
-                    assert_that(
-                        cpu.l3_cache,
-                        f"All CPUs in NUMA node {cpu.numa_node} should have the same "
-                        f"L3 cache mapping, expected "
-                        f"{numa_to_l3_mapping[cpu.numa_node]} "
-                        f"but found {cpu.l3_cache} for CPU {cpu.cpu}",
-                    ).is_equal_to(numa_to_l3_mapping[cpu.numa_node])
-
-            # For each socket, verify L3 caches are only shared within the socket
-            for socket, numa_nodes in socket_to_numa_nodes.items():
-                l3_caches_in_socket = socket_to_l3_caches[socket]
-
-                # Get L3 caches used by other sockets
-                other_socket_l3_caches = set()
-                for other_socket, other_l3_caches in socket_to_l3_caches.items():
-                    if other_socket != socket:
-                        other_socket_l3_caches.update(other_l3_caches)
-
-                # Verify no L3 cache is shared across sockets
-                shared_l3_caches = l3_caches_in_socket.intersection(
-                    other_socket_l3_caches
-                )
-                assert_that(
-                    len(shared_l3_caches),
-                    f"L3 caches should not be shared across sockets. "
-                    f"Socket {socket} shares L3 cache(s) {shared_l3_caches} with "
-                    f"other sockets",
-                ).is_equal_to(0)
-
-                log.debug(
-                    f"Socket {socket}: NUMA nodes {sorted(numa_nodes)} use "
-                    f"L3 cache(s) {sorted(l3_caches_in_socket)}"
-                )
+            self._verify_socket_aware_mapping(
+                cpu_info, socket_to_numa_nodes, socket_to_l3_caches, log
+            )
 
     @TestCaseMetadata(
         description="""
@@ -351,3 +306,90 @@ class CPU(TestSuite):
                 "L3 cache of each core must be mapped to the NUMA node "
                 "associated with the core.",
             ).is_equal_to(numa_node_id)
+
+    def _is_one_to_one_mapping(
+        self,
+        socket_to_numa_nodes: dict[int, set[int]],
+        socket_to_l3_caches: dict[int, set[int]],
+    ) -> bool:
+        """Check if NUMA nodes and L3 caches have a 1:1 mapping."""
+        all_numa_nodes = set()
+        all_l3_caches = set()
+        for numa_nodes in socket_to_numa_nodes.values():
+            all_numa_nodes.update(numa_nodes)
+        for l3_caches in socket_to_l3_caches.values():
+            all_l3_caches.update(l3_caches)
+
+        return all_numa_nodes == all_l3_caches
+
+    def _verify_one_to_one_mapping(self, cpu_info: list, log: Logger) -> None:
+        """Verify traditional 1:1 mapping between NUMA nodes and L3 caches."""
+        log.debug("Detected 1:1 mapping between NUMA nodes and L3 caches")
+        for cpu in cpu_info:
+            assert_that(
+                cpu.l3_cache,
+                "L3 cache of each core must be mapped to the NUMA node "
+                "associated with the core.",
+            ).is_equal_to(cpu.numa_node)
+
+    def _verify_socket_aware_mapping(
+        self,
+        cpu_info: list,
+        socket_to_numa_nodes: dict[int, set[int]],
+        socket_to_l3_caches: dict[int, set[int]],
+        log: Logger,
+    ) -> None:
+        """Verify shared L3 cache mapping within sockets."""
+        log.debug("Detected shared L3 cache within sockets")
+
+        # Verify consistency: all CPUs in same NUMA node should have same L3 cache
+        self._verify_numa_consistency(cpu_info)
+
+        # Verify isolation: L3 caches should not be shared across sockets
+        self._verify_socket_isolation(socket_to_numa_nodes, socket_to_l3_caches, log)
+
+    def _verify_numa_consistency(self, cpu_info: list) -> None:
+        """Verify all CPUs in the same NUMA node have the same L3 cache."""
+        numa_to_l3_mapping = {}
+        for cpu in cpu_info:
+            if cpu.numa_node not in numa_to_l3_mapping:
+                numa_to_l3_mapping[cpu.numa_node] = cpu.l3_cache
+            else:
+                # Verify consistency: all CPUs in same NUMA node should have same L3
+                assert_that(
+                    cpu.l3_cache,
+                    f"All CPUs in NUMA node {cpu.numa_node} should have the same "
+                    f"L3 cache mapping, expected "
+                    f"{numa_to_l3_mapping[cpu.numa_node]} "
+                    f"but found {cpu.l3_cache} for CPU {cpu.cpu}",
+                ).is_equal_to(numa_to_l3_mapping[cpu.numa_node])
+
+    def _verify_socket_isolation(
+        self,
+        socket_to_numa_nodes: dict[int, set[int]],
+        socket_to_l3_caches: dict[int, set[int]],
+        log: Logger,
+    ) -> None:
+        """Verify L3 caches are not shared across sockets."""
+        for socket, numa_nodes in socket_to_numa_nodes.items():
+            l3_caches_in_socket = socket_to_l3_caches[socket]
+
+            # Get L3 caches used by other sockets
+            other_socket_l3_caches = set()
+            for other_socket, other_l3_caches in socket_to_l3_caches.items():
+                if other_socket != socket:
+                    other_socket_l3_caches.update(other_l3_caches)
+
+            # Verify no L3 cache is shared across sockets
+            shared_l3_caches = l3_caches_in_socket.intersection(other_socket_l3_caches)
+            assert_that(
+                len(shared_l3_caches),
+                f"L3 caches should not be shared across sockets. "
+                f"Socket {socket} shares L3 cache(s) {shared_l3_caches} with "
+                f"other sockets",
+            ).is_equal_to(0)
+
+            log.debug(
+                f"Socket {socket}: NUMA nodes {sorted(numa_nodes)} use "
+                f"L3 cache(s) {sorted(l3_caches_in_socket)}"
+            )


### PR DESCRIPTION
## Summary of Changes
1. **Added support for CPU architectures with shared L3 cache**: The test now handles two patterns - traditional 1:1 mapping (where each NUMA node has its own L3 cache) and architectures where multiple NUMA nodes within a socket share the same L3 cache.
2. **Implemented socket-aware verification**: Added logic to detect and validate shared L3 cache configurations, ensuring that L3 caches are only shared within the same socket and not across different sockets.
3. **Enhanced validation with three key checks**:
   - **Consistency check**: Ensures all CPUs in the same NUMA node use the same L3 cache
   - **Socket isolation check**: Verifies L3 caches are not shared across different sockets
   - **NUMA-to-L3 mapping check**: Confirms each NUMA node consistently maps to exactly one L3 cache
4. **Improved compatibility**: The test no longer incorrectly fails on VMs like `Standard_M176bs_3_v3` where multiple vNUMA nodes legitimately share L3 cache within a socket, reducing false positives while maintaining the ability to detect actual misconfigurations.