### PR TITLE
Handle perftool installation for trixie

### DIFF
--- a/lisa/tools/perf.py
+++ b/lisa/tools/perf.py
@@ -41,10 +41,9 @@ class Perf(Tool):
                 # Similar issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=983314 # noqa: E501
                 self.node.os.install_packages("linux-perf-5.10")
                 self._command = "perf_5.10"
-            elif (
-                isinstance(self.node.os, Debian)
-                and self.node.os.information.codename == "bookworm"
-            ):
+            elif isinstance(
+                self.node.os, Debian
+            ) and self.node.os.information.codename in {"bookworm", "trixie"}:
                 # bookworm, where command "perf" works
                 self.node.os.install_packages("linux-perf")
             else:


### PR DESCRIPTION
Follow the same install steps as bookworm for trixie as well
this is tested with the following tests:
PerfToolSuite.perf_epoll
PerfToolSuite.perf_messaging
 with debian 12 and 13