### PR TITLE
Add IPv6 support in NetworkInterface feature

### DIFF
--- a/lisa/features/__init__.py
+++ b/lisa/features/__init__.py
@@ -21,7 +21,13 @@ from .hibernation import Hibernation, HibernationEnabled, HibernationSettings
 from .infiniband import Infiniband
 from .isolated_resource import IsolatedResource
 from .nested_virtualization import NestedVirtualization
-from .network_interface import NetworkInterface, Sriov, Synthetic
+from .network_interface import (
+    NetworkInterface,
+    Sriov,
+    SriovIPv6,
+    Synthetic,
+    SyntheticIPv6,
+)
 from .nfs import Nfs
 from .nvme import Nvme, NvmeSettings
 from .password_extension import PasswordExtension
@@ -69,6 +75,8 @@ __all__ = [
     "SecurityProfileSettings",
     "SecurityProfileType",
     "Sriov",
+    "SriovIPv6",
+    "SyntheticIPv6",
     "StopState",
     "VMStatus",
     "Synthetic",

--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -70,3 +70,13 @@ Sriov = partial(NetworkInterfaceOptionSettings, data_path=schema.NetworkDataPath
 Synthetic = partial(
     NetworkInterfaceOptionSettings, data_path=schema.NetworkDataPath.Synthetic
 )
+SriovIPv6 = partial(
+    NetworkInterfaceOptionSettings,
+    data_path=schema.NetworkDataPath.Sriov,
+    ip_version=schema.IPVersion.IPv6,
+)
+SyntheticIPv6 = partial(
+    NetworkInterfaceOptionSettings,
+    data_path=schema.NetworkDataPath.Synthetic,
+    ip_version=schema.IPVersion.IPv6,
+)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -783,9 +783,32 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
     def settings_type(cls) -> Type[schema.FeatureSettings]:
         return schema.NetworkInterfaceOptionSettings
 
+    @classmethod
+    def create_setting(
+        cls, *args: Any, **kwargs: Any
+    ) -> Optional[schema.FeatureSettings]:
+        # All Azure VMs support synthetic and SRIOV networking
+        # All Azure VMs can support both IPv4 and IPv6 via ARM template configuration
+        return schema.NetworkInterfaceOptionSettings(
+            data_path=search_space.SetSpace(
+                items=[
+                    schema.NetworkDataPath.Synthetic,
+                    schema.NetworkDataPath.Sriov,
+                ]
+            ),
+            ip_version=search_space.SetSpace(
+                is_allow_set=True,
+                items=[
+                    schema.IPVersion.IPv4,
+                    schema.IPVersion.IPv6,
+                ],
+            ),
+        )
+
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         super()._initialize(*args, **kwargs)
         self._initialize_information(self._node)
+        
         all_nics = self._get_all_nics()
         # store extra synthetic and sriov nics count
         # in order to restore nics status after testing which needs change nics

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -12,7 +12,7 @@ from lisa.operating_system import Posix
 from lisa.tools import Cat
 from lisa.tools.start_configuration import StartConfiguration
 from lisa.tools.whoami import Whoami
-from lisa.util import LisaException, find_patterns_in_lines
+from lisa.util import LisaException, find_patterns_in_lines, get_matched_str
 
 
 class IpInfo:
@@ -345,6 +345,17 @@ class Ip(Tool):
         matched = self._get_matched_dict(result.stdout)
         assert "ip_addr" in matched, f"not find ip address for nic {nic_name}"
         return matched["ip_addr"]
+
+    def get_ipv6_address(self, nic_name: str) -> str:
+        """Get the global IPv6 address for a network interface."""
+        result = self.run(f"-6 addr show {nic_name}", force_run=True, sudo=True)
+
+        # Regex to match IPv6 addresses with global scope
+        # Example: inet6 2001:db8::5/128 scope global dynamic noprefixroute
+        ipv6_pattern = re.compile(r"inet6\s+([0-9a-fA-F:]+)\/\d+\s+scope\s+global")
+
+        ipv6_address = get_matched_str(result.stdout, ipv6_pattern)
+        return ipv6_address
 
     def get_default_route_info(self) -> tuple[str, str]:
         result = self.run("route", force_run=True, sudo=True)

--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import ipaddress
 import re
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, cast
@@ -131,11 +132,11 @@ class Lagscope(Tool, KillableMixin):
         for key in self._busy_pool_keys:
             sysctl.write(key, self._original_settings[key])
 
-    def run_as_server_async(self, ip: str = "", use_ipv6: bool = False) -> Process:
+    def run_as_server_async(self, ip: str = "") -> Process:
         # -r: run as a receiver
         # -rip: run as server mode with specified ip address
         cmd = ""
-        if use_ipv6:
+        if ipaddress.ip_address(ip).version == 6:
             cmd += " -6"
         if ip:
             cmd += f" -r{ip}"
@@ -162,7 +163,6 @@ class Lagscope(Tool, KillableMixin):
         count_of_histogram_intervals: int = 30,
         dump_csv: bool = True,
         daemon: bool = False,
-        use_ipv6: bool = False,
     ) -> Process:
         # -s: run as a sender
         # -i: test interval
@@ -176,7 +176,7 @@ class Lagscope(Tool, KillableMixin):
         # -R: dumps raw latencies into csv file
         # -D: run as daemon
         cmd = f"{self.command} -s{server_ip} "
-        if use_ipv6:
+        if ipaddress.ip_address(server_ip).version == 6:
             cmd += " -6 "
         if run_time_seconds:
             cmd += f" -t{run_time_seconds} "
@@ -397,7 +397,7 @@ class BSDLagscope(Lagscope):
         # This is not supported on FreeBSD.
         return
 
-    def run_as_server_async(self, ip: str = "", use_ipv6: bool = False) -> Process:
+    def run_as_server_async(self, ip: str = "") -> Process:
         return self.node.tools[Sockperf].start_server_async("tcp")
 
     def run_as_client_async(
@@ -413,7 +413,6 @@ class BSDLagscope(Lagscope):
         count_of_histogram_intervals: int = 30,
         dump_csv: bool = True,
         daemon: bool = False,
-        use_ipv6: bool = False,
     ) -> Process:
         return self.node.tools[Sockperf].run_client_async("tcp", server_ip)
 

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -213,8 +213,11 @@ class Ntttcp(Tool):
         dev_differentiator: str = "Hypervisor callback interrupts",
         run_as_daemon: bool = False,
         udp_mode: bool = False,
+        use_ipv6: bool = False,
     ) -> Process:
         cmd = ""
