### PR TITLE
dpdk: force recent stable default source on mana

### DIFF
--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -118,12 +118,17 @@ class DpdkTestResources:
 
 
 def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
+    # if mana is present, force a source build of 24.11
+    # if no other source was provided.
+    if node.nics.is_mana_device_present():
+        variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
+        variables["dpdk_branch"] = variables.get("dpdk_branch", "v24.11")
     # DPDK packages 17.11 which is EOL and doesn't have the
     # net_vdev_netvsc pmd used for simple handling of hyper-v
     # guests. Force stable source build on this platform.
     # Default to 20.11 unless another version is provided by the
     # user. 20.11 is the latest dpdk version for 18.04.
-    if isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
+    elif isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
         variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
 


### PR DESCRIPTION
MANA is new and using the package manager turns out to be less reliable than just building an LKG version of DPDK and rdma-core.

This change forces a default source build for that hardware. This will help stabilize issues where tests need to install then re-install dpdk from both apt and source on mana, as well.