### PR TITLE
Fix verify_max_gpu_provision test to use dynamic GPU counts

### DIFF
--- a/microsoft/testsuites/gpu/gpusuite.py
+++ b/microsoft/testsuites/gpu/gpusuite.py
@@ -124,11 +124,20 @@ class GpuTestSuite(TestSuite):
         timeout=TIMEOUT,
         # min_gpu_count is 8 since it is current
         # max GPU count available in Azure
-        requirement=simple_requirement(min_gpu_count=8),
+        requirement=simple_requirement(min_gpu_count=2),
         priority=3,
     )
     def verify_max_gpu_provision(self, node: Node, log: Logger) -> None:
-        _gpu_provision_check(8, node, log)
+        actual_gpu_count = node.capability.gpu_count
+        if not isinstance(actual_gpu_count, int):
+            raise SkippedException("GPU count is not available")
+        # For "max" GPU test, we want to test with high GPU counts
+        if actual_gpu_count < 2:
+            raise SkippedException(
+                f"Test is for scenarios with more than 2 GPUs,  "
+                f" current Node only has {actual_gpu_count} GPUs."
+            )
+        _gpu_provision_check(actual_gpu_count, node, log)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Updates to the `verify_max_gpu_provision` test to dynamically validate GPU count based on actual node capabilities instead of hardcoding it to 8 GPUs. This fixes test failures for VMs with less than 8 GPUs and cases where container policies don't provide the required information.

- Changed test to dynamically use `node.capability.gpu_count` 
- Minimum requirement reduced from 8 to 2 GPUs to test "multiple GPU" scenarios
- Test now adapts to actual hardware capabilities rather than fixed assumptions