### PR TITLE
DPDK: add first jumbo frame test

### DIFF
--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -468,13 +468,11 @@ class Ip(Tool):
                 "Could not fetch interface details with 'ip -d link show'"
             ),
         ).stdout
-        try:
-            groups = find_group_in_lines(
-                details, self.__ip_detail_show_regex, single_line=False
-            )
-            detail = groups[attribute]
-        except KeyError:
-            detail = ""
+
+        groups = find_group_in_lines(
+            details, self.__ip_detail_show_regex, single_line=False
+        )
+        detail = groups.get(attribute, "")
         return detail
 
     def get_interface_list(self) -> list[str]:

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -12,7 +12,7 @@ from lisa.operating_system import Posix
 from lisa.tools import Cat
 from lisa.tools.start_configuration import StartConfiguration
 from lisa.tools.whoami import Whoami
-from lisa.util import LisaException, find_patterns_in_lines
+from lisa.util import LisaException, find_group_in_lines, find_patterns_in_lines
 
 
 class IpInfo:
@@ -468,13 +468,14 @@ class Ip(Tool):
                 "Could not fetch interface details with 'ip -d link show'"
             ),
         ).stdout
-        found = self.__ip_detail_show_regex.match(details)
-        if not found:
-            return ""
-        detail = found.group(attribute)
-        if not detail:
-            return ""
-        return str(detail)
+        try:
+            groups = find_group_in_lines(
+                details, self.__ip_detail_show_regex, single_line=False
+            )
+            detail = groups[attribute]
+        except KeyError:
+            detail = ""
+        return detail
 
     def get_interface_list(self) -> list[str]:
         raise NotImplementedError()

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -657,7 +657,7 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for the dpdk netvsc pmd using jumbo frames.
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with jumbo frames.
             Default is set to request an mtu of 9k, test will skip if it's not possible.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the expected

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -658,6 +658,7 @@ class Dpdk(TestSuite):
     @TestCaseMetadata(
         description="""
             Tests a basic sender/receiver setup for the netvsc pmd using jumbo frames.
+            Default is set to request an mtu of 9k, test will skip if it's not possible.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the expected
             order-of-magnitude.

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -657,7 +657,7 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for the netvsc pmd using jumbo frames.
+            Tests a basic sender/receiver setup for the dpdk netvsc pmd using jumbo frames.
             Default is set to request an mtu of 9k, test will skip if it's not possible.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the expected

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -657,6 +657,36 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
+            Tests a basic sender/receiver setup for the netvsc pmd using jumbo frames.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the expected
+            order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+    )
+    def verify_dpdk_send_receive_multi_txrx_queue_max_mtu_netvsc(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        try:
+            verify_dpdk_send_receive_multi_txrx_queue(
+                environment, log, variables, "netvsc", result=result, set_mtu=9000
+            )
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
+
+    @TestCaseMetadata(
+        description="""
             Tests a basic sender/receiver setup for default failsafe driver setup.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the expected

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -553,7 +553,10 @@ class DpdkTestpmd(Tool):
             extra_args += f" --txq={queues} --rxq={queues}"
 
         if mtu:
-            extra_args += f" --max-pkt-len={mtu} --txpkts=9000 --tx-offloads=0x00008000"
+            extra_args += (
+                f" --max-pkt-len={mtu} --txpkts={mtu} --tx-offloads=0x00008000"
+                f" --mbuf-size={mtu}"
+            )
 
         assert_that(forwarding_cores).described_as(
             ("DPDK tests need at least one forwading core. ")
@@ -569,7 +572,7 @@ class DpdkTestpmd(Tool):
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_include_info} -- --forward-mode={mode} "
             f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
-            "--mbuf-size=2048,8096"
+            #
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -488,6 +488,7 @@ class DpdkTestpmd(Tool):
         extra_args: str = "",
         multiple_queues: bool = False,
         service_cores: int = 1,
+        mtu: int = 0,
     ) -> str:
         #   testpmd \
         #   -l <core-list> \
@@ -550,6 +551,9 @@ class DpdkTestpmd(Tool):
             extra_args += f" --txd={txd} --rxd={txd} --stats 2"
         if queues > 1:
             extra_args += f" --txq={queues} --rxq={queues}"
+
+        if mtu:
+            extra_args += f" --max-pkt-len={mtu} --txpkts=9000 --tx-offloads=0x00008000"
 
         assert_that(forwarding_cores).described_as(
             ("DPDK tests need at least one forwading core. ")

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -489,6 +489,7 @@ class DpdkTestpmd(Tool):
         multiple_queues: bool = False,
         service_cores: int = 1,
         mtu: int = 0,
+        mbuf_size: int = 0,
     ) -> str:
         #   testpmd \
         #   -l <core-list> \
@@ -555,7 +556,7 @@ class DpdkTestpmd(Tool):
         if mtu:
             extra_args += (
                 f" --max-pkt-len={mtu} --txpkts={mtu} --tx-offloads=0x00008000"
-                f" --mbuf-size={mtu}"
+                f" --mbuf-size={mbuf_size}"
             )
 
         assert_that(forwarding_cores).described_as(

--- a/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -573,7 +573,6 @@ class DpdkTestpmd(Tool):
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_include_info} -- --forward-mode={mode} "
             f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
-            #
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -193,6 +193,7 @@ def generate_send_receive_run_info(
     receiver: DpdkTestResources,
     multiple_queues: bool = False,
     use_service_cores: int = 1,
+    set_mtu: int = 0,
 ) -> Dict[DpdkTestResources, str]:
     snd_nic, rcv_nic = [x.node.nics.get_secondary_nic() for x in [sender, receiver]]
 
