### PR TITLE
Logger: mitigate underlying recursive logging and refactoring.

### DIFF
--- a/lisa/main.py
+++ b/lisa/main.py
@@ -21,7 +21,7 @@ from lisa.util.logger import (
     create_file_handler,
     get_logger,
     remove_handler,
-    set_level,
+    set_console_level,
     uninit_logger,
 )
 from lisa.util.perf_timer import create_timer
@@ -117,7 +117,7 @@ def main() -> int:
         initialize_runtime_folder(args.log_path, args.working_path, args.run_id)
 
         log_level = DEBUG if (args.debug) else INFO
-        set_level(log_level)
+        set_console_level(log_level)
 
         file_handler = create_file_handler(
             Path(f"{constants.RUN_LOCAL_LOG_PATH}/lisa-{constants.RUN_ID}.log")

--- a/lisa/util/logger.py
+++ b/lisa/util/logger.py
@@ -199,7 +199,7 @@ def create_file_handler(
     return file_handler
 
 
-def set_level(level: int) -> None:
+def set_console_level(level: int) -> None:
     _console_handler.setLevel(level)
 
 

--- a/lisa/util/logger.py
+++ b/lisa/util/logger.py
@@ -103,16 +103,23 @@ class LogWriter(object):
         self._level = level
         self._log = logger
         self._buffer: str = ""
+        self._flushing: bool = False
 
     def write(self, message: str) -> None:
-        self._buffer = "".join([self._buffer, message])
-        if "\n" in message:
-            self.flush()
+        if not self._flushing:
+            self._buffer = "".join([self._buffer, message])
+            if "\n" in message:
+                self.flush()
 
     def flush(self) -> None:
-        if len(self._buffer) > 0:
-            self._log.lines(self._level, self._buffer)
-            self._buffer = ""
+        if len(self._buffer) > 0 and not self._flushing:
+            self._flushing = True
+            try:
+                buffer = self._buffer
+                self._buffer = ""
+                self._log.lines(self._level, buffer)
+            finally:
+                self._flushing = False
 
     def close(self) -> None:
         self.flush()


### PR DESCRIPTION
If the log is misconfigured during development, the logger may enter recursive stats. Use recursive detection to prevent a stack overflow. This doesn't fix the issue but prevents failure in LISA and makes troubleshooting easier.

Additional refactoring to improve code readability.
