### PR TITLE
stress_ng: remove --oom-avoid

### DIFF
--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -95,7 +95,7 @@ class StressNg(Tool):
         v_flag = "-v" if verbose else ""
         return self.run_async(
             f"{v_flag} --sequential {num_workers} --class {class_name} "
-            f"--timeout {timeout_secs} --oom-avoid",
+            f"--timeout {timeout_secs}",
             sudo=sudo,
         )
 


### PR DESCRIPTION
Undoing a change from #4159.

While --oom-avoid does improve the stability of the stress-ng tests, this particular flag is not available on all versions of stress-ng that get picked up in testing.

Future improvements to stress-ng stability could consider reenabling this flag after making other modifications, such as always installing from source, or checking the version and/or availability of this flag before using it.