### PR TITLE
update AITL default to 2025 version

### DIFF
--- a/microsoft/utils/aitl/aitl.py
+++ b/microsoft/utils/aitl/aitl.py
@@ -18,7 +18,7 @@ from typing import Any
 
 _fmt = "%(asctime)s.%(msecs)03d[%(thread)d][%(levelname)s] %(name)s %(message)s"
 _datefmt = "%Y-%m-%d %H:%M:%S"
-_api_version = "2023-08-01-preview"
+_api_version = "2025-04-01-preview"
 
 
 def _generate_example(resource_type: str = "job") -> str:


### PR DESCRIPTION
Update aitl python wrapper to use 2025-04-01-preview version as default value.