### PR TITLE
Fixed 4 test cases against fedora

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -219,12 +219,15 @@ class Storage(TestSuite):
         priority=1,
         requirement=simple_requirement(
             supported_platform_type=[AZURE],
-            unsupported_os=[BSD, Windows, Fedora],
+            unsupported_os=[BSD, Windows],
             # This test is skipped as waagent does not support freebsd fully
-            # Fedora manages swap independently of waagent
         ),
     )
     def verify_swap(self, node: RemoteNode) -> None:
+        if type(node.os) is Fedora:
+            raise SkippedException(
+                "Swap is disabled by waagent on Fedora. Skipping the test."
+            )
         is_swap_enabled_wa_agent = node.tools[Waagent].is_swap_enabled()
         is_swap_enabled_distro = node.tools[Swap].is_swap_enabled()
         assert_that(

--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -32,7 +32,7 @@ from lisa.features.security_profile import (
     SecurityProfileType,
 )
 from lisa.node import Node
-from lisa.operating_system import BSD, Posix, Windows
+from lisa.operating_system import BSD, Fedora, Posix, Windows
 from lisa.schema import DiskControllerType, DiskOptionSettings, DiskType
 from lisa.sut_orchestrator import AZURE, HYPERV
 from lisa.sut_orchestrator.azure.features import AzureDiskOptionSettings, AzureFileShare
@@ -219,8 +219,9 @@ class Storage(TestSuite):
         priority=1,
         requirement=simple_requirement(
             supported_platform_type=[AZURE],
-            unsupported_os=[BSD, Windows],
+            unsupported_os=[BSD, Windows, Fedora],
             # This test is skipped as waagent does not support freebsd fully
+            # Fedora manages swap independently of waagent
         ),
     )
     def verify_swap(self, node: RemoteNode) -> None:

--- a/lisa/tools/dhclient.py
+++ b/lisa/tools/dhclient.py
@@ -72,8 +72,8 @@ class Dhclient(Tool):
                 value = int(group["number"])
                 is_default_value = False
         elif isinstance(self.node.os, Fedora):
-            # the default value in fedora is 45
-            value = 45
+            # the default value in fedora is 300
+            value = 300
             result = self.node.execute("NetworkManager --print-config", sudo=True)
             group = find_group_in_lines(result.stdout, self._fedora_pattern)
             if group and value != int(group["number"]):

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -227,7 +227,7 @@ class KdumpBase(Tool):
             return KdumpSuse(node)
         elif isinstance(node.os, CBLMariner):
             return KdumpCBLMariner(node)
-        elif isinstance(node.os, Fedora):
+        elif type(node.os) is Fedora:
             return KdumpFedora(node)
         else:
             raise UnsupportedDistroException(os=node.os)

--- a/lisa/tools/vdsotest.py
+++ b/lisa/tools/vdsotest.py
@@ -59,7 +59,7 @@ class Vdsotest(Tool):
                     "perl-CPAN",
                 ]
             )
-        elif isinstance(self.node.os, Fedora):
+        elif type(self.node.os) is Fedora:
             package_list.extend(["autoconf", "automake", "libtool"])
         else:
             raise LisaException(
@@ -76,7 +76,7 @@ class Vdsotest(Tool):
         # Fedora requires explicit C11 standard flag to avoid compilation errors.
         # Using -std=gnu11 ensures compatibility with the vdsotest source code while
         # avoiding issues with stricter compiler enforcement on newer GCC versions.
-        if isinstance(self.node.os, Fedora):
+        if type(self.node.os) is Fedora:
             self.node.execute(
                 "./configure CFLAGS='-std=gnu11'", cwd=code_path
             ).assert_exit_code()


### PR DESCRIPTION
verify_kdumpcrash_on_random_cpu, Added new class for fedora
verify_dhcp_client_timeout, Updated to 300 seconds 
verify_vdso, changed the flag to configure and compile

Skipped verify_swap for fedora, as swap is disabled by waagent.conf