### PR TITLE
File transfer transformer

### DIFF
--- a/lisa/tools/remote_copy.py
+++ b/lisa/tools/remote_copy.py
@@ -4,15 +4,17 @@ from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, List, Optional, Type
 
 from lisa.executable import Tool
+from lisa.tools.chmod import Chmod
 from lisa.tools.chown import Chown
 from lisa.tools.cp import Cp
 from lisa.tools.ls import Ls
 from lisa.tools.mkdir import Mkdir
 from lisa.tools.rm import Rm
 from lisa.tools.whoami import Whoami
+from lisa.util import LisaException, constants
 
 if TYPE_CHECKING:
-    from lisa.node import Node
+    from lisa.node import Node, RemoteNode
 
 
 class RemoteCopy(Tool):
@@ -232,6 +234,84 @@ class RemoteCopy(Tool):
             dest_files.extend(self._copy(dir_, destination_dir, recurse=recurse))
 
         return dest_files
+
+    def copy_between_remotes(
+        self,
+        src_node: "RemoteNode | Node",
+        src_path: PurePath,
+        dest_node: "RemoteNode | Node",
+        dest_path: PurePath,
+        recurse: bool = False,
+    ) -> int:
+        """
+        Copy a file or directory from src_node to dest_node using scp.
+        The scp command is executed on the src_node, pushing to dest_node.
+        Only key-based authentication is supported.
+        """
+        # Ensure src_path and dest_path are strings
+        src_path_str = str(src_path)
+        dest_path_str = str(dest_path)
+
+        # Import here to avoid circular import
+        from lisa.node import RemoteNode
+
+        # get the node connection details for scp command
+        if isinstance(dest_node, RemoteNode):
+            dest_connection = dest_node.connection_info
+        else:
+            raise LisaException(
+                "destination not a 'RemoteNode', hence `connection_info` unavailable"
+            )
+
+        dest_user = dest_connection[constants.ENVIRONMENTS_NODES_REMOTE_USERNAME]
+        dest_addr = dest_connection[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
+        dest_key = dest_connection[constants.ENVIRONMENTS_NODES_REMOTE_PRIVATE_KEY_FILE]
+        if not dest_user or not dest_addr or not dest_key:
+            raise ValueError("destination node connection info inaccessible")
+
+        # Use a temporary file for the key on src_node
+        tmp_key_name = "/tmp/.lisa_dest_key"
+        # Copy the dest_key to src_node (if not already present)
+        if not src_node.tools[Ls].path_exists(path=tmp_key_name, sudo=False):
+            self._log.debug("copying ssh key to src node")
+            src_node.shell.copy(
+                local_path=PurePath(dest_key),
+                node_path=PurePath(tmp_key_name),
+            )
+            assert src_node.tools[Ls].path_exists(tmp_key_name), "copy failed"
+            src_node.tools[Chmod].chmod(
+                path=tmp_key_name,
+                permission="0600",
+                sudo=False,
+            )
+
+        self._log.debug(
+            f"scp command attributes:\n"
+            f"destination user: {dest_user}\n"
+            f"destination IP adress: {dest_addr}\n"
+            f"destination admin_key: {dest_key}\n"
+            f"location of key on src: {tmp_key_name}\n"
+        )
+        # Prepare scp command to run on src_node, pushing to dest_node
+        scp_opts = "-r" if recurse else ""
+        scp_cmd = (
+            f"scp {scp_opts} -i {tmp_key_name} -o StrictHostKeyChecking=no "
+            f"{src_path_str} {dest_user}@{dest_addr}:{dest_path_str}"
+        )
+        self._log.debug(f"scp command: {scp_cmd}")
+        scp_process = src_node.execute_async(
+            scp_cmd,
+            shell=True,
+            sudo=False,
+            no_info_log=False,
+        )
+
+        scp_result = scp_process.wait_result()
+
+        # Ensure to delete the ssh-key file for security
+        src_node.tools[Rm].remove_file(path=tmp_key_name, sudo=False)
+
+        return scp_result.exit_code if scp_result.exit_code is not None else -1
 
 
 class WindowsRemoteCopy(RemoteCopy):

--- a/lisa/transformers/file_uploader.py
+++ b/lisa/transformers/file_uploader.py
@@ -3,16 +3,18 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import PurePath
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Optional, Type
 
 from dataclasses_json import dataclass_json
 
 from lisa import schema
+from lisa.node import quick_connect
 from lisa.tools import Ls, Mkdir, RemoteCopy
 from lisa.transformers.deployment_transformer import (
     DeploymentTransformer,
     DeploymentTransformerSchema,
 )
+from lisa.util import field_metadata
 
 FILE_UPLOADER = "file_uploader"
 UPLOADED_FILES = "uploaded_files"
@@ -108,4 +110,163 @@ class FileUploaderTransformer(DeploymentTransformer):
             uploaded_files.append(name)
 
         result[UPLOADED_FILES] = uploaded_files
+        return result
+
+
+FILE_TRANSFER = "file_transfer"
+TRANSFERRED_FILES = "transferred_files"
+
+
+@dataclass_json
+@dataclass
+class FileTransferTransformerSchema(FileUploaderTransformerSchema):
+    # optional source node information, use schema.RemoteNode
+    source_node: schema.RemoteNode = field(
+        default_factory=schema.RemoteNode,
+        metadata=field_metadata(required=True),
+    )
+    # optional local path for temporary storage during file transfers
+    local_path: Optional[str] = ""
+    # flag to skip scp attempts
+    try_scp: Optional[bool] = True
+
+
+class FileTransferTransformer(FileUploaderTransformer):
+    """
+    This transformer transfers files between two remotes. It should be used when
+    environment is connected.
+    """
+
+    @classmethod
+    def type_name(cls) -> str:
+        return FILE_TRANSFER
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return FileTransferTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return [TRANSFERRED_FILES]
+
+    def _validate(self) -> None:
+        runbook: FileTransferTransformerSchema = self.runbook
+        source = runbook.source
+
+        # Cache the connected source node on the instance to avoid reconnecting.
+        self._source_node = quick_connect(runbook.source_node, runbook.name)
+        src_node = self._source_node
+
+        ls = src_node.tools[Ls]
+        if not ls.path_exists(source):
+            raise ValueError(f"source {source} doesn't exist on remote node.")
+
+        self._runbook_files: List[str] = runbook.files
+        if self._runbook_files == ["*"]:
+            self._runbook_files = []
+            files = ls.list(source, sudo=True)
+            if len(files) == 0:
+                self._log.debug("No files to transfer.")
+            for file in files:
+                self._runbook_files.append(PurePath(file).name)
+
+        for file in self._runbook_files:
+            assert ls.path_exists(
+                f"{source}/{file}"
+            ), f"Node does not contain file: {file}"
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        super()._initialize(*args, **kwargs)
+        runbook: FileTransferTransformerSchema = self.runbook
+        if not runbook.source_node:
+            raise ValueError("'source_node' must be provided.")
+
+    def _transfer_via_local(
+        self,
+        file_name: str,
+        src_copy: RemoteCopy,
+        dest_copy: RemoteCopy,
+        src_path: PurePath,
+        dest_path: PurePath,
+        local_path: Optional[PurePath],
+    ) -> None:
+        assert local_path, "local_path must be set when scp is unavailable"
+        self._log.info(f"downloading '{file_name}' from '{str(src_path)}'")
+        src_copy.copy_to_local(
+            src=src_path / file_name,
+            dest=local_path,
+            recurse=False,
+            sudo=False,
+        )
+        self._log.info(f"uploading '{file_name}' to '{str(dest_path)}'")
+        dest_copy.copy_to_remote(
+            src=local_path / file_name,
+            dest=dest_path,
+            recurse=False,
+            sudo=False,
+        )
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: FileTransferTransformerSchema = self.runbook
+        result: Dict[str, Any] = dict()
+        dest_copy = self._node.tools[RemoteCopy]
+        transferred_files: List[str] = []
+
+        src_purepath = PurePath(runbook.source)
+        dest_purepath = PurePath(runbook.destination)
+
+        # checking destination existence
+        self._check_dest_dir(runbook.destination)
+
+        src_node = self._source_node
+        src_copy = src_node.tools[RemoteCopy]
+        local_purepath: Optional[PurePath] = None
+        if runbook.local_path:
+            local_path_resolved: str = os.path.expandvars(
+                os.path.expanduser(runbook.local_path)
+            )
+            os.makedirs(local_path_resolved, exist_ok=True)
+
+            local_path = f"{local_path_resolved}/{src_purepath.name}"
+            os.makedirs(local_path, exist_ok=True)
+
+            local_purepath = PurePath(local_path)
+
+        scp_result: int = 0
+        if not runbook.try_scp:
+            scp_result = -1
+
+        for file_name in self._runbook_files:
+            if scp_result == 0:
+                self._log.info(
+                    f"remote-to-remote: '{file_name}' to '{str(dest_purepath)}'"
+                )
+                scp_result = dest_copy.copy_between_remotes(
+                    src_node=src_node,
+                    src_path=src_purepath / file_name,
+                    dest_node=self._node,
+                    dest_path=dest_purepath / file_name,
+                    recurse=False,
+                )
+                if scp_result == 0:
+                    transferred_files.append(file_name)
+                    continue
+
+            # Fallback to download/upload via local
+            # Skip dbg file due to its size if downloading and uploading
+            if "dbg" in file_name:
+                continue
+
+            self._transfer_via_local(
+                file_name=file_name,
+                src_copy=src_copy,
+                dest_copy=dest_copy,
+                src_path=src_purepath,
+                dest_path=dest_purepath,
+                local_path=local_purepath,
+            )
+            transferred_files.append(file_name)
+
+        self._log.info(f"files transferred: {transferred_files}")
+        result[TRANSFERRED_FILES] = transferred_files
         return result

--- a/lisa/transformers/file_uploader.py
+++ b/lisa/transformers/file_uploader.py
@@ -47,6 +47,29 @@ class FileUploaderTransformer(DeploymentTransformer):
     def _output_names(self) -> List[str]:
         return [UPLOADED_FILES]
 
+    def _validate(self) -> None:
+        runbook: FileUploaderTransformerSchema = self.runbook
+        source: PurePath = PurePath(runbook.source)
+
+        if not os.path.exists(runbook.source):
+            raise ValueError(f"source {runbook.source} doesn't exist.")
+
+        self._runbook_files: List[str] = runbook.files
+        if self._runbook_files == ["*"]:
+            self._runbook_files = []
+            files = os.listdir(runbook.source)
+            if len(files) == 0:
+                self._log.info("No files to upload")
+            for file in files:
+                self._runbook_files.append(file)
+
+        for file in self._runbook_files:
+            assert os.path.exists(source / file), f"Node does not contain file: {file}"
+
+        self._log.debug(
+            f"files to upload: {self._runbook_files} from: {runbook.source}"
+        )
+
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         super()._initialize(*args, **kwargs)
         runbook: FileUploaderTransformerSchema = self.runbook
@@ -57,8 +80,7 @@ class FileUploaderTransformer(DeploymentTransformer):
         if not runbook.files:
             raise ValueError("'files' must be provided.")
 
-        if not os.path.exists(runbook.source):
-            raise ValueError(f"source {runbook.source} doesn't exist.")
+        self._validate()
 
     def _internal_run(self) -> Dict[str, Any]:
         runbook: FileUploaderTransformerSchema = self.runbook


### PR DESCRIPTION
This PR introduces a new FileTransferTransformer that enables file copying between remote nodes using SCP, with automatic fallback to local download/upload if direct SCP fails. The PR also refactors the existing FileUploaderTransformer to share common validation and directory-checking logic.

**Changes:**
- Refactored FileUploaderTransformer to extract reusable methods (_check_dest_dir, _validate)
- Added FileTransferTransformer for remote-to-remote file transfers with SCP support
- Implemented copy_between_remotes method in RemoteCopy tool for direct node-to-node copying

| File | Description |
| ---- | ----------- |
| lisa/transformers/file_uploader.py | Refactored existing FileUploaderTransformer and added new FileTransferTransformer class that extends it to support remote-to-remote file transfers with SCP fallback mechanism |
| lisa/tools/remote_copy.py | Added copy_between_remotes method to enable direct SCP-based file transfers between remote nodes, with SSH key management |

---

**Test Suggestions (Required per LISA Guidelines):**

**Key Test Cases:**
Since this PR introduces new transformer functionality for file transfers, the following integration tests should be run to validate the changes:
- Tests that verify basic file transfer operations between nodes
- Tests that validate SCP functionality and fallback mechanisms
- Tests that check transformer dependency resolution and execution order

**Impacted LISA Features:**
The changes primarily impact file transfer capabilities and transformer infrastructure, so no specific LISA feature classes are directly affected by this core functionality change.