### PR TITLE
passthrough: Add PCI BDF list support for device pool

### DIFF
--- a/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
+++ b/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Dict, cast
 
 from lisa import Environment, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.base_tools import Cat
 from lisa.operating_system import Windows
 from lisa.sut_orchestrator import CLOUD_HYPERVISOR
 from lisa.testsuite import TestResult, simple_requirement
@@ -69,20 +70,58 @@ class DevicePassthroughFunctionalTests(TestSuite):
     ) -> None:
         lspci = node.tools[Lspci]
         platform = cast("CloudHypervisorPlatform", environment.platform)
-        pool_vendor_device_map = {}
+        pool_vendor_device_map: Dict[str, Dict[str, str]] = {}
         assert platform.platform_runbook.device_pools, "Device pool can't be empty"
+
+        from lisa.sut_orchestrator.util.schema import (
+            PciAddressIdentifier,
+            VendorDeviceIdIdentifier,
+        )
+
         for pool in platform.platform_runbook.device_pools:
             pool_type = str(pool.type.value)
             if not pool.devices:
                 raise LisaException(f"No devices defined for pool type: {pool_type}")
-            vendor_device_id = {
-                "vendor_id": pool.devices[0].vendor_id,
-                "device_id": pool.devices[0].device_id,
-            }
+            if isinstance(pool.devices, list):
+                first: VendorDeviceIdIdentifier = pool.devices[0]
+                vendor_device_id = {
+                    "vendor_id": first.vendor_id,
+                    "device_id": first.device_id,
+                }
+            elif isinstance(pool.devices, PciAddressIdentifier):
+                # Resolve vendor/device IDs from host sysfs for BDF pools.
+                if not pool.devices.pci_bdf:
+                    raise LisaException(f"Pool '{pool_type}' has no pci_bdf entries")
+                vendor_device_id = self._vendor_device_from_host_bdf(
+                    platform, pool.devices.pci_bdf[0]
+                )
+            elif isinstance(pool.devices, dict):
+                # dataclasses_json fallback: raw dict form from runbook.
+                if "pci_bdf" in pool.devices:
+                    bdf_list = pool.devices["pci_bdf"]
+                    if not bdf_list:
+                        raise LisaException(f"Pool '{pool_type}' pci_bdf list is empty")
+                    vendor_device_id = self._vendor_device_from_host_bdf(
+                        platform, bdf_list[0]
+                    )
+                elif "vendor_id" in pool.devices and "device_id" in pool.devices:
+                    vendor_device_id = {
+                        "vendor_id": pool.devices["vendor_id"],
+                        "device_id": pool.devices["device_id"],
+                    }
+                else:
+                    raise LisaException(
+                        f"Pool '{pool_type}' devices dict has neither 'pci_bdf' "
+                        f"nor 'vendor_id'/'device_id' keys: {pool.devices}"
+                    )
+            else:
+                raise LisaException(
+                    f"Pool '{pool_type}' has unrecognised devices type: "
+                    f"{type(pool.devices)}"
+                )
             pool_vendor_device_map[pool_type] = vendor_device_id
 
-        # Get the node's runbook to check its passthrough requirements
-        # Import at runtime to avoid libvirt dependency on non-libvirt platforms
+        # Import at runtime to avoid libvirt dependency on other platforms.
         from lisa.sut_orchestrator.libvirt.schema import BaseLibvirtNodeSchema
 
         node_runbook: "BaseLibvirtNodeSchema" = node.capability.get_extended_runbook(
@@ -112,3 +151,17 @@ class DevicePassthroughFunctionalTests(TestSuite):
                     f"device(s) but expected {req.count}. "
                     f"Vendor/Device ID: {ven_id}:{dev_id}"
                 )
+
+    @staticmethod
+    def _vendor_device_from_host_bdf(
+        platform: "CloudHypervisorPlatform",
+        bdf: str,
+    ) -> Dict[str, str]:
+        """Read vendor_id and device_id for a BDF from host sysfs."""
+        cat = platform.host_node.tools[Cat]
+        vendor_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/vendor", sudo=True).strip()
+        device_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/device", sudo=True).strip()
+        # Normalize to 4-digit lowercase hex used by lspci identifiers.
+        vendor_id = vendor_raw.lower().replace("0x", "").zfill(4)
+        device_id = device_raw.lower().replace("0x", "").zfill(4)
+        return {"vendor_id": vendor_id, "device_id": device_id}

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -330,6 +330,7 @@ def perf_ntttcp(  # noqa: C901
     server_nic_name: Optional[str] = None,
     client_nic_name: Optional[str] = None,
     variables: Optional[Dict[str, Any]] = None,
+    skip_server_task_max: bool = False,
 ) -> List[Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]]:
     # Either server and client are set explicitly or we use the first two nodes
     # from the environment. We never combine the two options. We need to specify
