### PR TITLE
Add libbpf-tools test suite and fix package detection for dnf5

### DIFF
--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 from __future__ import annotations
 
-from typing import cast
-
 from assertpy import assert_that
 
 from lisa import (
@@ -14,7 +12,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import Posix
+from lisa.operating_system import BSD, Windows
 from lisa.sut_orchestrator import AZURE, HYPERV, READY
 
 
@@ -28,7 +26,7 @@ from lisa.sut_orchestrator import AZURE, HYPERV, READY
     """,
     requirement=simple_requirement(
         supported_platform_type=[AZURE, READY, HYPERV],
-        supported_os=[Posix],
+        unsupported_os=[BSD, Windows],
     ),
 )
 class LibbpfToolsSuite(TestSuite):
@@ -46,22 +44,21 @@ class LibbpfToolsSuite(TestSuite):
         priority=2,
     )
     def verify_libbpf_tools_package_available(self, node: Node) -> None:
-        # Cast for mypy - supported_os filter ensures node.os is Posix
-        posix_os = cast(Posix, node.os)
-
         # Check if package is already installed
-        package_exists = posix_os.package_exists("libbpf-tools")
-
+        package_exists = node.os.package_exists("libbpf-tools")
+        
         if not package_exists:
             # Check if package is available in repositories
-            if not posix_os.is_package_in_repo("libbpf-tools"):
-                raise SkippedException("libbpf-tools package not found in repositories")
-
+            if not node.os.is_package_in_repo("libbpf-tools"):
+                raise SkippedException(
+                    "libbpf-tools package not found in repositories"
+                )
+            
             # Package is available, install it
-            posix_os.install_packages("libbpf-tools")
-
+            node.os.install_packages("libbpf-tools")
+        
         # Verify package is now installed
-        package_installed = posix_os.package_exists("libbpf-tools")
+        package_installed = node.os.package_exists("libbpf-tools")
         assert_that(package_installed).described_as(
             "libbpf-tools package should be installed"
         ).is_true()
@@ -84,7 +81,7 @@ class LibbpfToolsSuite(TestSuite):
     def verify_libbpf_tools_binaries_executable(self, node: Node) -> None:
         # Ensure package is installed by calling the availability test
         self.verify_libbpf_tools_package_available(node)
-
+        
         # List of common libbpf-tools to test
         # We'll test them with --help or similar to verify they execute
         # Note: Fedora and CBL-Mariner use "bpf-" prefix, Ubuntu/Debian don't
@@ -95,27 +92,27 @@ class LibbpfToolsSuite(TestSuite):
             "runqlat",  # Scheduler run queue latency
             "tcpconnect",  # Trace TCP connections
         ]
-
+        
         successful_tools = []
         failed_tools = []
         skipped_tools = []
-
+        
         for base_tool_name in tools_to_test:
             # Try both with and without bpf- prefix
             tool_found = False
             tool_name = None
             tool_path = None
-
+            
             for prefix in ["bpf-", ""]:
                 candidate = f"{prefix}{base_tool_name}"
                 which_result = node.execute(f"which {candidate}", sudo=True)
-
+                
                 if which_result.exit_code == 0:
                     tool_name = candidate
                     tool_path = which_result.stdout.strip()
                     tool_found = True
                     break
-
+            
             if not tool_found:
                 node.log.debug(
                     f"{base_tool_name} not found in PATH "
@@ -123,7 +120,7 @@ class LibbpfToolsSuite(TestSuite):
                 )
                 skipped_tools.append(base_tool_name)
                 continue
-
+            
             # Try running with help flag
             cmd = f"{tool_path} -h"
             result = node.execute(cmd, sudo=True)
@@ -141,7 +138,7 @@ class LibbpfToolsSuite(TestSuite):
                     f"Exit code: {result.exit_code}, "
                     f"stdout: {result.stdout}, stderr: {result.stderr}"
                 )
-
+        
         # Log summary
         node.log.info(
             f"libbpf-tools test summary: "
@@ -149,7 +146,7 @@ class LibbpfToolsSuite(TestSuite):
             f"{len(failed_tools)} failed, "
             f"{len(skipped_tools)} skipped"
         )
-
+        
         # We should have at least some tools working
         assert_that(len(successful_tools)).described_as(
             f"At least one libbpf tool should execute successfully. "
@@ -157,7 +154,7 @@ class LibbpfToolsSuite(TestSuite):
             f"Failed: {failed_tools}, "
             f"Skipped: {skipped_tools}"
         ).is_greater_than(0)
-
+        
         # Ideally no tools should fail (skipping is OK if not installed)
         assert_that(len(failed_tools)).described_as(
             f"No libbpf tools should fail to execute. Failed tools: {failed_tools}"
@@ -181,41 +178,41 @@ class LibbpfToolsSuite(TestSuite):
     def verify_execsnoop_traces_execution(self, node: Node) -> None:
         # Ensure package is installed by calling the availability test
         self.verify_libbpf_tools_package_available(node)
-
+        
         # Check if execsnoop exists
         which_result = node.execute("which execsnoop", sudo=True)
         if which_result.exit_code != 0:
             raise SkippedException("execsnoop tool not found")
-
+        
         # Run execsnoop for a short duration and capture output
         # We'll run a simple command that should show up in the trace
         test_command = "/bin/echo 'test_libbpf_trace'"
-
+        
         # Start execsnoop in background, run for 5 seconds
         execsnoop_cmd = "timeout 5 execsnoop > /tmp/execsnoop_output.txt 2>&1 &"
         node.execute(execsnoop_cmd, sudo=True, shell=True)
-
+        
         # Wait a moment for execsnoop to initialize
         node.execute("sleep 1")
-
+        
         # Execute our test command
         node.execute(test_command)
-
+        
         # Wait for execsnoop to finish
         node.execute("sleep 5")
-
+        
         # Read the output
         result = node.execute("cat /tmp/execsnoop_output.txt", sudo=True)
-
+        
         # Clean up
         node.execute("rm -f /tmp/execsnoop_output.txt", sudo=True)
-
+        
         # Verify our test command appears in the trace
         # execsnoop output typically shows command names
         assert_that(result.stdout).described_as(
             "execsnoop output should contain trace of executed commands"
         ).is_not_empty()
-
+        
         # We should see 'echo' in the output since we ran /bin/echo
         assert_that(result.stdout.lower()).described_as(
             f"execsnoop should trace the echo command. Output: {result.stdout}"

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT license.
 from __future__ import annotations
 
+from typing import cast
+
 from assertpy import assert_that
 
 from lisa import (
@@ -12,7 +14,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import BSD, Windows
+from lisa.operating_system import Posix
 from lisa.sut_orchestrator import AZURE, HYPERV, READY
 
 
@@ -26,7 +28,7 @@ from lisa.sut_orchestrator import AZURE, HYPERV, READY
     """,
     requirement=simple_requirement(
         supported_platform_type=[AZURE, READY, HYPERV],
-        unsupported_os=[BSD, Windows],
+        supported_os=[Posix],
     ),
 )
 class LibbpfToolsSuite(TestSuite):
