### PR TITLE
Remove deprecated warn function and replace with warning

### DIFF
--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -457,9 +457,9 @@ class RootRunner(Action):
             for runner in self._runners:
                 runner.close()
         except Exception as e:
-            self._log.warn(f"error on close runner: {e}")
+            self._log.warning(f"error on close runner: {e}")
 
         try:
             transformer.run(self._runbook_builder, constants.TRANSFORMER_PHASE_CLEANUP)
         except Exception as e:
-            self._log.warn(f"error on run cleanup transformers: {e}")
+            self._log.warning(f"error on run cleanup transformers: {e}")

--- a/lisa/runners/legacy_runner.py
+++ b/lisa/runners/legacy_runner.py
@@ -37,7 +37,7 @@ if platform.system() == "Windows":
         import win32file  # type: ignore
     except Exception:
         log = get_logger("init", "runner")
-        log.warn(
+        log.warning(
             "win32file package is not installed, legacy runner cannot run correctly."
         )
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -816,7 +816,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
 
     test_result = environment.source_test_result
     if not test_result:
-        log.warn(
+        log.warning(
             "LISA environment does not have a pointer to the test result object."
             "performance data reporting for this test will be broken!"
         )


### PR DESCRIPTION
The log.warn() function is supposedly deprecated as indicated by the strikethroughs wherever the function is called. So in this commit we replace it with the newer log.warning() method