### PR TITLE
Implement RootRunner.stop() method to properly handle runner shutdown

### DIFF
--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -284,9 +284,15 @@ class RootRunner(Action):
         await super().stop()
         # Set status to stopping and cancel ongoing tasks
         self.status = ActionStatus.STOPPING
-        cancel()
-        self._cleanup()
-        self.status = ActionStatus.STOPPED
+        try:
+            # Ensure cleanup is attempted even if cancel() raises.
+            try:
+                cancel()
+            finally:
+                self._cleanup()
+        finally:
+            # Always mark the action as stopped, even if errors occurred.
+            self.status = ActionStatus.STOPPED
 
     async def close(self) -> None:
         await super().close()

--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type
 
 from lisa import messages, notifier, schema, transformer
-from lisa.action import Action
+from lisa.action import Action, ActionStatus
 from lisa.combinator import Combinator
 from lisa.environment import Environment
 from lisa.messages import TestResultMessage, TestResultMessageBase, TestStatus
@@ -282,7 +282,11 @@ class RootRunner(Action):
 
     async def stop(self) -> None:
         await super().stop()
-        # TODO: to be implemented
+        # Set status to stopping and cancel ongoing tasks
+        self.status = ActionStatus.STOPPING
+        cancel()
+        self._cleanup()
+        self.status = ActionStatus.STOPPED
 
     async def close(self) -> None:
         await super().close()


### PR DESCRIPTION
The stop() method in the RootRunner class was not implemented (marked with TODO). This implementation adds proper shutdown logic that:
- Sets the status to STOPPING for proper state tracking
- Cancels any ongoing tasks
- Performs cleanup of runners and notifications
- Sets final status to STOPPED

This ensures graceful shutdown with proper resource cleanup and state management.