### PR TITLE
Add fix for modprobe tool

### DIFF
--- a/lisa/executable.py
+++ b/lisa/executable.py
@@ -491,6 +491,7 @@ class CustomScript(Tool):
             has_path_noexec = self.node.is_posix and self.node.is_path_mounted_noexec(
                 str(node_script_path)
             )
+            cwd_path = node_script_path
             for file in self._files:
                 remote_path = node_script_path.joinpath(file)
                 source_path = self._local_path.joinpath(file)
@@ -503,10 +504,10 @@ class CustomScript(Tool):
                     )
                     # After copying the file from the local node, then move the file
                     # to avoid permission issues.
-                    node_script_path = self._move_files_into_executable_dir(
+                    cwd_path = self._move_files_into_executable_dir(
                         node_script_path, file
                     )
-            self._cwd = node_script_path
+            self._cwd = cwd_path
         else:
             self._cwd = self._local_path
 

--- a/lisa/microsoft/testsuites/network/netinterface.py
+++ b/lisa/microsoft/testsuites/network/netinterface.py
@@ -78,13 +78,13 @@ class NetInterface(TestSuite):
                     node.close()
                 elif "cannot connect to TCP port" in str(e):
                     raise LisaException(
-                        f"After reloading netvsc module {test_count - 1} times, "
+                        f"After reloading netvsc module {test_count} times, "
                         f"encounter exception '{e}'. It is not clear if"
                         " the image has an issue. Please rerun this case."
                     )
                 else:
                     raise LisaException(
-                        f"After reloading netvsc module {test_count - 1} times, "
+                        f"After reloading netvsc module {test_count} times, "
                         f"encounter exception '{e}'."
                     )
 

--- a/lisa/tools/modprobe.py
+++ b/lisa/tools/modprobe.py
@@ -192,7 +192,20 @@ class Modprobe(Tool):
         )
         self._log.debug(f"running with parameters: {parameters}")
         modprobe_reloader_script: CustomScript = self.node.tools[modprobe_reloader_tool]
-        modprobe_reloader_script.run(parameters, sudo=True, shell=True, nohup=True)
+        result = modprobe_reloader_script.run(
+            parameters,
+            sudo=True,
+            shell=True,
+            nohup=True,
+            force_run=True,
+        )
+        result.assert_exit_code(
+            expected_exit_code=0,
+            message=(
+                f"Failed to start modprobe reloader script. Parameters: {parameters}"
+            ),
+            include_output=True,
+        )
 
         cat = self.node.tools[Cat]
         tried_times: int = 0


### PR DESCRIPTION
1. Add a check for the result of modprobe script.
2. Some systems have the security configuration that mount the filesystem with noexec option. Then any files can't be executed. In the PR, the mount option of the file path will be checked. If it has the mount option, the script file will be moved to usr/local/bin directory.