### PR TITLE
network: add BBR3 congestion control coverage

### DIFF
--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -51,7 +51,11 @@ def create_tcp_server_client(port: int, algo_output_path: str = "") -> None:
     client.connect((LOCALHOST, port))
 
     if algo_output_path:
-        algo = client.getsockopt(socket.IPPROTO_TCP, socket.TCP_CONGESTION, 64)
+        algo = client.getsockopt(
+            socket.IPPROTO_TCP,
+            socket.TCP_CONGESTION,  # type: ignore[attr-defined]
+            64,
+        )
         with open(algo_output_path, "w", encoding="utf-8") as algo_file:
             algo_file.write(algo.decode().strip("\x00"))
 

--- a/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
+++ b/lisa/microsoft/testsuites/network/TestScripts/lisa_tcp_test.py
@@ -18,7 +18,7 @@ LOCALHOST = "127.0.0.1"
 DEFAULT_PORT = 34567
 
 
-def create_tcp_server_client(port: int) -> None:
+def create_tcp_server_client(port: int, algo_output_path: str = "") -> None:
     """
     Create a TCP server-client connection and keep it alive.
 
@@ -50,6 +50,11 @@ def create_tcp_server_client(port: int) -> None:
     # Connect client
     client.connect((LOCALHOST, port))
 
+    if algo_output_path:
+        algo = client.getsockopt(socket.IPPROTO_TCP, socket.TCP_CONGESTION, 64)
+        with open(algo_output_path, "w", encoding="utf-8") as algo_file:
+            algo_file.write(algo.decode().strip("\x00"))
+
     print("CONNECTION_READY")
     sys.stdout.flush()
 
@@ -67,4 +72,5 @@ def create_tcp_server_client(port: int) -> None:
 if __name__ == "__main__":
     # Get port from command line argument, or use default
     port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
-    create_tcp_server_client(port)
+    algo_output_path = sys.argv[2] if len(sys.argv) > 2 else ""
+    create_tcp_server_client(port, algo_output_path)

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -348,7 +348,7 @@ class CongestionControlSuite(TestSuite):
         ss = node.tools[Ss]
 
         for port in range(self._PORT_RANGE_START, self._PORT_RANGE_END):
-            if not ss.connection_exists(port=port, sport=True):
+            if not ss.port_in_use(port=port, sport=True):
                 return port
 
         raise LisaException(

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -1,0 +1,341 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+from assertpy import assert_that
+
+from lisa import (
+    LisaException,
+    Node,
+    SkippedException,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.operating_system import CBLMariner
+from lisa.tools import KernelConfig, Modprobe, Rm, Ss, Sysctl
+from lisa.util import create_timer
+
+
+@TestSuiteMetadata(
+    area="network",
+    category="functional",
+    description="""
+    This test suite validates TCP congestion control behavior.
+    Current coverage focuses on BBR3-specific functionality.
+    """,
+    requirement=simple_requirement(
+        supported_os=[CBLMariner],
+    ),
+)
+class CongestionControlSuite(TestSuite):
+    _BBR3 = "bbr3"
+    _BBR3_MODULE = "tcp_bbr3"
+    _TCP_AVAILABLE = "net.ipv4.tcp_available_congestion_control"
+    _TCP_ACTIVE = "net.ipv4.tcp_congestion_control"
+    _BBR3_CONFIG = "CONFIG_TCP_CONG_BBR3"
+    _TCP_SCRIPT = "lisa_tcp_test.py"
+    _INVALID_ALGO = "lisa_invalid_cc_algorithm"
+    _PORT_RANGE_START = 34567
+    _PORT_RANGE_END = 34667
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies the BBR3 algorithm appears in available
+        TCP congestion control algorithms.
+
+        Steps:
+        1. Read available TCP congestion control algorithms.
+        2. Verify BBR3 is listed.
+
+        """,
+        priority=3,
+    )
+    def verify_bbr3_available(self, node: Node) -> None:
+        loaded_by_test = False
+        try:
+            available, loaded_by_test = self._ensure_bbr3_available(node)
+            assert_that(
+                available,
+                f"{self._BBR3} should be listed in {self._TCP_AVAILABLE}",
+            ).contains(self._BBR3)
+        finally:
+            self._cleanup_loaded_module(node, loaded_by_test)
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies the BBR3 algorithm can be selected and restored.
+
+        Steps:
+        1. Verify BBR3 is available.
+        2. Save the current TCP congestion control algorithm.
+        3. Set TCP congestion control to BBR3.
+        4. Verify BBR3 is active.
+        5. Restore the original algorithm.
+
+        """,
+        priority=2,
+    )
+    def verify_bbr3_set_and_restore(self, node: Node) -> None:
+        loaded_by_test = False
+        sysctl = node.tools[Sysctl]
+        original_algo = sysctl.get(self._TCP_ACTIVE).strip()
+
+        try:
+            _, loaded_by_test = self._ensure_bbr3_available(node)
+            sysctl.write(self._TCP_ACTIVE, self._BBR3)
+            active_algo = sysctl.get(self._TCP_ACTIVE).strip()
+            assert_that(
+                active_algo,
+                f"{self._TCP_ACTIVE} should be set to {self._BBR3}",
+            ).is_equal_to(self._BBR3)
+        finally:
+            sysctl.write(self._TCP_ACTIVE, original_algo)
+            restored_algo = sysctl.get(self._TCP_ACTIVE).strip()
+            assert_that(
+                restored_algo,
+                f"{self._TCP_ACTIVE} should be restored to {original_algo}",
+            ).is_equal_to(original_algo)
+            self._cleanup_loaded_module(node, loaded_by_test)
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies the BBR3 algorithm remains stable on a live TCP flow.
+
+        Steps:
+        1. Verify BBR3 is available.
+        2. Set TCP congestion control to BBR3.
+        3. Create a TCP connection and verify it reaches ESTAB.
+        4. Validate the connection remains established.
+        5. Restore the original algorithm and cleanup.
+
+        """,
+        priority=2,
+    )
+    def verify_bbr3_applies_to_live_tcp_flow(self, node: Node) -> None:
+        loaded_by_test = False
+        script_path = node.working_path / self._TCP_SCRIPT
+        connection_process = None
+        sysctl = node.tools[Sysctl]
+        rm = node.tools[Rm]
+        original_algo = sysctl.get(self._TCP_ACTIVE).strip()
+
+        try:
+            _, loaded_by_test = self._ensure_bbr3_available(node)
+            sysctl.write(self._TCP_ACTIVE, self._BBR3)
+            active_algo = sysctl.get(self._TCP_ACTIVE).strip()
+            assert_that(
+                active_algo,
+                f"{self._TCP_ACTIVE} should be set to {self._BBR3}",
+            ).is_equal_to(self._BBR3)
+
+            test_port = self._find_available_port(node)
+            self._copy_to_node(node, self._TCP_SCRIPT)
+
+            connection_process = node.execute_async(
+                f"python3 {script_path} {test_port}",
+                sudo=False,
+                nohup=True,
+            )
+
+            if not self._wait_for_connection_state(
+                node=node,
+                port=test_port,
+                expected_state=Ss.ConnState.ESTAB,
+                timeout=15,
+                poll_interval=0.5,
+            ):
+                raise LisaException(
+                    f"TCP connection on port {test_port} did not reach ESTAB."
+                )
+
+            time.sleep(2)
+
+            if not self._wait_for_connection_state(
+                node=node,
+                port=test_port,
+                expected_state=Ss.ConnState.ESTAB,
+                timeout=5,
+                poll_interval=0.5,
+            ):
+                raise LisaException(
+                    f"TCP connection on port {test_port} was not stable in ESTAB."
+                )
+        finally:
+            cleanup_errors: List[str] = []
+            if connection_process is not None:
+                pkill_result = node.execute(
+                    f"pkill -f {script_path}",
+                    sudo=True,
+                    expected_exit_code=None,
+                    expected_exit_code_failure_message=(
+                        f"Failed to kill background process for {script_path}"
+                    ),
+                )
+                if pkill_result.exit_code not in (0, 1):
+                    cleanup_errors.append(
+                        "Cleanup failed: pkill returned error code "
+                        f"{pkill_result.exit_code}."
+                    )
+                connection_process.wait_result(timeout=5, raise_on_timeout=False)
+
+            if node.shell.exists(script_path):
+                try:
+                    rm.remove_file(str(script_path), sudo=True)
+                except AssertionError as identifier:
+                    cleanup_errors.append(
+                        f"Failed to remove temporary script {script_path}: {identifier}"
+                    )
+
+            sysctl.write(self._TCP_ACTIVE, original_algo)
+            restored_algo = sysctl.get(self._TCP_ACTIVE).strip()
+            assert_that(
+                restored_algo,
+                f"{self._TCP_ACTIVE} should be restored to {original_algo}",
+            ).is_equal_to(original_algo)
+            self._cleanup_loaded_module(node, loaded_by_test)
+            if cleanup_errors:
+                raise LisaException(" ".join(cleanup_errors))
+
+    @TestCaseMetadata(
+        description="""
+        This test case verifies BBR3 kernel config and runtime state are consistent
+        as part of congestion-control validation.
+
+        Steps:
+        1. Check if BBR3 is enabled in kernel config.
+        2. Verify BBR3 appears in runtime available algorithms.
+
+        """,
+        priority=3,
+    )
+    def verify_bbr3_kernel_config_runtime_consistency(self, node: Node) -> None:
+        kernel_config = node.tools[KernelConfig]
+        if not kernel_config.is_enabled(self._BBR3_CONFIG):
+            raise SkippedException(f"{self._BBR3_CONFIG} is not enabled in kernel.")
+
+        loaded_by_test = False
+        try:
+            available, loaded_by_test = self._ensure_bbr3_available(node)
+            assert_that(
+                available,
+                f"{self._BBR3} should be listed in {self._TCP_AVAILABLE}",
+            ).contains(self._BBR3)
+        finally:
+            self._cleanup_loaded_module(node, loaded_by_test)
+
+    def _ensure_bbr3_available(self, node: Node) -> Tuple[List[str], bool]:
+        """
+        Helper function to be called before any bbr3 test case.
+        Check if bbr3 is available in the kernel config. If not, then skip the test.
+
+        If available, ensure that if it's a module then it's loaded, and ensure it's
+        listed in the available congestion control algorithms. 
+        If any of these steps fail, the overall test case is a failure.
+        Returns (available_algorithms, loaded_by_test)
+        """
+        available = self._get_available_algorithms(node)
+        if self._BBR3 in available:
+            return available, False
+
+        kernel_config = node.tools[KernelConfig]
+        if not kernel_config.is_enabled(self._BBR3_CONFIG):
+            raise SkippedException(
+                f"{self._BBR3} is not available in {self._TCP_AVAILABLE}. "
+                f"{self._BBR3_CONFIG} is not enabled in kernel. "
+                f"available algorithms: {', '.join(available) or 'none'}"
+            )
+
+        if kernel_config.is_built_as_module(self._BBR3_CONFIG):
+            try:
+                node.tools[Modprobe].load(self._BBR3_MODULE)
+            except AssertionError as identifier:
+                raise LisaException(
+                    f"Failed to load {self._BBR3_MODULE} while "
+                    f"{self._BBR3_CONFIG}=m. {identifier}"
+                ) from identifier
+
+            available = self._get_available_algorithms(node)
+            if self._BBR3 not in available:
+                raise LisaException(
+                    f"{self._BBR3} is still missing from {self._TCP_AVAILABLE} "
+                    f"after loading module {self._BBR3_MODULE}. "
+                    f"available algorithms: {', '.join(available) or 'none'}"
+                )
+            return available, True
+
+        raise LisaException(
+            f"{self._BBR3_CONFIG} is enabled but {self._BBR3} is missing from "
+            f"{self._TCP_AVAILABLE}. available algorithms: "
+            f"{', '.join(available) or 'none'}"
+        )
+
+    def _get_available_algorithms(self, node: Node) -> List[str]:
+        try:
+            raw = node.tools[Sysctl].get(self._TCP_AVAILABLE)
+        except AssertionError as identifier:
+            raise SkippedException(
+                f"{self._TCP_AVAILABLE} is not available on this kernel."
+            ) from identifier
+
+        return [algo.strip() for algo in raw.split() if algo.strip()]
+
+    def _cleanup_loaded_module(self, node: Node, loaded_by_test: bool) -> None:
+        if not loaded_by_test:
+            return
+
+        active_algo = node.tools[Sysctl].get(self._TCP_ACTIVE).strip()
+        if active_algo == self._BBR3:
+            return
+
+        node.tools[Modprobe].remove([self._BBR3_MODULE])
+
+    def _find_available_port(self, node: Node) -> int:
+        ss = node.tools[Ss]
+
+        for port in range(self._PORT_RANGE_START, self._PORT_RANGE_END):
+            if not ss.connection_exists(port=port, sport=True):
+                return port
+
+        raise LisaException(
+            f"No available ports found in range "
+            f"{self._PORT_RANGE_START}-{self._PORT_RANGE_END}"
+        )
+
+    def _copy_to_node(self, node: Node, filename: str) -> None:
+        file_path = Path(os.path.dirname(__file__)) / "TestScripts" / filename
+        if not node.shell.exists(node.working_path / filename):
+            node.shell.copy(file_path, node.working_path / filename)
+
+    def _wait_for_connection_state(
+        self,
+        node: Node,
+        port: int,
+        expected_state: Ss.ConnState,
+        timeout: int = 10,
+        poll_interval: float = 0.5,
+    ) -> bool:
+        timer = create_timer()
+        while timer.elapsed(stop=False) < timeout:
+            ss = node.tools[Ss]
+            if expected_state == Ss.ConnState.NONE:
+                connection_exists = ss.connection_exists(
+                    port=port, state=Ss.ConnState.ESTAB.value, sport=True
+                )
+                if not connection_exists:
+                    return True
+            else:
+                connection_exists = ss.connection_exists(
+                    port=port, state=expected_state.value, sport=True
+                )
+                if connection_exists:
+                    return True
+
+            time.sleep(poll_interval)
+
+        return False

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -17,7 +17,8 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.operating_system import CBLMariner
+from lisa.operating_system import BSD, Windows
+from lisa.sut_orchestrator import AZURE, HYPERV, READY
 from lisa.tools import Cat, KernelConfig, Modprobe, Rm, Ss, Sysctl
 from lisa.util import create_timer
 