@@ -44,21 +46,22 @@ class LibbpfToolsSuite(TestSuite):
         priority=2,
     )
     def verify_libbpf_tools_package_available(self, node: Node) -> None:
+        # Cast for mypy - supported_os filter ensures node.os is Posix
+        posix_os = cast(Posix, node.os)
+
         # Check if package is already installed
-        package_exists = node.os.package_exists("libbpf-tools")
-        
+        package_exists = posix_os.package_exists("libbpf-tools")
+
         if not package_exists:
             # Check if package is available in repositories
-            if not node.os.is_package_in_repo("libbpf-tools"):
-                raise SkippedException(
-                    "libbpf-tools package not found in repositories"
-                )
-            
+            if not posix_os.is_package_in_repo("libbpf-tools"):
+                raise SkippedException("libbpf-tools package not found in repositories")
+
             # Package is available, install it
-            node.os.install_packages("libbpf-tools")
-        
+            posix_os.install_packages("libbpf-tools")
+
         # Verify package is now installed
-        package_installed = node.os.package_exists("libbpf-tools")
+        package_installed = posix_os.package_exists("libbpf-tools")
         assert_that(package_installed).described_as(
             "libbpf-tools package should be installed"
         ).is_true()
@@ -81,7 +84,7 @@ class LibbpfToolsSuite(TestSuite):
     def verify_libbpf_tools_binaries_executable(self, node: Node) -> None:
         # Ensure package is installed by calling the availability test
         self.verify_libbpf_tools_package_available(node)
