### PR TITLE
ch_tests: avoid duplicate dmesg output in logs

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -55,7 +55,7 @@ class CloudHypervisorTestSuite(TestSuite):
         log.debug(f"Journalctl Docker Logs: {docker_log}")
 
         dmesg = node.tools[Dmesg]
-        dmesg_log = dmesg.get_output(force_run=True)
+        dmesg_log = dmesg.get_output(no_debug_log=True, force_run=True)
         log.debug(f"Dmesg Logs: {dmesg_log}")
 
     @TestCaseMetadata(


### PR DESCRIPTION
after_case() ends up emitting dmesg output twice to lisa logs:

  - first time as part of the dmesg tool
  - second time via the explicit log.debug

Keep the second one since it looks cleaner in the logs without the lisa log prefix. Use no_debug_logs=True to suppress theh output coming from the dmesg tool.