### PR TITLE
ch: ensure binary is in standard PATH via /usr/bin symlink

### DIFF
--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -115,6 +115,10 @@ class CloudHypervisorInstaller(BaseInstaller):
             "ln -sf /usr/local/bin/cloud-hypervisor /usr/bin/cloud-hypervisor",
             shell=True,
             sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "Failed to create symlink to cloud-hypervisor in /usr/bin"
+            ),
         )
 
 

--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -109,6 +109,14 @@ class QemuInstaller(BaseInstaller):
 class CloudHypervisorInstaller(BaseInstaller):
     _command = "cloud-hypervisor"
 
+    def _create_symlink_to_usr_bin(self) -> None:
+        """Create symlink in /usr/bin for non-login shells."""
+        self._node.execute(
+            "ln -sf /usr/local/bin/cloud-hypervisor /usr/bin/cloud-hypervisor",
+            shell=True,
+            sudo=True,
+        )
+
 
 class LibvirtInstaller(BaseInstaller):
     _command = "libvirtd"
@@ -427,6 +435,7 @@ class CloudHypervisorSourceInstaller(CloudHypervisorInstaller):
             shell=True,
             sudo=True,
         )
+        self._create_symlink_to_usr_bin()
 
     def _install_dependencies(self) -> None:
         linux: Linux = cast(Linux, self._node.os)
@@ -561,6 +570,7 @@ class CloudHypervisorBinaryInstaller(CloudHypervisorInstaller):
             "setcap cap_net_admin+ep /usr/local/bin/cloud-hypervisor",
             sudo=True,
         )
+        self._create_symlink_to_usr_bin()
         return self._get_version()
 
 

--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -11,7 +11,7 @@ from dataclasses_json import dataclass_json
 from lisa import schema
 from lisa.node import Node, quick_connect
 from lisa.operating_system import CBLMariner, Linux, Ubuntu
-from lisa.tools import Git, Sed, Service, Usermod, Wget, Whoami
+from lisa.tools import Git, Ln, Sed, Service, Usermod, Wget, Whoami
 from lisa.transformer import Transformer
 from lisa.util import (
     LisaException,
@@ -111,14 +111,12 @@ class CloudHypervisorInstaller(BaseInstaller):
 
     def _create_symlink_to_usr_bin(self) -> None:
         """Create symlink in /usr/bin for non-login shells."""
-        self._node.execute(
-            "ln -sf /usr/local/bin/cloud-hypervisor /usr/bin/cloud-hypervisor",
-            shell=True,
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=(
-                "Failed to create symlink to cloud-hypervisor in /usr/bin"
-            ),
+        ln = self._node.tools[Ln]
+        ln.create_link(
+            target="/usr/local/bin/cloud-hypervisor",
+            link="/usr/bin/cloud-hypervisor",
+            is_symbolic=True,
+            force=True,
         )
 
 


### PR DESCRIPTION
Create a symlink in /usr/bin (always in PATH) so the binary is accessible in all shell environments.