### PR TITLE
notifier: remove pytest-html dependency

### DIFF
--- a/lisa/notifiers/html.py
+++ b/lisa/notifiers/html.py
@@ -1,24 +1,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import html
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, List, Type, cast
+from datetime import datetime, timezone
+from pathlib import Path
+from string import Template
+from typing import Any, Dict, List, Type, cast
 
-import pytest
-from _pytest.config import Config
-from _pytest.reports import CollectReport, TestReport
 from dataclasses_json import dataclass_json
-from pytest_html.plugin import HTMLReport
 
 from lisa import schema
-from lisa.messages import (
-    MessageBase,
-    TestResultMessage,
-    TestRunMessage,
-    TestRunStatus,
-    TestStatus,
-)
+from lisa.messages import MessageBase, TestResultMessage, TestRunMessage, TestRunStatus
 from lisa.notifier import Notifier
 from lisa.secret import mask
 from lisa.util import LisaException, constants
@@ -36,14 +30,7 @@ class HtmlSchema(schema.Notifier):
 
 class Html(Notifier):
     """
-    This class leverage pytest-html to generate a beautiful html report. The reason of
-    not using pytest directly, since we didn't find a way to support planing deployment.
-    What we can implement in pytest is to cache unused environment, not able to detect
-    when is right time to delete it. The Caching mechanism doesn't deal with resource
-    efficiently, for example, 1) a vm holds compute quota in Azure, even it's shutted
-    down.
-    If someone knows how to plan test cases, and pick test cases dynamically during
-    test running, feel free to let us know. We can leverage pytest better.
+    This class generates a beautiful HTML report.
     """
 
     @classmethod
@@ -57,7 +44,7 @@ class Html(Notifier):
     def finalize(self) -> None:
         runbook = cast(HtmlSchema, self.runbook)
         self._log.info(f"report: {self._report_path}")
-        self._html_report.pytest_sessionfinish(session=self._session)
+        self._write_html_report()
         if runbook.auto_open:
             import webbrowser
 
@@ -73,71 +60,209 @@ class Html(Notifier):
 
     def _received_test_run(self, message: TestRunMessage) -> None:
         if message.status == TestRunStatus.INITIALIZING:
