### PR TITLE
tools: add arg to control failure in get_tag

### DIFF
--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -5,7 +5,6 @@ import pathlib
 import re
 from typing import Dict, List, Optional
 
-from assertpy import assert_that
 from semver import VersionInfo
 
 from lisa.executable import Tool
@@ -260,6 +259,7 @@ class Git(Tool):
         contains: str = "",
         return_last: bool = True,
         filter_: str = "",
+        fail_on_not_found: bool = True,
     ) -> str:
         sort_arg = ""
         contains_arg = ""
@@ -299,10 +299,19 @@ class Git(Tool):
         error_info = f"sortby:{sort_by} contains:{contains}"
         if filter_:
             error_info += f" filter:{filter_}"
-        assert_that(len(tags)).described_as(
-            "Error: could not find any tags with this sort or "
-            f"filter setting: {error_info}"
-        ).is_greater_than(0)
+
+        if len(tags) == 0:
+            if fail_on_not_found:
+                raise LisaException(
+                    "Could not find any tags with this sort or "
+                    f"filter setting: {error_info}"
+                )
+            else:
+                self._log.debug(
+                    "Could not find any tags with this sort or "
+                    f"filter setting: {error_info}"
+                )
+                return ""
 
         if return_last:
             return tags[-1]

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -129,7 +129,9 @@ class SourceInstaller(BaseInstaller):
         information = dict()
         if self._code_path:
             information["commit_id"] = git.get_latest_commit_id(cwd=self._code_path)
-            information["tag"] = git.get_tag(cwd=self._code_path)
+            information["tag"] = git.get_tag(
+                cwd=self._code_path, fail_on_not_found=False
+            )
             information["git_repository_url"] = git.get_repo_url(cwd=self._code_path)
             information["git_repository_branch"] = git.get_current_branch(
                 cwd=self._code_path


### PR DESCRIPTION
get_tag() throws an error whenever the current commit doesn't correspond to a tag. This is undesirable. There could be cases where we want to use untagged commits. For example, running kernel installer on an arbitrary kernel branch (instead of official one).

Add an argument to get_tag() that controls if the function fails when not tag is found. Set it to true by default to accommodate existin users.

For kernel installer, pass it as false.