### PR TITLE
Parallel: Support queue in TaskManager

### DIFF
--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -62,9 +62,11 @@ class RunnerTestCase(TestCase):
 
     def setUp(self) -> None:
         lisa.environment._global_environment_id = 0
+        start_test_result_message_processing()
 
     def tearDown(self) -> None:
         test_testsuite.cleanup_cases_metadata()  # Necessary side effects!
+        wait_for_test_result_messages()
 
     def test_merge_req_create_on_new(self) -> None:
         # if no predefined envs, can generate from requirement
@@ -743,8 +745,6 @@ class RunnerTestCase(TestCase):
     def _run_all_tests(self, runner: LisaRunner) -> List[TestResultMessage]:
         results_collector = RunnerResult(schema.Notifier())
         register_notifier(results_collector)
-
-        start_test_result_message_processing()
 
         try:
             runner.initialize()

--- a/selftests/test_testsuite.py
+++ b/selftests/test_testsuite.py
@@ -23,6 +23,8 @@ from lisa.testsuite import (
     get_suites_metadata,
     node_requirement,
     simple_requirement,
+    start_test_result_message_processing,
+    wait_for_test_result_messages,
 )
 from lisa.util.logger import Logger
 from selftests.test_environment import generate_runbook
@@ -171,6 +173,10 @@ class TestSuiteTestCase(TestCase):
 
     def setUp(self) -> None:
         cleanup_cases_metadata()
+        start_test_result_message_processing()
+
+    def tearDown(self) -> None:
+        wait_for_test_result_messages()
 
     def test_expanded_nodespace(self) -> None:
         cases = generate_cases_metadata()


### PR DESCRIPTION
This change implements queue for TaskManager and
use it in test results queuing.

- Replace thread-based test message processing with TaskManager in testsuite.py
- Enhance TaskManager with pending task queue and improved worker management
- Add proper task queuing mechanism to handle test result messages in order