### PR TITLE
Check for the sudo password prompt and introduce a fallback when the prompt is not detected.

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -185,10 +185,12 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
                     " that restrict the use of sudo in combination with /bin/sh."
                 )
                 return False
-            # Also check stdout for password prompts in case they appeared
-            # after the early check window (e.g. slow connection).
+            # Also check output for password prompts in case they appeared
+            # after the early check window (e.g. slow connection). The sudo
+            # prompt is typically written to stderr, so include both streams.
+            combined_output = (result.stdout or "") + (result.stderr or "")
             for prompt in self._sudo_password_prompts:
-                if prompt in result.stdout:
+                if prompt in combined_output:
                     self.log.debug(
                         "sudo requires a password (detected prompt in output). "
                         "sudo is available; password handling will follow."

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -164,6 +164,18 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
 
         # Further test: try running 'ls' with sudo /bin/sh
         process = self._execute("ls", shell=True, sudo=True, no_info_log=True)
+
+        # Check for a password prompt early (within 2 seconds) to avoid
+        # waiting the full timeout when sudo just needs a password.
+        for prompt in self._sudo_password_prompts:
+            if process.wait_output(prompt, timeout=2, error_on_missing=False):
+                self.log.debug(
+                    "sudo requires a password (detected prompt during probe). "
+                    "sudo is available; password handling will follow."
+                )
+                process.kill()
+                return True
+
         result = process.wait_result(timeout=10, raise_on_timeout=False)
         if result.exit_code != 0:
             # e.g. raw error: "user is not allowed to execute '/bin/sh -c ...'"
@@ -173,6 +185,15 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
                     " that restrict the use of sudo in combination with /bin/sh."
                 )
                 return False
+            # Also check stdout for password prompts in case they appeared
+            # after the early check window (e.g. slow connection).
+            for prompt in self._sudo_password_prompts:
+                if prompt in result.stdout:
+                    self.log.debug(
+                        "sudo requires a password (detected prompt in output). "
+                        "sudo is available; password handling will follow."
+                    )
+                    return True
 
         return True
 

--- a/lisa/node.py
+++ b/lisa/node.py
@@ -43,7 +43,12 @@ from lisa.util import (
 from lisa.util.constants import PATH_REMOTE_ROOT
 from lisa.util.logger import Logger, create_file_handler, get_logger, remove_handler
 from lisa.util.parallel import run_in_parallel
-from lisa.util.process import ExecutableResult, Process, process_command
+from lisa.util.process import (
+    SUDO_PASSWORD_PROMPTS,
+    ExecutableResult,
+    Process,
+    process_command,
+)
 from lisa.util.shell import LocalShell, Shell, SshShell, WslShell
 
 T = TypeVar("T")
@@ -53,12 +58,7 @@ __local_node: Optional[Node] = None
 class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixin):
     _factory: Optional[subclasses.Factory[Node]] = None
 
-    # [sudo] password for
-    # Password:
-    _sudo_password_prompts: List[str] = [
-        "[sudo] password for",
-        "Password:",
-    ]
+    _sudo_password_prompts: List[str] = SUDO_PASSWORD_PROMPTS
 
     def __init__(
         self,

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -29,6 +29,13 @@ from lisa.util import (
 from lisa.util.logger import Logger, LogWriter, add_handler, get_logger
 from lisa.util.shell import Shell, SshShell
 
+# Prompt strings that sudo writes when it requires a password.
+# Shared with lisa.node (which imports this list) so changes stay in sync.
+SUDO_PASSWORD_PROMPTS: List[str] = [
+    "[sudo] password for",
+    "Password:",
+]
+
 # [sudo] password for lisatest: \r\nsudo: timed out reading password
 # Password: \r\nsudo: timed out reading password
 TIMEOUT_READING_PASSWORD_PATTERNS = [
@@ -359,7 +366,7 @@ class Process:
                 self._stdout_writer.flush()
                 self._stderr_writer.flush()
                 buffer_content = self.log_buffer.getvalue()
-                for prompt in ["Password:", "[sudo] password for"]:
+                for prompt in SUDO_PASSWORD_PROMPTS:
                     if prompt in buffer_content:
                         prompt_found = True
                         break

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -341,18 +341,46 @@ class Process:
             and isinstance(self._shell, SshShell)
             and self._shell.is_sudo_required_password
         ):
+            if not self._shell.connection_info.password:
+                raise RequireUserPasswordException(
+                    "Running commands with sudo requires user's password,"
+                    " but no password is provided."
+                )
+
+            # Wait for the actual password prompt before sending the password.
+            # Newer sudo versions (e.g. 1.9.17+) flush the terminal input
+            # buffer (tcflush) before reading, so any password sent before
+            # the prompt appears is silently discarded.
+            prompt_found = False
             timer = create_timer()
-            while self.is_running():
-                time.sleep(0.01)
-                if timer.elapsed(False) > 0.5:
-                    if not self._shell.connection_info.password:
-                        raise RequireUserPasswordException(
-                            "Running commands with sudo requires user's password,"
-                            " but no password is provided."
-                        )
-                    self.input(f"{self._shell.connection_info.password}\n", False)
-                    self._log.debug("The user's password is input")
+            while self.is_running() and timer.elapsed(False) < 10:
+                # Flush writers to push partial lines (like "Password:"
+                # without a trailing newline) into the log buffer.
+                self._stdout_writer.flush()
+                self._stderr_writer.flush()
+                buffer_content = self.log_buffer.getvalue()
+                for prompt in ["Password:", "[sudo] password for"]:
+                    if prompt in buffer_content:
+                        prompt_found = True
+                        break
+                if prompt_found:
                     break
+                time.sleep(0.1)
+
+            if not prompt_found:
+                if not self.is_running():
+                    # Process exited without prompting — no password needed.
+                    return
+                self._log.debug(
+                    "Password prompt not detected within timeout, "
+                    "sending password as fallback."
+                )
+
+            # Brief delay after prompt detection to ensure sudo is fully
+            # ready to read from the terminal.
+            time.sleep(0.1)
+            self.input(f"{self._shell.connection_info.password}\n", False)
+            self._log.debug("The user's password is input")
 
     def input(self, content: str, is_log_input: bool = True) -> None:
         assert self._process, "The process object is None, the process may end."


### PR DESCRIPTION
sudo 1.9.17 flushes the terminal input buffer (tcflush) before reading the password. The old check_and_input_password() sent the password after a blind 0.5-second delay — well before sudo displayed its "Password:" prompt on the slow QEMU (~3 seconds). The password got buffered in the PTY, then sudo flushed it and read nothing, causing it to re-prompt and eventually time out. This is a behavioral change from sudo 1.9.15p5 which read whatever was already buffered.