### PR TITLE
dpdk: testpmd check packet drops

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -700,7 +700,7 @@ class DpdkTestpmd(Tool):
         self,
         search_key_constant: str,
         testpmd_output: str,
-        discard_first_and_last : bool = True,
+        discard_first_and_last: bool = True,
     ) -> List[int]:
         # Find all data in the output that matches
         # Apply a list of filters to the data
@@ -721,13 +721,15 @@ class DpdkTestpmd(Tool):
         data_as_integers = list(map(int, matches))
         assert_that(data_as_integers).described_as(
             f"Could not find any data in testpmd output"
-            f" for key {search_key_constant}").is_not_empty()
+            f" for key {search_key_constant}"
+        ).is_not_empty()
         data_as_integers = _discard_first_zeroes(data_as_integers)
         if discard_first_and_last:
             data_as_integers = _discard_first_and_last_sample(data_as_integers)
         assert_that(data_as_integers).described_as(
             f"Could not find any data in testpmd output"
-            f" for key {search_key_constant}.").is_not_empty()
+            f" for key {search_key_constant}."
+        ).is_not_empty()
         return data_as_integers
 
     def populate_performance_data(self) -> None:

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -770,8 +770,8 @@ class DpdkTestpmd(Tool):
             raise AssertionError(
                 "Test bug: tx packet data was 0, could not check dropped packets"
             )
