### PR TITLE
Fix: marketplace_raw does not get resolved image name

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2892,6 +2892,8 @@ class AzurePlatform(Platform):
                 node_runbook.marketplace.version = self._resolve_marketplace_image(
                     node_runbook.location, node_runbook.marketplace
                 ).version
+                # update raw values to reflect the resolved version
+                node_runbook.update_raw()
 
     def find_marketplace_image_location(self) -> List[str]:
         # locations used to query marketplace image information. Some image is not


### PR DESCRIPTION
Fix the bug which causes marketplace_raw to not get resolved image name. This causes the marketplace image test results to have "latest" in its image name.

This regression is due to https://github.com/microsoft/lisa/pull/3990/files#diff-23cef282c9cdd9bba151475396f0470d0775ad931d6f4f40a1c63f5f6165393dR1459-R1466

The change from `node_runbook.marketplace =` to `node_runbook.marketplace.version =` does NOT trigger the marketplace.setter

@marketplace.setter
def marketplace(self, value: Optional[AzureVmMarketplaceSchema]) -> None:
    self._parse_image_raw("marketplace", value)