### PR TITLE
tools/git: use --always with git describe

### DIFF
--- a/lisa/tools/git.py
+++ b/lisa/tools/git.py
@@ -412,7 +412,7 @@ class Git(Tool):
         ).stdout
 
         describe = self.run(
-            "describe",
+            "describe --always",
             shell=True,
             cwd=cwd,
             force_run=True,


### PR DESCRIPTION
If the repository doesn't have tags, git describe fails with:

  fatal: No names found, cannot describe anything.

From the official git documentation:

--always
  Show uniquely abbreviated commit object as fallback.

This makes our `git describe` command more robust and prevents exceptions in cases where there are no tags to describe the commit. It is possible that some forked (i.e. not upstream) repositories don't have tags. In these cases, instead of failing, fallback to commit id.