### PR TITLE
Add data disk vhd path support

### DIFF
--- a/docs/run_test/platform.rst
+++ b/docs/run_test/platform.rst
@@ -42,6 +42,9 @@ To run using vhd, add the following to runbook :
             ...
             vhd:
                vhd_path: "<VHD URL>"
+               data_vhd_paths:
+                  - vhd_uri: "<DATA VHD URL 0>"
+                  - vhd_uri: "<DATA VHD URL 1>"
                hyperv_generation: <1 or 2>
 
 The ``<VHD URL>`` can either be a SAS url or a blob url. If it is a SAS url, the image is copied to the resource group: ``lisa_shared_resource``, storage
@@ -52,6 +55,9 @@ increase the runtime. The copied VHD has to be manually deleted by the user.
 If the selected VM Size's Hypervisor Generation is '2', the ``hyperv_generation``
 parameter is necessary, and should be specified as 2. If ``hyperv_generation`` is
 not needed, you can specify the VHD path directly as a string: ``vhd: "<VHD URL>"``.
+
+You can attach data disks by specifying ``data_vhd_paths``. Each ``vhd_uri`` is handled
+the same way as the OS VHD path (including SAS/cross-region copy behavior).
 
 Use marketplace image
 ^^^^^^^^^^^^^^^^^^^^^

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "16291477761159155605"
+      "version": "0.36.177.2456",
+      "templateHash": "18099469189437246926"
     }
   },
   "functions": [
@@ -194,7 +194,7 @@
           ],
           "output": {
             "type": "object",
-            "value": "[if(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
+            "value": "[if(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(not(empty(parameters('dataDisk').vhd_details)), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
           }
         },
         "getOsDiskSharedGallery": {
@@ -512,6 +512,13 @@
         "description": "whether to use ultra disk"
       }
     },
+    "is_data_disk_with_vhd": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "whether to use data disk with vhd"
+      }
+    },
     "ip_service_tags": {
       "type": "object",
       "metadata": {
@@ -784,6 +791,29 @@
       },
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]"
     },
+    "nodes_data_disks_with_vhds": {
+      "copy": {
+        "name": "nodes_data_disks_with_vhds",
+        "count": "[length(range(0, mul(length(parameters('data_disks')), variables('node_count'))))]"
+      },
+      "condition": "[and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk')))]",
+      "type": "Microsoft.Compute/disks",
+      "apiVersion": "2022-03-02",
+      "name": "[format('{0}-data-disk-{1}', parameters('nodes')[div(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].name, mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks'))))]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "creationData": {
+          "createOption": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].create_option]",
+          "storageAccountId": "[resourceId(parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_resource_group_name, 'Microsoft.Storage/storageAccounts', parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_account_name)]",
+          "sourceUri": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.vhd_uri]"
+        }
+      },
+      "sku": {
+        "name": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].type]"
+      },
+      "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]"
+    },
     "nodes_vms": {
       "copy": {
         "name": "nodes_vms",
@@ -840,6 +870,7 @@
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]",
       "dependsOn": [
         "availability_set",
+        "nodes_data_disks_with_vhds",
         "nodes_disk",
         "nodes_image",
         "nodes_nics",
@@ -898,8 +929,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "17932923534203698710"
+              "version": "0.36.177.2456",
+              "templateHash": "15654609969338604205"
             }
           },
           "functions": [

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -545,10 +545,17 @@ class SharedImageGallerySchema(AzureImageSchema):
 
 @dataclass_json()
 @dataclass
+class DataVhdPath:
+    vhd_uri: str = ""
+
+
+@dataclass_json()
+@dataclass
 class VhdSchema(AzureImageSchema):
     vhd_path: str = ""
     cvm_gueststate_path: Optional[str] = None
     cvm_metadata_path: Optional[str] = None
+    data_vhd_paths: Optional[List[DataVhdPath]] = None
 
     def load_from_platform(self, platform: "AzurePlatform") -> None:
         # There are no platform tags to parse, but we can assume the
@@ -900,6 +907,9 @@ class AzureNodeSchema:
                     add_secret(vhd.cvm_gueststate_path, PATTERN_URL)
                 if vhd.cvm_metadata_path:
                     add_secret(vhd.cvm_metadata_path, PATTERN_URL)
+                if vhd.data_vhd_paths:
+                    for data_vhd in vhd.data_vhd_paths:
+                        add_secret(data_vhd.vhd_uri, PATTERN_URL)
                 # this step makes vhd_raw is validated, and
                 # filter out any unwanted content.
                 self.vhd_raw = vhd.to_dict()  # type: ignore
@@ -1131,6 +1141,7 @@ class DataDiskCreateOption:
     DATADISK_CREATE_OPTION_TYPE_EMPTY: str = "Empty"
     DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE: str = "FromImage"
     DATADISK_CREATE_OPTION_TYPE_ATTACH: str = "Attach"
+    DATADISK_CREATE_OPTION_TYPE_IMPORT: str = "Import"
 
     @staticmethod
     def get_create_option() -> List[str]:
@@ -1138,6 +1149,7 @@ class DataDiskCreateOption:
             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_EMPTY,
             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_ATTACH,
+            DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_IMPORT,
         ]
 
 
@@ -1163,6 +1175,14 @@ def get_disk_placement_priority() -> List[DiskPlacementType]:
         DiskPlacementType.RESOURCE,
         DiskPlacementType.NONE,
     ]
+
+
+@dataclass_json()
+@dataclass
+class VhdDetails:
+    vhd_uri: str = ""
+    storage_account_name: str = ""
+    storage_resource_group_name: str = ""
 
 
 @dataclass_json()
