### PR TITLE
Add dpkg tool

### DIFF
--- a/lisa/base_tools/__init__.py
+++ b/lisa/base_tools/__init__.py
@@ -1,5 +1,6 @@
 from .apt_add_repository import AptAddRepository
 from .cat import Cat
+from .dpkg import Dpkg
 from .mv import Mv
 from .rpm import Rpm
 from .sed import Sed
@@ -14,6 +15,7 @@ __all__ = [
     "Wget",
     "Cat",
     "Rpm",
+    "Dpkg",
     "YumConfigManager",
     "Service",
     "ServiceInternal",

--- a/lisa/base_tools/dpkg.py
+++ b/lisa/base_tools/dpkg.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import cast
+
+from lisa.executable import Tool
+
+
+class Dpkg(Tool):
+    @property
+    def command(self) -> str:
+        return "dpkg"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def install(self) -> bool:
+        from lisa.operating_system import Posix
+
+        posix_os: Posix = cast(Posix, self.node.os)
+        package_name = "dpkg"
+        posix_os.install_packages(package_name)
+        return self._check_exists()
+
+    def is_valid_package(self, file: str) -> bool:
+        # Check if the file is a valid deb package
+        result = self.run(
+            f"--info {file}",
+        )
+        return result.exit_code == 0
+
+    def install_local_package(self, file: str, force: bool = True) -> None:
+        # Install a single deb package
+        parameters = f"-i {file}"
+        if force:
+            parameters = f" --force-all {parameters}"
+        self.run(
+            parameters,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(f"failed to install {file}"),
+        )

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -5,6 +5,7 @@
 from lisa.base_tools import (
     AptAddRepository,
     Cat,
+    Dpkg,
     Mv,
     Rpm,
     Sed,
@@ -175,6 +176,7 @@ __all__ = [
     "Dnsmasq",
     "Docker",
     "DockerCompose",
+    "Dpkg",
     "Echo",
     "EfiBootMgr",
     "Ethtool",

--- a/lisa/transformers/package_installer.py
+++ b/lisa/transformers/package_installer.py
@@ -9,6 +9,7 @@ from dataclasses_json import dataclass_json
 from lisa import schema
 from lisa.operating_system import RPMDistro
 from lisa.tools import Rpm
+from lisa.tools.ls import Ls
 from lisa.transformers.deployment_transformer import (
     DeploymentTransformer,
     DeploymentTransformerSchema,
@@ -41,22 +42,54 @@ class PackageInstaller(DeploymentTransformer):
     def _validate(self) -> None:
         runbook: PackageInstallerSchema = self.runbook
         directory: PurePath = PurePath(runbook.directory)
-        for file in runbook.files:
+        node = self._node
+
+        self._runbook_files: List[str] = runbook.files
+        if self._runbook_files == ["*"]:
+            self._runbook_files = []
+            files = node.tools[Ls].list(str(directory))
+            for file in files:
+                self._runbook_files.append(PurePath(file).name)
+
+        for file in self._runbook_files:
             assert self._node.shell.exists(
                 directory / file
             ), f"Node does not contain package file: {file}"
             self._validate_package(str(directory / file))
 
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        super()._initialize(*args, **kwargs)
+        runbook: PackageInstallerSchema = self.runbook
+        if not runbook.directory:
+            self._log.debug("no 'directory' provided.")
+        if not runbook.files:
+            self._log.debug("no 'files' to install.")
+
+        self._validate()
+
     def _internal_run(self) -> Dict[str, Any]:
         runbook: PackageInstallerSchema = self.runbook
+        uname = self._node.tools[Uname]
+        installed_packages = []
 
-        self._log.info(f"Installing packages: {runbook.files}")
+        # Log kernel version before installation
+        kernel_version = uname.get_linux_information().kernel_version_raw
+        self._log.info(f"Kernel version before installation: {kernel_version}")
+
+        self._log.info(f"Installing packages: {self._runbook_files}")
         directory: PurePath = PurePath(runbook.directory)
-        for file in runbook.files:
-            self._install_package(self._node.get_str_path(directory.joinpath(file)))
+        for file in self._runbook_files:
+            self._install_package(self._node.get_str_path(directory / file))
+            installed_packages.append(file)
+
+        self._log.info(f"Successfully installed: {installed_packages}")
 
         if runbook.reboot:
             self._node.reboot(time_out=900)
+            kernel_version = uname.get_linux_information(
+                force_run=True
+            ).kernel_version_raw
+            self._log.info(f"Kernel version after reboot: " f"{kernel_version}")
 
         return {}
 

--- a/lisa/transformers/package_installer.py
+++ b/lisa/transformers/package_installer.py
@@ -7,9 +7,8 @@ from typing import Any, Dict, List, Type
 from dataclasses_json import dataclass_json
 
 from lisa import schema
-from lisa.operating_system import RPMDistro
-from lisa.tools import Rpm
-from lisa.tools.ls import Ls
+from lisa.operating_system import Debian, RPMDistro
+from lisa.tools import Dpkg, Ls, Rpm, Uname
 from lisa.transformers.deployment_transformer import (
     DeploymentTransformer,
     DeploymentTransformerSchema,
@@ -122,3 +121,33 @@ class RPMPackageInstallerTransformer(PackageInstaller):
 
     def _install_package(self, file: str) -> None:
         self._node.tools[Rpm].install_local_package(file, force=True, nodeps=True)
+
+
+class DEBPackageInstallerTransformer(PackageInstaller):
+    @classmethod
+    def type_name(cls) -> str:
+        return "deb_package_installer"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return PackageInstallerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _validate(self) -> None:
+        if not isinstance(self._node.os, Debian):
+            raise UnsupportedDistroException(
+                self._node.os,
+                f"'{self.type_name()}' transformer only supports Debian-based Distros.",
+            )
+        super()._validate()
+
+    def _validate_package(self, file: str) -> None:
+        assert self._node.tools[Dpkg].is_valid_package(
+            file
+        ), f"Provided file {file} is not a deb"
+
+    def _install_package(self, file: str) -> None:
+        self._node.tools[Dpkg].install_local_package(file, force=True)


### PR DESCRIPTION
This pull request introduces support for installing Debian packages (.deb) on nodes by adding a new **Dpkg** tool and **DEBPackageInstallerTransformer**. It also refactors the **PackageInstaller** transformer base class to support wildcard file selection, improved logging, and better error handling.

**Changes:**
- Adds a new Dpkg tool for managing Debian package installations
- Introduces DEBPackageInstallerTransformer for Debian-based distributions
- Enhances PackageInstaller base class with wildcard file selection, kernel version logging, and error handling

| File | Description |
| ---- | ----------- |
| lisa/tools/dpkg.py | New tool implementation for Debian package management with validation and installation capabilities |
| lisa/transformers/package_installer.py | Refactored base class to add wildcard file selection, kernel version logging, improved error handling; added DEBPackageInstallerTransformer |
| lisa/tools/__init__.py | Added import for the new Dpkg tool |