### PR TITLE
Upgrade Pillow version to support Python 3.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ azure = [
     "azure-keyvault-certificates ~= 4.7.0",
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
-    "Pillow <= 11.1.0",
+    "Pillow <= 12.0.0",
     "PyGObject <= 3.50.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]


### PR DESCRIPTION
This is needed because the newer Python version used by the lisa-overlake reporsitory (which uses lisa as a submodule) is not supported by the older Pillow version of 11.1.0.