### PR TITLE
Expand _get_kernel_version detection for latest Ubuntu versions

### DIFF
--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -300,9 +300,20 @@ class RepoInstaller(BaseInstaller):
         # linux-image-4.18.0-1025-azure/bionic-updates,bionic-security,now
         # 4.18.0-1025.27~18.04.1 amd64 [installed]
         # output 4.18.0-1025
+        # Ubuntu plucky example:
+        # Sorting... 0%
+        # Full Text Search... 50%
+        # linux-image-azure/plucky,now 6.14.0-1012.12 amd64 [installed,automatic]
+        # Linux kernel image for Azure systems (vmlinuz).
+        # linux-image-azure-6.14/plucky 6.14.0-1012.12 amd64
+        # Linux kernel image for Azure systems (vmlinuz).
+        # linux-image-azure-fde/plucky 6.14.0-1012.12 amd64
+        # Linux kernel image for Azure systems (kernel.efi).
+        # linux-image-azure-fde-6.14/plucky 6.14.0-1012.12 amd64
+        # Linux kernel image for Azure systems (kernel.efi).
         kernel_version_package_pattern = re.compile(
-            f"^{source}/[^ ]+ "  # noqa: E202
-            r"(?P<kernel_version>[^.]+\.[^.]+\.[^.-]+[.-][^.]+)\..*[\r\n]+",
+            f"[\r\n]+{source}/[^ ]+ "  # noqa: E202
+            r"(?P<kernel_version>[^.]+\.[^.]+\.[^.-]+[.-][^.]+)\..*installed.*[\r\n]+",
             re.M,
         )
         result = node.execute(f"apt search {source}", shell=True)

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -311,6 +311,9 @@ class RepoInstaller(BaseInstaller):
         # Linux kernel image for Azure systems (kernel.efi).
         # linux-image-azure-fde-6.14/plucky 6.14.0-1012.12 amd64
         # Linux kernel image for Azure systems (kernel.efi).
+        # Note that starting from Ubuntu 2404 \r is seen before the identified line.
+        # The \r is not recognized by ^ in Python.
+        # So [\r\n]+ is used instead of ^ to match the line.
         kernel_version_package_pattern = re.compile(
             f"[\r\n]+{source}/[^ ]+ "  # noqa: E202
             r"(?P<kernel_version>[^.]+\.[^.]+\.[^.-]+[.-][^.]+)\..*installed.*[\r\n]+",


### PR DESCRIPTION
Previous line endings are a bit different on older Ubuntu versions and recent ones.

Also extended pattern to select only installed kernel version.

Jammy:
\r\r\nlinux-image-azure/jammy-updates,jammy-security,jammy,now 6.8.0-1034.39~22.04.1 amd64 [installed,automatic]\r\n

Plucky:
\r\rlinux-image-azure/plucky,now 6.14.0-1012.12 amd64 [installed,automatic]\r\n