-        
+
         # List of common libbpf-tools to test
         # We'll test them with --help or similar to verify they execute
         # Note: Fedora and CBL-Mariner use "bpf-" prefix, Ubuntu/Debian don't
@@ -92,27 +95,27 @@ class LibbpfToolsSuite(TestSuite):
             "runqlat",  # Scheduler run queue latency
             "tcpconnect",  # Trace TCP connections
         ]
-        
+
         successful_tools = []
         failed_tools = []
         skipped_tools = []
-        
+
         for base_tool_name in tools_to_test:
             # Try both with and without bpf- prefix
             tool_found = False
             tool_name = None
             tool_path = None
-            
+
             for prefix in ["bpf-", ""]:
                 candidate = f"{prefix}{base_tool_name}"
                 which_result = node.execute(f"which {candidate}", sudo=True)
-                
+
                 if which_result.exit_code == 0:
                     tool_name = candidate
                     tool_path = which_result.stdout.strip()
                     tool_found = True
                     break
-            
+
             if not tool_found:
                 node.log.debug(
                     f"{base_tool_name} not found in PATH "
@@ -120,7 +123,7 @@ class LibbpfToolsSuite(TestSuite):
                 )
                 skipped_tools.append(base_tool_name)
                 continue
-            
+
             # Try running with help flag
             cmd = f"{tool_path} -h"
             result = node.execute(cmd, sudo=True)
@@ -138,7 +141,7 @@ class LibbpfToolsSuite(TestSuite):
                     f"Exit code: {result.exit_code}, "
                     f"stdout: {result.stdout}, stderr: {result.stderr}"
                 )
-        
+
         # Log summary
         node.log.info(
             f"libbpf-tools test summary: "
@@ -146,7 +149,7 @@ class LibbpfToolsSuite(TestSuite):
             f"{len(failed_tools)} failed, "
             f"{len(skipped_tools)} skipped"
         )
-        
+
         # We should have at least some tools working
         assert_that(len(successful_tools)).described_as(
             f"At least one libbpf tool should execute successfully. "
@@ -154,7 +157,7 @@ class LibbpfToolsSuite(TestSuite):
             f"Failed: {failed_tools}, "
             f"Skipped: {skipped_tools}"
         ).is_greater_than(0)
