### PR TITLE
Fix broken dpkg packages and pip install failures on newer distros

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1034,7 +1034,9 @@ class Debian(Linux):
                 )
                 self._log.debug(
                     "final dpkg configure result after repair: "
-                    f"exit_code={final_dpkg_result.exit_code}"
+                    f"exit_code={final_dpkg_result.exit_code}, "
+                    f"stdout={final_dpkg_result.stdout!r}, "
+                    f"stderr={final_dpkg_result.stderr!r}"
                 )
             else:
                 self._log.debug(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -981,9 +981,7 @@ class Debian(Linux):
         timer = create_timer()
         while timeout > timer.elapsed(False):
             # fix the dpkg, in case it's broken.
-            self._node.execute(
-                "dpkg --force-all --configure -a", sudo=True
-            )
+            self._node.execute("dpkg --force-all --configure -a", sudo=True)
             pidof_result = self._node.execute("pidof dpkg dpkg-deb")
             if pidof_result.exit_code == 1:
                 # no dpkg process running, safe to exit and attempt repair.

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -996,6 +996,20 @@ class Debian(Linux):
         if timeout < timer.elapsed():
             raise LisaTimeoutException("timeout to wait previous dpkg process stop.")
 
+        # Remove packages stuck in "reinst-required" state whose archive is
+        # missing (e.g. azsec-bpftrace on KernelCI images).
+        audit_result = self._node.execute("dpkg --audit", sudo=True, no_info_log=True)
+        if audit_result.stdout.strip():
+            self._log.debug(
+                f"Found packages needing repair: {audit_result.stdout.strip()}"
+            )
+            self._node.execute(
+                "dpkg --remove --force-remove-reinstreq "
+                "$(dpkg -l | grep ^.HR | awk '{print $2}') 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+
     def get_repositories(self) -> List[RepositoryInfo]:
         self._initialize_package_installation()
         repo_list_str = self._node.execute("apt-get update", sudo=True).stdout

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -981,12 +981,12 @@ class Debian(Linux):
         timer = create_timer()
         while timeout > timer.elapsed(False):
             # fix the dpkg, in case it's broken.
-            dpkg_result = self._node.execute(
+            self._node.execute(
                 "dpkg --force-all --configure -a", sudo=True
             )
             pidof_result = self._node.execute("pidof dpkg dpkg-deb")
-            if dpkg_result.exit_code == 0 and pidof_result.exit_code == 1:
-                # not found dpkg process, it's ok to exit.
+            if pidof_result.exit_code == 1:
+                # no dpkg process running, safe to exit and attempt repair.
                 break
             if is_first_time:
                 is_first_time = False
@@ -1027,6 +1027,16 @@ class Debian(Linux):
                     f"dpkg repair removal result: exit_code={remove_result.exit_code}, "
                     f"stdout={remove_result.stdout!r}, "
                     f"stderr={remove_result.stderr!r}"
+                )
+                # After removing reinst-required packages, re-run configure
+                # to bring dpkg to a clean state.
+                final_dpkg_result = self._node.execute(
+                    "dpkg --force-all --configure -a",
+                    sudo=True,
+                )
+                self._log.debug(
+                    "final dpkg configure result after repair: "
+                    f"exit_code={final_dpkg_result.exit_code}"
                 )
             else:
                 self._log.debug(

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1011,15 +1011,11 @@ class Debian(Linux):
                 no_info_log=True,
             )
             reinst_packages = [
-                pkg
-                for pkg in reinst_packages_result.stdout.splitlines()
-                if pkg.strip()
+                pkg for pkg in reinst_packages_result.stdout.splitlines() if pkg.strip()
             ]
             if reinst_packages:
                 packages_arg = " ".join(reinst_packages)
-                remove_cmd = (
-                    f"dpkg --remove --force-remove-reinstreq {packages_arg}"
-                )
+                remove_cmd = f"dpkg --remove --force-remove-reinstreq {packages_arg}"
                 remove_result = self._node.execute(
                     remove_cmd,
                     sudo=True,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1003,12 +1003,38 @@ class Debian(Linux):
             self._log.debug(
                 f"Found packages needing repair: {audit_result.stdout.strip()}"
             )
-            self._node.execute(
-                "dpkg --remove --force-remove-reinstreq "
-                "$(dpkg -l | grep ^.HR | awk '{print $2}') 2>/dev/null || true",
+            # Find packages stuck in "reinst-required" state (status code "HR").
+            reinst_packages_result = self._node.execute(
+                "dpkg -l | grep '^.HR' | awk '{print $2}'",
                 sudo=True,
                 shell=True,
+                no_info_log=True,
             )
+            reinst_packages = [
+                pkg
+                for pkg in reinst_packages_result.stdout.splitlines()
+                if pkg.strip()
+            ]
+            if reinst_packages:
+                packages_arg = " ".join(reinst_packages)
+                remove_cmd = (
+                    f"dpkg --remove --force-remove-reinstreq {packages_arg}"
+                )
+                remove_result = self._node.execute(
+                    remove_cmd,
+                    sudo=True,
+                    shell=True,
+                    no_info_log=True,
+                )
+                self._log.debug(
+                    f"dpkg repair removal result: exit_code={remove_result.exit_code}, "
+                    f"stdout={remove_result.stdout!r}, "
+                    f"stderr={remove_result.stderr!r}"
+                )
+            else:
+                self._log.debug(
+                    "No 'reinst-required' packages found to remove after audit."
+                )
 
     def get_repositories(self) -> List[RepositoryInfo]:
         self._initialize_package_installation()

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1003,9 +1003,10 @@ class Debian(Linux):
             self._log.debug(
                 f"Found packages needing repair: {audit_result.stdout.strip()}"
             )
-            # Find packages stuck in "reinst-required" state (status code "HR").
+            # Find packages stuck in "reinst-required" state:
+            # match any dpkg entry whose error flag (3rd column) is 'R'.
             reinst_packages_result = self._node.execute(
-                "dpkg -l | grep '^.HR' | awk '{print $2}'",
+                "dpkg -l | grep '^..R' | awk '{print $2}'",
                 sudo=True,
                 shell=True,
                 no_info_log=True,

--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -109,7 +109,8 @@ class Waagent(Tool):
         #    isolation (missing 'distro' module, deprecated platform APIs)
         # 2. The legacy 'setup.py install' works but requires compatible setuptools
         downgrade_result = self.node.execute(
-            f"{python_cmd} -m pip install 'setuptools<71' --force-reinstall",
+            f"{python_cmd} -m pip install 'setuptools<71' --force-reinstall "
+            "--break-system-packages",
             sudo=True,
         )
 
@@ -119,13 +120,22 @@ class Waagent(Tool):
             )
             # Fallback: try pip install with --no-build-isolation to avoid
             # downloading latest setuptools in isolated environment
-            self.node.execute(
-                f"{python_cmd} -m pip install --no-build-isolation .",
+            # Try with --break-system-packages first (needed for PEP 668),
+            # fall back without it for older pip versions.
+            fallback_result = self.node.execute(
+                f"{python_cmd} -m pip install --no-build-isolation "
+                "--break-system-packages .",
                 sudo=True,
                 cwd=self.node.working_path.joinpath("WALinuxAgent"),
-                expected_exit_code=0,
-                expected_exit_code_failure_message="Failed to install waagent",
             )
+            if fallback_result.exit_code != 0:
+                self.node.execute(
+                    f"{python_cmd} -m pip install --no-build-isolation .",
+                    sudo=True,
+                    cwd=self.node.working_path.joinpath("WALinuxAgent"),
+                    expected_exit_code=0,
+                    expected_exit_code_failure_message="Failed to install waagent",
+                )
         else:
             self.node.execute(
                 f"{python_cmd} setup.py install --force",

--- a/lisa/sut_orchestrator/azure/tools.py
+++ b/lisa/sut_orchestrator/azure/tools.py
@@ -116,6 +116,16 @@ class Waagent(Tool):
 
         if downgrade_result.exit_code != 0:
             self._log.debug(
+                "setuptools downgrade with --break-system-packages failed, "
+                "retrying without it (older pip may not support the flag)"
+            )
+            downgrade_result = self.node.execute(
+                f"{python_cmd} -m pip install 'setuptools<71' --force-reinstall",
+                sudo=True,
+            )
+
+        if downgrade_result.exit_code != 0:
+            self._log.debug(
                 "Failed to downgrade setuptools, trying pip install instead"
             )
             # Fallback: try pip install with --no-build-isolation to avoid


### PR DESCRIPTION
Two fixes for package installation failures on KernelCI and newer distro images.

### 1. Handle dpkg reinst-required packages (`operating_system.py`)

Packages stuck in dpkg "Half-installed, Reinst-required" state (e.g. `azsec-bpftrace` on KernelCI images) block all `apt-get` operations with exit code 100:
```
E: The package azsec-bpftrace needs to be reinstalled, but I can't find an archive for it.
```

Added detection and force-removal of such packages in `wait_running_package_process()` using `dpkg --audit` and `dpkg --remove --force-remove-reinstreq`.

References:
- [dpkg man page — package states & --force-remove-reinstreq](https://man7.org/linux/man-pages/man1/dpkg.1.html)
- [Debian dpkg FAQ — recovering broken packages](https://wiki.debian.org/Teams/Dpkg/FAQ)

### 2. Add `--break-system-packages` to pip commands (`tools.py`)

Python 3.11+ distros enforcing PEP 668 reject `pip install` into system environments. Added `--break-system-packages` to pip commands in `Waagent.upgrade_from_source()`, with fallback for older pip versions.

References:
- [PEP 668 — Marking Python base environments as "externally managed"](https://peps.python.org/pep-0668/)
- [pip docs — --break-system-packages](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-break-system-packages)