### PR TITLE
Fix IPTable Test

### DIFF
--- a/lisa/microsoft/testsuites/azure/net/component.py
+++ b/lisa/microsoft/testsuites/azure/net/component.py
@@ -41,7 +41,7 @@ class NetworkComponentTest(TestSuite):
         "allowlayer4",
     ]
     FILTERTABLE = "filter"
-    FILTERCHAIN = ["LOG", "MARK_ALLOWED_AND_ACCEPT", "LOG_DROP_OTHER"]
+    FILTERCHAIN = ["MARK_ALLOWED_AND_ACCEPT", "LOG_DROP_OTHER"]
     PACKETCOUNT = 40
     VMCOUNT = 1
     NICCOUNT = 1
@@ -175,6 +175,13 @@ class NetworkComponentTest(TestSuite):
         iptables.create_iptable_chain(
             table_name=self.NATTABLE,
             chain_names=self.NATCHAIN,
+        )
+
+        #Create new chains in filter table
+        log.info(f"Create new chains {self.FILTERCHAIN} in {self.FILTERTABLE} table")
+        iptables.create_iptable_chain(
+            table_name=self.FILTERTABLE,
+            chain_names=self.FILTERCHAIN,
         )
 
         # Add rules to prerouting chain in nat table

--- a/lisa/microsoft/testsuites/azure/net/component.py
+++ b/lisa/microsoft/testsuites/azure/net/component.py
@@ -177,7 +177,7 @@ class NetworkComponentTest(TestSuite):
             chain_names=self.NATCHAIN,
         )
 
-        #Create new chains in filter table
+        # Create new chains in filter table
         log.info(f"Create new chains {self.FILTERCHAIN} in {self.FILTERTABLE} table")
         iptables.create_iptable_chain(
             table_name=self.FILTERTABLE,


### PR DESCRIPTION
As part of test, we are trying to append a rule to FORWARD, this is failing because the rule depends on the two other chains MARK_ALLOWED_AND_ACCEPT and LOG_DROP_OTHER where the step to create these two chains in Filter table was missing. Added a new step which will create these two chains.