@@ -27,10 +28,11 @@ from lisa.util import create_timer
     category="functional",
     description="""
     This test suite validates TCP congestion control behavior.
-    Current coverage focuses on BBR3-specific functionality.
+    Current coverage focuses on BBR3-specific functionality (only for kernels that are built with BBR3 support)
     """,
     requirement=simple_requirement(
-        supported_os=[CBLMariner],
+        supported_platform_type=[AZURE, READY, HYPERV],
+        unsupported_os=[BSD, Windows],
     ),
 )
 class CongestionControlSuite(TestSuite):

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -3,7 +3,7 @@
 
 import os
 import time
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List, Optional, Tuple
 
 from assertpy import assert_that
@@ -28,7 +28,8 @@ from lisa.util import create_timer
     category="functional",
     description="""
     This test suite validates TCP congestion control behavior.
-    Current coverage focuses on BBR3-specific functionality (only for kernels that are built with BBR3 support)
+    Current coverage focuses on BBR3-specific functionality
+    (only for kernels that are built with BBR3 support).
     """,
     requirement=simple_requirement(
         supported_platform_type=[AZURE, READY, HYPERV],
@@ -267,7 +268,7 @@ class CongestionControlSuite(TestSuite):
         Check if bbr3 is available in the kernel config. If not, then skip the test.
 
         If available, ensure that if it's a module then it's loaded, and ensure it's
-        listed in the available congestion control algorithms. 
+        listed in the available congestion control algorithms.
         If any of these steps fail, the overall test case is a failure.
         Returns (available_algorithms, loaded_by_test)
         """
@@ -325,7 +326,7 @@ class CongestionControlSuite(TestSuite):
         if active_algo == self._BBR3:
             return
 
-        # Sometimes modprobe can fail to remove the module on the first try due to lingering references.
+        # Sometimes modprobe can fail on first remove due to lingering references.
         modprobe = node.tools[Modprobe]
         last_error: Optional[AssertionError] = None
         for _ in range(5):
@@ -366,7 +367,7 @@ class CongestionControlSuite(TestSuite):
     def _read_socket_congestion_algorithm(
         self,
         node: Node,
-        output_path: Path,
+        output_path: PurePath,
         timeout: int = 5,
         poll_interval: float = 0.2,
     ) -> str:

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -44,7 +44,6 @@ class CongestionControlSuite(TestSuite):
     _BBR3_CONFIG = "CONFIG_TCP_CONG_BBR3"
     _TCP_SCRIPT = "lisa_tcp_test.py"
     _TCP_ALGO_OUTPUT = "lisa_tcp_algo.txt"
-    _INVALID_ALGO = "lisa_invalid_cc_algorithm"
     _PORT_RANGE_START = 34567
     _PORT_RANGE_END = 34667
 

--- a/lisa/microsoft/testsuites/network/congestion_control.py
+++ b/lisa/microsoft/testsuites/network/congestion_control.py
@@ -395,10 +395,8 @@ class CongestionControlSuite(TestSuite):
         while timer.elapsed(stop=False) < timeout:
             ss = node.tools[Ss]
             if expected_state == Ss.ConnState.NONE:
-                connection_exists = ss.connection_exists(
-                    port=port, state=Ss.ConnState.ESTAB.value, sport=True
-                )
-                if not connection_exists:
+                port_in_use = ss.port_in_use(port=port, sport=True)
+                if not port_in_use:
                     return True
             else:
                 connection_exists = ss.connection_exists(

--- a/lisa/microsoft/testsuites/network/inet_diag.py
+++ b/lisa/microsoft/testsuites/network/inet_diag.py
@@ -57,7 +57,7 @@ class InetDiagSuite(TestSuite):
 
         for port in range(self._PORT_RANGE_START, self._PORT_RANGE_END):
             # Check if port is already in use
-            if not ss.connection_exists(port=port, sport=True):
+            if not ss.port_in_use(port=port, sport=True):
                 node.log.debug(f"Found available port: {port}")
                 return port
 

--- a/lisa/tools/ss.py
+++ b/lisa/tools/ss.py
@@ -95,6 +95,23 @@ class Ss(Tool):
 
         return True
 
+    def port_in_use(self, port: int, sport: bool = True) -> bool:
+        """
+        Check if any TCP socket currently uses the specified local/source port.
+
+        This check does not depend on a specific state (e.g. ESTAB/LISTEN).
+        """
+        port_filter = f"sport = {port}" if sport else f"dport = {port}"
+        result = self.run(
+            f"-tan {port_filter}",
+            shell=True,
+            force_run=True,
+            expected_exit_code=0,
+        )
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        # "ss -tan" always prints a header line. Additional lines indicate sockets.
+        return len(lines) > 1
+
     def kill_connection(
         self,
         port: int,


### PR DESCRIPTION
 **New network/congestion_control.py test suite**
  - Add a new congestion-control suite with BBR3 coverage: availability, set/restore, live TCP flow validation, and kernel-config/runtime consistency with runtime gating (skip when kernel is not built with BBR3 support)
    1. verify_bbr3_available: validates bbr3 is listed in tcp_available_congestion_control.
      2. verify_bbr3_set_and_restore: sets tcp_congestion_control=bbr3, verifies, then restores original value.
      3. verify_bbr3_applies_to_live_tcp_flow: creates a live TCP flow and verifies the socket-level congestion algorithm is bbr3.
      4. verify_bbr3_kernel_config_runtime_consistency: checks kernel config/runtime alignment for BBR3.

   
 **Changes to existing infrastructure**
  - Update lisa_tcp_test.py to record the live socket’s TCP_CONGESTION
  - Addition to Ss tool: Add Ss.port_in_use() and use it for port selection in networking suites
    - connection_exists() is state-based (default ESTAB) and can miss ports occupied in LISTEN/TIME_WAIT/other states.
    - port_in_use() checks whether any TCP socket is using the port, reducing intermittent bind/connect conflicts.
