### PR TITLE
Initial inet_diag test suite

### DIFF
--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -11,13 +11,14 @@ import socket
 import sys
 import threading
 import time
+from typing import List
 
 # Configuration
 LOCALHOST = "127.0.0.1"
 DEFAULT_PORT = 34567
 
 
-def create_tcp_server_client(port):
+def create_tcp_server_client(port: int) -> None:
     """
     Create a TCP server-client connection and keep it alive.
 
@@ -34,9 +35,9 @@ def create_tcp_server_client(port):
     client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     # Accept connection in background
-    accepted_conn = []
+    accepted_conn: List[socket.socket] = []
 
-    def accept_connection():
+    def accept_connection() -> None:
         conn, addr = server.accept()
         accepted_conn.append(conn)
         # Keep connection alive

--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -42,11 +42,9 @@ def create_tcp_server_client():
 
     accept_thread = threading.Thread(target=accept_connection, daemon=True)
     accept_thread.start()
-    time.sleep(0.5)
 
     # Connect client
     client.connect((LOCALHOST, TEST_PORT))
-    time.sleep(1)
 
     print("CONNECTION_READY")
     sys.stdout.flush()

--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -14,17 +14,20 @@ import time
 
 # Configuration
 LOCALHOST = "127.0.0.1"
-TEST_PORT = 34567
+DEFAULT_PORT = 34567
 
 
-def create_tcp_server_client():
+def create_tcp_server_client(port):
     """
     Create a TCP server-client connection and keep it alive.
+
+    Args:
+        port: The port number to use for the connection
     """
     # Create server socket
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server.bind((LOCALHOST, TEST_PORT))
+    server.bind((LOCALHOST, port))
     server.listen(1)
 
     # Create client socket
@@ -44,7 +47,7 @@ def create_tcp_server_client():
     accept_thread.start()
 
     # Connect client
-    client.connect((LOCALHOST, TEST_PORT))
+    client.connect((LOCALHOST, port))
 
     print("CONNECTION_READY")
     sys.stdout.flush()
@@ -61,4 +64,6 @@ def create_tcp_server_client():
 
 
 if __name__ == "__main__":
-    create_tcp_server_client()
+    # Get port from command line argument, or use default
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
+    create_tcp_server_client(port)

--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""
+Test script for creating and maintaining a TCP server-client connection.
+This script is used to test INET_DIAG_DESTROY functionality.
+"""
+
+import socket
+import sys
+import threading
+import time
+
+# Configuration
+LOCALHOST = "127.0.0.1"
+TEST_PORT = 34567
+
+
+def create_tcp_server_client():
+    """
+    Create a TCP server-client connection and keep it alive.
+    """
+    # Create server socket
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((LOCALHOST, TEST_PORT))
+    server.listen(1)
+
+    # Create client socket
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    # Accept connection in background
+    accepted_conn = []
+
+    def accept_connection():
+        conn, addr = server.accept()
+        accepted_conn.append(conn)
+        # Keep connection alive
+        while True:
+            time.sleep(1)
+
+    accept_thread = threading.Thread(target=accept_connection, daemon=True)
+    accept_thread.start()
+    time.sleep(0.5)
+
+    # Connect client
+    client.connect((LOCALHOST, TEST_PORT))
+    time.sleep(1)
+
+    print("CONNECTION_READY")
+    sys.stdout.flush()
+
+    # Keep script running to maintain connection
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.close()
+        server.close()
+
+
+if __name__ == "__main__":
+    create_tcp_server_client()

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -243,9 +243,6 @@ class InetDiagSuite(TestSuite):
                 f"TCP connection established successfully on port {test_port}"
             )
 
-            # Verify connection exists using assertion
-            self._verify_connection_exists(node, test_port, should_exist=True)
-
             # Destroy the connection using ss -K
             node.log.info(
                 f"Destroying connection on port {test_port} using ss -K"
@@ -267,9 +264,6 @@ class InetDiagSuite(TestSuite):
                     f"Connection on port {test_port} was not destroyed "
                     f"within timeout period"
                 )
