### PR TITLE
[dpdk] l3fwd test fixes and rescind test

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 
+import ipaddress
 import os
 import re
 from collections import OrderedDict
@@ -250,6 +251,17 @@ class Nics(InitializableMixin):
                 f"Had network interfaces: {self.get_nic_names()}"
             )
         return nic
+
+    def get_nic_by_subnet(self, subnet: str) -> NicInfo:
+        network = ipaddress.ip_network(subnet)
+        for nic in self.nics.values():
+            ip_addr = ipaddress.ip_address(nic.ip_addr)
+            if ip_addr in network:
+                self._node.log.debug(
+                    f"Found matching nic for subnet {subnet}: {str(nic)}"
+                )
+                return nic
+        raise LisaException(f"Could not find a nic for requested subnet: {subnet}")
 
     def unbind(self, nic: NicInfo) -> None:
         # unbind nic from current driver and return the old sysfs path

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -251,11 +251,18 @@ class Nics(InitializableMixin):
                 f"Had network interfaces: {self.get_nic_names()}"
             )
         return nic
-
+    # find nic by subnet address.
+    # ie: find me the nic for '10.0.1.0/24'
+    #     will return the nic with an address in that subnet
+    # see:
+    # https://docs.python.org/3/library/ipaddress.html#networks-as-containers-of-addresses
     def get_nic_by_subnet(self, subnet: str) -> NicInfo:
+        # parses the subnet and mask string ex '10.0.1.0/24'
         network = ipaddress.ip_network(subnet)
         for nic in self.nics.values():
+            # parse the ip address str for comparison
             ip_addr = ipaddress.ip_address(nic.ip_addr)
+            # if the ip address resides within the subnet
             if ip_addr in network:
                 self._node.log.debug(
                     f"Found matching nic for subnet {subnet}: {str(nic)}"

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -251,6 +251,7 @@ class Nics(InitializableMixin):
                 f"Had network interfaces: {self.get_nic_names()}"
             )
         return nic
+
     # find nic by subnet address.
     # ie: find me the nic for '10.0.1.0/24'
     #     will return the nic with an address in that subnet

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1176,11 +1176,8 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         # Step 4: once we find the matching subnet, assign the routing table to it.
         if subnet_az.address_prefix is not None:
             az_subnet = subnet_az.address_prefix
-        elif (
-            subnet_az.address_prefix is None
-            and subnet_az.address_prefixes
-        ):
-            az_subnet=""
+        elif subnet_az.address_prefix is None and subnet_az.address_prefixes:
+            az_subnet = ""
             # check subnet address prefixes if there are more than one
             for subnet in subnet_az.address_prefixes:
                 self._log.debug(f"Checking address prefixes: {subnet} == {subnet_mask}")
@@ -1190,15 +1187,18 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             if not az_subnet:
                 self._node.log.debug(
                     "Warning: could not find subnet to update in vnet "
-                    f"{virtual_network_name} skipping updates. Checked subnet prefixes: "
-                    + " ".join(subnet_az.address_prefixes)
+                    f"{virtual_network_name} skipping updates. "
+                    "Checked subnet prefixes: " + " ".join(subnet_az.address_prefixes)
                 )
                 return False
         else:
             # this is a weird situation where a virtual network has no subnets.
             # warn and return. It's unexpected, but we check every vnet in the RG.
-            self._node.log.debug(f"Warning: found a virtual network {virtual_network_name}"
-                                 " with no subnets.")
+            self._node.log.debug(
+                "Warning: found a virtual network "
+                f"{virtual_network_name}"
+                " with no subnets."
+            )
             return False
         self._log.debug(f"Checking subnet: {az_subnet} == {subnet_mask}")
         if az_subnet == subnet_mask:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1173,7 +1173,6 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             virtual_network_name=virtual_network_name,
             subnet_name=subnet_name,
         )
-        
         # Check the subnet address prefixes to find the desired subnet
         # must handle the case where there is a single address prefix
         # or an array of prefixes. These use distinct property names for some reason
@@ -1181,7 +1180,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             # single prefix is easy, save for later
             az_subnet = subnet_az.address_prefix
         # otherwise, check the prefixes in the array if it exists.