+        if use_ipv6:
+            cmd += " -6 "
         if server_ip:
             cmd += f" -r{server_ip} "
         cmd += (
@@ -308,6 +311,7 @@ class Ntttcp(Tool):
         dev_differentiator: str = "Hypervisor callback interrupts",
         run_as_daemon: bool = False,
         udp_mode: bool = False,
+        use_ipv6: bool = False,
     ) -> ExecutableResult:
         # -sserver_ip: run as a sender with server ip address
         # -P: Number of ports listening on receiver side [default: 16] [max: 512]
@@ -326,11 +330,15 @@ class Ntttcp(Tool):
         # the devices specified by the differentiator
         # Examples for differentiator: Hyper-V PCIe MSI, mlx4, Hypervisor callback
         # interrupts
-        cmd = (
+        cmd = ""
+        if use_ipv6:
+            cmd += " -6 "
+        cmd += (
             f" -s{server_ip} -P {ports_count} -n {threads_count} -t {run_time_seconds} "
             f"-W {warm_up_time_seconds} -C {cool_down_time_seconds} -b {buffer_size}k "
             f"--show-nic-packets {nic_name} "
         )
+
         if udp_mode:
             cmd += " -u "
         if dev_differentiator:

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import ipaddress
 import re
 import time
 from decimal import Decimal
@@ -213,10 +214,9 @@ class Ntttcp(Tool):
         dev_differentiator: str = "Hypervisor callback interrupts",
         run_as_daemon: bool = False,
         udp_mode: bool = False,
-        use_ipv6: bool = False,
     ) -> Process:
         cmd = ""
-        if use_ipv6:
+        if ipaddress.ip_address(server_ip).version == 6:
             cmd += " -6 "
         if server_ip:
             cmd += f" -r{server_ip} "
@@ -311,7 +311,6 @@ class Ntttcp(Tool):
         dev_differentiator: str = "Hypervisor callback interrupts",
         run_as_daemon: bool = False,
         udp_mode: bool = False,
-        use_ipv6: bool = False,
     ) -> ExecutableResult:
         # -sserver_ip: run as a sender with server ip address
         # -P: Number of ports listening on receiver side [default: 16] [max: 512]
@@ -331,7 +330,7 @@ class Ntttcp(Tool):
         # Examples for differentiator: Hyper-V PCIe MSI, mlx4, Hypervisor callback
         # interrupts
         cmd = ""
