### PR TITLE
add docker seccomp profile test

### DIFF
--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -66,20 +66,30 @@ class Docker(Tool):
     def run_container(
         self,
         image_name: str,
-        container_name: str,
+        ephemeral: bool = True,
+        container_name: Optional[str] = None,
         command: Optional[str] = None,
         extra_args: Optional[str] = None,
-        ephemeral: bool = True,
         expected_exit_code: Optional[int] = 0,
     ) -> ExecutableResult:
-        """Run a named container with optional extra arguments"""
+        """
+        Run a container using `docker run`
+
+        :param image_name: Name of the Docker image to run
+        :param ephemeral: Whether the container should be auto removed after exit.
+        :param container_name: Optional name for the container
+        :param command: Optional command to run inside the container
+        :param extra_args: Optional extra arguments to pass to the docker run command
+        :param expected_exit_code: Expected exit code for the docker run command
+        """
 
         parts = ["run"]
         if ephemeral:
             parts.append("--rm")
         if extra_args:
             parts.append(extra_args)
-        parts.append(f"--name {container_name}")
+        if container_name:
+            parts.append(f"--name {container_name}")
         parts.append(image_name)
         if command:
             parts.append(command)

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -47,7 +47,6 @@ class Docker(Tool):
         self.run(f"rm {container_name}", sudo=True, force_run=True)
 
     def pull_image(self, image: str, timeout: int = 600) -> None:
-        self._log.debug(f"Pulling Docker Image {image}")
         self.run(
             f"pull {image}",
             sudo=True,
@@ -68,25 +67,9 @@ class Docker(Tool):
         self,
         image_name: str,
         container_name: str,
-        docker_run_output: str,
-    ) -> None:
-        self.run(
-            f"run --name {container_name} {image_name} > {docker_run_output} 2>&1",
-            shell=True,
-            sudo=True,
-            cwd=self.node.working_path,
-            force_run=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message="Docker run failed.",
-        )
-
-    def run_container_v2(
-        self,
-        image_name: str,
-        container_name: str,
         command: Optional[str] = None,
         extra_args: Optional[str] = None,
-        ephemeral: bool = False,
+        ephemeral: bool = True,
         expected_exit_code: Optional[int] = 0,
     ) -> ExecutableResult:
         """Run a named container with optional extra arguments"""

--- a/microsoft/testsuites/docker/TestScripts/deny_chmod_seccomp.json
+++ b/microsoft/testsuites/docker/TestScripts/deny_chmod_seccomp.json
@@ -1,0 +1,9 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["chmod", "fchmod", "fchmodat"],
+      "action": "SCMP_ACT_ERRNO"
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces a new test, `verify_docker_seccomp_profile`, for the docker test suite to ensure seccomp profiles can be loaded and function correctly.

Note: I have added some new methods to the docker tools code, including a proposed update to the `run_container` method. If the new `run_container_v2` looks good, I can proceed to finalize and update the code to include only the new version.

Tested in local:
<img width="1650" height="311" alt="image" src="https://github.com/user-attachments/assets/9451da82-b20e-4779-bedf-68b0afa1e8f0" />
