### PR TITLE
mshv: use timeout tool for mshvtrace test

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -30,6 +30,7 @@ from lisa.tools import (
     Service,
     Stat,
     Tar,
+    Timeout,
 )
 from lisa.util import LisaException, SkippedException, find_group_in_lines
 from lisa.util.perf_timer import create_timer
@@ -307,10 +308,12 @@ class MshvHostTestSuite(TestSuite):
             create_result = node.execute(f"{mshvtrace_path} create", sudo=True)
             assert_that(create_result.exit_code).is_equal_to(0)
 
-            # 3. Collect trace for 30 seconds using node.execute with timeout argument
-            _ = node.execute(
-                f"{mshvtrace_path} collect -o {trace_output}", sudo=True, timeout=35
+            # 3. Collect trace for 5 seconds using timeout tool
+            collect_result = node.tools[Timeout].run_with_timeout(
+                command=f"{mshvtrace_path} collect -o {trace_output}", timeout=5
             )
+            assert_that(collect_result.exit_code).is_equal_to(0)
+
             trace_size = node.tools[Stat].get_total_size(trace_output, sudo=True)
             # 8192 is the min size of the trace file.
             assert_that(int(trace_size)).described_as(


### PR DESCRIPTION
LISA's execute function now raises exceptin on timeout. mshvtrace is
expected to run until killed and being killed after timeout isn't an
error in this testcase.

Instead of using the execute timeout and suppressing the resulting
exception, use the timeout tool instead.

Fixes a regression in our testcase due to commit 8ae13dc8df4fbf97a903a3707ffc254c29d65b84