@@ -203,6 +204,7 @@ def generate_send_receive_run_info(
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
+        mtu=set_mtu,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
@@ -210,6 +212,7 @@ def generate_send_receive_run_info(
         "rxonly",
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
+        mtu=set_mtu,
     )
 
     kit_cmd_pairs = {
@@ -548,6 +551,7 @@ def verify_dpdk_send_receive(
     use_service_cores: int = 1,
     multiple_queues: bool = False,
     result: Optional[TestResult] = None,
+    set_mtu: int = 0,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # helpful to have the public ips labeled for debugging
     external_ips = []
@@ -581,6 +585,7 @@ def verify_dpdk_send_receive(
         receiver,
         use_service_cores=use_service_cores,
         multiple_queues=multiple_queues,
+        set_mtu=set_mtu,
     )
     receive_timeout = kill_timeout + 10
     receive_result = receiver.node.tools[Timeout].start_with_timeout(
@@ -631,6 +636,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     variables: Dict[str, Any],
     pmd: str,
     result: Optional[TestResult] = None,
+    set_mtu: int = 0,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # get test duration variable if set
     # enables long-running tests to shakeQoS and SLB issue
@@ -643,6 +649,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
         use_service_cores=1,
         multiple_queues=True,
         result=result,
+        set_mtu=set_mtu,
     )
 
 

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -199,14 +199,16 @@ def generate_send_receive_run_info(
     # for MTU test: check that we can fetch the max MTU size for the NIC
     if set_mtu:
         check_nic = sender.node.nics.get_primary_nic().lower
-        maxmtu = sender.node.tools[Ip].get_detail(check_nic, "maxmtu")
+        maxmtu = int(sender.node.tools[Ip].get_detail(check_nic, "maxmtu"))
         if not maxmtu:
             raise SkippedException("Could not verify maxmtu for DPDK max mtu test.")
-        if set_mtu > int(maxmtu):
+        if set_mtu > maxmtu:
             raise SkippedException(
                 "Requested MTU size exceeds max mtu for DPDK mtu test: "
                 f"{set_mtu} > {maxmtu}."
             )
+    else:
+        maxmtu = 0
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
         0,
@@ -215,6 +217,7 @@ def generate_send_receive_run_info(
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
+        mbuf_size=maxmtu,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
@@ -223,6 +226,7 @@ def generate_send_receive_run_info(
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
+        mbuf_size=maxmtu,
     )
 
     kit_cmd_pairs = {

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -199,16 +199,17 @@ def generate_send_receive_run_info(
     # for MTU test: check that we can fetch the max MTU size for the NIC
     if set_mtu:
         check_nic = sender.node.nics.get_primary_nic().lower
-        maxmtu = int(sender.node.tools[Ip].get_detail(check_nic, "maxmtu"))
+        maxmtu = sender.node.tools[Ip].get_detail(check_nic, "maxmtu")
         if not maxmtu:
             raise SkippedException("Could not verify maxmtu for DPDK max mtu test.")
-        if set_mtu > maxmtu:
+        maxmtu_int = int(maxmtu)
+        if set_mtu > maxmtu_int:
             raise SkippedException(
                 "Requested MTU size exceeds max mtu for DPDK mtu test: "
                 f"{set_mtu} > {maxmtu}."
             )
     else:
-        maxmtu = 0
+        maxmtu_int = 0
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
         0,
@@ -217,7 +218,7 @@ def generate_send_receive_run_info(
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
-        mbuf_size=maxmtu,
+        mbuf_size=maxmtu_int,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         rcv_nic,
@@ -226,7 +227,7 @@ def generate_send_receive_run_info(
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
-        mbuf_size=maxmtu,
+        mbuf_size=maxmtu_int,
     )
 
     kit_cmd_pairs = {

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -196,7 +196,17 @@ def generate_send_receive_run_info(
     set_mtu: int = 0,
 ) -> Dict[DpdkTestResources, str]:
     snd_nic, rcv_nic = [x.node.nics.get_secondary_nic() for x in [sender, receiver]]
-
+    # for MTU test: check that we can fetch the max MTU size for the NIC
+    if set_mtu:
+        check_nic = sender.node.nics.get_primary_nic().lower
+        maxmtu = sender.node.tools[Ip].get_detail(check_nic, "maxmtu")
+        if not maxmtu:
+            raise SkippedException("Could not verify maxmtu for DPDK max mtu test.")
+        if set_mtu > int(maxmtu):
+            raise SkippedException(
+                "Requested MTU size exceeds max mtu for DPDK mtu test: "
+                f"{set_mtu} > {maxmtu}."
+            )
     snd_cmd = sender.testpmd.generate_testpmd_command(
         snd_nic,
         0,
@@ -562,6 +572,9 @@ def verify_dpdk_send_receive(
             ]
         else:
             raise SkippedException()
+        # skip MTU test if not on MANA (for now).
+        if set_mtu and not node.nics.is_mana_device_present():
+            raise SkippedException("set mtu test is intended for MANA VMs only.")
     log.debug((f"\nsender:{external_ips[0]}\nreceiver:{external_ips[1]}\n"))
 
     # get test duration variable if set


### PR DESCRIPTION
Adds a test that enables the --max-pkt-len option to testpmd. This enables the use of jumbo frames during the test.

A default of 9k is requested; however, the test also uses `ip` to check for the max size supported so it will skip if that size isn't supported.