### PR TITLE
DPDK: add netvsc rescind tests

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from enum import Enum
 from pathlib import PurePath
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 from urllib.parse import urlparse
@@ -444,3 +445,8 @@ def update_kernel_from_repo(node: Node) -> None:
         node.reboot()
     else:
         node.log.debug(f"Kernel update package '{package}' was not found.")
+
+
+class Pmd(str, Enum):
+    NETVSC = "netvsc"
+    FAILSAFE = "failsafe"

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -448,5 +448,16 @@ def update_kernel_from_repo(node: Node) -> None:
 
 
 class Pmd(str, Enum):
-    NETVSC = "netvsc"
+    # enum for selecting which poll mode (usermode) driver to use.
+    # https://learn.microsoft.com/en-us/azure/virtual-network/setup-dpdk
+    # each has slight differences covered in their docs.
+    # [vdev_]netvsc and mana are maintained by msft.
+    # failsafe is a more general driver that can allow users to configure
+    # their own failover scenarios. not maintained by msft though.
+    #
+    # librte_net_failsafe
+    # https://doc.dpdk.org/guides/nics/fail_safe.html
     FAILSAFE = "failsafe"
+    # librte_net_netvsc
+    # https://doc.dpdk.org/guides/nics/netvsc.html
+    NETVSC = "netvsc"

--- a/lisa/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkperf.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Tuple
 
 from assertpy import assert_that
