### PR TITLE
Fix CMake version detection for Lagscope installation on different distros

### DIFF
--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -416,8 +416,6 @@ class Lagscope(Tool, KillableMixin):
             # Clean the output: remove all whitespace and control characters
             raw_version = cmake_version_result.stdout
             # Extract only the first valid version pattern (digits.digits)
-            import re
-
             version_match = re.search(r"^(\d+\.\d+)", raw_version.strip())
             if version_match:
                 cmake_version = version_match.group(1)

--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -407,16 +407,27 @@ class Lagscope(Tool, KillableMixin):
 
         # Get the installed CMake version dynamically
         cmake_version_result = self.node.execute(
-            "cmake --version | head -n1 | grep -oP '\\d+\\.\\d+'",
+            "cmake --version | head -n1 | awk '{print $3}' | cut -d. -f1,2",
             shell=True,
         )
 
-        if cmake_version_result.exit_code == 0 and cmake_version_result.stdout.strip():
-            cmake_version = cmake_version_result.stdout.strip()
-            self._log.debug(f"Detected CMake version: {cmake_version}")
+        cmake_version = "3.5"  # Safe default fallback
+        if cmake_version_result.exit_code == 0 and cmake_version_result.stdout:
+            # Clean the output: remove all whitespace and control characters
+            raw_version = cmake_version_result.stdout
+            # Extract only the first valid version pattern (digits.digits)
+            import re
+
+            version_match = re.search(r"^(\d+\.\d+)", raw_version.strip())
+            if version_match:
+                cmake_version = version_match.group(1)
+                self._log.debug(f"Detected CMake version: {cmake_version}")
+            else:
+                self._log.debug(
+                    f"Could not parse CMake version from '{raw_version}', "
+                    f"using fallback: {cmake_version}"
+                )
         else:
-            # Fallback to a safe minimum version if detection fails
-            cmake_version = "3.5"
             self._log.debug(
                 f"Could not detect CMake version, using fallback: {cmake_version}"
             )


### PR DESCRIPTION
- Lagscope installation fails on certain Distros due to CMake version detection returning malformed output. 
- Changed version extraction code for cleaner shell-side parsing and added Python-side regex validation to extract only a valid X.Y version pattern.
- Also, set a safe default fallback (3.5) if version detection fails.