### PR TITLE
Add ai agent dependent package with a fixed version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ azure = [
 ]
 
 ai = [
+    "opentelemetry-semantic-conventions-ai == 0.4.13",
     "agent-framework-core == 1.0.0b260130",
     "agent-framework-azure-ai == 1.0.0b260130",
     "openai ~= 2.8.1",


### PR DESCRIPTION
The dependency pakcage of agent_framework, v0.4.14 of opentelemetry-semantic-conventions-ai (released on Feb 22), has deprecated some attributes. As a temporary workaround, we can pin the package to: opentelemetry-semantic-conventions-ai==0.4.13

https://github.com/microsoft/agent-framework/issues/4160