### PR TITLE
Fix NVMe remote disk detection with model-based identification 

### DIFF
--- a/lisa/features/nvme.py
+++ b/lisa/features/nvme.py
@@ -171,7 +171,7 @@ class Nvme(Feature):
                     # the "Accelerator" model. E.g., disk="/dev/nvme0"
                     # matches keys "/dev/nvme0n1", "/dev/nvme0n2", etc.
                     for ns_path, ns_model in device_models.items():
-                        if ns_path.startswith(disk) and ns_model:
+                        if ns_path.startswith(f"{disk}n") and ns_model:
                             if "nvme accelerator" in ns_model.lower():
                                 return True
                     return False

--- a/lisa/features/nvme.py
+++ b/lisa/features/nvme.py
@@ -176,7 +176,8 @@ class Nvme(Feature):
                                 return True
                     return False
 
-                return [disk for disk in disk_list if not _is_remote(disk)]
+                disk_list[:] = [disk for disk in disk_list if not _is_remote(disk)]
+                return disk_list
 
             # Fallback if nvme-cli is not available or doesn't return device models.
             os_disk_nvme_device = self._get_os_disk_nvme_device()

--- a/lisa/features/nvme.py
+++ b/lisa/features/nvme.py
@@ -151,6 +151,34 @@ class Nvme(Feature):
             self._node.features[Disk].get_os_disk_controller_type()
             == schema.DiskControllerType.NVME
         ):
+            # Try model-based detection first if nvme-cli is available,
+            # as it's more reliable. If not, fallback to legacy behavior.
+            nvme_cli = self._node.tools[Nvmecli]
+            device_models = nvme_cli.get_device_models()
+            if device_models:
+                # Remove any disk whose model contains "NVMe Accelerator".
+                # device_models keys are namespace paths (e.g., /dev/nvme0n1).
+                # disk_list may contain controller paths (e.g., /dev/nvme0) or
+                # namespace paths. For controller paths, check if ANY namespace
+                # under that controller is a remote "Accelerator" disk.
+                def _is_remote(disk: str) -> bool:
+                    # Direct match (namespace path like /dev/nvme0n1)
+                    model = device_models.get(disk, "")
+                    if model:
+                        return "nvme accelerator" in model.lower()
+                    # Prefix match (controller path like /dev/nvme0).
+                    # Check if any namespace under this controller has
+                    # the "Accelerator" model. E.g., disk="/dev/nvme0"
+                    # matches keys "/dev/nvme0n1", "/dev/nvme0n2", etc.
+                    for ns_path, ns_model in device_models.items():
+                        if ns_path.startswith(disk) and ns_model:
+                            if "nvme accelerator" in ns_model.lower():
+                                return True
+                    return False
+
+                return [disk for disk in disk_list if not _is_remote(disk)]
+
+            # Fallback if nvme-cli is not available or doesn't return device models.
             os_disk_nvme_device = self._get_os_disk_nvme_device()
             # Removing OS disk/device from the list.
             for disk in disk_list.copy():

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2237,10 +2237,26 @@ class Disk(AzureFeatureMixin, features.Disk):
         nvme = self._node.features[Nvme]
         if self.get_os_disk_controller_type() == schema.DiskControllerType.NVME:
             os_disk_namespace = nvme.get_nvme_os_disk_namespace()
+            if disk == os_disk_namespace:
+                return False
+
+            # First, try model-based detection. Azure remote disks (OS + data)
+            # use "MSFT NVMe Accelerator" model, while local NVMe resource disks
+            # use "Microsoft NVMe Direct Disk". This handles VM types where
+            # remote data disks are on different controllers than the OS disk
+            nvme_cli = self._node.tools[Nvmecli]
+            device_models = nvme_cli.get_device_models()
+            if device_models:
+                model = device_models.get(disk, "")
+                if model:
+                    # "MSFT NVMe Accelerator" = remote disk (OS + data)
+                    # "Microsoft NVMe Direct Disk" = local NVMe resource disk
+                    return "nvme accelerator" in model.lower()
+
+            # Fallback: legacy behavior — assume all remote disks share
+            # the same NVMe controller as the OS disk
             os_disk_controller = nvme.get_nvme_os_disk_controller()
-            # When disk_controller_type is NVME, all remote disks are connected to
-            # same NVMe controller. The same controller is used by OS disk.
-            if disk.startswith(os_disk_controller) and disk != os_disk_namespace:
+            if disk.startswith(os_disk_controller):
                 return True
             return False
 

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -366,6 +366,14 @@ class Nvmecli(Tool):
         except (json.JSONDecodeError, KeyError, TypeError):
             return {}
 
