### PR TITLE
Remove new lines in kprobe output

### DIFF
--- a/lisa/microsoft/testsuites/core/debug.py
+++ b/lisa/microsoft/testsuites/core/debug.py
@@ -92,7 +92,7 @@ class KernelDebug(TestSuite):
                     "/sys/kernel/debug/tracing/kprobe_events",
                     sudo=True,
                     force_run=True,
-                )
+                ).strip()
             ).described_as(
                 "after echoing 'p:my filp_close' to "
                 "/sys/kernel/debug/tracing/kprobe_events, "
@@ -105,7 +105,7 @@ class KernelDebug(TestSuite):
                     "/sys/kernel/debug/tracing/events/kprobes/my/enable",
                     sudo=True,
                     force_run=True,
-                )
+                ).strip()
             ).described_as(
                 "after echoing '1' to "
                 "/sys/kernel/debug/tracing/events/kprobes/my/enable, "


### PR DESCRIPTION
For Fedora 43, `verify_enable_kprobe` fails because the output contains newline characters

For example: 
```
AssertionError: [after echoing 'p:my filp_close' to /sys/kernel/debug/tracing/kprobe_events, its value should be changed into 'p:kprobes/my filp_close'] Expected **<p:kprobes/my filp_close
>** to be equal to <p:kprobes/my filp_close>, but was not.
```
Therefore, strip the newlines.