### PR TITLE
dont run verify_boot_error_fail_warnings test

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -1184,7 +1184,7 @@ class AzureImageStandard(TestSuite):
         2. If any unexpected failure, error, warning messages excluding ignorable ones
          existing, fail the case.
         """,
-        priority=1,
+        priority=5,
         requirement=simple_requirement(supported_platform_type=[AZURE, READY, HYPERV]),
     )
     def verify_boot_error_fail_warnings(self, node: Node) -> None:


### PR DESCRIPTION
verify_boot_error_fail_warnings: this test has a big list of errors to be ignored and that also needs handling with cases specific to distro. This add to the overhead of maintenance and has not been of much use in the recent time. Hence marking the priority as 5, to reduce the noise.