-
-            # Verify connection no longer exists using assertion
-            self._verify_connection_exists(node, test_port, should_exist=False)
 
             node.log.info(
                 "Successfully verified INET_DIAG_DESTROY functionality - "

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -236,9 +236,7 @@ class InetDiagSuite(TestSuite):
                     expected_exit_code=0,
                 ).stdout
                 node.log.debug(
-                    "Connection check on port %s:\n%s",
-                    test_port,
-                    ss_port_check,
+                    f"Connection check on port {test_port}:\n{ss_port_check}"
                 )
 
                 # Mark node as not safe to reuse by failing the test

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -126,23 +126,23 @@ class InetDiagSuite(TestSuite):
                 )
                 if connection_exists:
                     node.log.debug(
-                        "Connection on port %s reached state %s after %s "
-                        "(%d checks)",
-                        port,
-                        expected_state.value,
-                        timer.elapsed_text(stop=False),
-                        check_count,
+                        (
+                            f"Connection on port {port} reached state "
+                            f"{expected_state.value} after "
+                            f"{timer.elapsed_text(stop=False)} "
+                            f"({check_count} checks)"
+                        )
                     )
                     return True
 
             if check_count % 5 == 0:
                 node.log.debug(
-                    "Waiting for connection on port %s to reach state %s. "
-                    "Elapsed: %s, checks: %d",
-                    port,
-                    expected_state.value,
-                    timer.elapsed_text(stop=False),
-                    check_count,
+                    (
+                        f"Waiting for connection on port {port} to reach "
+                        f"state {expected_state.value}. Elapsed: "
+                        f"{timer.elapsed_text(stop=False)}, checks: "
+                        f"{check_count}"
+                    )
                 )
 
             time.sleep(poll_interval)
@@ -199,10 +199,7 @@ class InetDiagSuite(TestSuite):
         connection_process = None
         try:
             # Start the connection in background with nohup to keep it alive
-            node.log.debug(
-                "Starting TCP connection test script on port %s",
-                test_port,
-            )
+            node.log.debug(f"Starting TCP connection test script on port {test_port}")
             connection_process = node.execute_async(
                 f"python3 {script_path} {test_port}",
                 sudo=False,
@@ -258,10 +255,7 @@ class InetDiagSuite(TestSuite):
             )
 
             # Destroy the connection using ss -K
-            node.log.info(
-                "Destroying connection on port %s using ss -K",
-                test_port,
-            )
+            node.log.info(f"Destroying connection on port {test_port} using ss -K")
             ss.kill_connection(port=test_port, sport=True, sudo=True)
 
             # Wait for the connection to be destroyed using robust polling
@@ -289,9 +283,10 @@ class InetDiagSuite(TestSuite):
                     expected_exit_code=0,
                 ).stdout
                 node.log.debug(
-                    "Connection still exists on port %s:\n%s",
-                    test_port,
-                    ss_port_check,
+                    (
+                        f"Connection still exists on port {test_port}:\n"
+                        f"{ss_port_check}"
+                    )
                 )
 
                 # Check kernel config again
