### PR TITLE
fix(sched_core): skip on non-SMT hosts and install C dev headers

### DIFF
--- a/lisa/microsoft/testsuites/core/sched_core.py
+++ b/lisa/microsoft/testsuites/core/sched_core.py
@@ -77,6 +77,13 @@ class SchedCore(TestSuite):
 
         log.info("CONFIG_SCHED_CORE is enabled")
 
+        smt_result = node.execute("cat /sys/devices/system/cpu/smt/active", sudo=True)
+        if smt_result.stdout.strip() != "1":
+            raise SkippedException("SMT is not active; core scheduling requires SMT.")
+
+        assert isinstance(node.os, CBLMariner), "Expected CBLMariner OS"
+        node.os.install_packages(("glibc-devel", "kernel-headers", "binutils"))
+
         node_src = node.working_path / f"{self._file_name}.c"
         node_bin = node.working_path / self._file_name
 


### PR DESCRIPTION
Tested the changes from https://github.com/microsoft/lisa/pull/4299 on an AzureLinux Arm VM and hit errors where runtime SMT is not present. Therefore skip. Additionally, need to make sure on a clean VM that the headers are available.

- Add runtime SMT check before running prctl test; core scheduling returns ENODEV on hosts without hyperthreading (e.g. ARM64 VMs)
- Install glibc-devel, kernel-headers, and binutils to ensure the C test program compiles on minimal Azure Linux images

Validated on fresh Azure Arm64 and x86 VMs