### PR TITLE
Fix and normalize package path in package_installer validation

### DIFF
--- a/lisa/transformers/package_installer.py
+++ b/lisa/transformers/package_installer.py
@@ -54,7 +54,7 @@ class PackageInstaller(DeploymentTransformer):
             assert self._node.shell.exists(
                 directory / file
             ), f"Node does not contain package file: {file}"
-            self._validate_package(str(directory / file))
+            self._validate_package(self._node.get_str_path(directory / file))
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         super()._initialize(*args, **kwargs)


### PR DESCRIPTION
### Problem

When running LISA with a runbook that uses rpm_package_installer, LISA would fail during the deployment transformer stage (before the test cases even start running) with errors such as:
> FAILED   deployment failed. AssertionError: Provided file kernel_source\foo.rpm is not an rpm
 
 ### Root Cause

LISA regression introduced by commit d5f981c29.
Before this commit PackageInstaller had no `_initialize()` overwrite; this commit introduced it.
PackageInstaller started validating RPMs in `_initialize()` by calling `_validate()`, which makes a call `self._validate_package(str(directory / file))`. On Windows-hosted LISA: `str(directory / file)` can produce paths like "kernel_source\foo.rpm". Validation then runs `rpm -qp` on the Linux target and fails with: "Provided file ... is not an rpm".

This problem wasn't seen before, likely because `_validate()` wasn't on an (regularly) executed code path.

### Fix

Use correct node-normalized path conversion: `self._node.get_str_path(directory / file)`.