### PR TITLE
Add case to verify provision with swiotlb=force

### DIFF
--- a/lisa/tools/grub_config.py
+++ b/lisa/tools/grub_config.py
@@ -5,8 +5,7 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Debian
-from lisa.tools import Sed
+from lisa.operating_system import CBLMariner, Debian, Redhat
 from lisa.util import LisaException, UnsupportedDistroException
 
 if TYPE_CHECKING:
@@ -27,11 +26,13 @@ class GrubConfig(Tool):
                 return GrubConfigAzl3(node, args, kwargs)
         elif isinstance(node.os, Debian):
             return GrubConfigDebian(node, args, kwargs)
+        elif isinstance(node.os, Redhat):
+            return GrubConfigRedhat(node, args, kwargs)
 
         raise UnsupportedDistroException(
             os=node.os,
-            message="Grub tool only supported on CBLMariner 2.0/3.0 and "
-            "Debian-based distributions.",
+            message="Grub tool only supported on CBLMariner 2.0/3.0, "
+            "Debian-based distributions, and RHEL-based distributions.",
         )
 
     def __init__(
@@ -61,6 +62,8 @@ class GrubConfig(Tool):
         return self._check_exists()
 
     def _remove_existing_arg(self, arg: str, grub_file: str, line_regex: str) -> None:
+        from lisa.tools import Sed
+
         self.node.tools[Sed].delete_line_substring(
             match_line=line_regex,
             regex_to_delete=(r"\s" + arg + r"[^\"[:space:]]*"),
@@ -71,6 +74,8 @@ class GrubConfig(Tool):
     def _add_new_arg(
         self, arg: str, value: str, grub_file: str, line_regex: str
     ) -> None:
+        from lisa.tools import Sed
+
         self.node.tools[Sed].substitute(
             match_lines=line_regex,
             regexp='"$',
@@ -157,3 +162,119 @@ class GrubConfigDebian(GrubConfig):
             force_run=True,
             expected_exit_code=0,
         )
+
+
+class GrubConfigRedhat(GrubConfig):
+    _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
+    _GRUB_DEFAULT_FILE = "/etc/default/grub"
+
+    def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
+        super().__init__("grub2-mkconfig", "grub2-tools", node, *args, **kwargs)
+
+    def set_kernel_cmdline_arg(self, arg: str, value: str) -> None:
+        # Check if BLS (Boot Loader Specification) is enabled
+        if self._is_bls_enabled():
+            self._log.info("BLS is enabled, using grubby to modify kernel parameters")
+            self._set_kernel_arg_with_grubby(arg, value)
+        else:
+            self._log.info("BLS is not enabled, using grub2-mkconfig method")
+            self._set_kernel_arg_with_grub2(arg, value)
+
+    def _is_bls_enabled(self) -> bool:
+        """
+        Check if Boot Loader Specification (BLS) is enabled.
+        BLS is the default in RHEL 9 and newer versions.
+        """
+        # Check if GRUB_ENABLE_BLSCFG=true in /etc/default/grub
+        result = self.node.execute(
+            "grep -q '^GRUB_ENABLE_BLSCFG=true' /etc/default/grub", sudo=True
+        )
+        if result.exit_code == 0:
+            return True
+
+        return False
+
+    def _set_kernel_arg_with_grubby(self, arg: str, value: str) -> None:
+        """
+        Use grubby to set kernel parameters for BLS-enabled systems.
+        This is the recommended method for RHEL 9+.
+        """
+        # First, check if grubby is installed
+        grubby_check = self.node.execute("command -v grubby", sudo=True)
+        if grubby_check.exit_code != 0:
+            posix_os: Posix = self.node.os  # type: ignore
+            posix_os.install_packages("grubby")
+
+        # Use grubby to update kernel parameters for ALL kernels
+        self.node.execute(
+            f"grubby --update-kernel=ALL --args='{arg}={value}'",
+            sudo=True,
+            expected_exit_code=0,
+        )
+        self._log.info(f"Successfully added {arg}={value} using grubby")
+
+    def _set_kernel_arg_with_grub2(self, arg: str, value: str) -> None:
+        """
+        Use grub2-mkconfig to set kernel parameters for non-BLS systems.
+        """
+        self._validate_grub_file_exists(self._GRUB_DEFAULT_FILE)
+        self._remove_existing_arg(
+            arg, self._GRUB_DEFAULT_FILE, self._GRUB_CMDLINE_LINE_REGEX
+        )
+        self._add_new_arg(
+            arg, value, self._GRUB_DEFAULT_FILE, self._GRUB_CMDLINE_LINE_REGEX
+        )
+
+        # Determine correct GRUB config path (UEFI vs BIOS)
+        grub_cfg_path = self._get_grub_config_path()
+        self._log.info(f"Using GRUB config path: {grub_cfg_path}")
+
+        # Apply the changes using grub2-mkconfig
+        self.run(
+            f"-o {grub_cfg_path}",
+            sudo=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
+    def _get_grub_config_path(self) -> str:
+        """
+        Determine the correct GRUB configuration file path.
+        UEFI systems use /boot/efi/EFI/*/grub.cfg
+        BIOS systems use /boot/grub2/grub.cfg
+        """
+        from lisa.tools import Ls
+
+        ls_tool = self.node.tools[Ls]
+        uefi_check = ls_tool.run("/sys/firmware/efi", sudo=True, force_run=True)
+        if uefi_check.exit_code == 0:
+            self._log.debug("Detected UEFI system, checking for UEFI GRUB paths")
+
+            # UEFI system - check common UEFI paths
+            uefi_paths = [
+                "/boot/efi/EFI/redhat/grub.cfg",
+                "/boot/efi/EFI/centos/grub.cfg",
+                "/boot/efi/EFI/almalinux/grub.cfg",
+                "/boot/efi/EFI/rocky/grub.cfg",
+                "/boot/efi/EFI/BOOT/grub.cfg",
+            ]
+
+            for path in uefi_paths:
+                ls_result = ls_tool.run(path, sudo=True, force_run=True)
+                if ls_result.exit_code == 0:
+                    self._log.debug(f"Found UEFI GRUB config at: {path}")
+                    return path
+
+            # Fallback: try to find any grub.cfg in EFI directory
+            self._log.debug("Trying fallback: search for grub.cfg in EFI directory")
+            result = self.node.execute(
+                "find /boot/efi/EFI -name grub.cfg 2>/dev/null | head -1", sudo=True
+            )
+            if result.stdout.strip():
+                found_path = result.stdout.strip()
+                self._log.debug(f"Found GRUB config via fallback: {found_path}")
+                return found_path
+
+        # Default to BIOS path
+        self._log.debug("Using default BIOS GRUB config path")
+        return "/boot/grub2/grub.cfg"

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -34,7 +34,7 @@ from lisa.features import (
     Synthetic,
 )
 from lisa.features.security_profile import CvmDisabled
-from lisa.tools import Lspci
+from lisa.tools import GrubConfig, KernelConfig, Lspci
 from lisa.util import LisaException, constants
 from lisa.util.shell import wait_tcp_port_ready
 
@@ -289,6 +289,56 @@ class Provisioning(TestSuite):
             log.info(f"Max reboot time: {max(times):.2f}s")
             log.info(f"Average reboot time: {mean(times):.2f}s")
             log.info(f"Median reboot time: {median(times):.2f}s")
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that the system can boot and provision successfully
+        with the swiotlb=force kernel parameter enabled. This kernel parameter
+        forces the use of software I/O TLB for all DMA operations.
+
+        This is particularly relevant in Confidential Computing VMs,
+        where memory is encrypted and direct DMA access isn't possible.
+        In such cases, bounce buffering becomes mandatory.
+
+        Steps:
+        1. Set the swiotlb=force kernel parameter in grub configuration
+        2. Reboot the system to apply the kernel parameter
+        3. Run smoke test to verify system functionality
+        4. Verify the system is responsive after reboot
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            supported_features=[SerialConsole, StartStop],
+        ),
+    )
+    def verify_deployment_provision_swiotlb_force(
+        self, log: Logger, node: RemoteNode, log_path: Path
+    ) -> None:
+        # Check if CONFIG_SWIOTLB is available in kernel configuration
+        kernel_config = node.tools[KernelConfig]
+        if not kernel_config.is_enabled("CONFIG_SWIOTLB"):
+            raise SkippedException("CONFIG_SWIOTLB is not enabled in kernel")
+
+        grub_config = node.tools[GrubConfig]
+        grub_config.set_kernel_cmdline_arg("swiotlb", "force")
+
+        node.features[StartStop].restart(wait=True)
+
+        cmdline_result = node.execute("cat /proc/cmdline", sudo=True)
+        assert_that(cmdline_result.stdout).described_as(
+            f"swiotlb=force kernel parameter should be present in: "
+            f"{cmdline_result.stdout}"
+        ).contains("swiotlb=force")
+
+        self._smoke_test(
+            log=log,
+            node=node,
+            log_path=log_path,
+            case_name="verify_deployment_provision_swiotlb_force",
+            reboot_in_platform=True,
+            wait=True,
+            is_restart=True,
+        )
 
     def _smoke_test(
         self,

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -308,7 +308,7 @@ class Provisioning(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
-            supported_features=[SerialConsole],
+            environment_status=EnvironmentStatus.Deployed,
         ),
     )
     def verify_deployment_provision_swiotlb_force(

--- a/microsoft/testsuites/core/provisioning.py
+++ b/microsoft/testsuites/core/provisioning.py
@@ -321,7 +321,6 @@ class Provisioning(TestSuite):
 
         grub_config = node.tools[GrubConfig]
         grub_config.set_kernel_cmdline_arg("swiotlb", "force")
-
         node.features[StartStop].restart(wait=True)
 
         cmdline_result = node.execute("cat /proc/cmdline", sudo=True)


### PR DESCRIPTION
swiotlb=force is required for CVMs, which will support AN. 
This is for a MANA driver regression caused by
[730ff06d3f5c ("net: mana: Use page pool fragments for RX buffers instead of full pages to improve memory efficiency.")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=730ff06d3f5cc2ce0348414b78c10528b767d4a3).
The VM fails to get an IP via DHCP -- this is 100% repro. 

This is not a required param for non-cvm, but it should work well with non-cvm also.