@@ -329,14 +324,14 @@ class InetDiagSuite(TestSuite):
                 )
                 if pkill_result.exit_code == 0:
                     node.log.debug(
-                        "Sent SIGTERM to process for %s (pkill exit 0)",
-                        script_path,
+                        f"Sent SIGTERM to process for {script_path} " f"(pkill exit 0)"
                     )
                 else:
                     node.log.debug(
-                        "pkill (SIGTERM) for %s returned exit code %d",
-                        script_path,
-                        pkill_result.exit_code,
+                        (
+                            f"pkill (SIGTERM) for {script_path} returned "
+                            f"exit code {pkill_result.exit_code}"
+                        )
                     )
 
                 # If pkill failed unexpectedly (>1), treat as hard failure

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -322,7 +322,7 @@ class InetDiagSuite(TestSuite):
                 )
                 if pkill_result.exit_code == 0:
                     node.log.debug(
-                        f"Sent SIGTERM to process for {script_path} " f"(pkill exit 0)"
+                        f"Sent SIGTERM to process for {script_path} (pkill exit 0)"
                     )
                 else:
                     node.log.debug(

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -105,7 +105,7 @@ class InetDiagSuite(TestSuite):
         while timer.elapsed(stop=False) < timeout:
             check_count += 1
             ss = node.tools[Ss]
-            
+
             if expected_state == "NONE":
                 # Checking that connection does NOT exist
                 connection_exists = ss.connection_exists(
@@ -214,9 +214,7 @@ class InetDiagSuite(TestSuite):
         connection_process = None
         try:
             # Start the connection in background with nohup to keep it alive
-            node.log.debug(
-                f"Starting TCP connection test script on port {test_port}"
-            )
+            node.log.debug(f"Starting TCP connection test script on port {test_port}")
             connection_process = node.execute_async(
                 f"python3 {script_path} {test_port}",
                 sudo=False,
@@ -244,9 +242,7 @@ class InetDiagSuite(TestSuite):
             )
 
             # Destroy the connection using ss -K
-            node.log.info(
-                f"Destroying connection on port {test_port} using ss -K"
-            )
+            node.log.info(f"Destroying connection on port {test_port} using ss -K")
             ss.kill_connection(port=test_port, sport=True, sudo=True)
 
             # Wait for the connection to be destroyed using robust polling

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -1,0 +1,187 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lisa import (
+    Node,
+    SkippedException,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.operating_system import BSD, Windows
+from lisa.sut_orchestrator import AZURE, HYPERV, READY
+from lisa.tools import KernelConfig, Python
+
+
+@TestSuiteMetadata(
+    area="network",
+    category="functional",
+    description="""
+    This test suite validates INET_DIAG functionality, particularly
+    the INET_DIAG_DESTROY feature which allows administrative termination
+    of TCP connections via netlink socket interface. This is useful for
+    forcefully closing stuck connections or cleaning up resources.
+    """,
+    requirement=simple_requirement(
+        supported_platform_type=[AZURE, READY, HYPERV],
+        unsupported_os=[BSD, Windows],
+    ),
+)
+class InetDiagSuite(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that the INET_DIAG_DESTROY kernel feature
+        works correctly by creating a TCP connection and then destroying it
+        using the ss (socket statistics) command.
+
+        Steps:
+        1. Check if CONFIG_INET_DIAG_DESTROY is enabled in kernel config.
+        2. Create an established TCP connection using Python sockets.
+        3. Verify the connection exists using ss command.
+        4. Destroy the connection using 'ss -K' (kill socket).
+        5. Verify the connection was destroyed (no longer visible).
+        6. Verify attempting to use the socket fails with connection reset.
+        7. Clean up any remaining connections.
+
+        """,
+        priority=2,
+    )
+    def verify_inet_diag_destroy(self, node: Node) -> None:
+        kernel_config = node.tools[KernelConfig]
+        python = node.tools[Python]
+
+        # Check kernel configuration
+        if not kernel_config.is_enabled("CONFIG_INET_DIAG"):
+            raise SkippedException("CONFIG_INET_DIAG is not enabled in kernel")
+
+        if not kernel_config.is_enabled("CONFIG_INET_DIAG_DESTROY"):
+            raise SkippedException("CONFIG_INET_DIAG_DESTROY is not enabled in kernel")
+
+        # Verify ss command exists and supports -K flag
+        ss_version = node.execute("ss --version", shell=True)
+        assert_that(ss_version.exit_code).described_as(
+            "ss command should be available"
+        ).is_equal_to(0)
+
+        # Run the test directly using python -c instead of creating a file
+        test_script_cmd = f"""{python.command} -c '
+import socket, subprocess, time, sys, threading
+
+test_port = 34567
+server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", test_port))
+server.listen(1)
+client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+accepted_conns = []
+def accept_conn():
+    conn, addr = server.accept()
+    accepted_conns.append(conn)
+    time.sleep(30)
+
+accept_thread = threading.Thread(target=accept_conn, daemon=True)
+accept_thread.start()
+time.sleep(0.5)
+client.connect(("127.0.0.1", test_port))
+time.sleep(1)
+
+result = subprocess.run(
+    ["ss", "-tn", "sport", "=", str(test_port)],
+    capture_output=True, text=True
+)
+if "ESTAB" not in result.stdout:
+    print("ERROR: Connection not established")
+    sys.exit(1)
+print("BEFORE: Connection established on port", test_port)
+
+destroy_result = subprocess.run(
+    ["sudo", "ss", "-K", "sport", "=", str(test_port)],
+    capture_output=True, text=True
+)
+print("DESTROY: ss -K exit code:", destroy_result.returncode)
+time.sleep(1)
+
+check_result = subprocess.run(
+    ["ss", "-tn", "sport", "=", str(test_port)],
+    capture_output=True, text=True
+)
+print("AFTER: Checking for connection")
+if "ESTAB" in check_result.stdout:
+    print("ERROR: Connection still exists after ss -K")
+    sys.exit(1)
+
+try:
+    client.send(b"test")
+    print("ERROR: Socket still works")
+    sys.exit(1)
+except (BrokenPipeError, ConnectionResetError, OSError) as e:
+    print("SUCCESS: Socket properly destroyed -", type(e).__name__)
+
+server.close()
+client.close()
+print("TEST PASSED")
+'"""
+
+        # Run the test script
+        result = node.execute(
+            test_script_cmd,
+            shell=True,
+            sudo=True,
+            timeout=60,
+        )
+
+        # Check the output
+        node.log.debug(f"Test script output:\n{result.stdout}")
+        if result.stderr:
+            node.log.debug(f"Test script stderr:\n{result.stderr}")
+
+        # Verify the test passed
+        assert_that(result.exit_code).described_as(
+            "inet_diag_destroy test script should complete successfully"
+        ).is_equal_to(0)
+
+        assert_that(result.stdout).described_as(
+            "Test should report successful socket destruction"
+        ).contains("SUCCESS: Socket properly destroyed")
+
+        assert_that(result.stdout).described_as("Test should pass all checks").contains(
+            "TEST PASSED"
+        )
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies that CONFIG_INET_DIAG is enabled in the kernel,
+        which is required for socket diagnostic functionality. INET_DIAG provides
+        the interface for tools like ss to query socket information.
+
+        Steps:
+        1. Check if CONFIG_INET_DIAG is enabled in kernel config.
+        2. Verify ss command is available and functional.
+        3. Test basic ss functionality by listing sockets.
+
+        """,
+        priority=3,
+    )
+    def verify_inet_diag_enabled(self, node: Node) -> None:
+        kernel_config = node.tools[KernelConfig]
+
+        # Check kernel configuration
+        if not kernel_config.is_enabled("CONFIG_INET_DIAG"):
+            raise SkippedException("CONFIG_INET_DIAG is not enabled in kernel")
+
+        # Verify ss command works
+        result = node.execute("ss -s", shell=True)
+        assert_that(result.exit_code).described_as(
+            "ss -s command should work with INET_DIAG enabled"
+        ).is_equal_to(0)
+
+        assert_that(result.stdout).described_as(
+            "ss should provide socket statistics"
+        ).contains("TCP:")
+
+        node.log.info("CONFIG_INET_DIAG is enabled and functional")

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -119,6 +119,7 @@ from .resize_partition import ResizePartition
 from .rm import Rm
 from .sar import Sar
 from .sockperf import Sockperf
+from .ss import Ss
 from .ssh import Ssh
 from .sshpass import Sshpass
 from .start_configuration import StartConfiguration
@@ -277,6 +278,7 @@ __all__ = [
     "Service",
     "ServiceInternal",
     "Sockperf",
+    "Ss",
     "Ssh",
     "Sshpass",
     "StartConfiguration",

--- a/lisa/tools/ss.py
+++ b/lisa/tools/ss.py
@@ -2,8 +2,6 @@
 # Licensed under the MIT license.
 from __future__ import annotations
 
-import re
-
 from lisa.executable import Tool
 
 
@@ -15,11 +13,6 @@ class Ss(Tool):
     # Example output from ss -tn:
     # State   Recv-Q  Send-Q   Local Address:Port    Peer Address:Port
     # ESTAB   0       0        127.0.0.1:34567       127.0.0.1:45678
-    _connection_pattern = re.compile(
-        r"(?P<state>\S+)\s+\d+\s+\d+\s+"
-        r"(?P<local_addr>[0-9a-f.:]+):(?P<local_port>\d+)\s+"
-        r"(?P<peer_addr>[0-9a-f.:]+):(?P<peer_port>\d+)"
-    )
 
     @property
     def command(self) -> str:

--- a/lisa/tools/ss.py
+++ b/lisa/tools/ss.py
@@ -1,0 +1,138 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from lisa.executable import Tool
+
+
+class Ss(Tool):
+    """
+    ss - socket statistics tool for investigating sockets
+    """
+
+    # Example output from ss -tn:
+    # State   Recv-Q  Send-Q   Local Address:Port    Peer Address:Port
+    # ESTAB   0       0        127.0.0.1:34567       127.0.0.1:45678
+    _connection_pattern = re.compile(
+        r"(?P<state>\S+)\s+\d+\s+\d+\s+"
+        r"(?P<local_addr>[0-9a-f.:]+):(?P<local_port>\d+)\s+"
+        r"(?P<peer_addr>[0-9a-f.:]+):(?P<peer_port>\d+)"
+    )
+
+    @property
+    def command(self) -> str:
+        return "ss"
+
+    def _check_exists(self) -> bool:
+        return True
+
+    @property
+    def can_install(self) -> bool:
+        return False
+
+    @classmethod
+    def _freebsd_tool(cls) -> Optional[type[Tool]]:
+        return SsBsd
+
+    def has_kill_support(self) -> bool:
+        """
+        Check if ss supports the -K (kill) flag for INET_DIAG_DESTROY.
+        """
+        result = self.run("--help", force_run=True, expected_exit_code=0)
+        return "-K" in result.stdout or "-K" in result.stderr
+
+    def connection_exists(
+        self,
+        port: int,
+        local_addr: str = "",
+        state: str = "ESTAB",
+        sport: bool = True,
+    ) -> bool:
+        """
+        Check if a connection exists on the specified port.
+
+        Args:
+            port: Port number to check
+            local_addr: Optional local address to filter
+            state: Connection state (default: ESTAB)
+            sport: If True, check source port; if False, check destination port
+
+        Returns:
+            True if connection exists, False otherwise
+        """
+        port_filter = f"sport = {port}" if sport else f"dport = {port}"
+        cmd = f"-tn {port_filter}"
+
+        result = self.run(
+            cmd,
+            shell=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+
+        if not result.stdout:
+            return False
+
+        # Check if the state exists in output
+        if state not in result.stdout:
+            return False
+
+        # If local_addr specified, verify it matches
+        if local_addr:
+            return local_addr in result.stdout
+
+        return True
+
+    def kill_connection(
+        self,
+        port: int,
+        sport: bool = True,
+        sudo: bool = True,
+    ) -> None:
+        """
+        Kill (destroy) a connection on the specified port using ss -K.
+        Requires CONFIG_INET_DIAG_DESTROY kernel feature.
+
+        Args:
+            port: Port number of connection to kill
+            sport: If True, filter by source port; if False, by destination port
+            sudo: Whether to run with sudo (default: True, usually required)
+        """
+        port_filter = f"sport = {port}" if sport else f"dport = {port}"
+        cmd = f"-K {port_filter}"
+
+        self.run(
+            cmd,
+            shell=True,
+            force_run=True,
+            sudo=sudo,
+            expected_exit_code=0,
+        )
+
+    def get_statistics(self) -> str:
+        """
+        Get socket statistics summary using ss -s.
+
+        Returns:
+            Statistics output as string
+        """
+        result = self.run("-s", force_run=True, expected_exit_code=0)
+        return result.stdout
+
+
+class SsBsd(Ss):
+    """
+    BSD/FreeBSD variant - may have different flags or behavior
+    """
+
+    @property
+    def command(self) -> str:
+        # BSD might use sockstat or netstat instead
+        return "sockstat"
+
+    def has_kill_support(self) -> bool:
+        # BSD typically doesn't support ss -K
+        return False

--- a/lisa/tools/ss.py
+++ b/lisa/tools/ss.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 from lisa.executable import Tool
 
@@ -32,10 +31,6 @@ class Ss(Tool):
     @property
     def can_install(self) -> bool:
         return False
-
-    @classmethod
-    def _freebsd_tool(cls) -> Optional[type[Tool]]:
-        return SsBsd
 
     def has_kill_support(self) -> bool:
         """
@@ -121,18 +116,3 @@ class Ss(Tool):
         """
         result = self.run("-s", force_run=True, expected_exit_code=0)
         return result.stdout
-
-
-class SsBsd(Ss):
-    """
-    BSD/FreeBSD variant - may have different flags or behavior
-    """
-
-    @property
-    def command(self) -> str:
-        # BSD might use sockstat or netstat instead
-        return "sockstat"
-
-    def has_kill_support(self) -> bool:
-        # BSD typically doesn't support ss -K
-        return False


### PR DESCRIPTION
Add INET_DIAG_DESTROY Test Suite
Adds tests for CONFIG_INET_DIAG_DESTROY kernel feature - validates administrative TCP connection termination via ss -K.

[INET_DIAG_DESTROY ](https://github.com/torvalds/linux/blob/master/net/ipv4/Kconfig#L456)
"Provides a SOCK_DESTROY operation that allows privileged processes (e.g., a connection manager or a network administration tool such as ss) to close sockets opened by other processes. Closing a socket in this way interrupts any blocking read/write/connect operations on the socket and causes future socket calls to behave as if the socket had been disconnected. If unsure, say N."

Tests
verify_inet_diag_destroy (P2): Creates TCP connection, destroys with ss -K, verifies removal
verify_inet_diag_enabled (P3): Validates CONFIG_INET_DIAG and ss functionality

Validation
Tested on Fedora 43 and Ubuntu 