+        if not isinstance(nvme_devices, list):
+            self._log.debug(
+                f"Expected 'Devices' to be a list in nvme-cli JSON, "
+                f"got {type(nvme_devices).__name__}. "
+                f"Trying legacy disk detection."
+            )
+            return {}
+
         device_models: Dict[str, str] = {}
 
         for nvme_device in nvme_devices or []:

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -256,6 +256,23 @@ class Nvmecli(Tool):
         # ]
         # }
         # get nvme devices information ignoring stderror
+        #
+        # Sample nvme list output where NameSpace field is
+        # missing but DevicePath is present:
+        # /home/lisa# nvme list -o json 2>/dev/null
+        # "Devices" : [
+        #   {
+        #     "DevicePath" : "/dev/nvme0n1",
+        #     "Firmware" : "v1.00000",
+        #     "Index" : 0,
+        #     "ModelNumber" : "MSFT NVMe Accelerator v1.0",
+        #     "ProductName" : "Non-Volatile memory controller: Microsoft Corporation Device 0x00a9",  # noqa: E501
+        #     "SerialNumber" : "SN: 00000",
+        #     "UsedBytes" : 68719476736,
+        #     "MaximumLBA" : 134217728,
+        #     "PhysicalSize" : 68719476736,
+        #     "SectorSize" : 512
+        #   }
         nvme_list = self.run(
             "list -o json 2>/dev/null",
             shell=True,

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -285,7 +285,7 @@ class Nvmecli(Tool):
             # Legacy schema (flat fields):
             device_path = nvme_device.get("DevicePath")
             namespace_id = nvme_device.get("NameSpace")
-            
+
             # Some older nvme-cli versions (e.g., 1.8.x on RHEL 7) emit
             # DevicePath but omit the NameSpace field entirely.
             # Derive the namespace ID from the DevicePath if missing.
@@ -324,7 +324,7 @@ class Nvmecli(Tool):
     def get_namespace_ids(self, force_run: bool = False) -> List[Dict[str, int]]:
         device_paths_namespace_ids_map = self.get_devices(force_run=force_run)
         return [{path: nsid} for path, nsid in device_paths_namespace_ids_map.items()]
-    
+
     def get_device_models(self, force_run: bool = False) -> Dict[str, str]:
         """
         Return a mapping of NVMe device paths to their model names.

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -354,14 +354,20 @@ class Nvmecli(Tool):
         for nvme_device in nvme_devices or []:
             # Legacy schema (flat fields):
             device_path = nvme_device.get("DevicePath")
-            model = nvme_device.get("ModelNumber", "")
+            raw_model = nvme_device.get("ModelNumber", "")
+            model = raw_model.strip() if isinstance(raw_model, str) else ""
             if isinstance(device_path, str) and device_path.startswith("/dev/"):
-                device_models[device_path] = model.strip()
+                device_models[device_path] = model
 
             # New schema: Subsystems → Controllers → Namespaces
             for subsystem in nvme_device.get("Subsystems") or []:
                 for controller in (subsystem or {}).get("Controllers") or []:
-                    ctrl_model = (controller or {}).get("ModelNumber", "").strip()
+                    raw_ctrl_model = (controller or {}).get("ModelNumber", "")
+                    ctrl_model = (
+                        raw_ctrl_model.strip()
+                        if isinstance(raw_ctrl_model, str)
+                        else ""
+                    )
                     for namespace in (controller or {}).get("Namespaces") or []:
                         namespace_name = namespace.get("NameSpace")
                         if isinstance(namespace_name, str) and namespace_name:

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -283,7 +283,24 @@ class Nvmecli(Tool):
 
         for nvme_device in nvme_devices or []:
             # Legacy schema (flat fields):
-            _add(nvme_device.get("DevicePath"), nvme_device.get("NameSpace"))
+            device_path = nvme_device.get("DevicePath")
+            namespace_id = nvme_device.get("NameSpace")
+            
+            # Some older nvme-cli versions (e.g., 1.8.x on RHEL 7) emit
+            # DevicePath but omit the NameSpace field entirely.
+            # Derive the namespace ID from the DevicePath if missing.
+            if device_path and namespace_id is None:
+                # e.g., "/dev/nvme0n1" → "1", "/dev/nvme0n17" → "17"
+                ns_match = re.search(r"n(\d+)$", device_path)
+                if ns_match:
+                    namespace_id = int(ns_match.group(1))
+                    self._log.debug(
+                        f"NameSpace field missing in nvme-cli JSON for "
+                        f"{device_path}. Derived namespace_id={namespace_id} "
+                        f"from device path. nvme-cli version may be < 2.0."
+                    )
+
+            _add(device_path, namespace_id)
 
             # New schema: Subsystems → Controllers → Namespaces
             for subsystem in nvme_device.get("Subsystems") or []:

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -289,7 +289,7 @@ class Nvmecli(Tool):
             # Some older nvme-cli versions (e.g., 1.8.x on RHEL 7) emit
             # DevicePath but omit the NameSpace field entirely.
             # Derive the namespace ID from the DevicePath if missing.
-            if device_path and namespace_id is None:
+            if isinstance(device_path, str) and device_path and namespace_id is None:
                 # e.g., "/dev/nvme0n1" → "1", "/dev/nvme0n17" → "17"
                 ns_match = re.search(r"n(\d+)$", device_path)
                 if ns_match:

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -363,7 +363,7 @@ class Nvmecli(Tool):
 
         try:
             nvme_devices = json.loads(nvme_list.stdout)["Devices"]
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError, TypeError):
             return {}
 
         device_models: Dict[str, str] = {}

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -307,6 +307,50 @@ class Nvmecli(Tool):
     def get_namespace_ids(self, force_run: bool = False) -> List[Dict[str, int]]:
         device_paths_namespace_ids_map = self.get_devices(force_run=force_run)
         return [{path: nsid} for path, nsid in device_paths_namespace_ids_map.items()]
+    
+    def get_device_models(self, force_run: bool = False) -> Dict[str, str]:
+        """
+        Return a mapping of NVMe device paths to their model names.
+        Example return:
+            {
+                "/dev/nvme0n1": "MSFT NVMe Accelerator v1.0",
+                "/dev/nvme1n1": "Microsoft NVMe Direct Disk v2",
+            }
+        """
+        nvme_list = self.run(
+            "list -o json 2>/dev/null",
+            shell=True,
+            sudo=True,
+            force_run=force_run,
+            no_error_log=True,
+        )
+        if not nvme_list.stdout:
+            return {}
+
+        try:
+            nvme_devices = json.loads(nvme_list.stdout)["Devices"]
+        except (json.JSONDecodeError, KeyError):
+            return {}
+
+        device_models: Dict[str, str] = {}
+
+        for nvme_device in nvme_devices or []:
+            # Legacy schema (flat fields):
+            device_path = nvme_device.get("DevicePath")
+            model = nvme_device.get("ModelNumber", "")
+            if isinstance(device_path, str) and device_path.startswith("/dev/"):
+                device_models[device_path] = model.strip()
+
+            # New schema: Subsystems → Controllers → Namespaces
+            for subsystem in nvme_device.get("Subsystems") or []:
+                for controller in (subsystem or {}).get("Controllers") or []:
+                    ctrl_model = (controller or {}).get("ModelNumber", "").strip()
+                    for namespace in (controller or {}).get("Namespaces") or []:
+                        namespace_name = namespace.get("NameSpace")
+                        if isinstance(namespace_name, str) and namespace_name:
+                            device_models[f"/dev/{namespace_name}"] = ctrl_model
+
+        return device_models
 
 
 class BSDNvmecli(Nvmecli):

--- a/lisa/tools/nvmecli.py
+++ b/lisa/tools/nvmecli.py
@@ -308,7 +308,7 @@ class Nvmecli(Tool):
             # Derive the namespace ID from the DevicePath if missing.
             if isinstance(device_path, str) and device_path and namespace_id is None:
                 # e.g., "/dev/nvme0n1" → "1", "/dev/nvme0n17" → "17"
-                ns_match = re.search(r"n(\d+)$", device_path)
+                ns_match = re.search(r"nvme\d+n(\d+)$", device_path)
                 if ns_match:
                     namespace_id = int(ns_match.group(1))
                     self._log.debug(


### PR DESCRIPTION
The current code uses a controller-based heuristic to identify remote disks, which is unreliable on certain VM configurations.

**Changes**

- In **nvmecli.py**
   - **get_devices():** Add support for new nvme-cli JSON schema (Subsystems → Controllers → Namespaces) alongside the legacy flat schema.
   - **get_device_models():** New method returning a device-path-to-model mapping. Uses try/except for graceful fallback on malformed JSON.

- In **nvme.py**
   - **_remove_nvme_remote_disks():** Use model-based detection (checking for "NVMe Accelerator" in model name) as primary method. Includes prefix matching for controller paths (/dev/nvme0) against namespace keys (/dev/nvme0n1). Falls back to legacy controller-based heuristic if nvme-cli data is unavailable.

- In **features.py**
   - **_is_remote_data_disk():** Use model-based detection as primary method with legacy fallback.

**Notes**
- No behavior change on VMs with SCSI disk controllers.
- No behavior change on VMs where nvme-cli is unavailable (fallback path is preserved).
