### PR TITLE
Stress-ng add stability to test cases

### DIFF
--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -73,6 +73,7 @@ class StressNgTestSuite(TestSuite):
     @TestCaseMetadata(
         description="Runs stress-ng's 'cpu' class stressors for 60s each.",
         priority=4,
+        timeout=7200,  # 2 hours
     )
     def stress_ng_cpu_stressors(
         self,

--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -80,7 +80,7 @@ class StressNg(Tool):
         v_flag = "-v" if verbose else ""
         return self.run_async(
             f"{v_flag} --sequential {num_workers} --class {class_name} "
-            f"--timeout {timeout_secs}",
+            f"--timeout {timeout_secs} --oom-avoid",
             sudo=sudo,
         )
 

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -43,6 +43,7 @@ class ExecutableResult:
     _stderr: str
     exit_code: Optional[int]
     cmd: Union[str, List[str]]
+    _id_: str
     elapsed: float
     is_timeout: bool = False
 
@@ -71,7 +72,9 @@ class ExecutableResult:
         message: str = "",
         include_output: bool = False,
     ) -> AssertionBuilder:
-        message = "\n".join([message, f"Get unexpected exit code on cmd {self.cmd}"])
+        message = "\n".join(
+            [message, f"Get unexpected exit code on cmd {self._id_} {self.cmd}"]
+        )
         if include_output:
             message = "\n".join(
                 [message, "stdout:", self.stdout, "stderr:", self.stderr]
@@ -322,7 +325,7 @@ class Process:
             # FileNotFoundError: not found command on Windows
             # NoSuchCommandError: not found command on remote Posix
             self._result = ExecutableResult(
-                "", e.strerror, 1, split_command, self._timer.elapsed()
+                "", e.strerror, 1, split_command, self._id_, self._timer.elapsed()
             )
             self._log.log(stderr_level, f"not found command: {e}")
         except SshSpawnTimeoutException:
@@ -431,6 +434,7 @@ class Process:
             process_result.stderr_output.strip(),
             process_result.return_code,
             self._cmd,
+            self._id_,
             self._timer.elapsed(),
             is_timeout,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,20 +13,21 @@ classifiers = [
 ]
 dependencies = [
     "assertpy ~= 1.1",
-    "func-timeout ~= 4.3.5",
+    "charset_normalizer ~= 2.1.1",
     "dataclasses-json ~= 0.5.2",
+    "exceptiongroup ~= 1.3.1",
+    "func-timeout ~= 4.3.5",
     "paramiko ~= 3.5.1",
     "pluggy ~= 0.13.1",
     "python-dateutil ~= 2.8.1",
     "PyYAML ~= 6.0.1",
     "randmac ~= 0.1",
+    "requests ~= 2.32.4",
     "retry ~= 0.9.2",
     "semver ~= 2.13.0",
     "simpleeval ~= 0.9.12",
     "spurplus ~= 2.3.5",
     "websockets ~= 15.0.1",
-    "charset_normalizer ~= 2.1.1",
-    "requests ~= 2.32.4",
 ]
 dynamic = ["version"]
 license = {text = "MIT"}


### PR DESCRIPTION
1. CPU class has 67+ tests, running for 60s each needs over an hour (the default) to execute
2. Using `--oom-avoid` flag prevents failures due to OOM kill on the IO class tests
3. Make error messages more descriptive: return a list of all failures instead of just the first error, correlate the cmd id to the error, categorize failures by initialization, execution, and kernel panics.