### PR TITLE
Add Max NICs hard codes NICs to add

### DIFF
--- a/lisa/microsoft/testsuites/network/synthetic.py
+++ b/lisa/microsoft/testsuites/network/synthetic.py
@@ -140,7 +140,8 @@ class Synthetic(TestSuite):
         use_new_environment=True,
         requirement=simple_requirement(
             network_interface=schema.NetworkInterfaceOptionSettings(
-                data_path=schema.NetworkDataPath.Synthetic
+                data_path=schema.NetworkDataPath.Synthetic,
+                max_nic_count=IntRange(min=8),
             ),
         ),
     )
@@ -172,7 +173,8 @@ class Synthetic(TestSuite):
         use_new_environment=True,
         requirement=simple_requirement(
             network_interface=schema.NetworkInterfaceOptionSettings(
-                data_path=schema.NetworkDataPath.Synthetic
+                data_path=schema.NetworkDataPath.Synthetic,
+                max_nic_count=IntRange(min=8),
             ),
         ),
     )


### PR DESCRIPTION
Fixes issue in f4add1205d820edd89215c9172e25375788f2e72

In the future we can potentially change these tests to add (max_nics - 1) NICs instead of hard coding 7.