### PR TITLE
dpdk: multiple senders single receiver multiple port testpmd

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -461,3 +461,8 @@ class Pmd(str, Enum):
     # librte_net_netvsc
     # https://doc.dpdk.org/guides/nics/netvsc.html
     NETVSC = "netvsc"
+
+
+# set a threshold for an expected PPS minimum with DPDK.
+# this is absolutely arbitrary, synthetic pps is usually less than 1.2m pps (for now)
+DPDK_PPS_THRESHOLD = 1_200_000

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Tuple
 
 from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.common import (
+    DPDK_PPS_THRESHOLD,
     DPDK_STABLE_GIT_REPO,
     PackageManagerInstall,
     Pmd,
@@ -571,7 +572,7 @@ class Dpdk(TestSuite):
             assert_that(pps).described_as(
                 f"{tx_or_rx}-PPS ({pps}) should have been greater "
                 "than 2^20 (~1m) PPS before sriov disable."
-            ).is_greater_than(2**20)
+            ).is_greater_than(DPDK_PPS_THRESHOLD)
         # not checking if traffic is below some arbitrary
         # threshold because it's a moving target. New skus
         # will be faster. Let's just check for the hotplug

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.common import (
     AZ_ROUTE_ALL_TRAFFIC,
+    DPDK_PPS_THRESHOLD,
     DPDK_STABLE_GIT_REPO,
     Downloader,
     GitDownloader,
@@ -674,7 +675,7 @@ def verify_dpdk_build(
     node.tools[Dmesg].check_kernel_errors(force_run=True)
     assert_that(tx_pps).described_as(
         f"TX-PPS ({tx_pps}) should have been greater than 2^20 (~1m) PPS."
-    ).is_greater_than(2**20)
+    ).is_greater_than(DPDK_PPS_THRESHOLD)
     return test_kit
 
 
@@ -761,10 +762,10 @@ def verify_dpdk_send_receive(
     # differences in NIC type throughput can lead to different snd/rcv counts
     assert_that(rcv_rx_pps).described_as(
         "Throughput for RECEIVE was below the correct order-of-magnitude"
-    ).is_greater_than(2**20)
+    ).is_greater_than(DPDK_PPS_THRESHOLD)
     assert_that(snd_tx_pps).described_as(
         "Throughput for SEND was below the correct order of magnitude"
-    ).is_greater_than(2**20)
+    ).is_greater_than(DPDK_PPS_THRESHOLD)
 
     return sender, receiver
 
@@ -904,11 +905,11 @@ def verify_dpdk_mutliple_ports(
     # differences in NIC type throughput can lead to different snd/rcv counts
     assert_that(rcv_rx_pps).described_as(
         "Throughput for RECEIVE was below the correct order-of-magnitude"
-    ).is_greater_than(2**20)
+    ).is_greater_than(DPDK_PPS_THRESHOLD)
     for sender_pps in sender_pps_measurements:
         assert_that(sender_pps).described_as(
             "Throughput for SEND was below the correct order of magnitude"
-        ).is_greater_than(2**20)
+        ).is_greater_than(DPDK_PPS_THRESHOLD)
 
     return receiver_kit, sender_port_a, sender_port_b
 


### PR DESCRIPTION
Adds a test with multiple senders and a single receiver using two ports.

The largest change for this requires fixing the argument generation and handling of which nics to use. Now, nics are picked explicitly by subnet to ensure senders and receivers are able to reach each other. Nic name and list order are not reliable.

The other change is passing a list of NicInfo objects to the argument generation functions instead of relying on an implicit default. Now, multiple ports can be included arbitrarily.