### PR TITLE
Fix incorrect "Likely hung in" diagnostic for CH integration tests

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -682,18 +682,53 @@ class CloudHypervisorTests(Tool):
             assert_msg = assertions[0].strip()[:100]
             diagnostic_messages.append(f"Assertion: {assert_msg}")
 
-        # Add "likely hung in" diagnostic for timeouts based on last successful test
-        oks = re.findall(r"test\s+(\S+)\s+\.\.\.\s+ok", stdout)
-        if oks and hasattr(self, "_ordered_subtests"):
-            try:
-                last_ok = oks[-1]
-                i = self._ordered_subtests.index(last_ok)
-                if i + 1 < len(self._ordered_subtests):
-                    diagnostic_messages.append(
-                        f"Likely hung in: {self._ordered_subtests[i + 1]}"
-                    )
-            except (ValueError, IndexError):
-                pass
+        # Only check for hung tests if we don't already have explicit test
+        # failures (failed tests have their own diagnostic messages, hung
+        # test detection is for timeouts)
+        if not failed_tests:
+            # Add "likely hung in" diagnostic for timeouts
+            # Look for tests that started but didn't finish
+            started_pattern = r"test\s+(\S+)\s+\.\.\."
+            started_tests = re.findall(started_pattern, stdout)
+
+            # Get tests that finished (ok, FAILED, ignored, etc.)
+            finished_pattern = r"test\s+(\S+)\s+\.\.\.\s+(ok|FAILED|ignored)"
+            finished_matches = re.findall(finished_pattern, stdout)
+            finished_tests = [match[0] for match in finished_matches]
+
+            # Find tests that started but never finished, preserving order
+            # and uniqueness
+            hung_tests = list(
+                dict.fromkeys(
+                    [test for test in started_tests if test not in finished_tests]
+                )
+            )
+
+            # Priority 1: Check for "has been running" messages for tests
+            # that didn't finish
+            running_pattern = r"test\s+(\S+)\s+has been running for over \d+ seconds"
+            running_tests = re.findall(running_pattern, stdout)
+
+            # Cross-check: only report running tests that actually didn't
+            # finish
+            hung_running_tests = [t for t in running_tests if t in hung_tests]
+
+            if hung_running_tests:
+                # Found test explicitly marked as running too long AND
+                # didn't finish
+                diagnostic_messages.append(f"Likely hung in: {hung_running_tests[0]}")
+            elif hung_tests:
+                # Use the LAST unfinished test (most recent one that
+                # didn't complete)
+                diagnostic_messages.append(f"Likely hung in: {hung_tests[-1]}")
+            elif finished_tests:
+                # All detected tests finished but watchdog still triggered
+                # This means hang occurred after last successful test
+                # (setup/teardown/next test)
+                diagnostic_messages.append(
+                    f"Hang occurred after last successful test: "
+                    f"{finished_tests[-1]}"
+                )
 
         return diagnostic_messages
 


### PR DESCRIPTION
The previous logic assumed the next test in the ordered list hung, which incorrectly blamed tests that had already passed. Now detects tests that started but didn't finish by comparing started vs finished test patterns in the stdout output.