### PR TITLE
Fix objtool checksum error by adding libxxhash-dev to build dependencies

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -394,7 +394,13 @@ class SourceInstaller(BaseInstaller):
             self._fix_mirrorlist_to_vault(node)
         if isinstance(os, Redhat):
             for package in list(
-                ["elfutils-libelf-devel", "openssl-devel", "dwarves", "bc"]
+                [
+                    "elfutils-libelf-devel",
+                    "openssl-devel",
+                    "dwarves",
+                    "bc",
+                    "xxhash-devel",
+                ]
             ):
                 if os.is_package_in_repo(package):
                     os.install_packages(package)
@@ -425,6 +431,7 @@ class SourceInstaller(BaseInstaller):
                     "bc",
                     "ccache",
                     "zstd",
+                    "libxxhash-dev",
                 ]
             )
         elif isinstance(os, CBLMariner):
@@ -444,6 +451,7 @@ class SourceInstaller(BaseInstaller):
                     "xz-libs",
                     "openssl-libs",
                     "openssl-devel",
+                    "xxhash-devel",
                 ]
             )
         else:


### PR DESCRIPTION
The objtool --checksum feature introduced for live‑patch builds requires libxxhash with XXH3 (≥ 0.8.0). Without this, builds fail with:

> objtool: --checksum not supported; install xxhash-devel/libxxhash-dev and recompile

This PR adds libxxhash-dev to the build dependencies to ensure checksum generation works correctly and prevents the said error during kernel module installation.
Refer: https://lkml.org/lkml/2025/10/17/1516