### PR TITLE
fix verify_cpu_count and improve PowerShell

### DIFF
--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -371,6 +371,14 @@ class WindowsLscpu(Lscpu):
         self._log.debug(f"thread per core: {thread_per_core}")
         return thread_per_core
 
+    def calculate_vcpu_count(self, force_run: bool = False) -> int:
+        calculated_cpu_count = (
+            self.get_core_per_socket_count(force_run=force_run)
+            * self.get_socket_count(force_run=force_run)
+            * self.get_thread_per_core_count(force_run=force_run)
+        )
+        return calculated_cpu_count
+
     def _get_core_count(self, force_run: bool = False) -> int:
         result = self.node.tools[PowerShell].run_cmdlet(
             self.__computer_system_command, force_run=force_run

--- a/lisa/tools/powershell.py
+++ b/lisa/tools/powershell.py
@@ -84,7 +84,12 @@ class PowerShell(Tool):
         no_debug_log: bool = True,
     ) -> ExecutableResult:
         result = process.wait_result(timeout=timeout)
-        stderr = self._parse_error_message(result.stderr)
+
+        # If Powershell is used to run cmd, there maybe no stderr.
+        stderr = ""
+        if result.stderr:
+            stderr = self._parse_error_message(result.stderr)
+
         if result.exit_code != 0 or stderr:
             if fail_on_error:
                 raise LisaException(


### PR DESCRIPTION
- Implement calculate_vcpu_count() method in WindowsLscpu class to fix verify_cpu_count test failure on Windows
- Add null check for stderr in PowerShell.wait_result() to prevent errors when PowerShell is used to run cmd commands with no stderr output