### PR TITLE
Include eastus2 in default region list

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -175,6 +175,7 @@ LOCATIONS = [
     "brazilsouth",
     "australiaeast",
     "uksouth",
+    "eastus2",
 ]
 RESOURCE_GROUP_LOCATION = "westus3"
 

--- a/selftests/azure/azure_locations_eastus2.json
+++ b/selftests/azure/azure_locations_eastus2.json
@@ -1,0 +1,5 @@
+{
+    "updated_time": "9999-09-21T12:16:46.895330",
+    "location": "eastus2",
+    "capabilities": {}
+}


### PR DESCRIPTION
We have quota for Standard_NCC40ads_H100_v5 in eastus2, and I want to increase the chances that it gets picked up across all of our validation to cover CGPU scenarios.