@@ -1204,6 +1224,7 @@ class DataDiskSchema:
             validate=validate.OneOf(DataDiskCreateOption.get_create_option())
         ),
     )
+    vhd_details: Optional[VhdDetails] = None
 
 
 @dataclass_json()
@@ -1238,6 +1259,7 @@ class AzureArmParameter:
     virtual_network_name: str = AZURE_VIRTUAL_NETWORK_NAME
     subnet_prefix: str = AZURE_SUBNET_PREFIX
     is_ultradisk: bool = False
+    is_data_disk_with_vhd: bool = False
     use_ipv6: bool = False
     enable_vm_nat: bool = False
     create_public_address: bool = True

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -117,6 +117,7 @@ from .common import (
     DataDiskSchema,
     DiskPlacementType,
     SharedImageGallerySchema,
+    VhdDetails,
     check_or_create_resource_group,
     check_or_create_storage_account,
     convert_to_azure_node_space,
@@ -1240,9 +1241,18 @@ class AzurePlatform(Platform):
                     == features.get_azure_disk_type(schema.DiskType.UltraSSDLRS)
                 ]
             )
+
             # Set data disk array
             arm_parameters.data_disks = self._generate_data_disks(
                 node, node_arm_parameters
+            )
+
+            arm_parameters.is_data_disk_with_vhd = any(
+                [
+                    x
+                    for x in arm_parameters.data_disks
+                    if x.vhd_details is not None and x.vhd_details.vhd_uri != ""
+                ]
             )
 
             if not arm_parameters.location:
@@ -1404,6 +1414,15 @@ class AzurePlatform(Platform):
             vhd.cvm_metadata_path = get_deployable_storage_path(
                 self, vhd.cvm_metadata_path, azure_node_runbook.location, log
             )
+
+            # Process data VHD paths if provided
+            if vhd.data_vhd_paths:
+                for data_vhd in vhd.data_vhd_paths:
+                    if data_vhd.vhd_uri:
+                        data_vhd.vhd_uri = get_deployable_storage_path(
+                            self, data_vhd.vhd_uri, azure_node_runbook.location, log
+                        )
+
             azure_node_runbook.vhd = vhd
             azure_node_runbook.marketplace = None
             azure_node_runbook.shared_gallery = None
@@ -1471,6 +1490,16 @@ class AzurePlatform(Platform):
             vhd.cvm_metadata_path = get_deployable_storage_path(
                 self, vhd.cvm_metadata_path, arm_parameters.location, log
             )
+
+            # Process data VHD paths if provided
+            if vhd.data_vhd_paths:
+                for data_vhd in vhd.data_vhd_paths:
+                    if data_vhd.vhd_uri:
+                        # Validate and process each data VHD URI
+                        data_vhd.vhd_uri = get_deployable_storage_path(
+                            self, data_vhd.vhd_uri, arm_parameters.location, log
+                        )
+
             arm_parameters.vhd = vhd
             arm_parameters.osdisk_size_in_gb = max(
                 arm_parameters.osdisk_size_in_gb,
@@ -2305,7 +2334,40 @@ class AzurePlatform(Platform):
     ) -> List[DataDiskSchema]:
         data_disks: List[DataDiskSchema] = []
         assert node.capability.disk
-        if azure_node_runbook.marketplace:
+
+        # Handle data VHD paths if provided
+        if (
+            azure_node_runbook.vhd
+            and azure_node_runbook.vhd.vhd_path
+            and azure_node_runbook.vhd.data_vhd_paths
+        ):
+            for data_vhd in azure_node_runbook.vhd.data_vhd_paths:
+                if data_vhd.vhd_uri:
+                    if azure_node_runbook.data_disk_type == "UltraSSD_LRS":
+                        raise SkippedException(
+                            "Currently, LISA doesn't support 'UltraSSD_LRS' disk type "
+                            "for data disk with 'import' creation option."
+                        )
+                    result_dict = get_vhd_details(self, data_vhd.vhd_uri)
+                    data_disks.append(
+                        DataDiskSchema(
+                            node.capability.disk.data_disk_caching_type,
+                            0,  # size is not needed for imported disk
+                            0,
+                            0,
+                            azure_node_runbook.data_disk_type,
+                            DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_IMPORT,
+                            VhdDetails(
+                                vhd_uri=data_vhd.vhd_uri,
+                                storage_account_name=result_dict.get("account_name"),
+                                storage_resource_group_name=result_dict.get(
+                                    "resource_group_name"
+                                ),
+                            ),
+                        )
+                    )
+
+        elif azure_node_runbook.marketplace:
             marketplace = self.get_image_info(
                 azure_node_runbook.location, azure_node_runbook.marketplace
             )
@@ -2328,6 +2390,7 @@ class AzurePlatform(Platform):
                             0,
                             azure_node_runbook.data_disk_type,
                             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
+                            None,
                         )
                     )
         assert isinstance(
@@ -2351,6 +2414,7 @@ class AzurePlatform(Platform):
                     node.capability.disk.data_disk_throughput,
                     azure_node_runbook.data_disk_type,
                     DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_EMPTY,
+                    None,
                 )
             )
         runbook = node.capability.get_extended_runbook(AzureNodeSchema)


### PR DESCRIPTION
Add data_vhd_paths in the runbook. Users can provide the data disk VHD paths to create a VM with data disks.
azure:
  vm_size: Standard_DS2_v2
  location: westus3
  vhd:
    vhd_path: "https://mystorageaccount.blob.core.windows.net/vhds/myos.vhd"
    data_vhd_paths:
      - vhd_uri: "https://mystorageaccount.blob.core.windows.net/vhds/data0.vhd"
      - vhd_uri: "https://mystorageaccount.blob.core.windows.net/vhds/data1.vhd"