-        
+
         # Ideally no tools should fail (skipping is OK if not installed)
         assert_that(len(failed_tools)).described_as(
             f"No libbpf tools should fail to execute. Failed tools: {failed_tools}"
@@ -178,41 +181,41 @@ class LibbpfToolsSuite(TestSuite):
     def verify_execsnoop_traces_execution(self, node: Node) -> None:
         # Ensure package is installed by calling the availability test
         self.verify_libbpf_tools_package_available(node)
-        
+
         # Check if execsnoop exists
         which_result = node.execute("which execsnoop", sudo=True)
         if which_result.exit_code != 0:
             raise SkippedException("execsnoop tool not found")
-        
+
         # Run execsnoop for a short duration and capture output
         # We'll run a simple command that should show up in the trace
         test_command = "/bin/echo 'test_libbpf_trace'"
-        
+
         # Start execsnoop in background, run for 5 seconds
         execsnoop_cmd = "timeout 5 execsnoop > /tmp/execsnoop_output.txt 2>&1 &"
         node.execute(execsnoop_cmd, sudo=True, shell=True)
-        
+
         # Wait a moment for execsnoop to initialize
         node.execute("sleep 1")
-        
+
         # Execute our test command
         node.execute(test_command)
-        
+
         # Wait for execsnoop to finish
         node.execute("sleep 5")
-        
+
         # Read the output
         result = node.execute("cat /tmp/execsnoop_output.txt", sudo=True)
-        
+
         # Clean up
         node.execute("rm -f /tmp/execsnoop_output.txt", sudo=True)
-        
+
         # Verify our test command appears in the trace
         # execsnoop output typically shows command names
         assert_that(result.stdout).described_as(
             "execsnoop output should contain trace of executed commands"
         ).is_not_empty()
-        
+
         # We should see 'echo' in the output since we ran /bin/echo
         assert_that(result.stdout.lower()).described_as(
             f"execsnoop should trace the echo command. Output: {result.stdout}"

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -147,7 +147,7 @@ class LibbpfToolsSuite(TestSuite):
                 node.log.info(f"✓ {tool_name} executed successfully")
             else:
                 failed_tools.append(tool_name)
-                node.log.warning(
+                node.log.debug(
                     f"✗ {tool_name} failed to execute. "
                     f"Exit code: {result.exit_code}, "
                     f"stdout: {result.stdout}, stderr: {result.stderr}"

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -201,20 +201,21 @@ class LibbpfToolsSuite(TestSuite):
         # We'll run a simple command that should show up in the trace
         test_command = "/bin/echo 'test_libbpf_trace'"
 
-        # Start execsnoop in background, run for 5 seconds
-        execsnoop_cmd = f"timeout 5 {tool_name} > /tmp/execsnoop_output.txt 2>&1 &"
+        # Start execsnoop in background, run for 10 seconds to ensure we capture events
+        # This is longer than our wait times to avoid race conditions
+        execsnoop_cmd = f"timeout 10 {tool_name} > /tmp/execsnoop_output.txt 2>&1 &"
         node.execute(execsnoop_cmd, sudo=True, shell=True)
 
         # Wait a moment for execsnoop to initialize
-        node.execute("sleep 1")
+        node.execute("sleep 2")
 
         # Execute our test command
         node.execute(test_command)
 
-        # Wait for execsnoop to finish
-        node.execute("sleep 5")
+        # Wait for trace to be captured (total wait: 2s init + 2s capture = 4s < 10s timeout)
+        node.execute("sleep 2")
 
-        # Read the output
+        # Read the output (execsnoop should still be running)
         result = node.execute("cat /tmp/execsnoop_output.txt", sudo=True)
 
         # Clean up

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -44,28 +44,14 @@ class LibbpfToolsSuite(TestSuite):
         priority=2,
     )
     def verify_libbpf_tools_package_available(self, node: Node) -> None:
-        # Check if package exists in repositories
+        # Check if package is already installed
         package_exists = node.os.package_exists("libbpf-tools")
         
         if not package_exists:
-            # Try checking if it's available in repos but not installed
-            from lisa.operating_system import Fedora, Debian
-            
-            if isinstance(node.os, Fedora):
-                result = node.execute("dnf list available libbpf-tools", sudo=True)
-                if result.exit_code != 0:
-                    raise SkippedException(
-                        "libbpf-tools package not found in repositories"
-                    )
-            elif isinstance(node.os, Debian):
-                result = node.execute("apt-cache show libbpf-tools", sudo=True)
-                if result.exit_code != 0:
-                    raise SkippedException(
-                        "libbpf-tools package not found in repositories"
-                    )
-            else:
+            # Check if package is available in repositories
+            if not node.os.is_package_in_repo("libbpf-tools"):
                 raise SkippedException(
-                    f"libbpf-tools availability check not implemented for {node.os}"
+                    "libbpf-tools package not found in repositories"
                 )
             
             # Package is available, install it

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -83,11 +83,11 @@ class LibbpfToolsSuite(TestSuite):
             # Package is available, install it
             posix_os.install_packages("libbpf-tools")
 
-        # Verify package is now installed
-        package_installed = posix_os.package_exists("libbpf-tools")
-        assert_that(package_installed).described_as(
-            "libbpf-tools package should be installed"
-        ).is_true()
+            # Verify package is now installed
+            package_installed = posix_os.package_exists("libbpf-tools")
+            assert_that(package_installed).described_as(
+                "libbpf-tools package should be installed"
+            ).is_true()
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/bpf/libbpf_tools.py
+++ b/lisa/microsoft/testsuites/bpf/libbpf_tools.py
@@ -1,0 +1,233 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lisa import (
+    Node,
+    SkippedException,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.operating_system import BSD, Windows
+from lisa.sut_orchestrator import AZURE, HYPERV, READY
+
+
+@TestSuiteMetadata(
+    area="bpf",
+    category="functional",
+    description="""
+    This test suite validates libbpf-tools package functionality.
+    libbpf-tools provides eBPF-based observability tools for performance
+    analysis and troubleshooting.
+    """,
+    requirement=simple_requirement(
+        supported_platform_type=[AZURE, READY, HYPERV],
+        unsupported_os=[BSD, Windows],
+    ),
+)
+class LibbpfToolsSuite(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that the libbpf-tools package is available
+        and can be installed on the system.
+
+        Steps:
+        1. Check if libbpf-tools package exists in repositories.
+        2. Install the package if not already installed.
+        3. Verify installation was successful.
+
+        """,
+        priority=2,
+    )
+    def verify_libbpf_tools_package_available(self, node: Node) -> None:
+        # Check if package exists in repositories
+        package_exists = node.os.package_exists("libbpf-tools")
+        
+        if not package_exists:
+            # Try checking if it's available in repos but not installed
+            from lisa.operating_system import Fedora, Debian
+            
+            if isinstance(node.os, Fedora):
+                result = node.execute("dnf list available libbpf-tools", sudo=True)
+                if result.exit_code != 0:
+                    raise SkippedException(
+                        "libbpf-tools package not found in repositories"
+                    )
+            elif isinstance(node.os, Debian):
+                result = node.execute("apt-cache show libbpf-tools", sudo=True)
+                if result.exit_code != 0:
+                    raise SkippedException(
+                        "libbpf-tools package not found in repositories"
+                    )
+            else:
+                raise SkippedException(
+                    f"libbpf-tools availability check not implemented for {node.os}"
+                )
+            
+            # Package is available, install it
+            node.os.install_packages("libbpf-tools")
+        
+        # Verify package is now installed
+        package_installed = node.os.package_exists("libbpf-tools")
+        assert_that(package_installed).described_as(
+            "libbpf-tools package should be installed"
+        ).is_true()
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that key libbpf-tools binaries can be
+        executed successfully.
+
+        Steps:
+        1. Ensure libbpf-tools package is installed.
+        2. Test execsnoop tool (traces exec() syscalls).
+        3. Test opensnoop tool (traces open() syscalls).
+        4. Test biolatency tool (block I/O latency histogram).
+        5. Verify each tool can run and produce help output.
+
+        """,
+        priority=2,
+    )
+    def verify_libbpf_tools_binaries_executable(self, node: Node) -> None:
+        # Ensure package is installed by calling the availability test
+        self.verify_libbpf_tools_package_available(node)
+        
+        # List of common libbpf-tools to test
+        # We'll test them with --help or similar to verify they execute
+        # Note: Fedora and CBL-Mariner use "bpf-" prefix, Ubuntu/Debian don't
+        tools_to_test = [
+            "execsnoop",  # Trace exec() syscalls
+            "opensnoop",  # Trace open() syscalls
+            "biolatency",  # Block I/O latency
+            "runqlat",  # Scheduler run queue latency
+            "tcpconnect",  # Trace TCP connections
+        ]
+        
+        successful_tools = []
+        failed_tools = []
+        skipped_tools = []
+        
+        for base_tool_name in tools_to_test:
+            # Try both with and without bpf- prefix
+            tool_found = False
+            tool_name = None
+            tool_path = None
+            
+            for prefix in ["bpf-", ""]:
+                candidate = f"{prefix}{base_tool_name}"
+                which_result = node.execute(f"which {candidate}", sudo=True)
+                
+                if which_result.exit_code == 0:
+                    tool_name = candidate
+                    tool_path = which_result.stdout.strip()
+                    tool_found = True
+                    break
+            
+            if not tool_found:
+                node.log.debug(
+                    f"{base_tool_name} not found in PATH "
+                    "(tried with and without bpf- prefix), skipping"
+                )
+                skipped_tools.append(base_tool_name)
+                continue
+            
+            # Try running with help flag
+            cmd = f"{tool_path} -h"
+            result = node.execute(cmd, sudo=True)
+
+            # Most BPF tools return 0 for --help or -h
+            # Some might return 1, but they should still produce output
+            has_output = len(result.stdout) > 0 or len(result.stderr) > 0
+            if result.exit_code == 0 or has_output:
+                successful_tools.append(tool_name)
+                node.log.info(f"✓ {tool_name} executed successfully")
+            else:
+                failed_tools.append(tool_name)
+                node.log.warning(
+                    f"✗ {tool_name} failed to execute. "
+                    f"Exit code: {result.exit_code}, "
+                    f"stdout: {result.stdout}, stderr: {result.stderr}"
+                )
+        
+        # Log summary
+        node.log.info(
+            f"libbpf-tools test summary: "
+            f"{len(successful_tools)} successful, "
+            f"{len(failed_tools)} failed, "
+            f"{len(skipped_tools)} skipped"
+        )
+        
+        # We should have at least some tools working
+        assert_that(len(successful_tools)).described_as(
+            f"At least one libbpf tool should execute successfully. "
+            f"Successful: {successful_tools}, "
+            f"Failed: {failed_tools}, "
+            f"Skipped: {skipped_tools}"
+        ).is_greater_than(0)
+        
+        # Ideally no tools should fail (skipping is OK if not installed)
+        assert_that(len(failed_tools)).described_as(
+            f"No libbpf tools should fail to execute. Failed tools: {failed_tools}"
+        ).is_equal_to(0)
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that execsnoop can actually trace exec()
+        syscalls by running a simple command and capturing the trace.
+
+        Steps:
+        1. Ensure libbpf-tools package is installed.
+        2. Start execsnoop in background.
+        3. Execute a test command (e.g., /bin/ls).
+        4. Stop execsnoop.
+        5. Verify the test command was traced in the output.
+
+        """,
+        priority=3,
+    )
+    def verify_execsnoop_traces_execution(self, node: Node) -> None:
+        # Ensure package is installed by calling the availability test
+        self.verify_libbpf_tools_package_available(node)
+        
+        # Check if execsnoop exists
+        which_result = node.execute("which execsnoop", sudo=True)
+        if which_result.exit_code != 0:
+            raise SkippedException("execsnoop tool not found")
+        
+        # Run execsnoop for a short duration and capture output
+        # We'll run a simple command that should show up in the trace
+        test_command = "/bin/echo 'test_libbpf_trace'"
+        
+        # Start execsnoop in background, run for 5 seconds
+        execsnoop_cmd = "timeout 5 execsnoop > /tmp/execsnoop_output.txt 2>&1 &"
+        node.execute(execsnoop_cmd, sudo=True, shell=True)
+        
+        # Wait a moment for execsnoop to initialize
+        node.execute("sleep 1")
+        
+        # Execute our test command
+        node.execute(test_command)
+        
+        # Wait for execsnoop to finish
+        node.execute("sleep 5")
+        
+        # Read the output
+        result = node.execute("cat /tmp/execsnoop_output.txt", sudo=True)
+        
+        # Clean up
+        node.execute("rm -f /tmp/execsnoop_output.txt", sudo=True)
+        
+        # Verify our test command appears in the trace
+        # execsnoop output typically shows command names
+        assert_that(result.stdout).described_as(
+            "execsnoop output should contain trace of executed commands"
+        ).is_not_empty()
+        
+        # We should see 'echo' in the output since we ran /bin/echo
+        assert_that(result.stdout.lower()).described_as(
+            f"execsnoop should trace the echo command. Output: {result.stdout}"
+        ).contains("echo")

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1699,10 +1699,10 @@ class RPMDistro(Linux):
                 if "installed packages" in row_lower:
                     in_installed_section = True
                     continue
-                elif "available packages" in row_lower:
+                if "available packages" in row_lower:
                     in_installed_section = False
                     continue
-                
+
                 # Only check for package in the installed section
                 if in_installed_section and package in row:
                     return True

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -227,8 +227,7 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None:
-        ...
+    def capture_system_information(self, saved_path: Path) -> None: ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -738,8 +737,7 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix):
-    ...
+class BSD(Posix): ...
 
 
 class BMC(Posix):
@@ -760,8 +758,7 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix):
-    ...
+class Linux(Posix): ...
 
 
 class CoreOs(Linux):
@@ -1553,8 +1550,7 @@ class FreeBSD(BSD):
         )
 
 
-class OpenBSD(BSD):
-    ...
+class OpenBSD(BSD): ...
 
 
 @dataclass
@@ -1699,10 +1695,10 @@ class RPMDistro(Linux):
                 if "installed packages" in row_lower:
                     in_installed_section = True
                     continue
-                elif "available packages" in row_lower:
+                if "available packages" in row_lower:
                     in_installed_section = False
                     continue
-                
+
                 # Only check for package in the installed section
                 if in_installed_section and package in row:
                     return True

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -227,7 +227,8 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None: ...
+    def capture_system_information(self, saved_path: Path) -> None:
+        ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -737,7 +738,8 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix): ...
+class BSD(Posix):
+    ...
 
 
 class BMC(Posix):
@@ -758,7 +760,8 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix): ...
+class Linux(Posix):
+    ...
 
 
 class CoreOs(Linux):
@@ -1550,7 +1553,8 @@ class FreeBSD(BSD):
         )
 
 
-class OpenBSD(BSD): ...
+class OpenBSD(BSD):
+    ...
 
 
 @dataclass
@@ -1695,10 +1699,10 @@ class RPMDistro(Linux):
                 if "installed packages" in row_lower:
                     in_installed_section = True
                     continue
-                if "available packages" in row_lower:
+                elif "available packages" in row_lower:
                     in_installed_section = False
                     continue
-
+                
                 # Only check for package in the installed section
                 if in_installed_section and package in row:
                     return True


### PR DESCRIPTION

## Summary
This PR adds a new test suite for validating the `libbpf-tools` package functionality and fixes a bug in LISA's package detection for RPM-based distributions.

## Changes

### New Test Suite: `libbpf_tools.py`
Added comprehensive test coverage for the `libbpf-tools` package, which provides eBPF-based observability tools for performance analysis and troubleshooting.

**Test Cases:**
1. **`verify_libbpf_tools_package_available`** - Verifies package availability in repositories and installs if needed
2. **`verify_libbpf_tools_binaries_executable`** - Tests execution of 5 key BPF tools (execsnoop, opensnoop, biolatency, runqlat, tcpconnect)

**Features:**
- Handles distribution-specific binary naming (Fedora uses `bpf-` prefix, Ubuntu/Debian do not)
- Skips on distributions where the package isn't available
- Validates both tool availability 

### Bug Fix: `operating_system.py`
Fixed bug in `RPMDistro._package_exists()` method that caused false positives when detecting installed packages.

Fedora 43 uses dnf5 which outputs Available packages along with installed packages when checking installed packages.
```
$ docker run --rm -it fedora:latest bash -c "dnf list installed libbpf-tools; echo 'Exit code:' \$?"
Updating and loading repositories:
 Fedora 43 openh264 (From Cisco) - x86_64                                                                                               100% |   4.0 KiB/s |   5.8 KiB |  00m01s
 Fedora 43 - x86_64 - Updates                                                                                                           100% |   5.6 MiB/s |  12.7 MiB |  00m02s
 Fedora 43 - x86_64                                                                                                                     100% |   9.2 MiB/s |  35.4 MiB |  00m04s
Repositories loaded.
**Available packages**
libbpf-tools.x86_64 0.35.0-2.fc43 fedora
Exit code: 0
```

## Testing
- locally on Fedora 43 machine
- remotely on Azure VM

## Files Changed
- `lisa/microsoft/testsuites/bpf/libbpf_tools.py` - New test suite 
- `lisa/operating_system.py` - Bug fix in `RPMDistro._package_exists()` method

## Related Issues
This fix resolves package detection issues that could affect any test relying on `package_exists()` for RPM-based distributions, particularly those using DNF5 or newer DNF versions.