### PR TITLE
SIGTransformer: Ignore os_type

### DIFF
--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -628,6 +628,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_image_architecture = features.pop(
                 "architecture", runbook.gallery_image_architecture
             )
+            features.pop("os_type", None)
         elif runbook.gallery_image_securitytype:
             features = {"SecurityType": runbook.gallery_image_securitytype}
 


### PR DESCRIPTION
os_type was added to image properties in #4151 but it should be ignored for SIGTransformer.