### PR TITLE
Add test panic detection for CH and stress-ng

### DIFF
--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -26,7 +26,7 @@ from lisa.features import SerialConsole
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.testsuite import TestResult
 from lisa.tools import StressNg
-from lisa.util import KernelPanicException, SkippedException
+from lisa.util import KernelPanicException, SkippedException, check_test_panic
 from lisa.util.logger import Logger
 from lisa.util.process import Process
 
@@ -268,7 +268,11 @@ class StressNgTestSuite(TestSuite):
             )
 
             execution_status, execution_summary = self._monitor_stress_execution(
-                stress_processes, nodes, log, job_file_name
+                stress_processes,
+                nodes,
+                log,
+                job_file_name,
+                test_result,
             )
 
         except Exception as execution_error:
@@ -339,6 +343,7 @@ class StressNgTestSuite(TestSuite):
         nodes: List[RemoteNode],
         log: Logger,
         job_file_name: str,
+        test_result: TestResult,
     ) -> Tuple[TestStatus, str]:
         """
         Monitor stress-ng execution and capture stress-ng info output.
@@ -355,8 +360,23 @@ class StressNgTestSuite(TestSuite):
         for i, process in enumerate(stress_processes):
             node_name = nodes[i].name
             try:
-                process.wait_result(timeout=self.TIME_OUT, expected_exit_code=0)
+                result = process.wait_result(
+                    timeout=self.TIME_OUT,
+                    expected_exit_code=0,
+                )
                 log.info(f"{node_name} completed successfully")
+
+                # Check test output for panic markers
+                test_output = f"{result.stdout}\n{result.stderr}".strip()
+                if test_output:
+                    check_test_panic(
+                        test_output,
+                        stage=f"stress-ng job {job_file_name}",
+                        log=log,
+                        test_result=test_result,
+                        node_name=node_name,
+                        source="stress-ng output",
+                    )
 
                 # Process YAML output if applicable
                 node_output = self._process_yaml_output(nodes[i], job_file_name, log)
@@ -370,6 +390,30 @@ class StressNgTestSuite(TestSuite):
                 log.error(f"{node_name} failed: {e}")
                 # Store the exception to re-raise after collecting all outputs
                 exceptions_to_raise.append(e)
+
+                # Check test output for panic markers even on failure
+                # Use log_buffer from the process if available
+                try:
+                    buf = getattr(process, "log_buffer", None)
+                    if buf:
+                        test_output = buf.getvalue().strip()
+                        if test_output:
+                            check_test_panic(
+                                test_output,
+                                stage=f"stress-ng job {job_file_name} (failed)",
+                                log=log,
+                                test_result=test_result,
+                                node_name=node_name,
+                                source="stress-ng captured output",
+                            )
+                except Exception as panic_check_error:
+                    # Don't mask the original test failure, but surface details of
+                    # any unexpected error encountered while checking for panics.
+                    log.debug(
+                        f"Failed to check test panic on {node_name}: "
+                        f"{panic_check_error!r}",
+                        exc_info=True,
+                    )
 
         # Combine all node outputs, including node names for clarity
         execution_summary = f"Job: {job_file_name}\n\n"

--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import hashlib
 import ipaddress
 import random
 import re
@@ -42,6 +43,7 @@ from lisa.util.perf_timer import create_timer
 
 if TYPE_CHECKING:
     from lisa.operating_system import OperatingSystem
+    from lisa.testsuite import TestResult
     from lisa.util.logger import Logger
 
 T = TypeVar("T")
@@ -143,6 +145,12 @@ PANIC_IGNORABLE_PATTERNS: List[Pattern[str]] = [
     # more NUMA nodes on AMD processors.
     # The call trace is annoying but does not affect correct operation of the VM.
     re.compile(r"(.*RIP: 0010:topology_sane.isra.*)$", re.MULTILINE),
+]
+
+TEST_PANIC_PATTERNS: List[Pattern[str]] = [
+    # Rust panics - must have "panicked at" with backtrace markers
+    re.compile(r"^(.*panicked at .*)$", re.MULTILINE),
+    re.compile(r"^(.*stack backtrace:.*)$", re.MULTILINE | re.IGNORECASE),
 ]
 
 # Root filesystem mount failure patterns
@@ -384,6 +392,24 @@ class KernelPanicException(LisaException):
             "details from the serial console log. Please download the test logs and "
             "retrieve the serial_log from 'environments' directory, or you can ask "
             f"support. Detected Panic phrases: {self.panics}"
+        )
+
+
+class PostTestPanicDetectedError(LisaException):
+    """
+    This exception is raised when a test panic is detected in test output.
+    """
+
+    def __init__(self, stage: str, panics: List[Any], source: str = "test log") -> None:
+        self.stage = stage
+        self.panics = panics
+        self.source = source
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        return (
+            f"{self.stage} found test panic in {self.source}. "
+            f"Detected Test Panic lines: {self.panics}"
         )
 
 
@@ -977,6 +1003,58 @@ def check_panic(content: str, stage: str, log: "Logger") -> None:
 
     if panics:
         raise KernelPanicException(stage, panics)
+
+
+def append_test_panic_to_test_result(
+    test_result: "TestResult", node_name: str, panics: List[str]
+) -> None:
+    # Filter out empty/whitespace-only lines and remove duplicates
+    # while preserving order
+    filtered_panics = [p.strip() for p in panics if p and p.strip()]
+    unique_panics = list(dict.fromkeys(filtered_panics))
+    panic_lines = "\n".join(unique_panics)
+
+    panic_id = hashlib.sha256(f"{node_name}\x00{panic_lines}".encode()).hexdigest()[:16]
+
+    panic_summary = (
+        f"TEST PANIC DETECTED on {node_name} [id:{panic_id}]\n"
+        f"Detected Test Panic Lines:\n{panic_lines}\n"
+    )
+
+    # Check if we've already added this exact panic (by id) to avoid duplicates
+    # from both success and failure paths
+    if test_result.message and f"[id:{panic_id}]" in test_result.message:
+        return
+
+    if test_result.message:
+        test_result.message += f"\n\n{panic_summary}"
+    else:
+        test_result.message = panic_summary
+
+
+def check_test_panic(
+    content: str,
+    stage: str,
+    log: "Logger",
+    test_result: Optional["TestResult"] = None,
+    node_name: str = "",
+    source: str = "test log",
+) -> None:
+    log.debug("checking test panic...")
+    panics = [
+        x
+        for sublist in find_patterns_in_lines(str(content), TEST_PANIC_PATTERNS)
+        for x in sublist
+        if x
+    ]
+
+    if panics:
+        if test_result is not None:
+            # Append panic info to existing test result message, don't raise
+            append_test_panic_to_test_result(test_result, node_name, panics)
+        else:
+            # Only raise exception if no test_result context
+            raise PostTestPanicDetectedError(stage, panics, source)
 
 
 def check_rootfs_failure(content: str, log: "Logger") -> None:


### PR DESCRIPTION
Implements test-level panic detection to catch Rust panics in Cloud Hypervisor integration tests and stress-ng test runs. Unlike kernel panics, these are test framework panics that don't cause VM crashes but still indicate test failures.

Key features:
- New TestPanicException class for test-level panics (distinct from KernelPanicException)
- TEST_PANIC_PATTERNS: Detects 'panicked at' and 'stack backtrace:' markers
- check_test_panic() function scans logs and appends panic details to TestResult.message
- Preserves original failure message (e.g., test names) and adds panic context

This enables catching test panics in CH integration tests and stress workloads while maintaining detailed failure information for debugging.