### PR TITLE
Add root filesystem mount fialure check and related exception

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -72,8 +72,10 @@ from lisa.util import (
     LisaTimeoutException,
     NotMeetRequirementException,
     ResourceAwaitableException,
+    RootFsMountFailedException,
     SkippedException,
     check_panic,
+    check_rootfs_failure,
     constants,
     dump_file,
     field_metadata,
@@ -717,6 +719,7 @@ class AzurePlatform(Platform):
             log_file_name.write_bytes(log_response_content)
             if check_serial_console is True:
                 check_panic(log_response_content.decode("utf-8"), "provision", log)
+                check_rootfs_failure(log_response_content.decode("utf-8"), log)
 
     def _get_node_information(self, node: Node) -> Dict[str, str]:
         platform_runbook = cast(schema.Platform, self.runbook)
@@ -1705,7 +1708,7 @@ class AzurePlatform(Platform):
                     self._save_console_log_and_check_panic(
                         resource_group_name, environment, log, True
                     )
-                except KernelPanicException as ex:
+                except (KernelPanicException, RootFsMountFailedException) as ex:
                     if (
                         "OSProvisioningTimedOut: OS Provisioning for VM"
                         in error_message

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -106,6 +106,15 @@ PANIC_IGNORABLE_PATTERNS: List[Pattern[str]] = [
     re.compile(r"(.*RIP: 0010:topology_sane.isra.*)$", re.MULTILINE),
 ]
 
+# Root filesystem mount failure patterns
+ROOTFS_FAILURE_PATTERNS: List[Pattern[str]] = [
+    # Warning: dracut-initqueue timeout - starting timeout scripts
+    # Warning: dracut-initqueue: starting timeout scripts
+    re.compile(r"^(.*dracut-initqueue.*timeout.*)$", re.MULTILINE),
+    # ALERT!  UUID=fbf1c3fe-02ca-4347-93ae-458f0bce93a6 does not exist.  Dropping to a shell!  # noqa: E501
+    re.compile(r"^(.*UUID=.*does not exist.*)$", re.MULTILINE),
+]
+
 
 class LisaException(Exception):
     def __init__(self, *args: object) -> None:
@@ -336,6 +345,24 @@ class KernelPanicException(LisaException):
             "details from the serial console log. Please download the test logs and "
             "retrieve the serial_log from 'environments' directory, or you can ask "
             f"support. Detected Panic phrases: {self.panics}"
+        )
+
+
+class RootFsMountFailedException(LisaException):
+    """
+    This exception is used to indicate root filesystem mount failure.
+    """
+
+    def __init__(self, message: List[Any], source: str = "serial log") -> None:
+        self.message = message
+        self.source = source
+
+    def __str__(self) -> str:
+        return (
+            f"found root filesystem mount failure in {self.source}. Possible causes "
+            "include: missing or incorrect UUID, unsupported or corrupted filesystem, "
+            "or missing storage drivers. Please verify disk presence, UUID accuracy, "
+            f"and initramfs contents. Detected root filesystem issues: {self.message}"
         )
 
 
@@ -911,6 +938,18 @@ def check_panic(content: str, stage: str, log: "Logger") -> None:
 
     if panics:
         raise KernelPanicException(stage, panics)
+
+
+def check_rootfs_failure(content: str, log: "Logger") -> None:
+    """
+    Check if console log contains root filesystem mount failure message.
+    If found, raise RootFsMountFailedException.
+    """
+    log.debug("checking root filesystem mount failure...")
+    matched = find_patterns_in_lines(str(content), ROOTFS_FAILURE_PATTERNS)
+    all_matches = [item for sublist in matched for item in sublist]
+    if all_matches:
+        raise RootFsMountFailedException(all_matches)
 
 
 def to_bool(value: Union[str, bool, int]) -> bool:

--- a/microsoft/testsuites/core/storage.py
+++ b/microsoft/testsuites/core/storage.py
@@ -283,7 +283,9 @@ class Storage(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test verifies nvme disk controller type of the VM.
+        This test verifies nvme disk controller type of the VM. It requires NVMe
+        supported VM sizes such as DsV6, EsV6 series. If the image doesn't support NVMe
+        or the NVMe driver is not in initramfs, the VM might timeout to provision.
 
         Steps:
         1. Get the disk type of the boot partition.


### PR DESCRIPTION
Some images may not support NVMe due to the absence of the NVMe driver in the initramfs. This results in failure to find the root device, causing the VM provisioning timeout. This PR introduces a check to detect such failures and raises a corresponding exception, enabling us to triage provisioning timeouts caused by missing NVMe support.