### PR TITLE
Small testcase improvements

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -68,7 +68,6 @@ class Wget(Tool):
         download_pure_path = self.node.get_pure_path(download_path)
         if overwrite and self.node.shell.exists(download_pure_path):
             self.node.shell.remove(download_pure_path, recursive=True)
-            force_run = True
         command = f"'{url}' --no-check-certificate"
         if filename:
             command = f"{command} -O {download_path}"
@@ -82,7 +81,7 @@ class Wget(Tool):
             no_error_log=True,
             shell=True,
             sudo=sudo,
-            force_run=force_run,
+            force_run=True,
             timeout=timeout,
         )
 

--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -405,6 +405,8 @@ class Infiniband(Feature):
                 raise UnsupportedDistroException(
                     node.os, f"{mlnx_ofed_download_url} doesn't exist."
                 )
+            else:
+                raise
         tar = node.tools[Tar]
         tar.extract(
             file=f"{self.resource_disk_path}/{tarball_name}",


### PR DESCRIPTION
This pull request improves error handling and debugging information in the `verify_irqbalance` test and the `install_ofed` method. The main focus is to make failures easier to diagnose by capturing and surfacing more detailed error messages when issues occur during package checks or network traffic generation.

Key improvements:

**Enhanced error handling and logging in `verify_irqbalance`:**

* Wrapped the `iperf3` client run in a try/except block to catch `AssertionError`. This prevents failures from iperf3 exiting with an error code even though it ran fine. The iperf3 exit code is not important if we see the IRQ rebalance occurring.

**Improved exception propagation in `install_ofed`:**

* Changed the logic to re-raise the caught exception if the Mellanox OFED download URL exists but another error occurs, ensuring that unexpected issues are not silently ignored.
* Always run wget with force-run to prevent pulling a cached result unexpectedly.