### PR TITLE
Modrpobe command update for verbose is false

### DIFF
--- a/lisa/tools/scripts/modprobe_reloader.sh
+++ b/lisa/tools/scripts/modprobe_reloader.sh
@@ -30,7 +30,7 @@ if [ "$module_name" = "hv_netvsc" ]; then
   (
     j=1
     while [ $j -le "$times" ]; do
-      { modprobe -r "$v" "$module_name"; modprobe "$v" "$module_name"; } >> "$log_file" 2>&1
+      { modprobe -r $v "$module_name"; modprobe $v "$module_name"; } >> "$log_file" 2>&1
       j=$((j + 1))
     done
     sleep 1
@@ -52,7 +52,7 @@ else
   (
     j=1
     while [ $j -le "$times" ]; do
-      { modprobe -r "$v" "$module_name"; modprobe "$v" "$module_name"; } >> "$log_file" 2>&1
+      { modprobe -r $v "$module_name"; modprobe $v "$module_name"; } >> "$log_file" 2>&1
       j=$((j + 1))
     done
   ) &


### PR DESCRIPTION
When verbose is false , module remove and reload does not work . Removing the double quotes on $v in modprobe command 

**lisatest@lisa--386-e0-n0:~$ v=""
lisatest@lisa--386-e0-n0:~$ modprobe  "$v" hv_netvsc
modprobe: FATAL: Module  not found in directory /lib/modules/6.14.0-1012-azure**
lisatest@lisa--386-e0-n0:~$
 
**lisatest@lisa--386-e0-n0:~$ v=""
lisatest@lisa--386-e0-n0:~$ modprobe  $v hv_netvsc**


lisatest@lisa--386-e0-n0:~$ v="-v"
lisatest@lisa--386-e0-n0:~$ modprobe  "$v" hv_netvsc
lisatest@lisa--386-e0-n0:~$ v="-v"
lisatest@lisa--386-e0-n0:~$ modprobe  $v hv_netvsc