### PR TITLE
tools/hyperv: simplify delete_nat_mapping

### DIFF
--- a/lisa/tools/hyperv.py
+++ b/lisa/tools/hyperv.py
@@ -484,16 +484,18 @@ class HyperV(Tool):
         )
 
     # delete NAT mapping for a port or internal IP
-    def delete_nat_mapping(
-        self, external_port: Optional[int] = None, internal_ip: Optional[str] = None
-    ) -> None:
-        if external_port is None:
-            external_port = self.node.tools[PowerShell].run_cmdlet(
-                f"Get-NetNatStaticMapping | "
-                f"Where-Object {{$_.InternalIPAddress -eq '{internal_ip}'}}"
-                f" | Select-Object -ExpandProperty ExternalPort",
-                force_run=True,
-            )
+    def delete_nat_mapping(self, internal_ip: str) -> None:
+        external_port = self.node.tools[PowerShell].run_cmdlet(
+            f"Get-NetNatStaticMapping | "
+            f"Where-Object {{$_.InternalIPAddress -eq '{internal_ip}'}}"
+            f" | Select-Object -ExpandProperty ExternalPort",
+            force_run=True,
+        )
+
+        if not external_port:
+            self._log.debug(f"Mapping for internal IP {internal_ip} does not exist")
+            return
+
         mapping_id = self.get_nat_mapping_id(external_port)
         if mapping_id:
             # delete the NAT mapping if it exists


### PR DESCRIPTION
Get rid of the external_port parameter. It is not used in any call site both internally and externally. Now, internal_ip can be made non-optional.

Also make sure we're able to find an external port corresponding to the given internal_ip before proceeding with deletion. This avoids some transient failures where no external port is found due to which the Remove-NetNatStaticMapping command fails and the VM delete fails (because this function is invoked in the deletion path). Failing VM deletion should be the last resort since that failing to delete a VM will cause stale VMs to remain on the host (very important when the host is a lab server that is re-used across test runs).