-        self.dropped_packet_percentage = self.tx_packet_drops / self.tx_total_packets
-        assert_that(self.dropped_packet_percentage).described_as(
+        self.packet_drop_rate = self.tx_packet_drops / self.tx_total_packets
+        assert_that(self.packet_drop_rate).described_as(
             "More than 33% of the tx packets were dropped!"
         ).is_close_to(0, 0.33)
 
@@ -780,8 +780,8 @@ class DpdkTestpmd(Tool):
             raise AssertionError(
                 "Test bug: rx packet data was 0 could not check dropped packets."
             )
-        self.dropped_packet_percentage = self.rx_packet_drops / self.rx_total_packets
-        assert_that(self.dropped_packet_percentage).described_as(
+        self.packet_drop_rate = self.rx_packet_drops / self.rx_total_packets
+        assert_that(self.packet_drop_rate).described_as(
             "More than 1% of the received packets were dropped!"
         ).is_close_to(0, 0.01)
 

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -422,7 +422,7 @@ class DpdkTestpmd(Tool):
         _tx_drop_key: r"TX-dropped:\s+([0-9]+)",
         _rx_drop_key: r"RX-dropped:\s+([0-9]+)",
         _tx_total_key: r"TX-packets:\s+([0-9]+)",
-        _rx_total_key: r"TX-packets:\s+([0-9]+)",
+        _rx_total_key: r"RX-packets:\s+([0-9]+)",
     }
     _source_build_dest_dir = "/usr/local/bin"
 
@@ -770,18 +770,18 @@ class DpdkTestpmd(Tool):
             raise AssertionError(
                 "Test bug: tx packet data was 0, could not check dropped packets"
             )
-        dropped_packet_percentage = self.tx_packet_drops / self.tx_total_packets
-        assert_that(dropped_packet_percentage).described_as(
-            "More than 20% of the tx packets were dropped!"
-        ).is_close_to(0, 0.2)
+        self.dropped_packet_percentage = self.tx_packet_drops / self.tx_total_packets
+        assert_that(self.dropped_packet_percentage).described_as(
+            "More than 33% of the tx packets were dropped!"
+        ).is_close_to(0, 0.33)
 
     def check_rx_packet_drops(self) -> None:
         if self.rx_total_packets == 0:
             raise AssertionError(
                 "Test bug: rx packet data was 0 could not check dropped packets."
             )
-        dropped_packet_percentage = self.rx_packet_drops / self.rx_total_packets
-        assert_that(dropped_packet_percentage).described_as(
+        self.dropped_packet_percentage = self.rx_packet_drops / self.rx_total_packets
+        assert_that(self.dropped_packet_percentage).described_as(
             "More than 1% of the received packets were dropped!"
         ).is_close_to(0, 0.01)
 

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -783,7 +783,7 @@ class DpdkTestpmd(Tool):
             )
         self.packet_drop_rate = self.tx_packet_drops / self.tx_total_packets
         assert_that(self.packet_drop_rate).described_as(
-            'More than 33% of the tx packets were dropped!'
+            "More than 33% of the tx packets were dropped!"
         ).is_close_to(0, 0.33)
 
     def check_rx_packet_drops(self) -> None:

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -783,10 +783,11 @@ def annotate_packet_drops(
     log: Logger, result: Optional[TestResult], receiver: DpdkTestResources
 ) -> None:
     try:
-        if result and hasattr(receiver.testpmd, "dropped_packet_percentage"):
-            dropped_packets = receiver.testpmd.dropped_packet_percentage
-            result.information["rx_pkt_drop_percent"] = int(100 * dropped_packets)
-            log.debug(f"Adding packet drop percentage: {dropped_packets}")
+        if result and hasattr(receiver.testpmd, "packet_drop_rate"):
+            dropped_packets = receiver.testpmd.packet_drop_rate
+            fmt_drop_rate = f"{dropped_packets:.2f}"
+            result.information["rx_pkt_drop_rate"] = fmt_drop_rate
+            log.debug(f"Adding packet drop percentage: {fmt_drop_rate}")
     except AssertionError as err:
         receiver.node.log.debug(f"Could not add rx packet drop percentage: {str(err)}")
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -773,7 +773,22 @@ def verify_dpdk_send_receive(
     # verify receiver didn't drop most of the packets
     receiver.testpmd.check_rx_packet_drops()
 
+    # annotate the amount of dropped packets on the receiver
+    annotate_packet_drops(log, result, receiver)
+
     return sender, receiver
+
+
+def annotate_packet_drops(
+    log: Logger, result: Optional[TestResult], receiver: DpdkTestResources
+) -> None:
+    try:
+        if result and hasattr(receiver.testpmd, "dropped_packet_percentage"):
+            dropped_packets = receiver.testpmd.dropped_packet_percentage
+            result.information["rx_pkt_drop_percent"] = int(100 * dropped_packets)
+            log.debug(f"Adding packet drop percentage: {dropped_packets}")
+    except AssertionError as err:
+        receiver.node.log.debug(f"Could not add rx packet drop percentage: {str(err)}")
 
 
 def verify_dpdk_send_receive_multi_txrx_queue(

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -767,6 +767,12 @@ def verify_dpdk_send_receive(
         "Throughput for SEND was below the correct order of magnitude"
     ).is_greater_than(DPDK_PPS_THRESHOLD)
 
+    # verify sender didn't drop most of the packets
+    sender.testpmd.check_tx_packet_drops()
+
+    # verify receiver didn't drop most of the packets
+    receiver.testpmd.check_rx_packet_drops()
+
     return sender, receiver
 
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -689,6 +689,7 @@ def verify_dpdk_send_receive(
     multiple_queues: bool = False,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
+    check_sender_packet_drops:bool=False,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # helpful to have the public ips labeled for debugging
     external_ips = []
@@ -767,8 +768,11 @@ def verify_dpdk_send_receive(
         "Throughput for SEND was below the correct order of magnitude"
     ).is_greater_than(DPDK_PPS_THRESHOLD)
 
-    # verify sender didn't drop most of the packets
-    sender.testpmd.check_tx_packet_drops()
+    # sender packet drops are common when network bandwidth is
+    # artificially throttled by the sku, so checking sender
+    # is optional
+    if check_sender_packet_drops:
+        sender.testpmd.check_tx_packet_drops()
 
     # verify receiver didn't drop most of the packets
     receiver.testpmd.check_rx_packet_drops()

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -689,7 +689,7 @@ def verify_dpdk_send_receive(
     multiple_queues: bool = False,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
-    check_sender_packet_drops:bool=False,
+    check_sender_packet_drops: bool = False,
 ) -> Tuple[DpdkTestResources, DpdkTestResources]:
     # helpful to have the public ips labeled for debugging
     external_ips = []


### PR DESCRIPTION
Gathers and checks packet drops at the end of send receive tests. Senders are allowed to drop more packets, we intentionally tune it to maximize the PPS, so some drops are expected. The rough metric in this PR is that the percentage of packets dropped should not exceed 20% on the sender and 1% on the receiver. 