### PR TITLE
add test case support for ipv6, add test case for ipv6

### DIFF
--- a/lisa/features/network_interface.py
+++ b/lisa/features/network_interface.py
@@ -70,3 +70,13 @@ Sriov = partial(NetworkInterfaceOptionSettings, data_path=schema.NetworkDataPath
 Synthetic = partial(
     NetworkInterfaceOptionSettings, data_path=schema.NetworkDataPath.Synthetic
 )
+SriovIpv6Internal = partial(
+    NetworkInterfaceOptionSettings,
+    data_path=schema.NetworkDataPath.Sriov,
+    ip_version=schema.IpProtocol.ipv6,
+)
+SyntheticIpv6Internal = partial(
+    NetworkInterfaceOptionSettings,
+    data_path=schema.NetworkDataPath.Synthetic,
+    ip_version=schema.IpProtocol.ipv6,
+)

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -709,6 +709,11 @@ class NetworkDataPath(str, Enum):
     Sriov = "Sriov"
 
 
+class IpProtocol(str, Enum):
+    ipv4 = "IPv4"
+    ipv6 = "IPv6"
+
+
 _network_data_path_priority: List[NetworkDataPath] = [
     NetworkDataPath.Sriov,
     NetworkDataPath.Synthetic,
@@ -751,6 +756,21 @@ class NetworkInterfaceOptionSettings(FeatureSettings):
         default_factory=partial(search_space.IntRange, min=1),
         metadata=field_metadata(
             allow_none=True, decoder=search_space.decode_count_space
+        ),
+    )
+    ip_version: Optional[Union[search_space.SetSpace[IpProtocol], IpProtocol]] = field(
+        default_factory=partial(
+            search_space.SetSpace,
+            items=[IpProtocol.ipv4, IpProtocol.ipv6],
+        ),
+        metadata=field_metadata(
+            decoder=partial(
+                search_space.decode_nullable_set_space,
+                base_type=IpProtocol,
+                default_values=[IpProtocol.ipv4, IpProtocol.ipv6],
+            ),
+            required=False,
+            allow_none=True,
         ),
     )
 

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1314,7 +1314,6 @@ class RemoteNode(Node):
     username: str = constants.DEFAULT_USER_NAME
     password: str = ""
     private_key_file: str = ""
-    use_ipv6: bool = False
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         add_secret(self.username, PATTERN_HEADTAIL)

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "16291477761159155605"
+      "templateHash": "7375950074177020167"
     }
   },
   "functions": [
@@ -522,7 +522,21 @@
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "whether to use ipv6"
+        "description": "whether to use ipv6 (legacy parameter for backward compatibility)"
+      }
+    },
+    "use_ipv6_public": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "whether to use ipv6 for public IP addresses"
+      }
+    },
+    "use_ipv6_internal": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "whether to use ipv6 for internal IP addresses"
       }
     },
     "enable_vm_nat": {
@@ -585,7 +599,7 @@
             "input": {
               "name": "[format('{0}{1}', parameters('subnet_prefix'), range(0, parameters('subnet_count'))[copyIndex('subnets')])]",
               "properties": {
-                "addressPrefixes": "[concat(createArray(format('10.0.{0}.0/24', range(0, parameters('subnet_count'))[copyIndex('subnets')])), if(parameters('use_ipv6'), createArray(format('2001:db8:{0}::/64', range(0, parameters('subnet_count'))[copyIndex('subnets')])), createArray()))]",
+                "addressPrefixes": "[concat(createArray(format('10.0.{0}.0/24', range(0, parameters('subnet_count'))[copyIndex('subnets')])), if(or(parameters('use_ipv6'), parameters('use_ipv6_internal')), createArray(format('2001:db8:{0}::/64', range(0, parameters('subnet_count'))[copyIndex('subnets')])), createArray()))]",
                 "defaultOutboundAccess": "[parameters('enable_vm_nat')]",
                 "networkSecurityGroup": {
                   "id": "[resourceId('Microsoft.Network/networkSecurityGroups', format('{0}-nsg', toLower(parameters('virtual_network_name'))))]"
@@ -595,7 +609,7 @@
           }
         ],
         "addressSpace": {
-          "addressPrefixes": "[concat(createArray('10.0.0.0/16'), if(parameters('use_ipv6'), createArray('2001:db8::/32'), createArray()))]"
+          "addressPrefixes": "[concat(createArray('10.0.0.0/16'), if(or(parameters('use_ipv6'), parameters('use_ipv6_internal')), createArray('2001:db8::/32'), createArray()))]"
         }
       },
       "dependsOn": [
@@ -690,7 +704,7 @@
         "name": "nodes_public_ip_ipv6",
         "count": "[length(range(0, variables('node_count')))]"
       },
-      "condition": "[and(parameters('use_ipv6'), parameters('create_public_address'))]",
+      "condition": "[and(or(parameters('use_ipv6'), parameters('use_ipv6_public')), parameters('create_public_address'))]",
       "type": "Microsoft.Network/publicIPAddresses",
       "apiVersion": "2020-05-01",
       "name": "[format('{0}-public-ipv6', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
@@ -887,6 +901,12 @@
           "use_ipv6": {
             "value": "[parameters('use_ipv6')]"
           },
+          "use_ipv6_public": {
+            "value": "[parameters('use_ipv6_public')]"
+          },
+          "use_ipv6_internal": {
+            "value": "[parameters('use_ipv6_internal')]"
+          },
           "create_public_address": {
             "value": "[parameters('create_public_address')]"
           }
@@ -899,7 +919,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "17932923534203698710"
+              "templateHash": "797006272337831175"
             }
           },
           "functions": [
@@ -955,6 +975,12 @@
             "use_ipv6": {
               "type": "bool"
             },
+            "use_ipv6_public": {
+              "type": "bool"
+            },
+            "use_ipv6_internal": {
+              "type": "bool"
+            },
             "create_public_address": {
               "type": "bool"
             }
@@ -975,7 +1001,7 @@
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
               "properties": {
-                "ipConfigurations": "[concat(createArray(createObject('name', 'IPv4Config', 'properties', createObject('privateIPAddressVersion', 'IPv4', 'publicIPAddress', if(and(equals(0, range(0, parameters('nic_count'))[copyIndex()]), parameters('create_public_address')), variables('publicIpAddress'), null()), 'subnet', createObject('id', if(not(empty(parameters('existing_subnet_ref'))), parameters('existing_subnet_ref'), format('{0}/subnets/{1}{2}', parameters('vnet_id'), parameters('subnet_prefix'), range(0, parameters('nic_count'))[copyIndex()]))), 'privateIPAllocationMethod', 'Dynamic'))), if(parameters('use_ipv6'), createArray(createObject('name', 'IPv6Config', 'properties', createObject('privateIPAddressVersion', 'IPv6', 'publicIPAddress', if(and(equals(0, range(0, parameters('nic_count'))[copyIndex()]), parameters('create_public_address')), variables('publicIpAddressV6'), null()), 'subnet', createObject('id', if(not(empty(parameters('existing_subnet_ref'))), parameters('existing_subnet_ref'), format('{0}/subnets/{1}{2}', parameters('vnet_id'), parameters('subnet_prefix'), range(0, parameters('nic_count'))[copyIndex()]))), 'privateIPAllocationMethod', 'Dynamic'))), createArray()))]",
+                "ipConfigurations": "[concat(createArray(createObject('name', 'IPv4Config', 'properties', createObject('privateIPAddressVersion', 'IPv4', 'publicIPAddress', if(and(equals(0, range(0, parameters('nic_count'))[copyIndex()]), parameters('create_public_address')), variables('publicIpAddress'), null()), 'subnet', createObject('id', if(not(empty(parameters('existing_subnet_ref'))), parameters('existing_subnet_ref'), format('{0}/subnets/{1}{2}', parameters('vnet_id'), parameters('subnet_prefix'), range(0, parameters('nic_count'))[copyIndex()]))), 'privateIPAllocationMethod', 'Dynamic'))), if(or(parameters('use_ipv6'), parameters('use_ipv6_internal')), createArray(createObject('name', 'IPv6Config', 'properties', createObject('privateIPAddressVersion', 'IPv6', 'publicIPAddress', if(and(and(equals(0, range(0, parameters('nic_count'))[copyIndex()]), parameters('create_public_address')), or(parameters('use_ipv6'), parameters('use_ipv6_public'))), variables('publicIpAddressV6'), null()), 'subnet', createObject('id', if(not(empty(parameters('existing_subnet_ref'))), parameters('existing_subnet_ref'), format('{0}/subnets/{1}{2}', parameters('vnet_id'), parameters('subnet_prefix'), range(0, parameters('nic_count'))[copyIndex()]))), 'privateIPAllocationMethod', 'Dynamic'))), createArray()))]",
                 "enableAcceleratedNetworking": "[parameters('enable_sriov')]"
               }
             }

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1126,11 +1126,6 @@ class DiskPlacementType(str, Enum):
     NVME = "NvmeDisk"
 
 
