### PR TITLE
ch: detect VMM version from git repository for Docker-based tests

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -32,6 +32,7 @@ from lisa.util import SkippedException
 class CloudHypervisorTestSuite(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
+
         if not isinstance(node.os, (CBLMariner, Ubuntu)):
             raise SkippedException(
                 f"Cloud Hypervisor tests are not implemented in LISA for {node.os.name}"
@@ -46,6 +47,7 @@ class CloudHypervisorTestSuite(TestSuite):
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
+
         node.tools[Modprobe].remove(["openvswitch"])
 
         journalctl = node.tools[Journalctl]

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1281,7 +1281,35 @@ exit $ec
 
         self.node.tools[Docker].start()
 
+        # Cache VMM version after installation completes
+        # This allows the platform hooks to pick it up automatically
+        self._cache_vmm_version()
+
         return self._check_exists()
+
+    def _cache_vmm_version(self) -> None:
+        """
+        Detect and cache cloud-hypervisor version after installation.
+        This is called automatically after the tool is installed, ensuring
+        the version is available for platform information hooks.
+        """
+        from lisa.sut_orchestrator.platform_utils import get_vmm_version
+
+        try:
+            vmm_version = get_vmm_version(self.node)
+            if vmm_version and vmm_version != "UNKNOWN":
+                self._log.info(f"Cloud-Hypervisor version detected: {vmm_version}")
+                # get_vmm_version() already caches the version in extended_resources
+
+                # Refresh environment information so it picks up the new VMM version
+                env = getattr(self.node, "environment", None)
+                if env is not None and hasattr(env, "get_information"):
+                    env.get_information(force_run=True)
+                    self._log.debug(
+                        "Refreshed environment information to include VMM version"
+                    )
+        except Exception as e:
+            self._log.debug(f"Could not cache VMM version: {e}")
 
     def _list_subtests(self, hypervisor: str, test_type: str) -> List[str]:
         cmd_args = f"tests --hypervisor {hypervisor} --{test_type} -- -- --list"

--- a/lisa/sut_orchestrator/platform_utils.py
+++ b/lisa/sut_orchestrator/platform_utils.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, cast
 
 from lisa import features
 from lisa.node import Node
@@ -27,21 +28,105 @@ KEY_MSHV_VERSION = "mshv_version"
 KEY_HOST_VERSION = "host_version"
 
 
+def _cache_vmm_version_in_node(node: Node, version: str) -> None:
+    """Helper to cache VMM version in node's extended_resources."""
+    capability = cast(Any, node.capability)
+    extended_resources = getattr(capability, "extended_resources", None)
+    if extended_resources is None:
+        extended_resources = {}
+        capability.extended_resources = extended_resources
+    extended_resources[KEY_VMM_VERSION] = version
+
+
 def get_vmm_version(node: Node) -> str:
+    """
+    Detects cloud-hypervisor VMM version from cached value, local binary,
+    or git repository.
+
+    Checks in order:
+    1. Cached value from CloudHypervisorTests tool (if installed)
+    2. Local binary (fast, works for most installations)
+    3. Git repository (for Docker-based tests where binaries are compiled on-demand)
+
+    Returns the version string as reported by ``cloud-hypervisor --version`` after
+    the ``cloud-hypervisor `` prefix (for example, ``"v41.0.0-41.0.120.g4ea35aaf"``
+    or ``"48.0.235"``), or ``"UNKNOWN"`` if detection fails.
+    """
     result: str = "UNKNOWN"
     try:
-        if node.is_connected and node.is_posix:
-            node.log.debug("detecting vmm version...")
-            output = node.execute(
-                "cloud-hypervisor --version",
-                shell=True,
-            ).stdout
-            output = filter_ansi_escape(output)
+        # Check if CloudHypervisorTests tool has already cached the version.
+        # This lookup does not require SSH connectivity and should be usable
+        # even during teardown when the node may be disconnected.
+        extended_resources = getattr(node.capability, "extended_resources", None)
+        if extended_resources and KEY_VMM_VERSION in extended_resources:
+            cached_version = extended_resources.get(KEY_VMM_VERSION)
+            if cached_version:
+                node.log.debug(f"Using cached VMM version: {cached_version}")
+                return str(cached_version)
+
+        # If there is no cached value, only proceed with SSH-based detection
+        # when the node is connected and running a POSIX-compatible OS.
+        if not (node.is_connected and node.is_posix):
+            return result
+
+        node.log.debug("detecting vmm version...")
+        # Primary method: Try local binary installation (fast, works for most cases)
+        node.log.debug("Trying local binary: cloud-hypervisor --version")
+        local_result = node.execute(
+            "cloud-hypervisor --version", shell=True, sudo=False
+        )
+
+        if local_result.exit_code == 0:
+            output = filter_ansi_escape(local_result.stdout)
             match = re.search(VMM_VERSION_PATTERN, output.strip())
             if match:
                 result = match.group("ch_version")
+                node.log.debug(
+                    f"Successfully detected VMM version from local binary: {result}"
+                )
+                return result
+
+        # Fallback method: Extract version from git repository
+        # For Docker-based tests where cloud-hypervisor is compiled from source
+        node.log.debug("Local binary not found, trying git repository...")
+
+        # Construct path dynamically using node's working path
+        # CloudHypervisorTests tool clones repo to:
+        # <lisa_working_path>/tool/<tool_name>/cloud-hypervisor
+        git_repo_path = (
+            f"{node.get_pure_path(str(node.working_path))}/tool/"
+            "cloudhypervisortests/cloud-hypervisor"
+        )
+        git_cmd = (
+            f"cd {git_repo_path} 2>/dev/null && "
+            "git describe --tags --always --dirty 2>&1"
+        )
+        git_result = node.execute(git_cmd, shell=True, sudo=False)
+
+        if git_result.exit_code == 0 and git_result.stdout.strip():
+            version_str = git_result.stdout.strip()
+            node.log.debug(f"Git describe output: '{version_str}'")
+
+            # Strip -dirty suffix if present
+            version_str = version_str.replace("-dirty", "")
+
+            # Extract clean version number from git describe output
+            # Handles patterns: "msft/v48.0.235", "v48.0.235-7-g6fed5f8e7", "v48.0.235"
+            # Extracts only the tag version, excluding commit count and hash suffixes
+            version_match = re.search(r"(?:msft/)?v?([\d.]+)", version_str)
+            if version_match:
+                result = version_match.group(1)
+                node.log.debug(
+                    f"Successfully detected VMM version from git repository: {result}"
+                )
+                return result
+
     except Exception as e:
-        node.log.debug(f"error on run vmm: {e}")
+        node.log.debug(f"Error during VMM version detection: {type(e).__name__}: {e}")
+
+    node.log.debug(f"VMM version detection result: {result}")
+    # Cache the result to avoid repeated detection attempts
+    _cache_vmm_version_in_node(node, result)
     return result
 
 


### PR DESCRIPTION
Problem:

Cloud-hypervisor performance tests report VMM version as 'UNKNOWN' instead of actual version (e.g., '48.0.235'). Tests run cloud-hypervisor inside Docker containers which are build environments without pre-compiled binaries, making binary-based version detection unreliable.

Root Cause:
1. Tests execute cloud-hypervisor by compiling from source inside Docker build containers
2. Previous version detection attempted to query non-existent binaries in Docker images
3. Version detection ran during teardown when SSH session was closing, causing failures

Solution:
1. Primary: Extract version from git repository where tests clone cloud-hypervisor source
   - Uses 'git describe --tags' matching how tests report version metadata
   - Handles patterns: 'msft/v48.0.235', 'v48.0.235-7-g6fed5f8e7'
