### PR TITLE
SharedImageGalleryTransformer: Take marketplace features

### DIFF
--- a/docs/run_test/transformers.rst
+++ b/docs/run_test/transformers.rst
@@ -95,6 +95,22 @@ Usage
         rename:
           azure_sig_url: shared_gallery
 
+Alternatively, if your SIG is created from a marketplace image, you can provide the source marketplace image instead of manually specifying architecture, Hyper-V generation, and security type:
+
+.. code:: yaml
+
+    transformer:
+      - type: azure_sig
+        vhd: "https://sc.blob.core.windows.net/vhds/pageblob.vhd"
+        gallery_resource_group_name: rg_name
+        gallery_name: galleryname
+        gallery_image_location:
+          - westus3
+          - westus2
+        gallery_image_name: image_name
+        gallery_image_fullname: Microsoft Linux arm64 0.0.1
+        marketplace_source: "canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest"
+
 Process
 ````````
   - Create Resource group
@@ -221,6 +237,24 @@ type: string | Default: Standard_LRS | Allowed Values: Premium_LRS, Standard_ZRS
 host_caching_type
 ^^^^^^^^^^^^^^^^^
 type: string | Default: "None" | Allowed Values: "None", "ReadOnly", "ReadWrite"
+
+
+marketplace_source
+^^^^^^^^^^^^^^^^^^
+type: string | Default: ""
+
+Optional marketplace image identifier to automatically derive architecture, Hyper-V generation, and security type from the source marketplace image. This is useful when creating a SIG from a marketplace image-based VHD.
+
+When specified, this parameter will override:
+  - ``gallery_image_architecture``
+  - ``gallery_image_hyperv_generation``
+  - ``gallery_image_securitytype``
+
+Format: ``<publisher> <offer> <sku> <version>``
+
+Example: ``canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest``
+
+Note: If marketplace_source is not provided, you must manually specify gallery_image_architecture, gallery_image_hyperv_generation, and gallery_image_securitytype as needed.
 
 
 rename

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2550,7 +2550,7 @@ def check_or_create_gallery_image(
     gallery_image_osstate: str,
     gallery_image_hyperv_generation: int,
     gallery_image_architecture: str,
-    gallery_image_securitytype: str,
+    gallery_image_features: Dict[str, Any],
 ) -> None:
     try:
         compute_client = get_compute_client(platform)
@@ -2582,12 +2582,13 @@ def check_or_create_gallery_image(
                 ],
             }
 
-            if gallery_image_securitytype:
+            if gallery_image_features:
                 image_post_body["features"] = [
                     {
-                        "name": "SecurityType",
-                        "value": gallery_image_securitytype,
+                        "name": key,
+                        "value": value,
                     }
+                    for (key, value) in gallery_image_features.items()
                 ]
             operation = compute_client.gallery_images.begin_create_or_update(
                 gallery_resource_group_name,

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -27,6 +27,7 @@ from lisa.util import (
 
 from .common import (
     AZURE_SHARED_RG_NAME,
+    AzureNodeSchema,
     check_blob_exist,
     check_or_create_gallery,
     check_or_create_gallery_image,
@@ -572,6 +573,10 @@ class SigTransformerSchema(schema.Transformer):
             ),
         ),
     )
+    # Marketplace image to take features from.
+    # Will override gallery_image_architecture,
+    # gallery_image_hyperv_generation, and gallery_image_securitytype
+    marketplace_source: str = field(default="")
 
 
 class SharedGalleryImageTransformer(Transformer):
@@ -614,6 +619,18 @@ class SharedGalleryImageTransformer(Transformer):
             raise_error=True,
         )
 
+        # Get features from marketplace image if specified
+        features = self._get_image_features(platform, runbook.marketplace_source)
+        if features:
+            runbook.gallery_image_hyperv_generation = features.pop(
+                "hyper_v_generation", runbook.gallery_image_hyperv_generation
+            )
+            runbook.gallery_image_architecture = features.pop(
+                "architecture", runbook.gallery_image_architecture
+            )
+        elif runbook.gallery_image_securitytype:
+            features = {"SecurityType": runbook.gallery_image_securitytype}
+
         (
             gallery_image_publisher,
             gallery_image_offer,
@@ -650,7 +667,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_image_osstate,
             runbook.gallery_image_hyperv_generation,
             runbook.gallery_image_architecture,
-            runbook.gallery_image_securitytype,
+            features,
         )
 
         check_or_create_gallery_image_version(
@@ -677,3 +694,26 @@ class SharedGalleryImageTransformer(Transformer):
 
         self._log.info(f"SIG Url: {sig_url}")
         return {self.__sig_name: sig_url}
+
+    def _get_image_features(
+        self, platform: AzurePlatform, marketplace: str
+    ) -> Dict[str, Any]:
+        if not marketplace:
+            return {}
+        node_schema = AzureNodeSchema(marketplace_raw=marketplace)
+        if not node_schema.marketplace:
+            return {}
+        features = node_schema.marketplace._get_info(platform)
+
+        # Convert hyper_v_generation to int from form "V1", "V2"
+        if (
+            features.get("hyper_v_generation", None)
+            and features["hyper_v_generation"].strip("V").isdigit()
+        ):
+            features["hyper_v_generation"] = int(
+                features["hyper_v_generation"].strip("V")
+            )
+        else:
+            features.pop("hyper_v_generation", None)
+
+        return features


### PR DESCRIPTION
If a SIG is created from a marketplace image, you can provide the source image instead of specifying all of the features, hyper-v gen, and architecture individually.