### PR TITLE
Move storage perf logic to common.py

### DIFF
--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -16,8 +16,10 @@ from lisa import (
     SkippedException,
     notifier,
     run_in_parallel,
+    schema,
 )
 from lisa.features import Nvme
+from lisa.features.disks import Disk
 from lisa.messages import (
     DiskPerformanceMessage,
     DiskSetupType,
@@ -760,6 +762,103 @@ def perf_sockperf(
 
         for sysctl in sysctls:
             sysctl.reset()
+
+
+def perf_premium_datadisks(
+    node: Node,
+    test_result: TestResult,
+    disk_setup_type: DiskSetupType = DiskSetupType.raw,
+    disk_type: DiskType = DiskType.premiumssd,
+    block_size: int = 4,
+    start_iodepth: int = 1,
+    max_iodepth: int = 256,
+) -> None:
+    disk = node.features[Disk]
+    data_disks = disk.get_raw_data_disks()
+    disk_count = len(data_disks)
+    assert_that(disk_count).described_as(
+        "At least 1 data disk for fio testing."
+    ).is_greater_than(0)
+    partition_disks = reset_partitions(node, data_disks)
+    filename = ":".join(partition_disks)
+    cpu = node.tools[Lscpu]
+    thread_count = cpu.get_thread_count()
+    perf_disk(
+        node,
+        start_iodepth,
+        max_iodepth,
+        filename,
+        test_name=inspect.stack()[1][3],
+        core_count=thread_count,
+        disk_count=disk_count,
+        disk_setup_type=disk_setup_type,
+        disk_type=disk_type,
+        numjob=thread_count,
+        block_size=block_size,
+        size_mb=8192,
+        overwrite=True,
+        test_result=test_result,
+    )
+
+
+def perf_resource_disks(
+    node: Node,
+    test_result: TestResult,
+    disk_setup_type: DiskSetupType = DiskSetupType.raw,
+    block_size: int = 4,
+    start_iodepth: int = 1,
+    max_iodepth: int = 256,
+) -> None:
+    disk = node.features[Disk]
+    resource_disks = disk.get_resource_disks()
+    disk_count = len(resource_disks)
+    if disk_count == 0:
+        raise SkippedException(
+            "No resource disk found, skipping resource disk performance test."
+        )
+    resource_disk_type = disk.get_resource_disk_type()
+    if schema.ResourceDiskType.NVME == resource_disk_type:
+        perf_nvme(
+            node,
+            test_result,
+            disk_type=DiskType.localnvme,
+        )
+        return
+    elif schema.ResourceDiskType.SCSI == resource_disk_type:
+        # If there is only one resource disk and its SCSI type,
+        # it will be mounted at /mnt.
+        # Create a file under and use it as fio filename.
+        # If there are multiple resource disks, reset partitions and
+        # use the partition disks as fio filename.
+        if disk_count == 1:
+            filename = f"{disk.get_resource_disk_mount_point()}/fiodata"
+        else:
+            partition_disks = reset_partitions(node, resource_disks)
+            filename = ":".join(partition_disks)
+        core_count = node.tools[Lscpu].get_core_count()
+
+        perf_disk(
+            node,
+            start_iodepth,
+            max_iodepth,
+            filename,
+            test_name=inspect.stack()[1][3],
+            core_count=core_count,
+            disk_count=disk_count,
+            disk_setup_type=disk_setup_type,
+            disk_type=DiskType.localssd,
+            numjob=core_count,
+            block_size=block_size,
+            size_mb=8192,
+            overwrite=True,
+            test_result=test_result,
+        )
+
+    else:
+        raise SkippedException(
+            f"Resource disk type {resource_disk_type} not supported for "
+            f"performance test."
+        )
 
 
 def calculate_middle_average(values: List[Union[float, int]]) -> float:

--- a/lisa/microsoft/testsuites/performance/storageperf.py
+++ b/lisa/microsoft/testsuites/performance/storageperf.py
@@ -7,13 +7,6 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, cast
 
 from assertpy import assert_that
-from microsoft.testsuites.performance.common import (
-    perf_disk,
-    perf_nvme,
-    reset_partitions,
-    reset_raid,
-    stop_raid,
-)
 
 from lisa import (
     Environment,
@@ -29,6 +22,14 @@ from lisa import (
 from lisa.features import AvailabilityZoneEnabled, Disk
 from lisa.features.network_interface import Sriov, Synthetic
 from lisa.messages import DiskSetupType, DiskType
+from lisa.microsoft.testsuites.performance.common import (
+    perf_disk,
+    perf_premium_datadisks,
+    perf_resource_disks,
+    reset_partitions,
+    reset_raid,
+    stop_raid,
+)
 from lisa.node import RemoteNode
 from lisa.operating_system import Debian, Redhat, Suse
 from lisa.sut_orchestrator.azure.features import AzureDiskOptionSettings
@@ -64,7 +65,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_ultra_datadisks_4k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(
+        perf_premium_datadisks(
             node=node,
             test_result=result,
             disk_type=DiskType.ultradisk,
@@ -86,7 +87,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_ultra_datadisks_1024k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(
+        perf_premium_datadisks(
             node=node,
             test_result=result,
             block_size=1024,
@@ -110,7 +111,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premiumv2_datadisks_4k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(
+        perf_premium_datadisks(
             node=node,
             test_result=result,
             disk_type=DiskType.premiumv2ssd,
@@ -134,7 +135,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premiumv2_datadisks_1024k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(
+        perf_premium_datadisks(
             node=node,
             test_result=result,
             block_size=1024,
@@ -157,7 +158,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_4k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(node, result)
+        perf_premium_datadisks(node, result)
 
     @TestCaseMetadata(
         description="""
@@ -175,7 +176,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_1024k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(node, result, block_size=1024)
+        perf_premium_datadisks(node, result, block_size=1024)
 
     @TestCaseMetadata(
         description="""
@@ -188,7 +189,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_resource_disk_1024k(self, node: Node, result: TestResult) -> None:
-        self._perf_resource_disks(node, result, block_size=1024)
+        perf_resource_disks(node, result, block_size=1024)
 
     @TestCaseMetadata(
         description="""
@@ -201,7 +202,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_resource_disk_4k(self, node: Node, result: TestResult) -> None:
-        self._perf_resource_disks(node, result, block_size=4)
+        perf_resource_disks(node, result, block_size=4)
 
     @TestCaseMetadata(
         description="""
@@ -219,7 +220,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_standardssd_datadisks_4k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(node, result, disk_type=DiskType.standardssd)
+        perf_premium_datadisks(node, result, disk_type=DiskType.standardssd)
 
     @TestCaseMetadata(
         description="""
@@ -237,7 +238,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_standardssd_datadisks_1024k(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(
+        perf_premium_datadisks(
             node, result, disk_type=DiskType.standardssd, block_size=1024
         )
 
@@ -257,7 +258,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_io(self, node: Node, result: TestResult) -> None:
-        self._perf_premium_datadisks(node, result, max_iodepth=64)
+        perf_premium_datadisks(node, result, max_iodepth=64)
 
     @TestCaseMetadata(
         description="""
@@ -609,103 +610,6 @@ class StoragePerformance(TestSuite):
             client_node.tools[NFSClient].stop(mount_dir=client_nfs_mount_dir)
             server_node.tools[Mount].umount(
                 server_raid_disk_name, server_raid_disk_mount_dir
-            )
-
-    def _perf_premium_datadisks(
-        self,
-        node: Node,
-        test_result: TestResult,
-        disk_setup_type: DiskSetupType = DiskSetupType.raw,
-        disk_type: DiskType = DiskType.premiumssd,
-        block_size: int = 4,
-        start_iodepth: int = 1,
-        max_iodepth: int = 256,
-    ) -> None:
-        disk = node.features[Disk]
-        data_disks = disk.get_raw_data_disks()
-        disk_count = len(data_disks)
-        assert_that(disk_count).described_as(
-            "At least 1 data disk for fio testing."
-        ).is_greater_than(0)
-        partition_disks = reset_partitions(node, data_disks)
-        filename = ":".join(partition_disks)
-        cpu = node.tools[Lscpu]
-        thread_count = cpu.get_thread_count()
-        perf_disk(
-            node,
-            start_iodepth,
-            max_iodepth,
-            filename,
-            test_name=inspect.stack()[1][3],
-            core_count=thread_count,
-            disk_count=disk_count,
-            disk_setup_type=disk_setup_type,
-            disk_type=disk_type,
-            numjob=thread_count,
-            block_size=block_size,
-            size_mb=8192,
-            overwrite=True,
-            test_result=test_result,
-        )
-
-    def _perf_resource_disks(
-        self,
-        node: Node,
-        test_result: TestResult,
-        disk_setup_type: DiskSetupType = DiskSetupType.raw,
-        block_size: int = 4,
-        start_iodepth: int = 1,
-        max_iodepth: int = 256,
-    ) -> None:
-        disk = node.features[Disk]
-        resource_disks = disk.get_resource_disks()
-        disk_count = len(resource_disks)
-        if disk_count == 0:
-            raise SkippedException(
-                "No resource disk found, skipping resource disk performance test."
-            )
-        resource_disk_type = disk.get_resource_disk_type()
-        if schema.ResourceDiskType.NVME == resource_disk_type:
-            perf_nvme(
-                node,
-                test_result,
-                disk_type=DiskType.localnvme,
-            )
-            return
-        elif schema.ResourceDiskType.SCSI == resource_disk_type:
-            # If there is only one resource disk and its SCSI type,
-            # it will be mounted at /mnt.
-            # Create a file under and use it as fio filename.
-            # If there are multiple resource disks, reset partitions and
-            # use the partition disks as fio filename.
-            if disk_count == 1:
-                filename = f"{disk.get_resource_disk_mount_point()}/fiodata"
-            else:
-                partition_disks = reset_partitions(node, resource_disks)
-                filename = ":".join(partition_disks)
-            core_count = node.tools[Lscpu].get_core_count()
-
-            perf_disk(
-                node,
-                start_iodepth,
-                max_iodepth,
-                filename,
-                test_name=inspect.stack()[1][3],
-                core_count=core_count,
-                disk_count=disk_count,
-                disk_setup_type=disk_setup_type,
-                disk_type=DiskType.localssd,
-                numjob=core_count,
-                block_size=block_size,
-                size_mb=8192,
-                overwrite=True,
-                test_result=test_result,
-            )
-
-        else:
-            raise SkippedException(
-                f"Resource disk type {resource_disk_type} not supported for "
-                f"performance test."
             )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:


### PR DESCRIPTION
This allows the logic to be reused in other test cases and extensions.