### PR TITLE
dpdk: implement ASAN build and invocation

### DIFF
--- a/lisa/tools/meson.py
+++ b/lisa/tools/meson.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 from pathlib import PurePath
-from typing import cast
+from typing import List, Optional, cast
 
 from lisa.executable import Tool
 from lisa.operating_system import Posix
@@ -97,9 +97,18 @@ class Meson(Tool):
 
         return self._check_exists()
 
-    def setup(self, args: str, cwd: PurePath, build_dir: str = "build") -> PurePath:
+    def setup(
+        self,
+        args: str,
+        cwd: PurePath,
+        build_dir: str = "build",
+        variables: Optional[List[str]] = None,
+    ) -> PurePath:
+        variable_defs = ""
+        if variables:
+            variable_defs = " ".join([f"-D{x}" for x in variables])
         self.run(
-            f"{args} {build_dir}",
+            f"{args} {build_dir} {variable_defs}",
             force_run=True,
             shell=True,
             cwd=cwd,

--- a/lisa/tools/timeout.py
+++ b/lisa/tools/timeout.py
@@ -21,6 +21,7 @@ class Timeout(Tool):
         timeout: int,
         signal: int = SIGTERM,
         kill_timeout: int = 0,
+        update_envs: Optional[Dict[str, str]] = None,
     ) -> ExecutableResult:
         # timeout [OPTION] DURATION COMMAND [ARG]...
 
@@ -39,6 +40,7 @@ class Timeout(Tool):
             timeout=timeout,
             signal=signal,
             kill_timeout=kill_timeout,
+            update_envs=update_envs,
         ).wait_result(timeout=command_timeout)
 
     def start_with_timeout(

--- a/lisa/tools/timeout.py
+++ b/lisa/tools/timeout.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional
+
 from lisa.executable import ExecutableResult, Process, Tool
 from lisa.util.constants import SIGTERM
 
@@ -46,9 +48,16 @@ class Timeout(Tool):
         signal: int = SIGTERM,
         kill_timeout: int = 0,
         delay_start: int = 0,
+        update_envs: Optional[Dict[str, str]] = None,
     ) -> Process:
         # timeout [OPTION] DURATION COMMAND [ARG]...
         params = f"-s {signal} --preserve-status {timeout} {command}"
         if kill_timeout:
             params = f"--kill-after {kill_timeout} " + params
-        return self.run_async(parameters=params, force_run=True, shell=True, sudo=True)
+        return self.run_async(
+            parameters=params,
+            force_run=True,
+            shell=True,
+            sudo=True,
+            update_envs=update_envs,
+        )

--- a/microsoft/testsuites/dpdk/common.py
+++ b/microsoft/testsuites/dpdk/common.py
@@ -226,7 +226,9 @@ class Installer:
         )
 
     # run the defined setup and installation steps.
-    def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
+    def do_installation(
+        self, required_version: Optional[VersionInfo] = None, **kwargs: Any
+    ) -> None:
         self._setup_node()
         if self._should_install():
             self._uninstall()
@@ -238,6 +240,7 @@ class Installer:
         node: Node,
         os_dependencies: Optional[DependencyInstaller] = None,
         downloader: Optional[Downloader] = None,
+        **kwargs: Any,
     ) -> None:
         self._node = node
         if not isinstance(self._node.os, Posix):
@@ -248,6 +251,9 @@ class Installer:
         self._package_manager_extra_args: List[str] = []
         self._os_dependencies = os_dependencies
         self._downloader = downloader
+        self._kwargs = kwargs
+        # default to no asan, it's applicable for source builds only
+        self.use_asan = bool(kwargs.pop("use_asan", False))
 
 
 # Base class for package manager installation
@@ -377,6 +383,10 @@ def is_url_for_tarball(url: str) -> bool:
         return False
     # check if '.tar' in [ '.tar', '.gz' ]
     return ".tar" in suffixes
+
+
+def find_libasan_so(node: Node) -> str:
+    return node.execute("find /usr/lib/ -name libasan.so", sudo=True, shell=True).stdout
 
 
 def is_url_for_git_repo(url: str) -> bool:

--- a/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/microsoft/testsuites/dpdk/dpdkutil.py
@@ -496,6 +496,7 @@ def start_testpmd_concurrent(
         run_kit: Tuple[DpdkTestResources, str],
     ) -> Tuple[DpdkTestResources, str]:
         testkit, cmd = run_kit
+
         return (testkit, testkit.testpmd.run_for_n_seconds(cmd, seconds))
 
     task_manager = run_in_parallel_async(
@@ -1348,7 +1349,7 @@ class DpdkDevnameInfo:
     def __init__(self, testpmd: DpdkTestpmd) -> None:
         self._node = testpmd.node
         self._testpmd = testpmd
-        self.env_args = None
+        self.env_args: Optional[Dict[str, str]] = None
 
     def get_port_info(self, nics: List[NicInfo], expect_ports: int = 1) -> str:
         # since we only need this for netvsc, we'll only generate


### PR DESCRIPTION
Implementing ASAN builds and invocations of DPDK, this requires:
- LD_PRELOAD to force loading of the libasan.so library before others to hook malloc and free etc.
- setting a meson build option -Db_sanitize=address
- enlightening the Installer class to be aware of whether ASAN is desired.
- passing a runbook option through to the DpdkTestpmd class from initialize_node_resources
- setting ASAN_OPTIONS=detect_leaks=0 since we don't care about memory leaks during teardown.

ASAN and DPDK are not enabled globally for all testing (yet). It's useful for debugging segfaults and memory corruption during patch testing so I'd like to make using it easier.

With this PR series, you can set "dpdk_use_asan" to true in a runbook and build with ASAN.