### PR TITLE
hyperv: add switch_name to platform schema with priority hierarchy

### DIFF
--- a/lisa/sut_orchestrator/hyperv/schema.py
+++ b/lisa/sut_orchestrator/hyperv/schema.py
@@ -59,6 +59,9 @@ class HypervPlatformSchema:
     extra_args: List[ExtraArgs] = field(default_factory=list)
     wait_delete: bool = False
     device_pools: Optional[List[HostDevicePoolSchema]] = None
+    # Optional default switch name for all VMs.
+    # Can be overridden per-node in HypervNodeSchema.
+    switch_name: Optional[str] = None
 
 
 @dataclass_json
@@ -75,6 +78,9 @@ class HypervNodeSchema:
     osdisk_size_in_gb: int = 30
     # Configuration options for device-passthrough.
     device_passthrough: Optional[List[DevicePassthroughSchema]] = None
+    # Optional switch name to use for VM network connection.
+    # If not specified, the default switch will be used.
+    switch_name: Optional[str] = None
 
 
 @dataclass_json()


### PR DESCRIPTION
Add switch_name to HypervPlatformSchema (not just HypervNodeSchema) to support platform-level default switch configuration.
This patch give ability to add specific swtich to VM in case you have multiple switch in enviroment.

Switch selection priority (highest to lowest):
1. Node-level: node_runbook.switch_name
2. Platform-level: hyperv_runbook.switch_name
3. Default: hv.get_default_switch()

This allows runbooks to specify:
  hyperv:
    switch_name: MySwitch  # Platform default for all nodes
  nodes:
    - hyperv: switch_name: NodeSpecificSwitch  # Override per node

Validation only runs for non-default switches to avoid unnecessary checks.