### PR TITLE
ch_tests_tool: prefer logging by dmesg tool over custom logging

### DIFF
--- a/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -55,8 +55,7 @@ class CloudHypervisorTestSuite(TestSuite):
         log.debug(f"Journalctl Docker Logs: {docker_log}")
 
         dmesg = node.tools[Dmesg]
-        dmesg_log = dmesg.get_output(no_debug_log=True, force_run=True)
-        log.debug(f"Dmesg Logs: {dmesg_log}")
+        dmesg.get_output(force_run=True)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
The dmesg tool already logs the dmesg contents to the LISA output. There is no need for the additional log.debug() call.

Using the built-in logging ensures consistency across different places. The log prefix is helpful in the root log, especially when multiple environments output logs, as it helps differentiate between them.

Suggested by @squirrelsc in #3975.