### PR TITLE
Move to osDiskImage.source.storageAccountId for ACG security update

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2634,7 +2634,7 @@ def check_or_create_gallery_image_version(
                         "hostCaching": host_caching_type,
                         "source": {
                             "uri": vhd_path,
-                            "id": (
+                            "storageAccountId": (
                                 f"/subscriptions/{platform.subscription_id}/"
                                 f"resourceGroups/{vhd_resource_group_name}"
                                 "/providers/Microsoft.Storage/storageAccounts/"


### PR DESCRIPTION
This security update has the following description:
If you use blobs as source to create ACG Image versions:
1. If you're using the old property ‘[properties.storageProfile.[osDiskImage/dataDiskImages].source.Id] you should move to the property [properties.storageProfile.osDiskImage.source.storageAccountId]. This property requires minimum api-version 2022-03-03.
2. Ensure that the identity (users/service principal, etc.) creating the Image has the Storage Account Contributor or ‘Microsoft.Storage/storageAccounts/listKeys/action’.