### PR TITLE
Test Case logs: Log environment used for the test case

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -724,7 +724,8 @@ class TestSuite:
             case_kwargs.update({"result": case_result})
 
             case_log.info(
-                f"test case '{case_result.runtime_data.full_name}' is running"
+                f"test case '{case_result.runtime_data.full_name}' "
+                f"is running on environment '{environment.name}'"
             )
             is_continue: bool = is_suite_continue
             total_timer = create_timer()
@@ -778,7 +779,9 @@ class TestSuite:
                     )
 
             case_log.info(
-                f"result: {case_result.status.name}, " f"elapsed: {total_timer}"
+                f"result: {case_result.status.name}, "
+                f"elapsed: {total_timer}, "
+                f"environment: {environment.name}"
             )
             case_result.unsubscribe_log(environment.log)
             case_result.close_log_file_handler()


### PR DESCRIPTION
It is difficult to map the environment used by the case when multiple cases are selected for a run.
This makes it easy to identify the environment from the LISA logs with INFO logging mode.