### PR TITLE
baremetal/idrac: handle VRM0021 virtual media attach errors

### DIFF
--- a/lisa/sut_orchestrator/baremetal/cluster/idrac.py
+++ b/lisa/sut_orchestrator/baremetal/cluster/idrac.py
@@ -469,6 +469,20 @@ class Idrac(Cluster):
                 # Re-raise to trigger retry
                 raise
 
+            # Check for VRM0021 virtual media attach mode errors that need iDRAC reset
+            # VRM0021: "Virtual Media is detached or Virtual Media devices are already
+            # in use" - indicates attach mode is wrong or stale session exists
+            if "VRM0021" in error_msg:
+                self._log.debug(
+                    "VRM0021 virtual media attach error detected. "
+                    "Ejecting media, resetting iDRAC to clear stale sessions..."
+                )
+                # Clear virtual media and reset iDRAC to fix attach mode/clear sessions
+                self._ensure_vm_cleared()
+                self._reset_idrac()
+                # Re-raise to trigger retry
+                raise
+
             # Check for RAC0904 or reachability errors that need iDRAC reset
             is_reachability_error = (
                 "RAC0904" in error_msg or "not accessible or reachable" in error_msg


### PR DESCRIPTION
Add VRM0021 error handling to recover from 'Virtual Media is detached or already in use' failures during bare-metal provisioning.

When VRM0021 occurs (iDRAC reports media detached or stale sessions exist), clear virtual media and reset iDRAC before retry. This follows the same pattern as existing RAC0904 error recovery.

Fixes deployment failures on bare-metal when iDRAC has stale virtual media state or incorrect attach mode configuration.