### PR TITLE
Remove AzureNodeSchema.hyperv_generation

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -670,10 +670,6 @@ class AzureNodeSchema:
     community_gallery_image_raw: Optional[Union[Dict[Any, Any], str]] = field(
         default=None, metadata=field_metadata(data_key="community_gallery_image")
     )
-    hyperv_generation: int = field(
-        default=1,
-        metadata=field_metadata(validate=validate.OneOf([1, 2])),
-    )
     # for marketplace image, which need to accept terms
     _purchase_plan: InitVar[Optional[AzureVmPurchasePlanSchema]] = None
 
@@ -1077,6 +1073,7 @@ class AzureNodeSchema:
 @dataclass_json()
 @dataclass
 class AzureNodeArmParameter(AzureNodeSchema):
+    hyperv_generation: int = 2
     nic_count: int = 1
     enable_sriov: bool = False
     os_disk_type: str = ""

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2681,7 +2681,7 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
             # Return Skipped Exception if security profile is set on Gen 1 VM
             if node_parameters.security_profile["security_type"] == "":
                 node_parameters.security_profile.clear()
-            elif 1 == node_parameters.hyperv_generation:
+            elif node_parameters.image and 1 == node_parameters.image.hyperv_generation:
                 raise SkippedException(
                     f"{settings.security_profile} " "can only be set on gen2 image/vhd."
                 )

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1457,9 +1457,11 @@ class AzurePlatform(Platform):
 
         if azure_node_runbook.marketplace:
             # resolve "latest" to specified version
-            azure_node_runbook.marketplace = self._resolve_marketplace_image(
+            # _resolve_marketplace_image may return a cached result,
+            #   avoid overriding image properties by only setting the version
+            azure_node_runbook.marketplace.version = self._resolve_marketplace_image(
                 azure_node_runbook.location, azure_node_runbook.marketplace
-            )
+            ).version
             image_info = self.get_image_info(
                 azure_node_runbook.location, azure_node_runbook.marketplace
             )
@@ -2884,9 +2886,12 @@ class AzurePlatform(Platform):
         for req in nodes_requirement:
             node_runbook = req.get_extended_runbook(AzureNodeSchema, AZURE)
             if node_runbook.location and node_runbook.marketplace:
-                node_runbook.marketplace = self._resolve_marketplace_image(
+                # resolve "latest" to specified version
+                # _resolve_marketplace_image may return a cached result,
+                #   avoid overriding image properties by only setting the version
+                node_runbook.marketplace.version = self._resolve_marketplace_image(
                     node_runbook.location, node_runbook.marketplace
-                )
+                ).version
 
     def find_marketplace_image_location(self) -> List[str]:
         # locations used to query marketplace image information. Some image is not

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2949,6 +2949,12 @@ class AzurePlatform(Platform):
         if node_space.disk:
             self._set_disk_features(node_space, azure_runbook)
 
+        # Make sure the setter function is run on the updated image object,
+        # this syncs the object and the _raw field.
+        azure_runbook.image = image
+        # this syncs the _extended_runbook and the extended_schemas
+        node_space.set_extended_runbook(azure_runbook, AZURE)
+
     def _set_disk_features(
         self, node_space: schema.NodeSpace, azure_runbook: AzureNodeSchema
     ) -> None:

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -507,7 +507,7 @@ class AzurePlatform(Platform):
             features.SecurityProfile,
             features.ACC,
             features.IsolatedResource,
-            features.VhdGeneration,
+            features.HyperVGeneration,
             features.Architecture,
             features.Nfs,
             features.Availability,


### PR DESCRIPTION
There were three places where hyperv_generation were being tracked:
* VhdGeneration / HyperVGeneration (Feature)
* AzureNodeSchema (now removed)
* AzureImageSchema

It makes sense to treat the VM capability as a feature, and to put the image capability in the image schema. This makes the third hyperv_generation redundant.