### PR TITLE
dpdk: l3fwd test fixes

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -777,12 +777,13 @@ class DpdkTestpmd(Tool):
         self.rx_total_packets = self.get_data_from_testpmd_output(
             self._rx_total_key, self._last_run_output
         )[-1]
-        self.tx_bps_data = self.get_data_from_testpmd_output(
-            self._tx_bps_key, self._last_run_output
-        )
-        self.rx_bps_data = self.get_data_from_testpmd_output(
-            self._rx_bps_key, self._last_run_output
-        )
+        if self.has_dpdk_version() and self.get_dpdk_version() > "21.11.0":
+            self.tx_bps_data = self.get_data_from_testpmd_output(
+                self._tx_bps_key, self._last_run_output
+            )
+            self.rx_bps_data = self.get_data_from_testpmd_output(
+                self._rx_bps_key, self._last_run_output
+            )
 
     def get_mean_rx_pps(self) -> int:
         self._check_pps_data("RX")

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1239,7 +1239,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
             pmd,
             hugepage_size,
             sample_apps=["l3fwd"],
-            test_nics=[subnet_b_nics[forwarder]],
+            test_nics=[subnet_a_nics[forwarder], subnet_b_nics[forwarder]],
         )
     except (NotEnoughMemoryException, UnsupportedOperationException) as err:
         raise SkippedException(err)
@@ -1431,7 +1431,7 @@ def generate_l3fwd_command(
     config_tups = []
     included_cores = []
     last_core = 1
-    server_app_path = fwd_kit.testpmd.get_example_app_path("dpdk-l3fwd")
+    server_app_path = fwd_kit.testpmd.get_example_app_path("l3fwd")
     # create the list of tuples for p,q,c
     # 2 ports, N queues, N cores for MANA
     # 2 ports, N queues, 2N cores for MLX


### PR DESCRIPTION
fixing some issues with the l3fwd tests post-rebase/refactoring
- app name was old form, dpdk-l3fwd. changes to 'l3fwd'
- test nic list includes eth1 (was implicit before)
- fix missing key in old dpdk apps