-            self._html_report.pytest_sessionstart(self._session)
-            self._html_report.title = message.run_name
-            information = OrderedDict(
-                {
-                    "test project": message.test_project,
-                    "test pass": message.test_pass,
-                    "tags": message.tags,
-                    "runbook_path": constants.RUNBOOK_FILE,
-                    "runbook": mask(constants.RUNBOOK),
-                }
-            )
-            setattr(  # noqa: B010
-                self._config,
-                "_metadata",
-                OrderedDict(
-                    {key: value for key, value in information.items() if value}
-                ),
+            self._title = message.run_name
+            metadata_dict = {
+                "test project": message.test_project,
+                "test pass": message.test_pass,
+                "tags": message.tags,
+                "runbook_path": constants.RUNBOOK_FILE,
+                "runbook": mask(constants.RUNBOOK),
+            }
+            # Filter out None/empty values
+            self._metadata = OrderedDict(
+                {key: value for key, value in metadata_dict.items() if value}
             )
         elif message.status == TestRunStatus.FAILED:
-            report = CollectReport(
-                nodeid="run failed",
-                outcome="failed",
-                longrepr=message.message,
-                result=None,
+            self._collection_errors.append(
+                {"nodeid": "run failed", "message": message.message}
             )
-            self._html_report.pytest_collectreport(report)
 
     def _received_test_result(self, message: TestResultMessage) -> None:
-        if message.status in [TestStatus.PASSED, TestStatus.FAILED, TestStatus.SKIPPED]:
-            new_status: Any = message.status.name.lower()
-            report = TestReport(
-                nodeid=f"{message.id_}:{message.name}",
-                location=("", None, ""),
-                keywords=dict(),
-                outcome=new_status,
-                longrepr=message.message,
-                when="call",
-                duration=message.elapsed,
-                duration_formatter="%H:%M:%S.%f",
-            )
-            if message.information:
-                report.sections.append(
-                    (
-                        "information",
-                        "\n".join(
-                            [
-                                f"{key}: {value}"
-                                for key, value in message.information.items()
-                            ]
-                        ),
-                    )
-                )
-            self._html_report.pytest_runtest_logreport(report)
+        # Store or overwrite result indexed by test ID
+        self._test_results[message.id_] = message
 
     def _subscribed_message_type(self) -> List[Type[MessageBase]]:
         return [TestResultMessage, TestRunMessage]
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         runbook = cast(HtmlSchema, self.runbook)
-        # disable global capture, because it causes "handle is invalid" error in
-        # Windows 11
-        global_config = Config.fromdictargs({"capture": "no"}, {})
-        self._session = pytest.Session.from_config(global_config)
         self._report_path = constants.RUN_LOCAL_LOG_PATH / runbook.path
+        self._test_results: Dict[str, TestResultMessage] = {}
+        self._collection_errors: List[Dict[str, str]] = []
+        self._title = "LISA Test Report"
+        self._metadata = OrderedDict()
+        self._start_time = datetime.now(timezone.utc)
 
-        # enable capture in html config, so the detail log can output
-        self._config = Config.fromdictargs({"self_contained_html": True}, {})
-        self._html_report = HTMLReport(self._report_path, self._config)
+    def _write_html_report(self) -> None:
+        """Generate and write the HTML report."""
+        # Calculate statistics
+        test_results_list = list(self._test_results.values())
+        total = len(test_results_list)
+        passed = sum(1 for r in test_results_list if r.status.name.lower() == "passed")
+        failed = sum(1 for r in test_results_list if r.status.name.lower() == "failed")
+        skipped = sum(
+            1 for r in test_results_list if r.status.name.lower() == "skipped"
+        )
+        errors = len(self._collection_errors)
+        duration = sum(r.elapsed for r in test_results_list)
+
+        html_content = self._generate_html_from_template(
+            total, passed, failed, skipped, errors, duration
+        )
+
+        # Write to file
+        self._report_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._report_path, "w", encoding="utf-8") as f:
+            f.write(html_content)
+
+    def _generate_html_from_template(
+        self,
+        total: int,
+        passed: int,
+        failed: int,
+        skipped: int,
+        errors: int,
+        duration: float,
+    ) -> str:
+        """Generate the complete HTML content from template."""
+        # Load template
+        template_path = Path(__file__).parent / "html_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            template_content = f.read()
+
+        # Prepare template variables
+        error_summary = (
+            f', <span class="error count">{errors} errors</span>' if errors > 0 else ""
+        )
+
+        # Use string.Template for safe substitution (avoids CSS/JS brace conflicts)
+        template = Template(template_content)
+        html_content = template.substitute(
+            title=html.escape(self._title),
+            timestamp=self._start_time.strftime("%Y-%m-%d at %H:%M:%S UTC"),
+            metadata_rows=self._generate_metadata_rows(),
+            total=total,
+            duration=f"{duration:.2f}",
+            passed=passed,
+            failed=failed,
+            skipped=skipped,
+            error_summary=error_summary,
+            collection_error_rows=self._generate_collection_error_rows(),
+            test_result_rows=self._generate_test_result_rows(),
+        )
+
+        return html_content
+
+    def _generate_metadata_rows(self) -> str:
+        """Generate HTML rows for metadata table."""
+        rows = []
+        for key, value in self._metadata.items():
+            # Convert lists to comma-separated strings
+            if isinstance(value, list):
+                value_str = ", ".join(str(v) for v in value)
+            else:
+                value_str = str(value)
+            rows.append(
+                f"<tr><td>{html.escape(key)}</td>"
+                f"<td>{html.escape(value_str)}</td></tr>"
+            )
+        return "\n".join(rows)
+
+    def _generate_collection_error_rows(self) -> str:
+        """Generate HTML rows for collection errors."""
+        rows = []
+        for error in self._collection_errors:
+            rows.append(
+                f"""<tr class="error">
+<td class="col-result">ERROR</td>
+<td class="col-name">{html.escape(error['nodeid'])}</td>
+<td class="col-duration">N/A</td>
+<td class="col-message">{html.escape(error['message'])}</td>
+</tr>"""
+            )
+        return "\n".join(rows)
+
+    def _generate_test_result_rows(self) -> str:
+        """Generate HTML rows for test results."""
+        # Sort results: unknown/other first, then failed, skipped, passed
+        status_order = {"failed": 1, "skipped": 2, "passed": 3}
+        sorted_results = sorted(
+            self._test_results.values(),
+            key=lambda r: status_order.get(r.status.name.lower(), 0),
+        )
+
+        rows = []
+        for result in sorted_results:
+            # Format duration as HH:MM:SS.fff
+            hours = int(result.elapsed // 3600)
+            minutes = int((result.elapsed % 3600) // 60)
+            seconds = result.elapsed % 60
+            duration_str = f"{hours:02d}:{minutes:02d}:{seconds:06.3f}"
+
+            status_str = result.status.name.lower()
+
+            # Build information and analysis sections if available
+            # Expand by default for failed and skipped tests
+            extra_html = ""
+            has_info = bool(result.information)
+            has_analysis = bool(result.analysis)
+
+            if has_info or has_analysis:
+                # Expand by default for failed and skipped tests
+                is_expanded = status_str in ["failed", "skipped"]
+                extra_display = "block" if is_expanded else "none"
+                arrow_symbol = "▼" if is_expanded else "▶"
+                active_class = "active" if is_expanded else ""
+
+                sections = []
+
+                # Add information section
+                if has_info:
+                    info_lines = [
+                        f"{html.escape(k)}: {html.escape(str(v))}"
+                        for k, v in result.information.items()
+                    ]
+                    sections.append(
+                        f"""
+<div class="collapsible {active_class}" onclick="toggleExtra(this)">"""
+                        f"""{arrow_symbol} Information</div>
+<div class="extra" style="display: {extra_display};">
+<pre>{'<br/>'.join(info_lines)}</pre>
+</div>"""
+                    )
+
+                # Add analysis section
+                if has_analysis:
+                    analysis_lines = [
+                        f"{html.escape(k)}: {html.escape(str(v))}"
+                        for k, v in result.analysis.items()
+                    ]
+                    sections.append(
+                        f"""
+<div class="collapsible {active_class}" onclick="toggleExtra(this)">"""
+                        f"""{arrow_symbol} Analysis</div>
+<div class="extra" style="display: {extra_display};">
+<pre>{'<br/>'.join(analysis_lines)}</pre>
+</div>"""
+                    )
+
+                extra_html = f"""
+<td colspan="4">
+{''.join(sections)}
+</td>"""
+
+            message_display = html.escape(result.message) if result.message else ""
+
+            rows.append(
+                f"""<tr class="{status_str}">
+<td class="col-result {status_str}">{status_str.upper()}</td>
+<td class="col-name">{html.escape(result.id_)}:{html.escape(result.name)}</td>
+<td class="col-duration">{duration_str}</td>
+<td class="col-message">{message_display}</td>
+</tr>"""
+            )
+
+            if extra_html:
+                rows.append(f"<tr class='{status_str}'>" f"{extra_html}\n</tr>")
+
+        return "\n".join(rows)

--- a/lisa/notifiers/html_template.html
+++ b/lisa/notifiers/html_template.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>$title</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-size: 17px;
+            line-height: 1.6;
+            color: #24292f;
+            background: linear-gradient(135deg, #f5f7fa 0%, #e4e8ec 100%);
+            padding: 40px 20px;
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.07), 0 10px 20px rgba(0, 0, 0, 0.1);
+            padding: 40px;
+        }
+        h1 {
+            font-size: 36px;
+            font-weight: 700;
+            color: #0969da;
+            margin-bottom: 12px;
+            letter-spacing: -0.5px;
+        }
+        h2 {
+            font-size: 24px;
+            font-weight: 600;
+            color: #1f2937;
+            margin-top: 40px;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 3px solid #0969da;
+        }
+        p {
+            color: #57606a;
+            margin-bottom: 20px;
+        }
+        a {
+            color: #0969da;
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+        a:hover {
+            color: #0550ae;
+            text-decoration: underline;
+        }
+        table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            margin: 20px 0;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        /********* ENVIRONMENT TABLE *********/
+        #environment {
+            background: white;
+        }
+        #environment td {
+            padding: 12px 16px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        #environment td:first-child {
+            font-weight: 600;
+            color: #374151;
+            width: 200px;
+            background-color: #f9fafb;
+        }
+        #environment td:last-child {
+            color: #1f2937;
+        }
+        #environment tr:last-child td {
+            border-bottom: none;
+        }
+        #environment tr:hover {
+            background-color: #f3f4f6;
+        }
+        /********* SUMMARY SECTION *********/
+        .summary {
+            background: linear-gradient(135deg, #f8fafc 0%, #e0f2fe 100%);
+            padding: 24px 28px;
+            border-radius: 10px;
+            border-left: 5px solid #0969da;
+            font-size: 16px;
+            margin: 20px 0;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+        }
+        .summary .count {
+            font-weight: 700;
+            font-size: 22px;
+        }
+        /********* TEST RESULTS TABLE *********/
+        .results-table {
+            width: 100%;
+            background: white;
+            font-size: 16px;
+        }
+        .results-table th {
+            padding: 14px 16px;
+            background: linear-gradient(180deg, #374151 0%, #1f2937 100%);
+            color: white;
+            font-weight: 600;
+            text-align: left;
+            text-transform: uppercase;
+            font-size: 14px;
+            letter-spacing: 0.5px;
+        }
+        .results-table th:first-child {
+            border-top-left-radius: 8px;
+        }
+        .results-table th:last-child {
+            border-top-right-radius: 8px;
+        }
+        .results-table td {
+            padding: 14px 16px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        .results-table tbody tr {
+            transition: all 0.2s ease;
+        }
+        .results-table tbody tr:hover {
+            transform: translateX(2px);
+            box-shadow: -3px 0 0 #0969da;
+        }
+        .results-table tbody tr:last-child td {
+            border-bottom: none;
+        }
+        .results-table tr.passed {
+            background-color: #ecfdf5;
+            border-left: 4px solid #10b981;
+        }
+        .results-table tr.failed {
+            background-color: #fef2f2;
+            border-left: 4px solid #ef4444;
+        }
+        .results-table tr.skipped {
+            background-color: #fffbeb;
+            border-left: 4px solid #f59e0b;
+        }
+        .results-table tr.error {
+            background-color: #fef2f2;
+            border-left: 4px solid #dc2626;
+        }
+        .col-result {
+            width: 10%;
+            font-weight: 700;
+            text-transform: uppercase;
+            font-size: 14px;
+            letter-spacing: 0.5px;
+        }
+        .col-name {
+            width: 35%;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 15px;
+        }
+        .col-duration {
+            width: 12%;
+            font-weight: 600;
+            color: #6b7280;
+        }
+        .col-message {
+            width: 43%;
+            color: #1f2937;
+            font-size: 15px;
+            font-weight: 500;
+        }
+        .passed {
+            color: #059669;
+        }
+        .failed, .error {
+            color: #dc2626;
+        }
+        .skipped {
+            color: #d97706;
+        }
+        .collapsible {
+            cursor: pointer;
+            user-select: none;
+            color: #0969da;
+            font-weight: 600;
+            padding: 4px 8px;
+            border-radius: 4px;
+            display: inline-block;
+            transition: all 0.2s;
+        }
+        .collapsible:hover {
+            background-color: #dbeafe;
+        }
+        .collapsible.active {
+            color: #0550ae;
+            background-color: #bfdbfe;
+        }
+        .extra {
+            background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+            padding: 16px 20px;
+            margin: 8px 0;
+            border-radius: 6px;
+            border-left: 3px solid #6b7280;
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 14px;
+            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
+        }
+        .extra pre {
+            margin: 0;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            color: #1f2937;
+            line-height: 1.5;
+        }
+        /* Responsive design */
+        @media (max-width: 768px) {
+            .container {
+                padding: 20px;
+            }
+            h1 {
+                font-size: 28px;
+            }
+            h2 {
+                font-size: 20px;
+            }
+            .results-table {
+                font-size: 12px;
+            }
+        }
+        /* Print styles */
+        @media print {
+            body {
+                background: white;
+                padding: 0;
+            }
+            .container {
+                box-shadow: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>$title</h1>
+        <p>Report generated on $timestamp</p>
+
+        <h2>Environment</h2>
+        <table id="environment">
+$metadata_rows
+        </table>
+
+        <h2>Summary</h2>
+        <p class="summary">
+            <span class="count">$total</span> tests ran in <span class="count">$duration</span> seconds.<br/>
+            <span class="passed count">$passed passed</span>,
+            <span class="failed count">$failed failed</span>,
+            <span class="skipped count">$skipped skipped</span>
+            $error_summary
+        </p>
+
+        <h2>Results</h2>
+        <table class="results-table">
+            <thead>
+                <tr>
+                    <th class="col-result">Result</th>
+                    <th class="col-name">Test</th>
+                    <th class="col-duration">Duration</th>
+                    <th class="col-message">Message</th>
+                </tr>
+            </thead>
+            <tbody>
+$collection_error_rows
+$test_result_rows
+            </tbody>
+        </table>
+    </div>
+
+    <script>
+        function toggleExtra(element) {
+            // Toggle arrow symbol
+            if (element.textContent.trim().startsWith('▶')) {
+                element.textContent = element.textContent.replace('▶', '▼');
+                element.classList.add('active');
+            } else {
+                element.textContent = element.textContent.replace('▼', '▶');
+                element.classList.remove('active');
+            }
+
+            // Toggle extra content visibility
+            var extra = element.nextElementSibling;
+            if (extra && extra.classList.contains('extra')) {
+                if (extra.style.display === 'none') {
+                    extra.style.display = 'block';
+                } else {
+                    extra.style.display = 'none';
+                }
+            }
+        }
+    </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "paramiko ~= 3.5.1",
     "pluggy ~= 0.13.1",
     "python-dateutil ~= 2.8.1",
-    "pytest-html ~= 3.2.0",
     "PyYAML ~= 6.0.1",
     "randmac ~= 0.1",
     "retry ~= 0.9.2",


### PR DESCRIPTION
Replace pytest-html dependency with custom HTML
report generator using string.Template. This
change provides better control over report
formatting and reduces external dependencies.