-        if use_ipv6:
+        if ipaddress.ip_address(server_ip).version == 6:
             cmd += " -6 "
         cmd += (
             f" -s{server_ip} -P {ports_count} -n {threads_count} -t {run_time_seconds} "

--- a/microsoft/testsuites/network/sriov.py
+++ b/microsoft/testsuites/network/sriov.py
@@ -38,6 +38,7 @@ from lisa.tools import (
     Lscpu,
     Service,
 )
+from lisa.tools.ip import Ip
 from lisa.util import (
     LisaException,
     LisaTimeoutException,
@@ -876,6 +877,29 @@ class Sriov(TestSuite):
                     f"More than half of the vCPUs {unused_cpu} didn't have increased "
                     "interrupt count!"
                 ).is_greater_than(unused_cpu)
+
+    @TestCaseMetadata(
+        description="""
+        Verify IPv6 networking functionality with IPv6
+        1. Create an Azure VM with AN Enabled and IPv6 enabled
+        2. Verify that the NIC has an IPv6 address
+        """,
+        priority=2,
+        requirement=node_requirement(
+            node=schema.NodeSpace(
+                network_interface=features.SriovIPv6(),
+            )
+        ),
+    )
+    def verify_sriov_ipv6_basic(self, node: Node, log: Logger) -> None:
+        ip = node.tools[Ip]
+        # for each nic, verify that ipv6 exists using nic name
+        for nic in node.nics.nics.keys():
+            nic_ipv6 = ip.get_ipv6_address(nic)
+            assert_that(
+                nic_ipv6,
+                f"Expected IPv6 address but found none on nic {nic}",
+            ).is_not_empty()
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")

--- a/microsoft/testsuites/performance/common.py
+++ b/microsoft/testsuites/performance/common.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import inspect
+import ipaddress
 import pathlib
 from functools import partial
 from typing import Any, Dict, List, Optional, Union, cast
@@ -259,7 +260,6 @@ def perf_ntttcp(  # noqa: C901
     lagscope_server_ip: Optional[str] = None,
     server_nic_name: Optional[str] = None,
     client_nic_name: Optional[str] = None,
-    use_ipv6: bool = False,
 ) -> List[Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]]:
     # Either server and client are set explicitly or we use the first two nodes
     # from the environment. We never combine the two options. We need to specify
@@ -342,22 +342,14 @@ def perf_ntttcp(  # noqa: C901
             )
             dev_differentiator = "Hypervisor callback interrupts"
 
-        if use_ipv6:
-            # Retrieve IPv6 address of server, which is the address
-            # of the default nic.
-            server_ip_address = server.tools[Ip].get_ipv6_address(
-                server.nics.default_nic
-            )
-        else:
-            server_ip_address = server.internal_address
+        server_ip_address = server.internal_address
 
         server_lagscope.run_as_server_async(
             ip=(
                 lagscope_server_ip
                 if lagscope_server_ip is not None
                 else server_ip_address
-            ),
-            use_ipv6=use_ipv6,
+            )
         )
         max_server_threads = 64
         perf_ntttcp_message_list: List[
@@ -384,7 +376,6 @@ def perf_ntttcp(  # noqa: C901
                 buffer_size=buffer_size,
                 dev_differentiator=dev_differentiator,
                 udp_mode=udp_mode,
-                use_ipv6=use_ipv6,
             )
             client_lagscope_process = client_lagscope.run_as_client_async(
                 server_ip=server_ip_address,
@@ -396,7 +387,6 @@ def perf_ntttcp(  # noqa: C901
                 length_of_histogram_intervals=0,
                 count_of_histogram_intervals=0,
                 dump_csv=False,
-                use_ipv6=use_ipv6,
             )
             client_ntttcp_result = client_ntttcp.run_as_client(
                 client_nic_name,
@@ -406,7 +396,6 @@ def perf_ntttcp(  # noqa: C901
                 ports_count=num_threads_p,
                 dev_differentiator=dev_differentiator,
                 udp_mode=udp_mode,
-                use_ipv6=use_ipv6,
             )
             server.tools[Kill].by_name(server_ntttcp.command)
             server_ntttcp_result = server_result.wait_result()

--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -15,6 +15,7 @@ from lisa import (
 )
 from lisa.environment import Environment, Node
 from lisa.features import Sriov, Synthetic
+from lisa.features.network_interface import SriovIPv6, SyntheticIPv6
 from lisa.operating_system import BSD, Windows
 from lisa.testsuite import TestResult
 from lisa.tools import Sysctl

--- a/microsoft/testsuites/performance/networkperf.py
+++ b/microsoft/testsuites/performance/networkperf.py
@@ -15,7 +15,6 @@ from lisa import (
 )
 from lisa.environment import Environment, Node
 from lisa.features import Sriov, Synthetic
-from lisa.features.network_interface import SriovIPv6, SyntheticIPv6
 from lisa.operating_system import BSD, Windows
 from lisa.testsuite import TestResult
 from lisa.tools import Sysctl


### PR DESCRIPTION
Add IPv6 feature by utilizing the existing use_ipv6 runbook parameter.
IPv6 Features enables IPv6 support in VNet, Subnet and enable IPv6 on the nic interface.

The Primary IP of the VM continues to be IPv4, hence no change is required in host that is running LISA. The communication between the VMs uses IPv6.