-        elif subnet_az.address_prefix is None and subnet_az.address_prefixes:            
+        elif subnet_az.address_prefix is None and subnet_az.address_prefixes:
             az_subnet = ""
             # check subnet address prefixes if there are more than one
             for subnet in subnet_az.address_prefixes:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1189,8 +1189,8 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             # if we could not find any, warn and return.
             if not az_subnet:
                 self._node.log.debug(
-                    f"Warning: could not find subnet to update in vnet {virtual_network_name},"
-                    " skipping updates. Checked subnet prefixes: "
+                    "Warning: could not find subnet to update in vnet "
+                    f"{virtual_network_name} skipping updates. Checked subnet prefixes: "
                     + " ".join(subnet_az.address_prefixes)
                 )
                 return False

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1189,7 +1189,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     az_subnet = subnet
             # if we could not find any, warn and return.
             if not az_subnet:
-                self._node.log.debug(
+                self._log.debug(
                     "Warning: could not find subnet to update in vnet "
                     f"{virtual_network_name} skipping updates. "
                     "Checked subnet prefixes: " + " ".join(subnet_az.address_prefixes)
@@ -1200,7 +1200,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         # so it's possible there's just another one that contains the subnet we want.
         # so just warn and return to the higher function to keep checking.
         else:
-            self._node.log.debug(
+            self._log.debug(
                 "Warning: found a virtual network "
                 f"{virtual_network_name}"
                 " with no subnets."

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -390,6 +390,12 @@ class Ip(Tool):
         return matched["ip_addr"]
 
     def get_subnet_address(self, nic_name: str) -> str:
+        """
+        Get the subnet address of a nic from 'ip'.
+        Note these are not always strict subnet addresses, 
+        they usually include the host bits within the subnet mask.
+        ex: '10.0.1.4/24'
+        """
         result = self.run(f"addr show {nic_name}", force_run=True, sudo=True)
         matched = self._get_matched_dict(result.stdout)
         assert "ip_addr" in matched, f"not find ip address for nic {nic_name}"

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -392,7 +392,7 @@ class Ip(Tool):
     def get_subnet_address(self, nic_name: str) -> str:
         """
         Get the subnet address of a nic from 'ip'.
-        Note these are not always strict subnet addresses, 
+        Note these are not always strict subnet addresses,
         they usually include the host bits within the subnet mask.
         ex: '10.0.1.4/24'
         """

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 from __future__ import annotations
 
+import ipaddress
 import re
 from typing import Dict, List, Optional, Type, cast
 
@@ -68,7 +69,7 @@ class Ip(Tool):
         (
             r"\d+: (?P<name>\w+): \<.+\> .+\n\s+link\/(?:ether|infiniband|loopback)"
             r" (?P<mac>[0-9a-z:]+)( .+\n(?:(?:.+\n\s+|.*)altname \w+))?"
-            r"(.*(?:\s+inet (?P<ip_addr>[\d.]+)\/.*\n))?"
+            r"(.*(?:\s+inet (?P<ip_addr>[\d.]+)\/(?P<subnet_mask>\d+).*\n))?"
         )
     )
     # capturing from ip route show
@@ -167,6 +168,7 @@ class Ip(Tool):
             "name": matched.group("name"),
             "mac": matched.group("mac"),
             "ip_addr": matched.group("ip_addr"),
+            "subnet_mask": matched.group("subnet_mask"),
         }
 
     def is_device_up(self, nic_name: str) -> bool:
@@ -387,6 +389,14 @@ class Ip(Tool):
         assert "ip_addr" in matched, f"not find ip address for nic {nic_name}"
         return matched["ip_addr"]
 
+    def get_subnet_address(self, nic_name: str) -> str:
+        result = self.run(f"addr show {nic_name}", force_run=True, sudo=True)
+        matched = self._get_matched_dict(result.stdout)
+        assert "ip_addr" in matched, f"not find ip address for nic {nic_name}"
+        assert "subnet_mask" in matched, f"not find subnet_mask for nic {nic_name}"
+
+        return matched["ip_addr"] + "/" + matched["subnet_mask"]
+
     def get_default_route_info(self) -> tuple[str, str]:
         result = self.run("route", force_run=True, sudo=True)
         result.assert_exit_code()
@@ -427,8 +437,13 @@ class Ip(Tool):
             ),
         ).stdout.splitlines()
         delete_routes = []
+        subnet_addr = self.get_subnet_address(device)
+        # parse non-strict subnet address returned by ip addr
+        # to get the parent subnet
+        subnet = ipaddress.ip_network(subnet_addr, strict=False)
+
         for route in all_routes:
-            if f"dev {device}" in route:
+            if f"dev {device}" in route or str(subnet) in route:
                 delete_routes.append(route)
         if len(delete_routes) == 0:
             self._log.warn(

--- a/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/microsoft/testsuites/dpdk/dpdksuite.py
@@ -921,6 +921,47 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
+        description=(
+            """
+                Run the L3 forwarding test for DPDK.
+                This test creates a DPDK port forwarding setup between
+                two NICs on the same VM. It forwards packets from a sender on
+                subnet_a to a receiver on subnet_b. Without l3fwd,
+                packets will not be able to jump the subnets.  This imitates
+                a network virtual appliance setup, firewall, or other data plane
+                tool for managing network traffic with DPDK.
+        """
+        ),
+        priority=3,
+        requirement=simple_requirement(
+            supported_os=[Ubuntu],
+            min_core_count=8,
+            min_count=3,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+    )
+    def verify_dpdk_l3fwd_ntttcp_tcp_hotplug(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        force_dpdk_default_source(variables)
+        pmd = "netvsc"
+        verify_dpdk_l3fwd_ntttcp_tcp(
+            environment,
+            log,
+            variables,
+            HugePageSize.HUGE_2MB,
+            pmd=pmd,
+            result=result,
+            rescind_sriov=True,
+        )
+
+    @TestCaseMetadata(
         description="""
                 Run the l3fwd test using GiB hugepages.
                 This test creates a DPDK port forwarding setup between

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -489,7 +489,7 @@ def start_testpmd_concurrent(
         output[result[0]] = result[1]
 
     def _run_command_with_testkit(
-        run_kit: Tuple[DpdkTestResources, str]
+        run_kit: Tuple[DpdkTestResources, str],
     ) -> Tuple[DpdkTestResources, str]:
         testkit, cmd = run_kit
         return (testkit, testkit.testpmd.run_for_n_seconds(cmd, seconds))
@@ -867,7 +867,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         for node in environment.nodes.list()
         if node.nics.get_primary_nic().ip_addr.endswith("6")
     ][0]
-    
+
     if not (
         forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.X64
         and isinstance(forwarder.os, Ubuntu)

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -816,17 +816,9 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     result: Optional[TestResult] = None,
     rescind_sriov: bool = False,
 ) -> None:
-    
     # This is currently the most complicated DPDK test. There is a lot that can
     # go wrong, so we restrict the test to netvsc and only a few distros.
     # Current usage is checking for regressions in the host, not validating all distros.
-    # with this in mind, restrict this test to newer ubuntu
-    if not (
-        forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.X64
-        and isinstance(forwarder.os, Ubuntu)
-        and forwarder.os.information.version >= "22.4.0"
-    ):
-        raise SkippedException("l3fwd test not compatible, use X64 Ubuntu >= 22.04")
     #
     # SUMMARY:
     #  The test attempts to change this initial default LISA setup:
@@ -844,6 +836,11 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     #  With the goal of guaranteeing that snv_VM cannot reach
     #  rcv_VM on Subnet B/C without traffic being forwarded through
     #  DPDK on  fwd_VM
+    #
+    #  There are a fetch catches; one must enable ip forwarding at the azure
+    #  network level and also set up a similar virutal network routing setup.
+    #  You must have a matching topology from the guest and cloud perspectives
+    #  or traffic will be dropped at the mismatched layer.
     #
     # Our key objectives are:
     # 1. intercepting traffic from  snd_nic_a bound for rcv_nic_b,
@@ -871,7 +868,12 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         if node.nics.get_primary_nic().ip_addr.endswith("6")
     ][0]
     
-
+    if not (
+        forwarder.tools[Lscpu].get_architecture() == CpuArchitecture.X64
+        and isinstance(forwarder.os, Ubuntu)
+        and forwarder.os.information.version >= "22.4.0"
+    ):
+        raise SkippedException("l3fwd test not compatible, use X64 Ubuntu >= 22.04")
 
     # get core count, quick skip if size is too small.
     available_threads = forwarder.tools[Lscpu].get_thread_count()


### PR DESCRIPTION
- Adds a set of node.nic and Ip tool to get addresses and interfaces by subnet address; device names and ordering are not stable enough.
- Handles an unexpected condition in NetworkInterface azure functions for routing tables and subnets to handle when address_prefix is a list like object instead of an array.
- Adds a rescind version of the l3fwd test