-from microsoft.testsuites.dpdk.common import force_dpdk_default_source
+from microsoft.testsuites.dpdk.common import Pmd, force_dpdk_default_source
 from microsoft.testsuites.dpdk.dpdkutil import (
     DpdkTestResources,
     SkippedException,
@@ -64,7 +64,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         sender_kit = verify_dpdk_build(
-            node, log, variables, "failsafe", HugePageSize.HUGE_2MB, result=result
+            node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_2MB, result=result
         )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
@@ -110,7 +110,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         sender_kit = verify_dpdk_build(
-            node, log, variables, "netvsc", HugePageSize.HUGE_2MB, result=result
+            node, log, variables, Pmd.NETVSC, HugePageSize.HUGE_2MB, result=result
         )
         sender_fields: Dict[str, Any] = {}
         test_case_name = result.runtime_data.metadata.name
@@ -154,7 +154,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test("failsafe", result, log, variables)
+        self._run_dpdk_perf_test(Pmd.FAILSAFE, result, log, variables)
 
     @TestCaseMetadata(
         description="""
@@ -175,7 +175,7 @@ class DpdkPerformance(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self._run_dpdk_perf_test("netvsc", result, log, variables)
+        self._run_dpdk_perf_test(Pmd.NETVSC, result, log, variables)
 
     @TestCaseMetadata(
         description="""
@@ -198,7 +198,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self._run_dpdk_perf_test(
-            "failsafe",
+            Pmd.FAILSAFE,
             result,
             log,
             variables,
@@ -225,7 +225,7 @@ class DpdkPerformance(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self._run_dpdk_perf_test(
-            "netvsc",
+            Pmd.NETVSC,
             result,
             log,
             variables,
@@ -262,13 +262,13 @@ class DpdkPerformance(TestSuite):
             log,
             variables,
             HugePageSize.HUGE_2MB,
-            pmd="netvsc",
+            pmd=Pmd.NETVSC,
             is_perf_test=True,
         )
 
     def _run_dpdk_perf_test(
         self,
-        pmd: str,
+        pmd: Pmd,
         test_result: TestResult,
         log: Logger,
         variables: Dict[str, Any],

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -418,7 +418,7 @@ class Dpdk(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def verify_dpdk_testpmd_hotplug_receive_failsafe_pmd(
+    def verify_dpdk_testpmd_hotplug_receiver_failsafe_pmd(
         self,
         environment: Environment,
         log: Logger,
@@ -442,7 +442,7 @@ class Dpdk(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def verify_dpdk_testpmd_hotplug_receive_netvsc_pmd(
+    def verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd(
         self,
         environment: Environment,
         log: Logger,
@@ -463,7 +463,7 @@ class Dpdk(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def verify_dpdk_testpmd_hotplug_send_only_failsafe_pmd(
+    def verify_dpdk_testpmd_hotplug_sender_failsafe_pmd(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.FAILSAFE)
@@ -481,7 +481,7 @@ class Dpdk(TestSuite):
             supported_features=[IsolatedResource],
         ),
     )
-    def verify_dpdk_testpmd_hotplug_send_only_netvsc_pmd(
+    def verify_dpdk_testpmd_hotplug_sender_netvsc_pmd(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.NETVSC)
@@ -494,7 +494,7 @@ class Dpdk(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
         pmd: Pmd = Pmd.FAILSAFE,
-    ):
+    ) -> None:
         test_kits = init_nodes_concurrent(
             environment,
             log,
@@ -529,7 +529,7 @@ class Dpdk(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
         pmd: Pmd = Pmd.FAILSAFE,
-    ):
+    ) -> None:
         try:
             test_kit = initialize_node_resources(
                 node, log, variables, pmd, HugePageSize.HUGE_2MB

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -566,11 +566,11 @@ class Dpdk(TestSuite):
                 f"{tx_or_rx}-PPS ({pps}) should have been greater "
                 "than 2^20 (~1m) PPS before sriov disable."
             ).is_greater_than(2**20)
-        else:
-            assert_that(pps).described_as(
-                f"{tx_or_rx}-PPS ({pps}) should have been less "
-                "than 2^20 (~1m) PPS after sriov disable."
-            ).is_less_than(2**20)
+        # not checking if traffic is below some arbitrary
+        # threshold because it's a moving target. New skus
+        # will be faster. Let's just check for the hotplug
+        # messages to verify we got the hotplug
+        # from the lower level.
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -8,6 +8,7 @@ from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.common import (
     DPDK_STABLE_GIT_REPO,
     PackageManagerInstall,
+    Pmd,
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
@@ -101,7 +102,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         verify_dpdk_build(
-            node, log, variables, "netvsc", HugePageSize.HUGE_2MB, result=result
+            node, log, variables, Pmd.NETVSC, HugePageSize.HUGE_2MB, result=result
         )
 
     @TestCaseMetadata(
@@ -155,7 +156,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         verify_dpdk_build(
-            node, log, variables, "netvsc", HugePageSize.HUGE_1GB, result=result
+            node, log, variables, Pmd.NETVSC, HugePageSize.HUGE_1GB, result=result
         )
 
     @TestCaseMetadata(
@@ -183,7 +184,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         verify_dpdk_build(
-            node, log, variables, "failsafe", HugePageSize.HUGE_2MB, result=result
+            node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_2MB, result=result
         )
 
     @TestCaseMetadata(
@@ -211,7 +212,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         verify_dpdk_build(
-            node, log, variables, "failsafe", HugePageSize.HUGE_1GB, result=result
+            node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_1GB, result=result
         )
 
     @TestCaseMetadata(
@@ -240,7 +241,7 @@ class Dpdk(TestSuite):
         force_dpdk_default_source(variables)
         try:
             test_kit = initialize_node_resources(
-                node, log, variables, "netvsc", HugePageSize.HUGE_2MB
+                node, log, variables, Pmd.NETVSC, HugePageSize.HUGE_2MB
             )
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
@@ -326,7 +327,7 @@ class Dpdk(TestSuite):
         # multiprocess test requires dpdk source.
         force_dpdk_default_source(variables)
         kill = node.tools[Kill]
-        pmd = "failsafe"
+        pmd = Pmd.FAILSAFE
         server_app_name = "dpdk-mp_server"
         client_app_name = "dpdk-mp_client"
         # initialize DPDK with sample applications selected for build
@@ -423,7 +424,9 @@ class Dpdk(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self.run_testpmd_hotplug_recv_test(environment, log, variables)
+        self.run_testpmd_hotplug_recv_test(
+            environment, log, variables, pmd=Pmd.FAILSAFE
+        )
 
     @TestCaseMetadata(
         description="""
@@ -445,7 +448,7 @@ class Dpdk(TestSuite):
         log: Logger,
         variables: Dict[str, Any],
     ) -> None:
-        self.run_testpmd_hotplug_recv_test(environment, log, variables, pmd="netvsc")
+        self.run_testpmd_hotplug_recv_test(environment, log, variables, pmd=Pmd.NETVSC)
 
     @TestCaseMetadata(
         description="""
@@ -463,7 +466,7 @@ class Dpdk(TestSuite):
     def verify_dpdk_testpmd_hotplug_send_only_failsafe_pmd(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        self.run_testpmd_hotplug_send_test(node, log, variables)
+        self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.FAILSAFE)
 
     @TestCaseMetadata(
         description="""
@@ -481,7 +484,7 @@ class Dpdk(TestSuite):
     def verify_dpdk_testpmd_hotplug_send_only_netvsc_pmd(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
-        self.run_testpmd_hotplug_send_test(node, log, variables)
+        self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.NETVSC)
 
     # common testpmd hotplug functions, send only and receiver versions
     # support both netvsc and failsafe pmd
@@ -490,7 +493,7 @@ class Dpdk(TestSuite):
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
-        pmd: str = "failsafe",
+        pmd: Pmd = Pmd.FAILSAFE,
     ):
         test_kits = init_nodes_concurrent(
             environment,
@@ -521,7 +524,11 @@ class Dpdk(TestSuite):
         self._check_rx_or_tx_pps_sriov_hotplug("RX", hotplug_tx_pps_set)
 
     def run_testpmd_hotplug_send_test(
-        self, node: Node, log: Logger, variables: Dict[str, Any], pmd: str = "failsafe"
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        pmd: Pmd = Pmd.FAILSAFE,
     ):
         try:
             test_kit = initialize_node_resources(
@@ -597,7 +604,7 @@ class Dpdk(TestSuite):
             )
         try:
             initialize_node_resources(
-                node, log, variables, "failsafe", HugePageSize.HUGE_2MB
+                node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_2MB
             )
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
@@ -647,7 +654,7 @@ class Dpdk(TestSuite):
         # setup and unwrap the resources for this test
         try:
             test_kit = initialize_node_resources(
-                node, log, variables, "failsafe", HugePageSize.HUGE_2MB
+                node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_2MB
             )
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
@@ -733,7 +740,7 @@ class Dpdk(TestSuite):
     ) -> None:
         try:
             verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, "failsafe", result=result
+                environment, log, variables, Pmd.FAILSAFE, result=result
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -764,7 +771,7 @@ class Dpdk(TestSuite):
     ) -> None:
         try:
             verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, "netvsc", result=result, set_mtu=9000
+                environment, log, variables, Pmd.NETVSC, result=result, set_mtu=9000
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -794,7 +801,7 @@ class Dpdk(TestSuite):
     ) -> None:
         try:
             verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, "netvsc", result=result
+                environment, log, variables, Pmd.NETVSC, result=result
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
@@ -827,7 +834,7 @@ class Dpdk(TestSuite):
                 environment,
                 log,
                 variables,
-                "failsafe",
+                Pmd.FAILSAFE,
                 HugePageSize.HUGE_2MB,
                 result=result,
             )
@@ -863,7 +870,7 @@ class Dpdk(TestSuite):
                 environment,
                 log,
                 variables,
-                "failsafe",
+                Pmd.FAILSAFE,
                 HugePageSize.HUGE_1GB,
                 result=result,
             )
@@ -898,7 +905,7 @@ class Dpdk(TestSuite):
                 environment,
                 log,
                 variables,
-                "netvsc",
+                Pmd.NETVSC,
                 HugePageSize.HUGE_2MB,
                 result=result,
             )
@@ -934,7 +941,7 @@ class Dpdk(TestSuite):
                 environment,
                 log,
                 variables,
-                "netvsc",
+                Pmd.NETVSC,
                 HugePageSize.HUGE_1GB,
                 result=result,
             )
@@ -971,7 +978,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         force_dpdk_default_source(variables)
-        pmd = "netvsc"
+        pmd = Pmd.NETVSC
         verify_dpdk_l3fwd_ntttcp_tcp(
             environment, log, variables, HugePageSize.HUGE_2MB, pmd=pmd, result=result
         )
@@ -1006,7 +1013,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         force_dpdk_default_source(variables)
-        pmd = "netvsc"
+        pmd = Pmd.NETVSC
         verify_dpdk_l3fwd_ntttcp_tcp(
             environment,
             log,
@@ -1045,7 +1052,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         force_dpdk_default_source(variables)
-        pmd = "netvsc"
+        pmd = Pmd.NETVSC
         verify_dpdk_l3fwd_ntttcp_tcp(
             environment,
             log,

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -520,8 +520,8 @@ class Dpdk(TestSuite):
             kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
         )
 
-        hotplug_tx_pps_set = receiver.testpmd.get_mean_rx_pps_sriov_hotplug()
-        self._check_rx_or_tx_pps_sriov_hotplug("RX", hotplug_tx_pps_set)
+        hotplug_pps_set = receiver.testpmd.get_mean_rx_pps_sriov_hotplug()
+        self._check_rx_or_tx_pps_sriov_hotplug("RX", hotplug_pps_set)
 
     def run_testpmd_hotplug_send_test(
         self,
@@ -547,8 +547,8 @@ class Dpdk(TestSuite):
             kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
         )
 
-        hotplug_tx_pps_set = testpmd.get_mean_tx_pps_sriov_hotplug()
-        self._check_rx_or_tx_pps_sriov_hotplug("TX", hotplug_tx_pps_set)
+        hotplug_pps_set = testpmd.get_mean_tx_pps_sriov_hotplug()
+        self._check_rx_or_tx_pps_sriov_hotplug("TX", hotplug_pps_set)
 
     def _check_rx_or_tx_pps_sriov_hotplug(
         self, tx_or_rx: str, pps: Tuple[int, int, int]
@@ -557,6 +557,11 @@ class Dpdk(TestSuite):
         self._check_rx_or_tx_pps(tx_or_rx, before_hotplug, sriov_enabled=True)
         self._check_rx_or_tx_pps(tx_or_rx, during_hotplug, sriov_enabled=False)
         self._check_rx_or_tx_pps(tx_or_rx, after_reenable, sriov_enabled=True)
+        after_over_before = after_reenable / before_hotplug
+        assert_that(after_over_before).described_as(
+            "Error: pps of vf was very different before and after hotplug. "
+            f"before: {before_hotplug} after: {after_reenable}"
+        ).is_close_to(1, tolerance=0.125)
 
     def _check_rx_or_tx_pps(
         self, tx_or_rx: str, pps: int, sriov_enabled: bool = True

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -1065,7 +1065,7 @@ def _discard_first_and_last_sample(data: List[int]) -> List[int]:
 
 
 def _mean(data: List[int]) -> int:
-    return sum(data) // len(data)
+    return 0 if len(data) == 0 else (sum(data) // len(data))
 
 
 def _check_for_dpdk_build_errors(result: ExecutableResult) -> None:

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -372,14 +372,17 @@ class DpdkTestpmd(Tool):
         )
     )
     _search_hotplug_regex_alt = re.compile(
-        r"EAL: PCI device [a-fA-F0-9]{4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}\.[a-fA-F0-9] "
+        r"EAL: PCI device [a-fA-F0-9]{4}:"
+        r"[a-fA-F0-9]{2}:[a-fA-F0-9]{2}\.[a-fA-F0-9] "
         r"on NUMA socket [0-9]+"
     )
     # for netvsc, we rely on the netvsc pmd debug log to fetch the information.
-    # when hotplug function finds a matching device, it logs this message (and the device args).
+    # when hotplug function finds a matching device, it logs
+    # this message (and the device args).
     # this code isn dpdk is in drivers/net/netvsc/hn_ethdev.c
     _search_hotplug_regex_netvsc = re.compile(
-        r"HN_DRIVER: netvsc_hotplug_retry\(\): Found matching MAC address, adding device"
+        r"HN_DRIVER: netvsc_hotplug_retry\(\): "
+        r"Found matching MAC address, adding device"
     )
 
     _hotplug_search_regexes = [

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -738,11 +738,11 @@ class DpdkTestpmd(Tool):
         self._check_pps_data("TX")
         return min(self.tx_pps_data)
 
-    def get_mean_tx_pps_sriov_rescind(self) -> Tuple[int, int, int]:
-        return self._get_pps_sriov_rescind(self._tx_pps_key)
+    def get_mean_tx_pps_sriov_hotplug(self) -> Tuple[int, int, int]:
+        return self._get_pps_sriov_hotplug(self._tx_pps_key)
 
-    def get_mean_rx_pps_sriov_rescind(self) -> Tuple[int, int, int]:
-        return self._get_pps_sriov_rescind(self._rx_pps_key)
+    def get_mean_rx_pps_sriov_hotplug(self) -> Tuple[int, int, int]:
+        return self._get_pps_sriov_hotplug(self._rx_pps_key)
 
     def get_example_app_path(self, app_name: str) -> PurePath:
         source_path = self.node.get_pure_path(
@@ -850,8 +850,8 @@ class DpdkTestpmd(Tool):
 
     def _install(self) -> bool:
         self._testpmd_output_after_reenable = ""
-        self._testpmd_output_before_rescind = ""
-        self._testpmd_output_during_rescind = ""
+        self._testpmd_output_before_hotplug = ""
+        self._testpmd_output_during_hotplug = ""
         self._last_run_output = ""
         node = self.node
         if not isinstance(node.os, (Debian, Fedora, Suse)):
@@ -970,16 +970,16 @@ class DpdkTestpmd(Tool):
 
         device_removal_index = self._last_run_output.find(search_str)
         assert_that(device_removal_index).described_as(
-            "Could not locate SRIOV rescind event in testpmd output"
+            "Could not locate SRIOV hotplug event in testpmd output"
         ).is_not_equal_to(-1)
 
-        self._testpmd_output_before_rescind = self._last_run_output[
+        self._testpmd_output_before_hotplug = self._last_run_output[
             :device_removal_index
         ]
-        after_rescind = self._last_run_output[device_removal_index:]
+        after_hotplug = self._last_run_output[device_removal_index:]
         # Identify the device add event using the hotplug search regexes
         for pattern in self._hotplug_search_regexes:
-            hotplug_match = pattern.finditer(after_rescind)
+            hotplug_match = pattern.finditer(after_hotplug)
             matches_list = list(hotplug_match)
             if not list(matches_list):
                 command_dumped = "timeout: the monitored command dumped core"
@@ -999,38 +999,38 @@ class DpdkTestpmd(Tool):
 
         self.node.log.info(f"Identified hotplug event: {last_match.group(0)}")
 
-        before_reenable = after_rescind[: last_match.start()]
-        after_reenable = after_rescind[last_match.end() :]
-        self._testpmd_output_during_rescind = before_reenable
+        before_reenable = after_hotplug[: last_match.start()]
+        after_reenable = after_hotplug[last_match.end() :]
+        self._testpmd_output_during_hotplug = before_reenable
         self._testpmd_output_after_reenable = after_reenable
 
-    def _get_pps_sriov_rescind(
+    def _get_pps_sriov_hotplug(
         self,
         key_constant: str,
     ) -> Tuple[int, int, int]:
         if not all(
             [
-                self._testpmd_output_during_rescind,
+                self._testpmd_output_during_hotplug,
                 self._testpmd_output_after_reenable,
-                self._testpmd_output_before_rescind,
+                self._testpmd_output_before_hotplug,
             ]
         ):
             self._split_testpmd_output()
 
-        before_rescind = self.get_data_from_testpmd_output(
+        before_hotplug = self.get_data_from_testpmd_output(
             key_constant,
-            self._testpmd_output_before_rescind,
+            self._testpmd_output_before_hotplug,
         )
-        during_rescind = self.get_data_from_testpmd_output(
+        during_hotplug = self.get_data_from_testpmd_output(
             key_constant,
-            self._testpmd_output_during_rescind,
+            self._testpmd_output_during_hotplug,
         )
         after_reenable = self.get_data_from_testpmd_output(
             key_constant,
             self._testpmd_output_after_reenable,
         )
         before, during, after = map(
-            _mean, [before_rescind, during_rescind, after_reenable]
+            _mean, [before_hotplug, during_hotplug, after_reenable]
         )
         return before, during, after
 
@@ -1056,7 +1056,7 @@ def _discard_first_and_last_sample(data: List[int]) -> List[int]:
     # can mess up the average since we're using an unweighted mean
 
     # discard first and last sample so long as there are enough to
-    # practically, we expect there to be > 20 unless rescind
+    # practically, we expect there to be > 20 unless hotplug
     # performance is hugely improved in the cloud
     if len(data) < 3:
         return data

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -16,6 +16,7 @@ from microsoft.testsuites.dpdk.common import (
     GitDownloader,
     Installer,
     PackageManagerInstall,
+    Pmd,
     TarDownloader,
     check_dpdk_support,
     is_url_for_git_repo,
@@ -197,7 +198,7 @@ def _ping_all_nodes_in_environment(environment: Environment) -> None:
 
 
 def generate_send_receive_run_info(
-    pmd: str,
+    pmd: Pmd,
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
     multiple_queues: bool = False,
@@ -289,9 +290,9 @@ def enable_uio_hv_generic(node: Node) -> None:
 
 
 def do_pmd_driver_setup(
-    node: Node, test_nics: List[NicInfo], testpmd: DpdkTestpmd, pmd: str = "failsafe"
+    node: Node, test_nics: List[NicInfo], testpmd: DpdkTestpmd, pmd: Pmd = Pmd.FAILSAFE
 ) -> None:
-    if pmd == "netvsc":
+    if pmd == Pmd.NETVSC:
         # setup system for netvsc pmd
         # https://doc.dpdk.org/guides/nics/netvsc.html
         enable_uio_hv_generic(node)
@@ -318,7 +319,7 @@ def initialize_node_resources(
     node: Node,
     log: Logger,
     variables: Dict[str, Any],
-    pmd: str,
+    pmd: Pmd,
     hugepage_size: HugePageSize,
     sample_apps: Union[List[str], None] = None,
     test_nics: Union[List[NicInfo], None] = None,
@@ -412,11 +413,11 @@ def initialize_node_resources(
     return DpdkTestResources(_node=node, _testpmd=testpmd, _rdma_core=rdma_core)
 
 
-def check_pmd_support(node: Node, pmd: str) -> None:
+def check_pmd_support(node: Node, pmd: Pmd) -> None:
     # Check environment (kernel, drivers, etc) supports selected PMD.
-    if pmd == "failsafe" and node.nics.is_mana_device_present():
+    if pmd == Pmd.FAILSAFE and node.nics.is_mana_device_present():
         raise SkippedException("Failsafe PMD test on MANA is not supported.")
-    if pmd == "netvsc" and not (
+    if pmd == Pmd.NETVSC and not (
         node.tools[Modprobe].load("uio_hv_generic", dry_run=True)
     ):
         raise SkippedException(
@@ -506,7 +507,7 @@ def init_nodes_concurrent(
     environment: Environment,
     log: Logger,
     variables: Dict[str, Any],
-    pmd: str,
+    pmd: Pmd,
     hugepage_size: HugePageSize,
     sample_apps: Union[List[str], None] = None,
     test_nic_count: int = 1,
@@ -548,7 +549,7 @@ def verify_dpdk_build(
     node: Node,
     log: Logger,
     variables: Dict[str, Any],
-    pmd: str,
+    pmd: Pmd,
     hugepage_size: HugePageSize,
     multiple_queues: bool = False,
     result: Optional[TestResult] = None,
@@ -587,7 +588,7 @@ def verify_dpdk_send_receive(
     environment: Environment,
     log: Logger,
     variables: Dict[str, Any],
-    pmd: str,
+    pmd: Pmd,
     hugepage_size: HugePageSize,
     use_service_cores: int = 1,
     multiple_queues: bool = False,
@@ -678,7 +679,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     environment: Environment,
     log: Logger,
     variables: Dict[str, Any],
-    pmd: str,
+    pmd: Pmd,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
@@ -810,7 +811,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     log: Logger,
     variables: Dict[str, Any],
     hugepage_size: HugePageSize,
-    pmd: str = "netvsc",
+    pmd: Pmd = Pmd.NETVSC,
     force_single_queue: bool = False,
     is_perf_test: bool = False,
     result: Optional[TestResult] = None,
@@ -1471,7 +1472,7 @@ def run_dpdk_symmetric_mp(
             node,
             log,
             variables,
-            "netvsc",
+            Pmd.NETVSC,
             HugePageSize.HUGE_2MB,
             test_nics=test_nics,
         )

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -440,12 +440,12 @@ def run_testpmd_concurrent(
     node_cmd_pairs: Dict[DpdkTestResources, str],
     seconds: int,
     log: Logger,
-    rescind_sriov: bool = False,
+    hotplug_sriov: bool = False,
 ) -> Dict[DpdkTestResources, str]:
     output: Dict[DpdkTestResources, str] = dict()
 
     task_manager = start_testpmd_concurrent(node_cmd_pairs, seconds, log, output)
-    if rescind_sriov:
+    if hotplug_sriov:
         time.sleep(10)  # run testpmd for a bit before disabling sriov
 
         test_kits = node_cmd_pairs.keys()
@@ -814,7 +814,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     force_single_queue: bool = False,
     is_perf_test: bool = False,
     result: Optional[TestResult] = None,
-    rescind_sriov: bool = False,
+    hotplug_sriov: bool = False,
 ) -> None:
     # This is currently the most complicated DPDK test. There is a lot that can
     # go wrong, so we restrict the test to netvsc and only a few distros.
@@ -1074,8 +1074,8 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         threads_count=ntttcp_threads_count,
         run_time_seconds=ntttcp_run_time,
     )
-    # rescind sriov and run again
-    if rescind_sriov:
+    # hotplug sriov and run again
+    if hotplug_sriov:
         forwarder.features[NetworkInterface].switch_sriov(
             enable=False, wait=False, reset_connections=False
         )
@@ -1113,8 +1113,8 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         receiver: ntttcp[receiver].create_ntttcp_result(receiver_result),
         sender: ntttcp[sender].create_ntttcp_result(sender_result, "client"),
     }
-    # compare results with those after the rescind if needed
-    if rescind_sriov:
+    # compare results with those after the hotplug if needed
+    if hotplug_sriov:
         _ntttcp_results_after = {
             receiver: ntttcp[receiver].create_ntttcp_result(
                 _receiver_after_result, role="server"
@@ -1430,8 +1430,8 @@ def run_dpdk_symmetric_mp(
     node: Node,
     log: Logger,
     variables: Dict[str, Any],
-    trigger_rescind: bool = False,
-    rescind_times: int = 1,
+    trigger_hotplug: bool = False,
+    hotplug_times: int = 1,
 ) -> None:
     """
     A runner function for symmetric_mp, one of the
@@ -1546,7 +1546,7 @@ def run_dpdk_symmetric_mp(
     )
     secondary.wait_output("APP: Finished Process Init", timeout=20)
 
-    # expect 150 pings by default, if we rescind we'll add to this count
+    # expect 150 pings by default, if we hotplug we'll add to this count
     expected_pings = 150
     ping.ping_async(
         target=test_nics[0].ip_addr,
@@ -1561,11 +1561,11 @@ def run_dpdk_symmetric_mp(
         ignore_error=True,
         interval=0.05,
     )
-    # optionally trigger rescind
-    if trigger_rescind:
-        # allow multiple rescinds for stress testing
-        while rescind_times > 0:
-            rescind_times -= 1
+    # optionally trigger hotplug
+    if trigger_hotplug:
+        # allow multiple hotplugs for stress testing
+        while hotplug_times > 0:
+            hotplug_times -= 1
             # turn SRIOV off
 
             node.features[NetworkInterface].switch_sriov(
@@ -1601,7 +1601,7 @@ def run_dpdk_symmetric_mp(
                 ignore_error=True,
                 interval=0.05,
             )
-            # expect additional pings for each post-rescind instance
+            # expect additional pings for each post-hotplug instance
             expected_pings += 100
 
     ping.ping_async(


### PR DESCRIPTION
Adding an sriov rescind test for netvsc pmd.

This required:
- additional regexes for detecting hotplugs
- adding test cases

I noted that it was easy to mix up which pmd was being used, so this PR also contains a commit to use an Enum for the pmd type. This is done in anticipation of adding mana direct tests. I'm also changing the hotplug test names to just 'hotplug' instead of 'sriov_rescind' for brevity. One implies the other, the path in the DPDK pmd uses the term 'hotplug'.