-class IpProtocol(str, Enum):
-    ipv4 = "IPv4"
-    ipv6 = "IPv6"
-
-
 def get_disk_placement_priority() -> List[DiskPlacementType]:
     return [
         DiskPlacementType.NVME,
@@ -1214,6 +1209,8 @@ class AzureArmParameter:
     subnet_prefix: str = AZURE_SUBNET_PREFIX
     is_ultradisk: bool = False
     use_ipv6: bool = False
+    use_ipv6_public: bool = False
+    use_ipv6_internal: bool = False
     enable_vm_nat: bool = False
     create_public_address: bool = True
     source_address_prefixes: List[str] = field(default_factory=list)
@@ -2274,7 +2271,10 @@ def get_primary_ip_addresses(
                 nic_index = 1
 
             ip_config = nic.ip_configurations[nic_index]
-            if use_ipv6 and ip_config.private_ip_address_version != IpProtocol.ipv6:
+            if (
+                use_ipv6
+                and ip_config.private_ip_address_version != schema.IpProtocol.ipv6
+            ):
                 raise LisaException(f"private address is not IPv6 in nic {nic.name}")
             private_ip = ip_config.private_ip_address
 
@@ -2291,7 +2291,8 @@ def get_primary_ip_addresses(
                 )
                 if (
                     use_ipv6
-                    and public_ip_address.public_ip_address_version != IpProtocol.ipv6
+                    and public_ip_address.public_ip_address_version
+                    != schema.IpProtocol.ipv6
                 ):
                     raise LisaException(f"public address is not IPv6 in nic {nic.name}")
 

--- a/lisa/sut_orchestrator/azure/nested_nodes_nics.bicep
+++ b/lisa/sut_orchestrator/azure/nested_nodes_nics.bicep
@@ -7,6 +7,8 @@ param existing_subnet_ref string
 param enable_sriov bool
 param tags object
 param use_ipv6 bool
+param use_ipv6_public bool = false
+param use_ipv6_internal bool = false
 param create_public_address bool
 
 func getPublicIpAddress(vmName string, publicIpName string) object => {
@@ -35,12 +37,12 @@ resource vm_nics 'Microsoft.Network/networkInterfaces@2023-06-01' = [for i in ra
           }
         }
       ],
-      use_ipv6 ? [
+      (use_ipv6 || use_ipv6_internal) ? [
         {
           name: 'IPv6Config'
           properties: {
             privateIPAddressVersion: 'IPv6'
-            publicIPAddress: ((0 == i && create_public_address) ? publicIpAddressV6 : null)
+            publicIPAddress: ((0 == i && create_public_address && (use_ipv6 || use_ipv6_public)) ? publicIpAddressV6 : null)
             subnet: {
               id: ((!empty(existing_subnet_ref)) ? existing_subnet_ref : '${vnet_id}/subnets/${subnet_prefix}${i}')
             }

--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import ipaddress
 import re
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, cast
@@ -134,8 +135,11 @@ class Lagscope(Tool, KillableMixin):
     def run_as_server_async(self, ip: str = "") -> Process:
         # -r: run as a receiver
         # -rip: run as server mode with specified ip address
+        # -6: use IPv6
         cmd = ""
         if ip:
+            if ipaddress.ip_address(ip).version == 6:
+                cmd += " -6 "
             cmd += f" -r{ip}"
         else:
             cmd += " -r"
@@ -171,7 +175,11 @@ class Lagscope(Tool, KillableMixin):
         # -c: count of histogram intervals
         # -R: dumps raw latencies into csv file
         # -D: run as daemon
-        cmd = f"{self.command} -s{server_ip} "
+        # -6: use IPv6
+        cmd = f"{self.command}"
+        if ipaddress.ip_address(server_ip).version == 6:
+            cmd += " -6 "
+        cmd += f" -s{server_ip} "
         if run_time_seconds:
             cmd += f" -t{run_time_seconds} "
         if count_of_histogram_intervals:

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import ipaddress
 import re
 import time
 from decimal import Decimal
@@ -216,6 +217,8 @@ class Ntttcp(Tool):
     ) -> Process:
         cmd = ""
         if server_ip:
+            if ipaddress.ip_address(server_ip).version == 6:
+                cmd += " -6 "
             cmd += f" -r{server_ip} "
         cmd += (
             f" -P {ports_count} -t {run_time_seconds} -W {warm_up_time_seconds} "
@@ -326,7 +329,10 @@ class Ntttcp(Tool):
         # the devices specified by the differentiator
         # Examples for differentiator: Hyper-V PCIe MSI, mlx4, Hypervisor callback
         # interrupts
-        cmd = (
+        cmd = ""
+        if ipaddress.ip_address(server_ip).version == 6:
+            cmd += " -6 "
+        cmd += (
             f" -s{server_ip} -P {ports_count} -n {threads_count} -t {run_time_seconds} "
             f"-W {warm_up_time_seconds} -C {cool_down_time_seconds} -b {buffer_size}k "
             f"--show-nic-packets {nic_name} "
@@ -779,7 +785,10 @@ class BSDNtttcp(Ntttcp):
         )
 
         # Setup command
-        cmd = (
+        cmd = ""
+        if ipaddress.ip_address(server_ip).version == 6:
+            cmd += " -6 "
+        cmd += (
             f" -r{server_ip} -P {ports_count} -t {run_time_seconds} -b {buffer_size}k "
         )
         if run_as_daemon:
@@ -815,7 +824,10 @@ class BSDNtttcp(Ntttcp):
             "Paramers nic_name, cool_down_time_seconds, warm_up_time_seconds, "
             "use_epoll and dev_differentiator are not supported in FreeBSD"
         )
-        cmd = (
+        cmd = ""
+        if ipaddress.ip_address(server_ip).version == 6:
+            cmd += " -6 "
+        cmd += (
             f" -s{server_ip} -P {ports_count} -n {threads_count}"
             f" -t {run_time_seconds} -b {buffer_size}k "
         )


### PR DESCRIPTION
1. Split use_ipv6 to use_ipv6_internal and use_ipv6_public
2. Remove dead code for use_ipv6
3. Add test case for ipv6 basic test
4. Add support for ipv6 for tools like ntttcp, lagscope, Ip


Rewrite code based on #3957 