### PR TITLE
Improve Deployment of CVM VHD

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -382,7 +382,7 @@ resource nodes_disk 'Microsoft.Compute/disks@2025-01-02' = [for i in range(0, no
   tags: tags
   location: location
   sku: {
-    name: 'Standard_LRS'
+    name: nodes[i].os_disk_type
   }
   properties: {
     osType: 'Linux'

--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -79,7 +79,7 @@ var ip_tags = [for key in objectKeys(ip_service_tags): {
   tag: ip_service_tags[key]
 }]
 
-func isCvmVhd(node object) bool => bool((!empty(node.vhd)) && (!empty(node.vhd.vmgs_path)))
+func isCvmVhd(node object) bool => bool((!empty(node.vhd)) && (!empty(node.vhd.cvm_gueststate_path)))
 
 func isVhd(node object) bool => bool((!empty(node.vhd)) && (!empty(node.vhd.vhd_path)))
 
@@ -360,7 +360,7 @@ resource nodes_public_ip_ipv6 'Microsoft.Network/publicIPAddresses@2020-05-01' =
   zones: (use_availability_zones ? availability_zones : null)
 }]
 
-resource nodes_image 'Microsoft.Compute/images@2019-03-01' = [for i in range(0, node_count): if (isVhd(nodes[i]) && empty(nodes[i].vhd.vmgs_path)) {
+resource nodes_image 'Microsoft.Compute/images@2019-03-01' = [for i in range(0, node_count): if (isVhd(nodes[i]) && empty(nodes[i].vhd.cvm_gueststate_path)) {
   name: '${nodes[i].name}-image'
   tags: tags
   location: location
@@ -377,7 +377,7 @@ resource nodes_image 'Microsoft.Compute/images@2019-03-01' = [for i in range(0, 
   }
 }]
 
-resource nodes_disk 'Microsoft.Compute/disks@2021-04-01' = [for i in range(0, node_count): if (isCvmVhd(nodes[i])) {
+resource nodes_disk 'Microsoft.Compute/disks@2025-01-02' = [for i in range(0, node_count): if (isCvmVhd(nodes[i])) {
   name: '${nodes[i].name}-disk'
   tags: tags
   location: location
@@ -396,7 +396,8 @@ resource nodes_disk 'Microsoft.Compute/disks@2021-04-01' = [for i in range(0, no
     creationData: {
       createOption: 'ImportSecure'
       storageAccountId: resourceId(shared_resource_group_name, 'Microsoft.Storage/storageAccounts', vhd_storage_name)
-      securityDataUri: nodes[i].vhd.vmgs_path
+      securityDataUri: nodes[i].vhd.cvm_gueststate_path
+      securityMetadataUri: empty(nodes[i].vhd.cvm_metadata_path) ? null : nodes[i].vhd.cvm_metadata_path
       sourceUri: nodes[i].vhd.vhd_path
     }
   }

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "6809515254395981153"
+      "templateHash": "8369789714257914259"
     }
   },
   "functions": [
@@ -22,7 +22,7 @@
           ],
           "output": {
             "type": "bool",
-            "value": "[bool(and(not(empty(parameters('node').vhd)), not(empty(parameters('node').vhd.vmgs_path))))]"
+            "value": "[bool(and(not(empty(parameters('node').vhd)), not(empty(parameters('node').vhd.cvm_gueststate_path))))]"
           }
         },
         "isVhd": {
@@ -711,7 +711,7 @@
         "name": "nodes_image",
         "count": "[length(range(0, variables('node_count')))]"
       },
-      "condition": "[and(__bicep.isVhd(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]]), empty(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.vmgs_path))]",
+      "condition": "[and(__bicep.isVhd(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]]), empty(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.cvm_gueststate_path))]",
       "type": "Microsoft.Compute/images",
       "apiVersion": "2019-03-01",
       "name": "[format('{0}-image', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
@@ -736,7 +736,7 @@
       },
       "condition": "[__bicep.isCvmVhd(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
       "type": "Microsoft.Compute/disks",
-      "apiVersion": "2021-04-01",
+      "apiVersion": "2025-01-02",
       "name": "[format('{0}-disk', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
       "tags": "[parameters('tags')]",
       "location": "[parameters('location')]",
@@ -753,7 +753,8 @@
         "creationData": {
           "createOption": "ImportSecure",
           "storageAccountId": "[resourceId(parameters('shared_resource_group_name'), 'Microsoft.Storage/storageAccounts', parameters('vhd_storage_name'))]",
-          "securityDataUri": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.vmgs_path]",
+          "securityDataUri": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.cvm_gueststate_path]",
+          "securityMetadataUri": "[if(empty(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.cvm_metadata_path), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.cvm_metadata_path)]",
           "sourceUri": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].vhd.vhd_path]"
         }
       },

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "8369789714257914259"
+      "templateHash": "16291477761159155605"
     }
   },
   "functions": [
@@ -741,7 +741,7 @@
       "tags": "[parameters('tags')]",
       "location": "[parameters('location')]",
       "sku": {
-        "name": "Standard_LRS"
+        "name": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].os_disk_type]"
       },
       "properties": {
         "osType": "Linux",

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,15 +5,15 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "9070223824614413840"
+      "version": "0.37.4.10188",
+      "templateHash": "6809515254395981153"
     }
   },
   "functions": [
     {
       "namespace": "__bicep",
       "members": {
-        "isCvm": {
+        "isCvmVhd": {
           "parameters": [
             {
               "type": "object",
@@ -335,7 +335,7 @@
           "output": {
             "type": "object",
             "nullable": true,
-            "value": "[if(__bicep.isCvm(parameters('node')), null(), __bicep.generateOsProfile(parameters('node'), parameters('admin_username'), parameters('admin_password'), parameters('admin_key_data')))]"
+            "value": "[if(__bicep.isCvmVhd(parameters('node')), null(), __bicep.generateOsProfile(parameters('node'), parameters('admin_username'), parameters('admin_password'), parameters('admin_key_data')))]"
           }
         },
         "getImageReference": {
@@ -348,7 +348,7 @@
           "output": {
             "type": "object",
             "nullable": true,
-            "value": "[if(__bicep.isCvm(parameters('node')), null(), __bicep.generateImageReference(parameters('node')))]"
+            "value": "[if(__bicep.isCvmVhd(parameters('node')), null(), __bicep.generateImageReference(parameters('node')))]"
           }
         },
         "getSecurityProfile": {
@@ -394,7 +394,7 @@
           ],
           "output": {
             "type": "object",
-            "value": "[if(__bicep.isCvm(parameters('node')), __bicep.getOSDisk(format('{0}-disk', parameters('node').name)), if(equals(parameters('node').os_disk_type, 'Ephemeral'), __bicep.getEphemeralOSImage(parameters('node')), __bicep.getOSImage(parameters('node'))))]"
+            "value": "[if(__bicep.isCvmVhd(parameters('node')), __bicep.getOSDisk(format('{0}-disk', parameters('node').name)), if(equals(parameters('node').os_disk_type, 'Ephemeral'), __bicep.getEphemeralOSImage(parameters('node')), __bicep.getOSImage(parameters('node'))))]"
           }
         },
         "getAvailabilitySetId": {
@@ -734,7 +734,7 @@
         "name": "nodes_disk",
         "count": "[length(range(0, variables('node_count')))]"
       },
-      "condition": "[__bicep.isCvm(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
+      "condition": "[__bicep.isCvmVhd(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
       "type": "Microsoft.Compute/disks",
       "apiVersion": "2021-04-01",
       "name": "[format('{0}-disk', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
@@ -747,7 +747,8 @@
         "osType": "Linux",
         "hyperVGeneration": "[format('V{0}', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].hyperv_generation)]",
         "securityProfile": {
-          "securityType": "ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey"
+          "securityType": "[parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].security_profile.encryption_type]",
+          "secureVMDiskEncryptionSetId": "[if(empty(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].security_profile.disk_encryption_set_id), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].security_profile.disk_encryption_set_id)]"
         },
         "creationData": {
           "createOption": "ImportSecure",
@@ -896,8 +897,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "6914571954054027821"
+              "version": "0.37.4.10188",
+              "templateHash": "17932923534203698710"
             }
           },
           "functions": [

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -536,6 +536,7 @@ class VhdSchema(AzureImageSchema):
                 [
                     SecurityProfileType.CVM,
                     SecurityProfileType.Stateless,
+                    SecurityProfileType.SecureBoot,
                 ],
             )
             self.encrypt_disk = search_space.SetSpace(True, [True, False])

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2542,14 +2542,6 @@ class SecurityProfileSettings(features.SecurityProfileSettings):
 
 
 class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
-    # Convert Security Profile Setting to Arm Parameter Value
-    _security_profile_mapping = {
-        SecurityProfileType.Standard: "",
-        SecurityProfileType.SecureBoot: "TrustedLaunch",
-        SecurityProfileType.CVM: "ConfidentialVM",
-        SecurityProfileType.Stateless: "ConfidentialVM",
-    }
-
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         super()._initialize(*args, **kwargs)
         self._initialize_information(self._node)
@@ -2615,42 +2607,81 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
         assert len(environment.nodes._list) == len(arm_parameters.nodes)
         for node, node_parameters in zip(environment.nodes._list, arm_parameters.nodes):
             assert node.capability.features
+
             security_profile = [
                 feature_setting
                 for feature_setting in node.capability.features.items
                 if feature_setting.type == FEATURE_NAME_SECURITY_PROFILE
             ]
-            if security_profile:
-                settings = security_profile[0]
-                assert isinstance(settings, SecurityProfileSettings)
-                assert isinstance(settings.security_profile, SecurityProfileType)
-                assert isinstance(settings.encrypt_disk, bool)
-                node_parameters.security_profile[
-                    "security_type"
-                ] = cls._security_profile_mapping[settings.security_profile]
-                if settings.security_profile == SecurityProfileType.Stateless:
-                    node_parameters.security_profile["secure_boot"] = False
-                    node_parameters.security_profile[
-                        "encryption_type"
-                    ] = "NonPersistedTPM"
+            if not security_profile:
+                continue
+
+            settings = security_profile[0]
+            assert isinstance(settings, SecurityProfileSettings)
+            assert isinstance(settings.security_profile, SecurityProfileType)
+            assert isinstance(settings.encrypt_disk, bool)
+
+            # Set Security Type and Encryption Type
+            # microsoft.compute/virtualmachines
+            #     SecurityProfile.securityType =
+            #         {'TrustedLaunch', 'ConfidentialVM', ''}
+            #     VMDiskSecurityProfile.securityEncryptionType =
+            #         {'DiskWithVMGuestState', 'NonPersistedTPM', 'VMGuestStateOnly'}
+            # microsoft.compute/disks (Replaces VMDiskSecurityProfile for VHDs)
+            #     DiskSecurityProfile.securityType =
+            #         {ConfidentialVM_DiskEncryptedWithCustomerKey',
+            #         'ConfidentialVM_DiskEncryptedWithPlatformKey',
+            #         'ConfidentialVM_NonPersistedTPM',
+            #         'ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey',
+            #         'TrustedLaunch'}
+            is_vhd = bool(node_parameters.vhd)
+            if SecurityProfileType.Standard == settings.security_profile:
+                node_parameters.security_profile["security_type"] = ""
+            elif SecurityProfileType.SecureBoot == settings.security_profile:
+                node_parameters.security_profile["secure_boot"] = True
+                node_parameters.security_profile["security_type"] = "TrustedLaunch"
+                node_parameters.security_profile["encryption_type"] = "TrustedLaunch"
+            elif SecurityProfileType.Stateless == settings.security_profile:
+                node_parameters.security_profile["secure_boot"] = False
+                node_parameters.security_profile["security_type"] = "ConfidentialVM"
+                node_parameters.security_profile["encryption_type"] = (
+                    "ConfidentialVM_NonPersistedTPM" if is_vhd else "NonPersistedTPM"
+                )
+            elif SecurityProfileType.CVM == settings.security_profile:
+                node_parameters.security_profile["secure_boot"] = True
+                node_parameters.security_profile["security_type"] = "ConfidentialVM"
+                if settings.encrypt_disk:
+                    if settings.disk_encryption_set_id:
+                        node_parameters.security_profile["encryption_type"] = (
+                            "ConfidentialVM_DiskEncryptedWithCustomerKey"
+                            if is_vhd
+                            else "DiskWithVMGuestState"
+                        )
+                    else:
+                        node_parameters.security_profile["encryption_type"] = (
+                            "ConfidentialVM_DiskEncryptedWithPlatformKey"
+                            if is_vhd
+                            else "DiskWithVMGuestState"
+                        )
                 else:
-                    node_parameters.security_profile["secure_boot"] = True
                     node_parameters.security_profile["encryption_type"] = (
-                        "DiskWithVMGuestState"
-                        if settings.encrypt_disk
+                        "ConfidentialVM_VMGuestStateOnlyEncryptedWithPlatformKey"
+                        if is_vhd
                         else "VMGuestStateOnly"
                     )
-                node_parameters.security_profile[
-                    "disk_encryption_set_id"
-                ] = settings.disk_encryption_set_id
 
-                if node_parameters.security_profile["security_type"] == "":
-                    node_parameters.security_profile.clear()
-                elif 1 == node_parameters.hyperv_generation:
-                    raise SkippedException(
-                        f"{settings.security_profile} "
-                        "can only be set on gen2 image/vhd."
-                    )
+            # Disk Encryption Set ID
+            node_parameters.security_profile[
+                "disk_encryption_set_id"
+            ] = settings.disk_encryption_set_id
+
+            # Return Skipped Exception if security profile is set on Gen 1 VM
+            if node_parameters.security_profile["security_type"] == "":
+                node_parameters.security_profile.clear()
+            elif 1 == node_parameters.hyperv_generation:
+                raise SkippedException(
+                    f"{settings.security_profile} " "can only be set on gen2 image/vhd."
+                )
 
 
 availability_type_priority: List[AvailabilityType] = [

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -119,7 +119,7 @@ from .common import (
     check_or_create_storage_account,
     convert_to_azure_node_space,
     get_compute_client,
-    get_deployable_vhd_path,
+    get_deployable_storage_path,
     get_environment_context,
     get_marketplace_ordering_client,
     get_node_context,
@@ -1414,13 +1414,15 @@ class AzurePlatform(Platform):
         if azure_node_runbook.vhd and azure_node_runbook.vhd.vhd_path:
             # vhd is higher priority
             vhd = azure_node_runbook.vhd
-            vhd.vhd_path = get_deployable_vhd_path(
+            vhd.vhd_path = get_deployable_storage_path(
                 self, vhd.vhd_path, azure_node_runbook.location, log
             )
-            if vhd.vmgs_path:
-                vhd.vmgs_path = get_deployable_vhd_path(
-                    self, vhd.vmgs_path, azure_node_runbook.location, log
-                )
+            vhd.cvm_gueststate_path = get_deployable_storage_path(
+                self, vhd.cvm_gueststate_path, azure_node_runbook.location, log
+            )
+            vhd.cvm_metadata_path = get_deployable_storage_path(
+                self, vhd.cvm_metadata_path, azure_node_runbook.location, log
+            )
             azure_node_runbook.vhd = vhd
             azure_node_runbook.marketplace = None
             azure_node_runbook.shared_gallery = None
@@ -1483,13 +1485,15 @@ class AzurePlatform(Platform):
         if arm_parameters.vhd and arm_parameters.vhd.vhd_path:
             # vhd is higher priority
             vhd = arm_parameters.vhd
-            vhd.vhd_path = get_deployable_vhd_path(
+            vhd.vhd_path = get_deployable_storage_path(
                 self, vhd.vhd_path, arm_parameters.location, log
             )
-            if vhd.vmgs_path:
-                vhd.vmgs_path = get_deployable_vhd_path(
-                    self, vhd.vmgs_path, arm_parameters.location, log
-                )
+            vhd.cvm_gueststate_path = get_deployable_storage_path(
+                self, vhd.cvm_gueststate_path, arm_parameters.location, log
+            )
+            vhd.cvm_metadata_path = get_deployable_storage_path(
+                self, vhd.cvm_metadata_path, arm_parameters.location, log
+            )
             arm_parameters.vhd = vhd
             arm_parameters.osdisk_size_in_gb = max(
                 arm_parameters.osdisk_size_in_gb,

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -36,7 +36,7 @@ from .common import (
     copy_vhd_using_azcopy,
     generate_user_delegation_sas_token,
     get_compute_client,
-    get_deployable_vhd_path,
+    get_deployable_storage_path,
     get_environment_context,
     get_or_create_storage_container,
     get_primary_ip_addresses,
@@ -601,7 +601,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_resource_group_location = image_location
         if not runbook.gallery_location:
             runbook.gallery_location = image_location
-        vhd_path = get_deployable_vhd_path(
+        vhd_path = get_deployable_storage_path(
             platform, runbook.vhd, image_location, self._log
         )
         vhd_details = get_vhd_details(platform, vhd_path)


### PR DESCRIPTION
Deployment of CVMs with VHD can now support more configurations already present in LISA, such as full disk encryption, CMK, and stateless. Also other OS disk types and Windows OS type.

Also added support for 3 blob "CVMv2" which will become the default CVM structure. This requires passing in a Metadata file along with the disk image and guest state image.

[Documentation for the deployment template](https://learn.microsoft.com/en-us/azure/templates/microsoft.compute/disks?pivots=deployment-language-bicep)

[Work is in progress to support CVMv2 in AzCLI](https://github.com/Azure/azure-cli/issues/31881)