### PR TITLE
Information: node_count

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -909,6 +909,7 @@ class AzurePlatform(Platform):
         node_runbook: Optional[AzureNodeSchema] = None
         if environment.nodes:
             node: Optional[Node] = environment.default_node
+            information["node_count"] = str(len(environment.nodes))
         else:
             node = None
 


### PR DESCRIPTION
Add node_count to the test result information field. This will let us know how many nodes are deployed for a given environment.