### PR TITLE
Fix false failures - verify_disks_device_timeout_setting

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -94,7 +94,11 @@ class Storage(TestSuite):
         self,
         node: RemoteNode,
     ) -> None:
-        if node.features[Disk].get_os_disk_controller_type() == DiskControllerType.NVME:
+        if (
+            node.features.is_supported(Disk)
+            and node.features[Disk].get_os_disk_controller_type()
+            == DiskControllerType.NVME
+        ):
             raise SkippedException(
                 "Disk controller type is NVMe. Device timeout verification is not",
                 " applicable for NVMe disks",

--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -94,6 +94,12 @@ class Storage(TestSuite):
         self,
         node: RemoteNode,
     ) -> None:
+        if node.features[Disk].get_os_disk_controller_type() == DiskControllerType.NVME:
+            raise SkippedException(
+                "Disk controller type is NVMe. Device timeout verification is not",
+                " applicable for NVMe disks",
+            )
+
         disks = node.features[Disk].get_all_disks()
         root_device_timeout_from_waagent = node.tools[
             Waagent


### PR DESCRIPTION
'verify_disks_device_timeout_setting' is one of the most failed testcases in VM SKU validation with NVMe DCT. Even though 'DiskControllerType.SCSI' a requirement of the testcase, its getting bypassed during the validation. This additional check reduces the total fail count of the test case.