### PR TITLE
Skip tests on L1VH Nodes

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -282,6 +282,11 @@ class MshvHostTestSuite(TestSuite):
         node: Node,
     ) -> None:
         mshvtrace_path = "/usr/sbin/mshvtrace"
+
+        if self._is_l1vh_partition(node, log):
+            raise SkippedException(
+                "L1VH Parent partition cannot collect performance traces."
+            )
         temp_dir = node.execute(
             "mktemp -d /tmp/mshvtrace_test_XXXXXX", sudo=True
         ).stdout.strip()


### PR DESCRIPTION
Skip mshvtrace test on L1VH nodes. Within mshvlog test, skip checking the size of the logfile.