### PR TITLE
xfrm: Add check that iproute version supports type and dev arguments

### DIFF
--- a/lisa/microsoft/testsuites/network/xfrm.py
+++ b/lisa/microsoft/testsuites/network/xfrm.py
@@ -49,7 +49,6 @@ class XfrmSuite(TestSuite):
     )
     def verify_xfrm_interface(self, node: Node) -> None:
         kernel_config = node.tools[KernelConfig]
-        ip = node.tools[Ip]
 
         # Check kernel configuration
         if not kernel_config.is_enabled("CONFIG_XFRM_INTERFACE"):
@@ -100,6 +99,8 @@ class XfrmSuite(TestSuite):
         # Some older iproute2 builds can recognize "type xfrm" but *cannot*
         # parse the required "dev ... if_id ..." arguments; in that case, skip.
         default_nic = node.nics.default_nic
+
+        ip = node.tools[Ip]
         supported, reason = ip.supports_xfrm(dev=default_nic, if_id=if_id)
         if not supported:
             raise SkippedException(reason)

--- a/lisa/microsoft/testsuites/network/xfrm.py
+++ b/lisa/microsoft/testsuites/network/xfrm.py
@@ -140,7 +140,7 @@ class XfrmSuite(TestSuite):
 
         finally:
             # Clean up - delete the test interface if it was created
-            ip.run(f"link del {interface_name}", sudo=True, force_run=True)
+            ip.delete_interface(interface_name)
 
             # Restore original module state if we modified it
             if not is_builtin and original_state_loaded is not None:

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -501,6 +501,74 @@ class Ip(Tool):
         detail = groups.get(attribute, "")
         return detail
 
+    def get_version(self) -> str:
+        """
+        Get iproute2 version string.
+        Returns the version output from 'ip -V'.
+        """
+        result = self.run("-V", sudo=False, force_run=True)
+        return result.stdout.strip()
+
+    def supports_xfrm(self, dev: str, if_id: str = "42") -> tuple[bool, str]:
+        """
+        Check if iproute2 supports XFRM interface creation with dev/if_id parameters.
+
+        Args:
+            dev: Network device name to use for the probe
+            if_id: Interface ID to use for the probe (default: "42")
+
+        Returns:
+            Tuple of (supported: bool, reason_if_not: str)
+            If supported is True, reason_if_not is empty.
+            If supported is False, reason_if_not contains the explanation.
+        """
+        probe_name = "xfrm-probe"
+        probe_cmd = f"link add {probe_name} type xfrm dev {dev} if_id {if_id}"
+
+        probe = self.run(probe_cmd, sudo=True, force_run=True)
+        if probe.exit_code == 0:
+            # Probe succeeded, clean up
+            self.run(f"link del {probe_name}", sudo=True, force_run=True)
+            return (True, "")
+
+        # Probe failed, determine why
+        probe_output = f"{probe.stdout}\n{probe.stderr}".lower()
+        full_output = f"{probe.stdout}{probe.stderr}".strip()
+
+        if "garbage instead of arguments" in probe_output:
+            version = self.get_version()
+            return (
+                False,
+                f"iproute2 doesn't support xfrm dev/if_id syntax. Version: {version}",
+            )
+        if (
+            "unknown" in probe_output and "type" in probe_output
+        ) or "not supported" in probe_output:
+            return (False, "System doesn't support xfrm link type")
+        if (
+            "no such device" in probe_output
+            or "failed policy validation" in probe_output
+        ):
+            return (
+                False,
+                f"Kernel/platform rejected xfrm link creation: {full_output}",
+            )
+        if (
+            "operation not permitted" in probe_output
+            or "permission denied" in probe_output
+        ):
+            return (
+                False,
+                "Insufficient permissions for xfrm operations (CAP_NET_ADMIN)",
+            )
+
+        # Unknown failure - include full output for debugging
+        error_msg = (
+            f"Unknown error (exit_code={probe.exit_code}): "
+            f"{full_output or '(no output)'}"
+        )
+        return (False, error_msg)
+
     def get_interface_list(self) -> list[str]:
         raise NotImplementedError()
 


### PR DESCRIPTION
On older systems, while the kernel may support the xfrm module, iproute does not support the creation of the xfrm type and thus the test case fails. This PR makes the XFRM interface test resilient to older iproute2 implementations by probing support fo`r ip link add ... type xfrm` including required `dev/if_id` arguments before attempting the real create.

- Adds a capability probe that uses the same dev <nic> if_id <id> syntax as the test.
- Skips gracefully on older iproute2 that can’t parse required arguments (e.g. “Garbage instead of arguments”), and includes ip -V details for easier diagnosis.
- Keeps “true failure” reserved for cases where interface creation reports success but the interface isn’t present afterwards.

Tested on
"marketplace_image: redhat:rhel:8.1:8.1.2020020415", (previously failing, now skipping)
Fedora 43 local VM