@@ -387,8 +388,9 @@ def perf_ntttcp(  # noqa: C901
         if need_reboot:
             client_sriov_count = len(client.nics.get_pci_nics())
             server_sriov_count = len(server.nics.get_pci_nics())
-        for ntttcp in [client_ntttcp, server_ntttcp]:
-            ntttcp.setup_system(udp_mode, set_task_max)
+        client_ntttcp.setup_system(udp_mode, set_task_max)
+        # skip_server_task_max: don't reboot the baremetal host (NIC DHCP state lost).
+        server_ntttcp.setup_system(udp_mode, set_task_max and not skip_server_task_max)
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
         client_nic = client.nics.default_nic

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -2,7 +2,8 @@
 # Licensed under the MIT license.
 import re
 from functools import partial
-from typing import Any, Callable, Dict, List, Tuple, cast
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from microsoft.testsuites.performance.common import (
     perf_iperf,
@@ -25,7 +26,7 @@ from lisa.environment import Environment, Node
 from lisa.operating_system import Windows
 from lisa.sut_orchestrator import CLOUD_HYPERVISOR
 from lisa.testsuite import TestResult
-from lisa.tools import Dhclient, Kill, Lspci, Sysctl
+from lisa.tools import Dhclient, Kill, Sysctl
 from lisa.tools.iperf3 import (
     IPERF_TCP_BUFFER_LENGTHS,
     IPERF_TCP_CONCURRENCY,
@@ -83,15 +84,17 @@ class NetworkPerformance(TestSuite):
         self,
         node: Node,
         result: TestResult,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
         server = self._get_host_as_server(variables)
-        client, _ = self._configure_passthrough_nic_for_node(node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_iperf(
             test_result=result,
@@ -119,15 +122,17 @@ class NetworkPerformance(TestSuite):
         self,
         node: Node,
         result: TestResult,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
         server = self._get_host_as_server(variables)
-        client, _ = self._configure_passthrough_nic_for_node(node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_iperf(
             test_result=result,
@@ -157,15 +162,17 @@ class NetworkPerformance(TestSuite):
         self,
         result: TestResult,
         node: Node,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
         server = self._get_host_as_server(variables)
-        client, _ = self._configure_passthrough_nic_for_node(node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_tcp_pps(
             test_result=result,
@@ -193,15 +200,17 @@ class NetworkPerformance(TestSuite):
         self,
         result: TestResult,
         node: Node,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
         server = self._get_host_as_server(variables)
-        client, _ = self._configure_passthrough_nic_for_node(node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_tcp_pps(
             test_result=result,
@@ -230,15 +239,17 @@ class NetworkPerformance(TestSuite):
         self,
         result: TestResult,
         node: Node,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        client, client_nic_name = self._configure_passthrough_nic_for_node(node)
         server = self._get_host_as_server(variables)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, client_nic_name = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_ntttcp(
             test_result=result,
@@ -246,6 +257,7 @@ class NetworkPerformance(TestSuite):
             server=server,
             server_nic_name=self._get_host_nic_name(server),
             client_nic_name=client_nic_name,
+            skip_server_task_max=True,  # host: TasksMax reboot clears NIC DHCP state
         )
 
     @TestCaseMetadata(
@@ -266,15 +278,17 @@ class NetworkPerformance(TestSuite):
         self,
         result: TestResult,
         node: Node,
+        log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        client, client_nic_name = self._configure_passthrough_nic_for_node(node)
         server = self._get_host_as_server(variables)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot(time_out=1200)
+        # Reboot guest into fresh state; never reboot the baremetal host.
+        cast(RemoteNode, node).reboot()
+
+        client, client_nic_name = self._configure_passthrough_nic_for_node(
+            node, log_path, host_node=server
+        )
 
         perf_ntttcp(
             test_result=result,
@@ -283,6 +297,7 @@ class NetworkPerformance(TestSuite):
             server_nic_name=self._get_host_nic_name(server),
             client_nic_name=client_nic_name,
             udp_mode=True,
+            skip_server_task_max=True,  # host: TasksMax reboot clears NIC DHCP state
         )
 
     # Network device passthrough tests between 2 guests
@@ -298,20 +313,22 @@ class NetworkPerformance(TestSuite):
             unsupported_os=[Windows],
         ),
     )
-    def perf_tcp_iperf_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_tcp_iperf_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         # Run iperf server on VM and client on another VM
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, _ = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, _ = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both guests first to avoid stale passthrough NIC state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(client_node, log_path)
+        server, _ = self._configure_passthrough_nic_for_node(server_node, log_path)
 
         perf_iperf(
             test_result=result,
@@ -334,20 +351,22 @@ class NetworkPerformance(TestSuite):
             unsupported_os=[Windows],
         ),
     )
-    def perf_udp_iperf_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_udp_iperf_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         # Run iperf server on VM and client on another VM
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, _ = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, _ = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both nodes; Libvirt may reuse them, boot into fresh state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(client_node, log_path)
+        server, _ = self._configure_passthrough_nic_for_node(server_node, log_path)
 
         perf_iperf(
             test_result=result,
@@ -373,20 +392,22 @@ class NetworkPerformance(TestSuite):
             unsupported_os=[Windows],
         ),
     )
-    def perf_tcp_single_pps_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_tcp_single_pps_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         # Run netperf server on VM and client on another VM
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, _ = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, _ = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both nodes; Libvirt may reuse them, boot into fresh state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(client_node, log_path)
+        server, _ = self._configure_passthrough_nic_for_node(server_node, log_path)
 
         perf_tcp_pps(
             test_result=result,
@@ -410,20 +431,22 @@ class NetworkPerformance(TestSuite):
             unsupported_os=[Windows],
         ),
     )
-    def perf_tcp_max_pps_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_tcp_max_pps_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         # Run netperf server on VM and client on another VM
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, _ = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, _ = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both nodes; Libvirt may reuse them, boot into fresh state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, _ = self._configure_passthrough_nic_for_node(client_node, log_path)
+        server, _ = self._configure_passthrough_nic_for_node(server_node, log_path)
 
         perf_tcp_pps(
             test_result=result,
@@ -448,19 +471,25 @@ class NetworkPerformance(TestSuite):
             supported_platform_type=[CLOUD_HYPERVISOR],
         ),
     )
-    def perf_tcp_ntttcp_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_tcp_ntttcp_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, client_nic_name = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, server_nic_name = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both nodes; Libvirt may reuse them, boot into fresh state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, client_nic_name = self._configure_passthrough_nic_for_node(
+            client_node, log_path
+        )
+        server, server_nic_name = self._configure_passthrough_nic_for_node(
+            server_node, log_path
+        )
 
         perf_ntttcp(
             test_result=result,
@@ -485,19 +514,25 @@ class NetworkPerformance(TestSuite):
             supported_platform_type=[CLOUD_HYPERVISOR],
         ),
     )
-    def perf_udp_1k_ntttcp_passthrough_two_guest(self, result: TestResult) -> None:
+    def perf_udp_1k_ntttcp_passthrough_two_guest(
+        self, result: TestResult, log_path: Path
+    ) -> None:
         environment = result.environment
         assert environment, "fail to get environment from testresult"
 
         client_node = cast(RemoteNode, environment.nodes[0])
-        client, client_nic_name = self._configure_passthrough_nic_for_node(client_node)
         server_node = cast(RemoteNode, environment.nodes[1])
-        server, server_nic_name = self._configure_passthrough_nic_for_node(server_node)
 
-        # Reboot the nodes. Libvirt sometime re-use the nodes.
-        # Try to run the test on fresh state of the nodes
-        client.reboot()
-        server.reboot()
+        # Reboot both nodes; Libvirt may reuse them, boot into fresh state.
+        client_node.reboot()
+        server_node.reboot()
+
+        client, client_nic_name = self._configure_passthrough_nic_for_node(
+            client_node, log_path
+        )
+        server, server_nic_name = self._configure_passthrough_nic_for_node(
+            server_node, log_path
+        )
 
         perf_ntttcp(
             test_result=result,
@@ -508,9 +543,16 @@ class NetworkPerformance(TestSuite):
             udp_mode=True,
         )
 
+    @staticmethod
+    def _norm_hex(value: str, width: int) -> str:
+        """Zero-pad lowercase hex PCI component; strips leading '0x'."""
+        return value.lower().replace("0x", "").zfill(width)
+
     def _configure_passthrough_nic_for_node(
         self,
         node: Node,
+        log_path: Path,
+        host_node: Optional[RemoteNode] = None,
     ) -> Tuple[RemoteNode, str]:
         from lisa.sut_orchestrator.libvirt.context import get_node_context
 
@@ -518,47 +560,67 @@ class NetworkPerformance(TestSuite):
         if not ctx.passthrough_devices:
             raise SkippedException("No passthrough devices found for node")
 
-        lspci = node.tools[Lspci]
-        pci_devices = lspci.get_devices_by_type(
-            constants.DEVICE_TYPE_SRIOV, force_run=True
-        )
-        device_addr = None
+        passthrough_dev = ctx.passthrough_devices[0]
+        if not passthrough_dev.device_list:
+            raise LisaException("passthrough_devices[0].device_list is empty")
+        device_addr_obj = passthrough_dev.device_list[0]
+        domain = self._norm_hex(device_addr_obj.domain or "0000", 4)
+        bus = self._norm_hex(device_addr_obj.bus, 2)
+        slot = self._norm_hex(device_addr_obj.slot, 2)
+        function = self._norm_hex(device_addr_obj.function, 1)
+        device_bdf = f"{domain}:{bus}:{slot}.{function}"
 
-        # Get the first non-virtio device
-        for device in pci_devices:
-            kernel_driver = lspci.get_used_module(device.slot)
-            if kernel_driver != "virtio-pci":
-                device_addr = device.slot
-                break
+        host_nic_name = ""
+        if host_node is not None:
+            _h = host_node.execute(
+                f"ls /sys/bus/pci/devices/{device_bdf}/net/ 2>/dev/null"
+                " | head -1 || true",
+                sudo=True,
+                shell=True,
+            ).stdout.strip()
+            _parts = _h.split()
+            host_nic_name = _parts[0] if _parts else ""
 
-        if device_addr is None:
-            raise LisaException(
-                f"No non-virtio passthrough device found. "
-                f"Available devices: {[d.slot for d in pci_devices]}"
-            )
-
-        # Get the interface name
-        err_msg: str = f"Can't find interface from PCI address: {device_addr}"
-        device_path = node.execute(
-            cmd=(
-                "find /sys/class/net/*/device/subsystem/devices"
-                f" -name '*{device_addr}*'"
-            ),
+        # Exclude management interface from passthrough NIC selection.
+        mgmt_ip_ssh = cast(RemoteNode, node).connection_info[
+            constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS
+        ]
+        mgmt_iface_raw = node.execute(
+            cmd=f"ip -4 route get {mgmt_ip_ssh} 2>/dev/null || true",
             sudo=True,
             shell=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=err_msg,
-        ).stdout
+        ).stdout.strip()
+        _m = re.search(r"\bdev\s+(\S+)", mgmt_iface_raw)
+        mgmt_iface = _m.group(1) if _m else ""
 
-        pattern = re.compile(r"/sys/class/net/(?P<INTERFACE_NAME>\w+)/device")
-        interface_name_raw = find_group_in_lines(
-            pattern=pattern,
-            lines=device_path,
+        # Enumerate PCI-backed interfaces as: "<iface> <driver> <carrier>".
+        iface_info_raw = node.execute(
+            cmd=(
+                "for iface in /sys/class/net/*/; do "
+                "iface=$(basename $iface); "
+                "[ -e /sys/class/net/$iface/device ] || continue; "
+                "drv=$(basename "
+                "$(readlink /sys/class/net/$iface/device/driver 2>/dev/null) "
+                "2>/dev/null); "
+                "carrier=$(cat /sys/class/net/$iface/carrier 2>/dev/null "
+                "|| echo 0); "
+                'echo "$iface $drv $carrier"; '
+                "done"
+            ),
+            sudo=False,
+            shell=True,
+        ).stdout.strip()
+
+        interface_name = self._find_guest_passthrough_iface(
+            node, mgmt_iface, iface_info_raw
         )
-        interface_name = interface_name_raw.get("INTERFACE_NAME", "")
-        assert interface_name, "Can not find interface name"
 
-        # Bring the interface up before configuring it
+        node.log.info(f"[passthrough-nic] GUEST iface={interface_name!r}")
+        if host_node is not None and host_nic_name:
+            host_node.log.info(
+                f"[passthrough-nic] HOST nic={host_nic_name!r} BDF={device_bdf!r}"
+            )
+
         node.execute(
             cmd=f"ip link set {interface_name} up",
             sudo=True,
@@ -568,29 +630,38 @@ class NetworkPerformance(TestSuite):
             ),
         )
 
-        # Wait for carrier (link up) - some NICs take time to negotiate
-        # Exit code 124 = timeout (no carrier), which is acceptable if DHCP works anyway
-        carrier_result = node.execute(
-            cmd=f"timeout 30 sh -c 'until cat /sys/class/net/{interface_name}/carrier"
-            f" 2>/dev/null | grep -q 1; do sleep 1; done'",
+        self._wait_for_carrier(node, interface_name)
+
+        # Flush stale address/route state from prior runs.
+        node.execute(
+            f"ip addr flush dev {interface_name} 2>/dev/null || true",
             sudo=True,
             shell=True,
         )
-        if carrier_result.exit_code == 124:
-            node.log.warning(
-                f"Interface {interface_name} carrier not detected after 30s. "
-                f"Proceeding with DHCP anyway - may fail if no physical link."
-            )
-        elif carrier_result.exit_code != 0:
-            raise LisaException(
-                f"Failed to check carrier on {interface_name}: "
-                f"exit code {carrier_result.exit_code}"
+        node.execute(
+            f"ip route flush dev {interface_name} 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+
+        dhcp_result = self._run_dhcp_on_iface(node, interface_name)
+        if dhcp_result.exit_code != 0:
+            self._raise_dhcp_failure(
+                node, interface_name, dhcp_result, host_node, host_nic_name
             )
 
-        # Configure the nw interface on guest with dhclient for the specific interface
-        node.tools[Dhclient].renew(interface_name)
+        # Wait briefly for IP address assignment.
+        node.execute(
+            cmd=(
+                f"for i in $(seq 1 10); do "
+                f"ip -4 -o addr show dev {interface_name} "
+                f"| grep -q 'inet ' && break; "
+                f"sleep 1; done"
+            ),
+            sudo=True,
+            shell=True,
+        )
 
-        # Get the interface ip
         err_msg = f"Failed to get interface details for: {interface_name}"
         interface_details = node.execute(
             cmd=f"ip addr show {interface_name}",
@@ -615,6 +686,307 @@ class NetworkPerformance(TestSuite):
         test_node.internal_address = passthrough_nic_ip
 
         return test_node, interface_name
+
+    def _find_guest_passthrough_iface(
+        self,
+        node: Node,
+        mgmt_iface: str,
+        iface_info_raw: str,
+    ) -> str:
+        """Select passthrough NIC, preferring non-virtio and carrier-up links."""
+        pt_candidates: List[Tuple[bool, str]] = []
+        virtio_fallback: List[Tuple[bool, str]] = []
+        for _line in iface_info_raw.splitlines():
+            _parts = _line.split()
+            if not _parts:
+                continue
+            _iface = _parts[0]
+            _drv = _parts[1] if len(_parts) > 1 else ""
+            _carrier_up = (_parts[2] == "1") if len(_parts) > 2 else False
+            if _iface in (mgmt_iface, "lo"):
+                continue
+            if _drv.startswith("virtio"):
+                virtio_fallback.append((_carrier_up, _iface))
+            else:
+                pt_candidates.append((_carrier_up, _iface))
+
+        # Fall back to virtio, then prefer link-up interfaces.
+        if not pt_candidates:
+            pt_candidates = virtio_fallback
+        pt_candidates.sort(key=lambda t: (not t[0], t[1]))
+
+        if not pt_candidates:
+            raise LisaException(
+                f"No passthrough NIC found in guest. "
+                f"Management iface: {mgmt_iface!r}, "
+                f"Enumerated (iface driver carrier): {iface_info_raw!r}"
+            )
+        return pt_candidates[0][1]
+
+    def _wait_for_carrier(self, node: Node, interface_name: str) -> None:
+        """Wait up to 60 s for link carrier; raise with diagnostics on failure."""
+        carrier_result = node.execute(
+            cmd=(
+                f"timeout 60 sh -c 'until cat /sys/class/net/{interface_name}/carrier"
+                f" 2>/dev/null | grep -q 1; do sleep 1; done'"
+            ),
+            sudo=True,
+            shell=True,
+        )
+        if carrier_result.exit_code == 124:
+            _nc_diag = node.execute(
+                cmd=(
+                    f"echo '--- ethtool ---';"
+                    f" ethtool {interface_name} 2>/dev/null || true;"
+                    f" echo '--- ip -d link ---';"
+                    f" ip -d link show {interface_name} 2>/dev/null || true;"
+                    f" echo '--- dmesg ---';"
+                    f" dmesg -T 2>/dev/null"
+                    f" | grep -E 'no carrier|carrier loss|"
+                    f"link up|link down|vfio|{interface_name}'"
+                    f" | tail -n 20 || true"
+                ),
+                sudo=True,
+                shell=True,
+            ).stdout.strip()
+            raise LisaException(
+                f"Interface {interface_name} NO-CARRIER after 60 s. "
+                f"Physical link is not up — DHCP would fail. Failing fast.\n"
+                f"{_nc_diag}"
+            )
+        elif carrier_result.exit_code != 0:
+            raise LisaException(
+                f"Failed to check carrier on {interface_name}: "
+                f"exit code {carrier_result.exit_code}"
+            )
+
+    def _install_dhclient_scripts(
+        self,
+        node: Node,
+        config_script: str,
+    ) -> None:
+        """Install minimal dhclient hook script for interface IP config."""
+        node.execute("mkdir -p /usr/local/bin /var/lib/dhcp", sudo=True, shell=True)
+        node.execute(
+            f"printf '#!/bin/sh\\n"
+            f"pfx=0\\n"
+            f"IFS=.\\n"
+            f'case "$reason" in\\n'
+            f'  BOUND|RENEW|REBIND|REBOOT) _mask="$new_subnet_mask" ;;\\n'
+            f'  *)                          _mask="$old_subnet_mask" ;;\\n'
+            f"esac\\n"
+            f"for _o in $_mask; do\\n"
+            f"  case $_o in\\n"
+            f"    255) pfx=$((pfx+8)) ;;\\n"
+            f"    254) pfx=$((pfx+7)) ;;\\n"
+            f"    252) pfx=$((pfx+6)) ;;\\n"
+            f"    248) pfx=$((pfx+5)) ;;\\n"
+            f"    240) pfx=$((pfx+4)) ;;\\n"
+            f"    224) pfx=$((pfx+3)) ;;\\n"
+            f"    192) pfx=$((pfx+2)) ;;\\n"
+            f"    128) pfx=$((pfx+1)) ;;\\n"
+            f"  esac\\n"
+            f"done\\n"
+            f"unset IFS\\n"
+            f'case "$reason" in\\n'
+            f"  BOUND|RENEW|REBIND|REBOOT)\\n"
+            f'    ip addr replace "${{new_ip_address}}/$pfx"'
+            f' dev "$interface" 2>/dev/null || true\\n'
+            f"    ;;\\n"
+            f"  EXPIRE|FAIL|RELEASE|STOP)\\n"
+            f'    ip addr del "${{old_ip_address}}/$pfx"'
+            f' dev "$interface" 2>/dev/null || true\\n'
+            f"    ;;\\n"
+            f"esac\\n"
+            f"exit 0\\n'"
+            f" | tee '{config_script}' >/dev/null"
+            f" && chmod 0755 '{config_script}'"
+            f" && chown root:root '{config_script}'",
+            sudo=True,
+            shell=True,
+        )
+        # Run script once to catch noexec mount issues early.
+        node.execute(f"'{config_script}'", sudo=True, shell=True)
+
+    def _run_dhcp_on_iface(self, node: Node, interface_name: str) -> Any:
+        """Run dhclient with safety guards and return its result."""
+        # Probe which DHCP client is available via the Dhclient tool.
+        # Our custom -sf hook is dhclient-specific; skip on images with only dhcpcd.
+        dhclient_tool = node.tools[Dhclient]
+        if dhclient_tool.command != "dhclient":
+            raise SkippedException(
+                f"Passthrough NIC DHCP requires dhclient; "
+                f"found '{dhclient_tool.command}' which is not supported."
+            )
+        dhcp_pid = f"/run/dhclient-{interface_name}.pid"
+        dhcp_lease = f"/var/lib/dhcp/dhclient-{interface_name}.leases"
+        config_script = "/usr/local/bin/lisa-dhclient-config"
+
+        def _wrap_aa(cmd: str) -> str:
+            """Run cmd under AppArmor 'unconfined' when aa-exec is available."""
+            return (
+                "sh -c '"
+                "if command -v aa-exec >/dev/null 2>&1; then "
+                f"aa-exec -p unconfined -- {cmd}; "
+                f"else {cmd}; "
+                "fi'"
+            )
+
+        self._install_dhclient_scripts(node, config_script)
+
+        # Isolate only the target interface from competing DHCP managers.
+        # NM: mark this interface unmanaged instead of stopping the service.
+        _nm_active = (
+            node.execute(
+                "systemctl is-active NetworkManager 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            ).stdout.strip()
+            == "active"
+        )
+        _nm_was_managed = _nm_active and (
+            node.execute(
+                f"nmcli -g GENERAL.NM-MANAGED device show {interface_name}"
+                " 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+            .stdout.strip()
+            .lower()
+            == "yes"
+        )
+        if _nm_was_managed:
+            node.execute(
+                f"nmcli device set {interface_name} managed no" " 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+        # systemd-networkd: write a per-interface drop-in that marks it
+        # unmanaged, then reload (no service stop needed).
+        _nd_dropin = f"/etc/systemd/network/90-{interface_name}-unmanaged.network"
+        _nd_was_managed = (
+            node.execute(
+                "systemctl is-active systemd-networkd 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            ).stdout.strip()
+            == "active"
+        ) and (
+            "unmanaged"
+            not in node.execute(
+                f"networkctl status {interface_name} 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            ).stdout
+        )
+        if _nd_was_managed:
+            node.execute(
+                f"printf '[Match]\\nName={interface_name}\\n\\n"
+                f"[Link]\\nUnmanaged=yes\\n' > {_nd_dropin}"
+                "; networkctl reload 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+        try:
+            # Release stale lease and kill leftover dhclient processes.
+            node.execute(
+                f"dhclient -r -pf {dhcp_pid} -lf {dhcp_lease}"
+                f" {interface_name} 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+            node.execute(
+                f"if [ -s {dhcp_pid} ]; then"
+                f'  kill "$(cat {dhcp_pid})" 2>/dev/null || true; fi'
+                f"; sleep 1"
+                f"; if [ -s {dhcp_pid} ]; then"
+                f'  kill -9 "$(cat {dhcp_pid})" 2>/dev/null || true; fi'
+                f"; rm -f {dhcp_pid}"
+                f"; pkill -f 'dhclient.*{interface_name}' 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+            node.execute(
+                f"ip addr flush dev {interface_name} 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+            # Real dhclient run with minimal config hook.
+            dhcp_cmd = (
+                f"dhclient -v -1 -4 -sf {config_script}"
+                f" -pf {dhcp_pid} -lf {dhcp_lease} {interface_name}"
+            )
+            dhcp_result = node.execute(
+                f"timeout -k 2s 30s {_wrap_aa(dhcp_cmd)}",
+                sudo=True,
+                shell=True,
+                timeout=45,
+            )
+        finally:
+            if _nd_was_managed:
+                node.execute(
+                    f"rm -f {_nd_dropin}" "; networkctl reload 2>/dev/null || true",
+                    sudo=True,
+                    shell=True,
+                )
+            if _nm_was_managed:
+                node.execute(
+                    f"nmcli device set {interface_name} managed yes"
+                    " 2>/dev/null || true",
+                    sudo=True,
+                    shell=True,
+                )
+        return dhcp_result
+
+    def _raise_dhcp_failure(
+        self,
+        node: Node,
+        interface_name: str,
+        dhcp_result: Any,
+        host_node: Optional[RemoteNode],
+        host_nic_name: str,
+    ) -> None:
+        """Gather diagnostics and raise LisaException for a DHCP failure."""
+        fail_link = node.execute(
+            f"ip -d link show {interface_name}", sudo=True, shell=True
+        ).stdout
+        fail_addr = node.execute(
+            f"ip -4 addr show {interface_name}", sudo=True, shell=True
+        ).stdout
+        fail_routes = node.execute("ip -4 route", sudo=True, shell=True).stdout
+        fail_rp = node.execute(
+            f"sysctl net.ipv4.conf.{interface_name}.rp_filter"
+            " net.ipv4.conf.all.rp_filter 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        ).stdout
+        fail_host_info = ""
+        if host_node is not None:
+            _iface_arg = host_nic_name or ""
+            _rp_iface = (
+                f" net.ipv4.conf.{host_nic_name}.rp_filter" if host_nic_name else ""
+            )
+            _h = host_node.execute(
+                f"echo '--- HOST ip link ---';"
+                f" ip -d link show {_iface_arg} 2>/dev/null || ip -d link show;"
+                f" echo '--- HOST ip route default ---';"
+                f" ip -4 route show default;"
+                f" echo '--- HOST rp_filter ---';"
+                f" sysctl net.ipv4.conf.all.rp_filter{_rp_iface} 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            ).stdout
+            fail_host_info = f"--- HOST diagnostics ---\n{_h}\n"
+        raise LisaException(
+            f"DHCP lease failed on interface {interface_name} "
+            f"(dhclient exit code {dhcp_result.exit_code}).\n"
+            f"dhclient output:\n{dhcp_result.stdout}\n"
+            f"--- ip -d link show ---\n{fail_link}\n"
+            f"--- ip -4 addr show ---\n{fail_addr}\n"
+            f"--- ip -4 route ---\n{fail_routes}\n"
+            f"--- rp_filter ---\n{fail_rp}\n"
+            f"{fail_host_info}"
+        )
 
     def _get_host_as_server(self, variables: Dict[str, Any]) -> RemoteNode:
         ip = variables.get("baremetal_host_ip", "")
@@ -643,7 +1015,8 @@ class NetworkPerformance(TestSuite):
             password=passwd,
             private_key_file=private_key,
         )
-        # Track baremetal host for cleanup
+        server.internal_address = ip
+        # Track baremetal host for cleanup.
         if server not in self._baremetal_hosts:
             self._baremetal_hosts.append(server)
         return server
@@ -659,8 +1032,6 @@ class NetworkPerformance(TestSuite):
             expected_exit_code_failure_message="Can not get IP route",
         ).stdout
 
-        # root [ /home/cloud ]# ip route show | grep 10.195.88.216 | grep default
-        # default via 10.195.88.1 dev eth1 proto dhcp src 10.195.88.216 metric 1024
         regex_pattern = re.compile(
             r"^default.*?dev\s+(?P<interface>\S+).*?src\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s"
         )
@@ -681,21 +1052,18 @@ class NetworkPerformance(TestSuite):
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")
 
-        # Combine environment nodes and baremetal host nodes for cleanup
+        # Include baremetal hosts in cleanup.
         all_nodes = list(environment.nodes.list())
         if self._baremetal_hosts:
             all_nodes.extend(self._baremetal_hosts)
 
-        # use these cleanup functions
         def do_process_cleanup(process: str, node: Node) -> None:
-            # Kill the process on the specific node
             kill = node.tools[Kill]
             kill.by_name(process, ignore_not_exist=True)
 
         def do_sysctl_cleanup(node: Node) -> None:
             node.tools[Sysctl].reset()
 
-        # to run parallel cleanup of processes on all nodes
         cleanup_tasks: List[Callable[[], None]] = []
         for process in ["lagscope", "netperf", "netserver", "ntttcp", "iperf3"]:
             for node in all_nodes:

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -186,23 +186,80 @@ class LibvirtDevicePool(BaseDevicePool):
             vendor_id=vendor_id,
             device_id=device_id,
         )
-        primary_nic_iommu = self.get_primary_nic_id()
-        for item in device_list:
-            device = DeviceAddressSchema()
-            domain, bus, slot, fn = self._parse_pci_address_str(addr=item.slot)
-            device.domain = domain
-            device.bus = bus
-            device.slot = slot
-            device.function = fn
-            iommu_group = self._get_device_iommu_group(device)
-            is_vfio_pci = self._is_driver_vfio_pci(device)
+        bdf_list = [i.slot for i in device_list]
+        self._create_pool(pool_type, bdf_list)
 
-            if not is_vfio_pci and iommu_group not in primary_nic_iommu:
-                pool = self.available_host_devices.get(pool_type, {})
-                devices = pool.get(iommu_group, [])
-                devices.append(device)
-                pool[iommu_group] = devices
-                self.available_host_devices[pool_type] = pool
+    def create_device_pool_from_pci_addresses(
+        self,
+        pool_type: HostDevicePoolType,
+        pci_addr_list: List[str],
+    ) -> None:
+        self.available_host_devices[pool_type] = {}
+        for bdf in pci_addr_list:
+            domain, bus, slot, fn = self._parse_pci_address_str(bdf)
+            device = self._get_pci_address_instance(domain, bus, slot, fn)
+            iommu_group = self._get_device_iommu_group(device)
+
+            # Strip the pool-key prefix to get the raw numeric id for sysfs.
+            sysfs_iommu_group = (
+                iommu_group[len("iommu_grp_") :]  # noqa: E203
+                if iommu_group.startswith("iommu_grp_")
+                else iommu_group
+            )
+            # Get all the devices of that iommu group
+            iommu_path = f"/sys/kernel/iommu_groups/{sysfs_iommu_group}/devices"
+            # Ls.list() returns full paths; extract the basename (bare BDF).
+            bdf_list = [
+                i.strip().split("/")[-1]
+                for i in self.host_node.tools[Ls].list(iommu_path)
+            ]
+            bdf_list.append(bdf.strip())
+
+            self._create_pool(pool_type, bdf_list)
+
+    def _create_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        bdf_list: List[str],
+    ) -> None:
+        iommu_grp_of_used_devices = []
+        primary_nic_iommu = self.get_primary_nic_id()
+        for bdf in bdf_list:
+            domain, bus, slot, fn = self._parse_pci_address_str(bdf)
+            dev = self._get_pci_address_instance(domain, bus, slot, fn)
+            is_vfio_pci = self._is_driver_vfio_pci(dev)
+            iommu_group = self._get_device_iommu_group(dev)
+
+            if iommu_group in iommu_grp_of_used_devices:
+                # No need to add this device in pool as one of the devices for this
+                # iommu group is in use
+                continue
+
+            if is_vfio_pci:
+                # Remove iommu group from pool: a device in it is already in use.
+                self.available_host_devices[pool_type].pop(iommu_group, None)
+                iommu_grp_of_used_devices.append(iommu_group)
+            elif iommu_group not in primary_nic_iommu:
+                devices = self.available_host_devices[pool_type].setdefault(
+                    iommu_group, []
+                )
+                if dev not in devices:
+                    devices.append(dev)
+
+    def _get_pci_address_instance(
+        self,
+        domain: str,
+        bus: str,
+        slot: str,
+        fn: str,
+    ) -> DeviceAddressSchema:
+        device = DeviceAddressSchema()
+        device.domain = domain
+        device.bus = bus
+        device.slot = slot
+        device.function = fn
+
+        return device
 
     def _add_device_passthrough_xml(
         self,

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from dataclasses_json import dataclass_json
 
@@ -47,6 +47,16 @@ class DeviceAddressSchema:
     bus: str = ""
     slot: str = ""
     function: str = ""
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, DeviceAddressSchema):
+            return (
+                self.domain == other.domain
+                and self.bus == other.bus
+                and self.slot == other.slot
+                and self.function == other.function
+            )
+        return False
 
 
 # QEMU orchestrator's global configuration options.

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -1,6 +1,11 @@
 from typing import Any, List, Optional
 
-from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
+from lisa.sut_orchestrator.util.schema import (
+    HostDevicePoolSchema,
+    HostDevicePoolType,
+    PciAddressIdentifier,
+    VendorDeviceIdIdentifier,
+)
 from lisa.util import LisaException
 
 
@@ -13,6 +18,13 @@ class BaseDevicePool:
         pool_type: HostDevicePoolType,
         vendor_id: str,
         device_id: str,
+    ) -> None:
+        raise NotImplementedError()
+
+    def create_device_pool_from_pci_addresses(
+        self,
+        pool_type: HostDevicePoolType,
+        pci_addr_list: List[str],
     ) -> None:
         raise NotImplementedError()
 
@@ -44,22 +56,57 @@ class BaseDevicePool:
                         f"Pool type '{pool_type}' is not supported by platform"
                     )
             for config in device_configs:
-                vendor_device_list = config.devices
-                if len(vendor_device_list) > 1:
-                    raise LisaException(
-                        "Device Pool does not support more than one "
-                        "vendor/device id list for given pool type"
+                devices = config.devices
+                if isinstance(devices, list) and all(
+                    isinstance(d, VendorDeviceIdIdentifier) for d in devices
+                ):
+                    if not devices:
+                        raise LisaException(
+                            "Device pool configuration has no vendor/device "
+                            "id entries for pool type"
+                        )
+                    if len(devices) > 1:
+                        raise LisaException(
+                            "Device Pool does not support more than one "
+                            "vendor/device id list for given pool type"
+                        )
+
+                    vendor_device_id = devices[0]
+                    vendor_id = vendor_device_id.vendor_id.strip()
+                    if not vendor_id:
+                        raise LisaException(
+                            "Device pool configuration has empty 'vendor_id'"
+                        )
+                    device_id = vendor_device_id.device_id.strip()
+                    if not device_id:
+                        raise LisaException(
+                            "Device pool configuration has empty 'device_id'"
+                        )
+
+                    self.create_device_pool(
+                        pool_type=config.type,
+                        vendor_id=vendor_id,
+                        device_id=device_id,
                     )
-
-                vendor_device_id = vendor_device_list[0]
-                assert vendor_device_id.vendor_id.strip()
-                vendor_id = vendor_device_id.vendor_id.strip()
-
-                assert vendor_device_id.device_id.strip()
-                device_id = vendor_device_id.device_id.strip()
-
-                self.create_device_pool(
-                    pool_type=config.type,
-                    vendor_id=vendor_id,
-                    device_id=device_id,
-                )
+                elif isinstance(devices, (dict, PciAddressIdentifier)):
+                    if isinstance(devices, dict):
+                        if "pci_bdf" not in devices:
+                            raise LisaException(
+                                "Key not found in device configuration: 'pci_bdf'"
+                            )
+                        pci_addr_list: List[str] = devices["pci_bdf"]
+                    else:
+                        pci_addr_list = devices.pci_bdf
+                    if not pci_addr_list:
+                        raise LisaException(
+                            "PCI address list 'pci_bdf' must not be empty"
+                        )
+                    self.create_device_pool_from_pci_addresses(
+                        pool_type=config.type,
+                        pci_addr_list=pci_addr_list,
+                    )
+                else:
+                    raise LisaException(
+                        f"Unknown device identifier of type: {type(devices)}"
+                        f", value: {devices}"
+                    )

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List
+from typing import List, Union, cast
 
 from dataclasses_json import dataclass_json
 
@@ -12,9 +12,16 @@ class HostDevicePoolType(Enum):
 
 @dataclass_json()
 @dataclass
-class DeviceIdentifier:
+class VendorDeviceIdIdentifier:
     vendor_id: str = ""
     device_id: str = ""
+
+
+@dataclass_json()
+@dataclass
+class PciAddressIdentifier:
+    # list of bdf like 0000:3b:00.0 - <domain>:<bus>:<slot>.<fn>
+    pci_bdf: List[str] = field(default_factory=list)
 
 
 # Configuration options for device-passthrough for the VM.
@@ -22,7 +29,9 @@ class DeviceIdentifier:
 @dataclass
 class HostDevicePoolSchema:
     type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
-    devices: List[DeviceIdentifier] = field(default_factory=list)
+    devices: Union[List[VendorDeviceIdIdentifier], PciAddressIdentifier] = field(
+        default_factory=lambda: cast(List[VendorDeviceIdIdentifier], [])
+    )
 
 
 @dataclass_json()


### PR DESCRIPTION
Previously, device pools could only be configured by vendor/device ID, which may pick unintended devices when multiple similar NICs are present. This change allows runbooks to specify exact PCI BDF addresses instead, giving full control over which device gets passed through to the guest.

The functional test is updated to handle BDF-only pool configs by reading vendor/device IDs directly from host sysfs at runtime, which remains reliable even after the driver is unbound for passthrough.

The network passthrough perf tests are refactored to robustly set up the guest NIC: it now waits for link carrier before attempting DHCP, pauses competing DHCP managers during the lease, and raises a clear diagnostic on failure. A skip_server_task_max flag prevents rebooting the baremetal host (which would lose its NIC DHCP state) during ntttcp setup.