### PR TITLE
passthrough: support hyper-v platform

### DIFF
--- a/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
+++ b/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
@@ -12,6 +12,7 @@ from lisa.util import LisaException, SkippedException
 
 if TYPE_CHECKING:
     from lisa.sut_orchestrator.libvirt.ch_platform import CloudHypervisorPlatform
+    from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 
 
 @TestSuiteMetadata(
@@ -94,7 +95,7 @@ class DevicePassthroughFunctionalTests(TestSuite):
                 if not pool.devices.pci_bdf:
                     raise LisaException(f"Pool '{pool_type}' has no pci_bdf entries")
                 vendor_device_id = self._vendor_device_from_host_bdf(
-                    platform, pool.devices.pci_bdf[0]
+                    platform, pool.type, pool.devices.pci_bdf[0]
                 )
             elif isinstance(pool.devices, dict):
                 # dataclasses_json fallback: raw dict form from runbook.
@@ -103,7 +104,7 @@ class DevicePassthroughFunctionalTests(TestSuite):
                     if not bdf_list:
                         raise LisaException(f"Pool '{pool_type}' pci_bdf list is empty")
                     vendor_device_id = self._vendor_device_from_host_bdf(
-                        platform, bdf_list[0]
+                        platform, pool.type, bdf_list[0]
                     )
                 elif "vendor_id" in pool.devices and "device_id" in pool.devices:
                     vendor_device_id = {
@@ -156,12 +157,20 @@ class DevicePassthroughFunctionalTests(TestSuite):
     @staticmethod
     def _vendor_device_from_host_bdf(
         platform: "CloudHypervisorPlatform",
+        pool_type: "HostDevicePoolType",
         bdf: str,
     ) -> Dict[str, str]:
         """Read vendor_id and device_id for a BDF from host sysfs."""
+        resolved_bdf = platform.device_pool.resolve_requested_pci_address(
+            pool_type, bdf.strip()
+        )
         cat = platform.host_node.tools[Cat]
-        vendor_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/vendor", sudo=True).strip()
-        device_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/device", sudo=True).strip()
+        vendor_raw = cat.read(
+            f"/sys/bus/pci/devices/{resolved_bdf}/vendor", sudo=True
+        ).strip()
+        device_raw = cat.read(
+            f"/sys/bus/pci/devices/{resolved_bdf}/device", sudo=True
+        ).strip()
         # Normalize to 4-digit lowercase hex used by lspci identifiers.
         vendor_id = vendor_raw.lower().replace("0x", "").zfill(4)
         device_id = device_raw.lower().replace("0x", "").zfill(4)

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -26,7 +26,7 @@ from lisa.environment import Environment, Node
 from lisa.operating_system import Windows
 from lisa.sut_orchestrator import CLOUD_HYPERVISOR
 from lisa.testsuite import TestResult
-from lisa.tools import Dhclient, Kill, Sysctl
+from lisa.tools import Dhclient, Kill, PowerShell, Sysctl
 from lisa.tools.iperf3 import (
     IPERF_TCP_BUFFER_LENGTHS,
     IPERF_TCP_CONCURRENCY,
@@ -615,9 +615,9 @@ class NetworkPerformance(TestSuite):
             node, mgmt_iface, iface_info_raw
         )
 
-        node.log.info(f"[passthrough-nic] GUEST iface={interface_name!r}")
+        node.log.debug(f"[passthrough-nic] GUEST iface={interface_name!r}")
         if host_node is not None and host_nic_name:
-            host_node.log.info(
+            host_node.log.debug(
                 f"[passthrough-nic] HOST nic={host_nic_name!r} BDF={device_bdf!r}"
             )
 
@@ -1016,6 +1016,15 @@ class NetworkPerformance(TestSuite):
             private_key_file=private_key,
         )
         server.internal_address = ip
+
+        server.initialize()
+
+        if isinstance(server.os, Windows):
+            raise SkippedException(
+                "Host/guest passthrough performance tests require a Linux "
+                "baremetal host; Windows baremetal hosts are not supported."
+            )
+
         # Track baremetal host for cleanup.
         if server not in self._baremetal_hosts:
             self._baremetal_hosts.append(server)
@@ -1058,11 +1067,49 @@ class NetworkPerformance(TestSuite):
             all_nodes.extend(self._baremetal_hosts)
 
         def do_process_cleanup(process: str, node: Node) -> None:
-            kill = node.tools[Kill]
-            kill.by_name(process, ignore_not_exist=True)
+            try:
+                if isinstance(node.os, Windows):
+                    escaped_process = process.replace("'", "''")
+                    node.tools[PowerShell].run_cmdlet(
+                        cmdlet=(
+                            f"$p = Get-Process -Name '{escaped_process}' "
+                            "-ErrorAction SilentlyContinue; "
+                            "if ($p) { $p | Stop-Process -Force "
+                            "-ErrorAction SilentlyContinue }"
+                        ),
+                        fail_on_error=False,
+                    )
+                    return
+
+                kill = node.tools[Kill]
+                kill.by_name(process, ignore_not_exist=True)
+            except LisaException as identifier_error:
+                log.debug(
+                    f"Skipping Kill tool-based cleanup for '{process}' on "
+                    f"node '{node.name}': {identifier_error}"
+                )
+                if isinstance(node.os, Windows):
+                    return
+
+                node.execute(
+                    cmd=(
+                        f"pids=$(pidof {process} 2>/dev/null || true); "
+                        '[ -z "$pids" ] || kill -9 $pids || true'
+                    ),
+                    shell=True,
+                    sudo=True,
+                )
 
         def do_sysctl_cleanup(node: Node) -> None:
-            node.tools[Sysctl].reset()
+            if isinstance(node.os, Windows):
+                return
+
+            try:
+                node.tools[Sysctl].reset()
+            except LisaException as sysctl_error:
+                log.debug(
+                    f"Skipping sysctl cleanup on node '{node.name}': " f"{sysctl_error}"
+                )
 
         cleanup_tasks: List[Callable[[], None]] = []
         for process in ["lagscope", "netperf", "netserver", "ntttcp", "iperf3"]:

--- a/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
+++ b/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 # Refer: https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/deploy/deploying-graphics-devices-using-dda  # noqa E501
 import re
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from lisa.node import Node
 from lisa.tools import PowerShell
@@ -49,6 +49,113 @@ class HypervAssignableDevices:
                 result.friendly_name = rec["friendly_name"]
                 devices.append(result)
         return devices
+
+    def get_assignable_devices_by_location_paths(
+        self,
+        location_paths: List[str],
+    ) -> List[DeviceAddressSchema]:
+        requested_paths = {path.strip() for path in location_paths if path.strip()}
+        if not requested_paths:
+            return []
+
+        output = self.__get_present_pci_devices_with_location_paths()
+
+        devices: List[DeviceAddressSchema] = []
+        matched_paths = set()
+        for rec in output:
+            device_id = str(rec.get("InstanceId", "")).strip()
+            if not device_id:
+                continue
+
+            available_paths = self.__normalize_location_paths(
+                rec.get("LocationPaths", rec.get("LocationPath"))
+            )
+            if not available_paths:
+                continue
+
+            matching_paths = requested_paths.intersection(available_paths)
+            if not matching_paths:
+                continue
+
+            matched_paths.update(matching_paths)
+            current_path = next(
+                path for path in available_paths if path in matching_paths
+            )
+            result = self.__get_dda_properties(device_id=device_id)
+            if not result:
+                raise LisaException(
+                    f"Device at location path '{current_path}' is present but "
+                    "is not assignable by Hyper-V DDA"
+                )
+
+            result.friendly_name = str(rec.get("FriendlyName", "") or "").strip()
+            devices.append(result)
+
+        missing_paths = requested_paths.difference(matched_paths)
+        if missing_paths:
+            raise LisaException(
+                "Could not find PCI device(s) for Hyper-V location path(s): "
+                f"{', '.join(sorted(missing_paths))}"
+            )
+
+        return devices
+
+    def __get_present_pci_devices_with_location_paths(self) -> List[Dict[str, Any]]:
+        cmd = (
+            "Get-PnpDevice -PresentOnly | "
+            "Where-Object {$_.InstanceId -like 'PCI\\*'} | "
+            "ForEach-Object { "
+            "$locationPaths = $null; "
+            "try { "
+            "$locationPaths = (Get-PnpDeviceProperty -InstanceId $_.InstanceId "
+            "'DEVPKEY_Device_LocationPaths' -ErrorAction Stop).Data; "
+            "} catch { } "
+            "$locationPath = $null; "
+            "if ($locationPaths -is [System.Array]) { "
+            "$locationPath = $locationPaths | Select-Object -First 1; "
+            "} else { "
+            "$locationPath = $locationPaths; "
+            "} "
+            "[PSCustomObject]@{ "
+            "FriendlyName = $_.FriendlyName; "
+            "InstanceId = $_.InstanceId; "
+            "LocationPath = $locationPath; "
+            "LocationPaths = $locationPaths "
+            "} "
+            "}"
+        )
+        output = self.pwsh.run_cmdlet(
+            cmdlet=cmd,
+            sudo=True,
+            force_run=True,
+            output_json=True,
+        )
+
+        if not output:
+            raise LisaException("No present PCI devices were found on the Hyper-V host")
+
+        if not isinstance(output, list):
+            output = [output]
+
+        result: List[Dict[str, Any]] = []
+        for rec in output:
+            if not isinstance(rec, dict):
+                continue
+
+            location_paths = self.__normalize_location_paths(
+                rec.get("LocationPaths", rec.get("LocationPath"))
+            )
+
+            result.append(
+                {
+                    "FriendlyName": str(rec.get("FriendlyName", "") or "").strip(),
+                    "InstanceId": str(rec.get("InstanceId", "") or "").strip(),
+                    "LocationPath": self.__get_first_location_path(location_paths),
+                    "LocationPaths": location_paths,
+                }
+            )
+
+        return result
 
     def __get_devices_by_vendor_device_id(
         self,
@@ -107,6 +214,25 @@ class HypervAssignableDevices:
             force_run=True,
         )
         return str(output.strip())
+
+    def __get_first_location_path(self, raw_location_path: Any) -> str:
+        location_paths = self.__normalize_location_paths(raw_location_path)
+        return location_paths[0] if location_paths else ""
+
+    def __normalize_location_paths(self, raw_location_paths: Any) -> List[str]:
+        if raw_location_paths is None:
+            return []
+
+        if isinstance(raw_location_paths, list):
+            location_paths = raw_location_paths
+        else:
+            location_paths = str(raw_location_paths).splitlines()
+
+        return [
+            location_path
+            for location_path in (str(entry).strip() for entry in location_paths)
+            if location_path
+        ]
 
     def __load_pnp_allocated_resources(self) -> List[Dict[str, str]]:
         # Command output result (just 2 device properties)
@@ -190,7 +316,7 @@ class HypervAssignableDevices:
                 result.append(extract_val)
         return result
 
-    def __get_mmio_end_address(self, start_addr: str) -> Optional[str]:
+    def __get_mmio_end_address(self, start_addr: int) -> Optional[str]:
         # MemoryType   Name                  Status
         # ----------   ----                  ------
         # WindowDecode 0xE1800000-0xE1BFFFFF OK
@@ -204,16 +330,17 @@ class HypervAssignableDevices:
             sudo=True,
             force_run=True,
         )
+        mmio_pattern = re.compile(r"(?P<start>0x[0-9A-Fa-f]+)-(?P<end>0x[0-9A-Fa-f]+)")
         end_addr_rec = None
         for rec in device_mem_addr.splitlines():
             rec = rec.strip()
-            if rec.find(start_addr) >= 0:
-                addr = rec.split("-")
-                start_addr_rec = addr[0].split()[-1]
-                end_addr_rec = addr[1].split()[0].strip()
+            match = mmio_pattern.search(rec)
+            if not match:
+                continue
 
-                err = "MMIO Starting address not matching"
-                assert start_addr == start_addr_rec, err
+            start_addr_rec = int(match.group("start"), 16)
+            if start_addr == start_addr_rec:
+                end_addr_rec = match.group("end")
                 break
         return end_addr_rec
 
@@ -224,73 +351,117 @@ class HypervAssignableDevices:
         """
         self.log.debug(f"PCI InstanceId: {device_id}")
 
+        if self.__requires_reserved_memory_region(device_id):
+            return None
+
+        if not self.__has_acs_compatible_up_hierarchy(device_id):
+            return None
+
+        if not self.__is_supported_device_type(device_id):
+            return None
+
+        location_path = self.__get_location_path(device_id)
+        if self.__is_device_disabled(device_id):
+            return None
+
+        allocated_resources = self.__get_allocated_resources(device_id)
+        if not self.__has_assignable_interrupts(allocated_resources):
+            return None
+
+        mmio_total = self.__get_total_mmio_in_mb(device_id, allocated_resources)
+        if mmio_total is None:
+            self.log.debug("It has no MMIO space")
+        elif mmio_total:
+            self.log.debug(f"Device '{device_id}', Total MMIO = {mmio_total}MB ")
+
+        device = DeviceAddressSchema()
+        device.location_path = location_path
+        device.instance_id = device_id
+        return device
+
+    def __requires_reserved_memory_region(self, device_id: str) -> bool:
         rmrr = self.__get_pnp_device_property(
             device_id=device_id,
             property_name=self.PKEY_REQUIRES_RESERVED_MEMORY_REGION,
-        )
-        rmrr = rmrr.strip()
+        ).strip()
         if rmrr != "False":
             self.log.debug(
                 "BIOS requires that this device remain attached to BIOS-owned memory."
                 "Not assignable."
             )
-            return None
+            return True
+        return False
 
+    def __has_acs_compatible_up_hierarchy(self, device_id: str) -> bool:
         acs_up = self.__get_pnp_device_property(
             device_id=device_id,
             property_name=self.PKEY_ACS_COMPATIBLE_UP_HIERARCHY,
-        )
-        acs_up = acs_up.strip()
+        ).strip()
         if acs_up == self.PROP_ACS_COMPATIBLE_UP_HIERARCHY_NOT_SUPPORTED:
             self.log.debug(
                 "Traffic from this device may be redirected to other devices in "
                 "the system. Not assignable."
             )
-            return None
+            return False
+        return True
 
+    def __is_supported_device_type(self, device_id: str) -> bool:
         dev_type = self.__get_pnp_device_property(
-            device_id=device_id, property_name=self.PKEY_DEVICE_TYPE
-        )
-        dev_type = dev_type.strip()
+            device_id=device_id,
+            property_name=self.PKEY_DEVICE_TYPE,
+        ).strip()
         if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_ENDPOINT:
             self.log.debug("Express Endpoint -- more secure.")
-        else:
-            if dev_type == (
-                self.PROP_DEVICE_TYPE_PCI_EXPRESS_ROOT_COMPLEX_INTEGRATED_ENDPOINT
-            ):
-                self.log.debug("Embedded Endpoint -- less secure.")
-            elif dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_LEGACY_ENDPOINT:
-                dev_base_class = self.__get_pnp_device_property(
-                    device_id=device_id,
-                    property_name=self.PKEY_BASE_CLASS,
-                )
-                dev_base_class = dev_base_class.strip()
-                if dev_base_class == self.PROP_BASE_CLASS_DISPLAY_CTRL:
-                    self.log.debug("Legacy Express Endpoint -- graphics controller.")
-                else:
-                    self.log.debug("Legacy, non-VGA PCI device. Not assignable.")
-                    return None
-            else:
-                if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_TREATED_AS_PCI:
-                    self.log.debug(
-                        "BIOS kept control of PCI Express for this device. "
-                        "Not assignable."
-                    )
-                else:
-                    self.log.debug(
-                        "Old-style PCI device, switch port, etc. " "Not assignable."
-                    )
-                return None
+            return True
 
-        # Get the device location path
-        location_path = self.__get_pnp_device_property(
+        if (
+            dev_type
+            == self.PROP_DEVICE_TYPE_PCI_EXPRESS_ROOT_COMPLEX_INTEGRATED_ENDPOINT
+        ):
+            self.log.debug("Embedded Endpoint -- less secure.")
+            return True
+
+        if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_LEGACY_ENDPOINT:
+            return self.__is_legacy_display_controller(device_id)
+
+        if dev_type == self.PROP_DEVICE_TYPE_PCI_EXPRESS_TREATED_AS_PCI:
+            self.log.debug(
+                "BIOS kept control of PCI Express for this device. " "Not assignable."
+            )
+        else:
+            self.log.debug("Old-style PCI device, switch port, etc. Not assignable.")
+        return False
+
+    def __is_legacy_display_controller(self, device_id: str) -> bool:
+        dev_base_class = self.__get_pnp_device_property(
+            device_id=device_id,
+            property_name=self.PKEY_BASE_CLASS,
+        ).strip()
+        if dev_base_class == self.PROP_BASE_CLASS_DISPLAY_CTRL:
+            self.log.debug("Legacy Express Endpoint -- graphics controller.")
+            return True
+
+        self.log.debug("Legacy, non-VGA PCI device. Not assignable.")
+        return False
+
+    def __get_location_path(self, device_id: str) -> str:
+        location_path_output = self.__get_pnp_device_property(
             device_id=device_id,
             property_name="DEVPKEY_Device_LocationPaths",
-        )
-        location_path = location_path.strip().splitlines()[0]
-        self.log.debug(f"Device locationpath: {location_path}")
-        assert location_path.find("PCI") == 0, "Location path is wrong"
+        ).strip()
+        location_paths = location_path_output.splitlines()
+        if not location_paths:
+            raise LisaException(f"Location path is empty for device '{device_id}'")
 
+        location_path = location_paths[0]
+        self.log.debug(f"Device locationpath: {location_path}")
+        if not location_path.startswith("PCI"):
+            raise LisaException(
+                f"Location path is wrong for device '{device_id}': {location_path}"
+            )
+        return location_path
+
+    def __is_device_disabled(self, device_id: str) -> bool:
         cmd = (
             "(Get-PnpDevice -PresentOnly -InstanceId "
             f"'{device_id}').ConfigManagerErrorCode"
@@ -299,64 +470,81 @@ class HypervAssignableDevices:
             cmdlet=cmd,
             force_run=True,
             sudo=True,
-        )
-        conf_mng_err_code = conf_mng_err_code.strip()
+        ).strip()
         self.log.debug(f"ConfigManagerErrorCode: {conf_mng_err_code}")
-        if conf_mng_err_code == "CM_PROB_DISABLED":
+        if conf_mng_err_code.upper() in {"22", "CM_PROB_DISABLED"}:
             self.log.debug(
                 "Device is Disabled, unable to check resource requirements, "
                 "it may be assignable."
             )
             self.log.debug("Enable the device and rerun this script to confirm.")
+            return True
+        return False
+
+    def __get_allocated_resources(self, device_id: str) -> List[Dict[str, str]]:
+        escaped_device_id = device_id.replace("\\", "\\\\")
+        return [
+            resource
+            for resource in self.pnp_allocated_resources
+            if resource["Dependent"].find(escaped_device_id) >= 0
+        ]
+
+    def __has_assignable_interrupts(
+        self,
+        allocated_resources: List[Dict[str, str]],
+    ) -> bool:
+        if not allocated_resources:
+            self.log.debug("It has no interrupts at all -- assignment can work.")
+            return True
+
+        msi_assignments = [
+            resource
+            for resource in allocated_resources
+            if resource["Antecedent"].find("IRQNumber=42949") >= 0
+        ]
+        if not msi_assignments:
+            self.log.debug(
+                "All of the interrupts are line-based, no assignment can work."
+            )
+            return False
+
+        self.log.debug("Its interrupts are message-based, assignment can work.")
+        return True
+
+    def __get_total_mmio_in_mb(
+        self,
+        device_id: str,
+        allocated_resources: List[Dict[str, str]],
+    ) -> Optional[int]:
+        mmio_assignments = [
+            resource
+            for resource in allocated_resources
+            if resource["__RELPATH"].find("Win32_DeviceMemoryAddres") >= 0
+        ]
+        if not mmio_assignments:
             return None
 
-        irq_assignements = [
-            i
-            for i in self.pnp_allocated_resources
-            if i["Dependent"].find(device_id.replace("\\", "\\\\")) >= 0
-        ]
-        if irq_assignements:
-            msi_assignments = [
-                i
-                for i in self.pnp_allocated_resources
-                if i["Antecedent"].find("IRQNumber=42949") >= 0
-            ]
-            if not msi_assignments:
-                self.log.debug(
-                    "All of the interrupts are line-based, no assignment can work."
-                )
-                return None
-            else:
-                self.log.debug("Its interrupts are message-based, assignment can work.")
-        else:
-            self.log.debug("It has no interrupts at all -- assignment can work.")
-
-        mmio_assignments = [
-            i
-            for i in self.pnp_allocated_resources
-            if i["Dependent"].find(device_id.replace("\\", "\\\\")) >= 0
-            and i["__RELPATH"].find("Win32_DeviceMemoryAddres") >= 0
-        ]
         mmio_total = 0
-        if mmio_assignments:
-            for rec in mmio_assignments:
-                antecedent_val = rec["Antecedent"]
-                addresses = antecedent_val.split('"')
-                assert len(addresses) >= 2, "Antecedent: Can't get MMIO Start Address"
-                start_address = hex(int(addresses[1].strip())).upper()
-                start_address_hex = start_address.replace("X", "x")
-                end_address = self.__get_mmio_end_address(start_address_hex)
-                assert end_address, "Can not get MMIO End Address"
+        for resource in mmio_assignments:
+            mmio_total += self.__get_mmio_size(device_id, resource["Antecedent"])
 
-                mmio = int(end_address, 16) - int(start_address, 16)
-                mmio_total += mmio
-            if mmio_total:
-                mmio_total = round(mmio_total / (1024 * 1024))
-                self.log.debug(f"Device '{device_id}', Total MMIO = {mmio_total}MB ")
-        else:
-            self.log.debug("It has no MMIO space")
+        return round(mmio_total / (1024 * 1024))
 
-        device = DeviceAddressSchema()
-        device.location_path = location_path
-        device.instance_id = device_id
-        return device
+    def __get_mmio_size(self, device_id: str, antecedent_val: str) -> int:
+        addresses = antecedent_val.split('"')
+        if len(addresses) < 2:
+            raise LisaException(
+                "Antecedent does not contain a valid MMIO start address: "
+                f"{antecedent_val}"
+            )
+
+        start_address = int(addresses[1].strip())
+        end_address = self.__get_mmio_end_address(start_address)
+        if not end_address:
+            raise LisaException(
+                "Cannot get MMIO end address for device "
+                f"'{device_id}' and start address "
+                f"0x{start_address:016X}"
+            )
+
+        return int(end_address, 16) - start_address

--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from lisa.node import RemoteNode
 from lisa.sut_orchestrator.hyperv.get_assignable_devices import HypervAssignableDevices
@@ -12,7 +12,7 @@ from lisa.sut_orchestrator.hyperv.schema import (
 from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
 from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
 from lisa.tools import HyperV, PowerShell
-from lisa.util import ResourceAwaitableException
+from lisa.util import LisaException, ResourceAwaitableException
 from lisa.util.logger import Logger
 
 from .context import DevicePassthroughContext, NodeContext
@@ -52,6 +52,192 @@ class HyperVDevicePool(BaseDevicePool):
             vendor_id=vendor_id,
             device_id=device_id,
         )
+        self._append_devices_to_pool(pool_type=pool_type, devices=devices)
+
+    def create_device_pool_from_pci_addresses(
+        self,
+        pool_type: HostDevicePoolType,
+        pci_addr_list: List[str],
+    ) -> None:
+        raise LisaException(
+            "Hyper-V device pools do not support 'pci_bdf'. Use vendor_id/"
+            "device_id matching or 'location_path' for DDA selection."
+        )
+
+    def create_device_pool_from_location_paths(
+        self,
+        pool_type: HostDevicePoolType,
+        location_paths: List[str],
+    ) -> None:
+        self._restore_devices_to_host(location_paths)
+        hv_dev = HypervAssignableDevices(
+            host_node=self._server,
+            log=self.log,
+        )
+        devices = hv_dev.get_assignable_devices_by_location_paths(location_paths)
+        self._append_devices_to_pool(pool_type=pool_type, devices=devices)
+
+    def _restore_devices_to_host(self, location_paths: List[str]) -> None:
+        for location_path in location_paths:
+            normalized_path = location_path.strip()
+            if not normalized_path:
+                continue
+
+            self._restore_device_to_host(normalized_path)
+
+    def _restore_device_to_host(self, location_path: str) -> None:
+        powershell = self._server.tools[PowerShell]
+        hv = self._server.tools[HyperV]
+
+        assigned_vm_names = self._get_assigned_vm_names(location_path)
+        for vm_name in assigned_vm_names:
+            vm_state = self._get_vm_state(vm_name)
+            if vm_state and vm_state.lower() != "off":
+                self.log.info(
+                    f"Stopping VM '{vm_name}' to reclaim passthrough device "
+                    f"'{location_path}'"
+                )
+                hv.stop_vm(vm_name, is_graceful=False)
+
+            self.log.info(
+                f"Reclaiming passthrough device '{location_path}' from VM "
+                f"'{vm_name}'"
+            )
+            escaped_vm_name = vm_name.replace("'", "''")
+            escaped_location_path = location_path.replace("'", "''")
+            powershell.run_cmdlet(
+                cmdlet=(
+                    "Remove-VMAssignableDevice "
+                    f"-LocationPath '{escaped_location_path}' "
+                    f"-VMName '{escaped_vm_name}'"
+                ),
+                force_run=True,
+            )
+
+        escaped_location_path = location_path.replace("'", "''")
+        powershell.run_cmdlet(
+            cmdlet=(
+                "Mount-VMHostAssignableDevice "
+                f"-LocationPath '{escaped_location_path}'"
+            ),
+            force_run=True,
+            fail_on_error=False,
+        )
+
+        pnp_device = self._get_pnp_device_by_location_path(location_path)
+        if not pnp_device:
+            return
+
+        instance_id = str(pnp_device.get("InstanceId", "") or "").strip()
+        config_manager_error_code = str(
+            pnp_device.get("ConfigManagerErrorCode", "") or ""
+        ).strip()
+        if instance_id and self._is_pnp_device_disabled(config_manager_error_code):
+            self.log.info(
+                f"Enabling disabled host device '{instance_id}' for location "
+                f"path '{location_path}'"
+            )
+            escaped_instance_id = instance_id.replace("'", "''")
+            powershell.run_cmdlet(
+                cmdlet=(
+                    f"Enable-PnpDevice -InstanceId '{escaped_instance_id}' "
+                    "-Confirm:$false"
+                ),
+                force_run=True,
+            )
+
+    def _is_pnp_device_disabled(self, config_manager_error_code: Any) -> bool:
+        normalized_code = str(config_manager_error_code or "").strip().upper()
+        return normalized_code in {"22", "CM_PROB_DISABLED"}
+
+    def _get_assigned_vm_names(self, location_path: str) -> List[str]:
+        escaped_location_path = location_path.replace("'", "''")
+        powershell = self._server.tools[PowerShell]
+        stdout = powershell.run_cmdlet(
+            cmdlet=(
+                f"$target = '{escaped_location_path}'; "
+                "Get-VM | ForEach-Object { "
+                "$vmName = $_.Name; "
+                "if (Get-VMAssignableDevice -VMName $vmName -LocationPath $target "
+                "-ErrorAction SilentlyContinue) { "
+                "Write-Output $vmName "
+                "} "
+                "}"
+            ),
+            force_run=True,
+        )
+        return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+    def _get_vm_state(self, vm_name: str) -> str:
+        escaped_vm_name = vm_name.replace("'", "''")
+        powershell = self._server.tools[PowerShell]
+        state = powershell.run_cmdlet(
+            cmdlet=f"(Get-VM -Name '{escaped_vm_name}').State",
+            force_run=True,
+            fail_on_error=False,
+        )
+        return str(state or "").strip()
+
+    def _get_pnp_device_by_location_path(
+        self, location_path: str
+    ) -> Optional[Dict[str, Any]]:
+        escaped_location_path = location_path.replace("'", "''")
+        powershell = self._server.tools[PowerShell]
+        output: Any = powershell.run_cmdlet(
+            cmdlet=(
+                f"$target = '{escaped_location_path}'; "
+                "Get-PnpDevice -PresentOnly | "
+                "Where-Object {$_.InstanceId -like 'PCI\\*'} | "
+                "ForEach-Object { "
+                "$locationPathData = $null; "
+                "try { "
+                "$locationPathData = (Get-PnpDeviceProperty -InstanceId $_.InstanceId "
+                "'DEVPKEY_Device_LocationPaths' -ErrorAction Stop).Data; "
+                "} catch { } "
+                "$locationPaths = @(); "
+                "if ($locationPathData -is [System.Array]) { "
+                "$locationPaths = @($locationPathData); "
+                "} elseif ($null -ne $locationPathData) { "
+                "$locationPaths = @([string]$locationPathData); "
+                "} "
+                "if ($locationPaths -contains $target) { "
+                "[PSCustomObject]@{ "
+                "FriendlyName = $_.FriendlyName; "
+                "InstanceId = $_.InstanceId; "
+                "ConfigManagerErrorCode = $_.ConfigManagerErrorCode "
+                "} "
+                "} "
+                "}"
+            ),
+            force_run=True,
+            output_json=True,
+            fail_on_error=False,
+        )
+
+        if not output:
+            return None
+
+        if isinstance(output, list):
+            output_list = cast(List[Dict[str, Any]], output)
+            if len(output_list) > 1:
+                raise LisaException(
+                    "Multiple PnP devices matched Hyper-V location path "
+                    f"'{location_path}'"
+                )
+            if not output_list:
+                return None
+            output = output_list[0]
+
+        if not isinstance(output, dict):
+            return None
+
+        return cast(Dict[str, Any], output)
+
+    def _append_devices_to_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        devices: List[DeviceAddressSchema],
+    ) -> None:
         primary_nic_id_list = self.get_primary_nic_id()
         pool = self.available_host_devices.get(pool_type, [])
         for dev in devices:
@@ -84,24 +270,28 @@ class HyperVDevicePool(BaseDevicePool):
     ) -> None:
         vm_name = node_context.vm_name
         devices_ctx = node_context.passthrough_devices
-        confing_commands = []
+        escaped_vm_name = vm_name.replace("'", "''")
+        config_commands: List[str] = []
         for ctx in devices_ctx:
             for device in ctx.device_list:
-                confing_commands.append(
+                escaped_location_path = device.location_path.replace("'", "''")
+                escaped_instance_id = device.instance_id.replace("'", "''")
+                config_commands.append(
                     f"Remove-VMAssignableDevice "
-                    f"-LocationPath '{device.location_path}' -VMName '{vm_name}'"
+                    f"-LocationPath '{escaped_location_path}' "
+                    f"-VMName '{escaped_vm_name}'"
                 )
-                confing_commands.append(
+                config_commands.append(
                     f"Mount-VMHostAssignableDevice -LocationPath "
-                    f"'{device.location_path}'"
+                    f"'{escaped_location_path}'"
                 )
-                confing_commands.append(
-                    f"Enable-PnpDevice -InstanceId '{device.instance_id}' "
+                config_commands.append(
+                    f"Enable-PnpDevice -InstanceId '{escaped_instance_id}' "
                     "-Confirm:$false"
                 )
 
         powershell = self._server.tools[PowerShell]
-        for cmd in confing_commands:
+        for cmd in config_commands:
             powershell.run_cmdlet(
                 cmdlet=cmd,
                 force_run=True,
@@ -114,48 +304,75 @@ class HyperVDevicePool(BaseDevicePool):
         # Get the NIC name via IP.
         # We will get vEthernet switch interface name, not actual NIC for baremetal
         cmd = (
-            "(Get-NetAdapter | Get-NetIPAddress | Where-Object "
-            f"{{$_.IPAddress -eq '{ip}'}}).InterfaceAlias"
+            "(Get-NetIPAddress | Where-Object "
+            f"{{$_.IPAddress -eq '{ip}'}} | "
+            "Select-Object -First 1 -ExpandProperty InterfaceAlias)"
         )
         interface_name = powershell.run_cmdlet(
             cmdlet=cmd,
             force_run=True,
-        )
+        ).strip()
+        if not interface_name:
+            raise LisaException(
+                f"Could not find a Hyper-V management interface for IP '{ip}'"
+            )
+        escaped_interface_name = interface_name.replace("'", "''")
 
         # Get the MAC for above interface
         cmd = (
             "(Get-NetAdapter | Where-Object "
-            f"{{$_.Name -eq '{interface_name}'}}).MacAddress"
+            f"{{$_.Name -eq '{escaped_interface_name}'}} | "
+            "Select-Object -First 1 -ExpandProperty MacAddress)"
         )
         mac_address = powershell.run_cmdlet(
             cmdlet=cmd,
             force_run=True,
-        )
+        ).strip()
+        if not mac_address:
+            raise LisaException(
+                "Could not resolve the MAC address for Hyper-V management "
+                f"interface '{interface_name}'"
+            )
 
         # Get all interfaces for above MAC Address
         cmd = (
             "(Get-NetAdapter | Where-Object "
-            f"{{$_.MacAddress -eq '{mac_address}'}}).Name"
+            f"{{$_.MacAddress -eq '{mac_address}'}} | "
+            "Select-Object -ExpandProperty Name)"
         )
         inf_names_str = powershell.run_cmdlet(
             cmdlet=cmd,
             force_run=True,
         )
         inf_names: List[str] = inf_names_str.strip().splitlines()
+        if not inf_names:
+            raise LisaException(
+                "Could not resolve Hyper-V adapters that share the MAC address "
+                f"'{mac_address}'"
+            )
 
         # Get device id for all above interface names we got
         pnp_device_id_list: List[str] = []
         for name in inf_names:
+            escaped_name = name.replace("'", "''")
             cmd = (
                 "(Get-NetAdapter | Where-Object "
-                f"{{$_.Name -eq '{name}'}}).PnPDeviceID"
+                f"{{$_.Name -eq '{escaped_name}'}} | "
+                "Select-Object -First 1 -ExpandProperty PnPDeviceID)"
             )
             interface_device_id = powershell.run_cmdlet(
                 cmdlet=cmd,
                 force_run=True,
             )
             interface_device_id = interface_device_id.strip()
-            pnp_device_id_list.append(interface_device_id)
+            if interface_device_id:
+                pnp_device_id_list.append(interface_device_id)
+
+        if not pnp_device_id_list:
+            raise LisaException(
+                "Could not resolve any PnP device IDs for the Hyper-V management "
+                f"interface '{interface_name}'"
+            )
 
         return pnp_device_id_list
 
@@ -173,22 +390,26 @@ class HyperVDevicePool(BaseDevicePool):
         devices: List[DeviceAddressSchema],
     ) -> None:
         # Assign the devices to the VM
-        confing_commands = []
+        escaped_vm_name = vm_name.replace("'", "''")
+        config_commands: List[str] = []
         for device in devices:
-            confing_commands.append(
-                f"Disable-PnpDevice -InstanceId '{device.instance_id}' -Confirm:$false"
+            escaped_instance_id = device.instance_id.replace("'", "''")
+            escaped_location_path = device.location_path.replace("'", "''")
+            config_commands.append(
+                f"Disable-PnpDevice -InstanceId '{escaped_instance_id}' "
+                "-Confirm:$false"
             )
-            confing_commands.append(
+            config_commands.append(
                 f"Dismount-VMHostAssignableDevice -Force "
-                f"-LocationPath '{device.location_path}'"
+                f"-LocationPath '{escaped_location_path}'"
             )
-            confing_commands.append(
-                f"Add-VMAssignableDevice -LocationPath '{device.location_path}' "
-                f"-VMName '{vm_name}'"
+            config_commands.append(
+                f"Add-VMAssignableDevice -LocationPath '{escaped_location_path}' "
+                f"-VMName '{escaped_vm_name}'"
             )
 
         powershell = self._server.tools[PowerShell]
-        for cmd in confing_commands:
+        for cmd in config_commands:
             powershell.run_cmdlet(
                 cmdlet=cmd,
                 force_run=True,

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -4,13 +4,18 @@
 import re
 import xml.etree.ElementTree as ET  # noqa: N817
 from itertools import combinations
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Set, cast
 
 from lisa.node import Node, RemoteNode
 from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
 from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
 from lisa.tools import Ls, Lspci, Modprobe
-from lisa.util import LisaException, ResourceAwaitableException, find_group_in_lines
+from lisa.util import (
+    LisaException,
+    ResourceAwaitableException,
+    constants,
+    find_group_in_lines,
+)
 
 from .context import DevicePassthroughContext, NodeContext
 from .schema import (
@@ -146,7 +151,6 @@ class LibvirtDevicePool(BaseDevicePool):
             shell=True,
         )
         stdout = result.stdout.strip()
-        assert len(stdout.splitlines()) == 1
         pci_address_pattern = re.compile(
             r"/(?P<root>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
             r"(?P<id>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
@@ -169,10 +173,12 @@ class LibvirtDevicePool(BaseDevicePool):
             iommu_grp = self._get_device_iommu_group(device)
             return [iommu_grp]
         else:
-            raise LisaException(
-                f"Can't find pci address of for: {interface_name}, "
-                f"stdout for command: {stdout}"
+            self.host_node.log.debug(
+                f"Primary interface '{interface_name}' is not backed by a PCI "
+                f"device on the libvirt host; skipping primary NIC IOMMU "
+                f"exclusion. Sysfs lookup output: {stdout or '<empty>'}"
             )
+            return []
 
     def create_device_pool(
         self,
@@ -195,10 +201,19 @@ class LibvirtDevicePool(BaseDevicePool):
         pci_addr_list: List[str],
     ) -> None:
         self.available_host_devices[pool_type] = {}
-        for bdf in pci_addr_list:
-            domain, bus, slot, fn = self._parse_pci_address_str(bdf)
+        requested_bdfs = [bdf.strip() for bdf in pci_addr_list]
+        iommu_device_paths = self._get_iommu_group_device_paths()
+        allow_single_candidate_fallback = len(requested_bdfs) == 1
+        for requested_bdf in requested_bdfs:
+            resolved_bdf = self._resolve_requested_pci_address(
+                pool_type,
+                requested_bdf,
+                iommu_device_paths=iommu_device_paths,
+                allow_single_candidate_fallback=allow_single_candidate_fallback,
+            )
+            domain, bus, slot, fn = self._parse_pci_address_str(resolved_bdf)
             device = self._get_pci_address_instance(domain, bus, slot, fn)
-            iommu_group = self._get_device_iommu_group(device)
+            iommu_group = self._get_device_iommu_group(device, iommu_device_paths)
 
             # Strip the pool-key prefix to get the raw numeric id for sysfs.
             sysfs_iommu_group = (
@@ -213,9 +228,100 @@ class LibvirtDevicePool(BaseDevicePool):
                 i.strip().split("/")[-1]
                 for i in self.host_node.tools[Ls].list(iommu_path)
             ]
-            bdf_list.append(bdf.strip())
+            if resolved_bdf not in bdf_list:
+                bdf_list.append(resolved_bdf)
 
             self._create_pool(pool_type, bdf_list)
+
+    def resolve_requested_pci_address(
+        self,
+        pool_type: HostDevicePoolType,
+        requested_bdf: str,
+    ) -> str:
+        return self._resolve_requested_pci_address(pool_type, requested_bdf)
+
+    def _resolve_requested_pci_address(
+        self,
+        pool_type: HostDevicePoolType,
+        requested_bdf: str,
+        iommu_device_paths: Optional[List[str]] = None,
+        allow_single_candidate_fallback: bool = True,
+    ) -> str:
+        if iommu_device_paths is None:
+            iommu_device_paths = self._get_iommu_group_device_paths()
+        available_iommu_devices = [
+            line.strip().split("/")[-1] for line in iommu_device_paths if line.strip()
+        ]
+
+        if requested_bdf in available_iommu_devices:
+            return requested_bdf
+
+        candidates = self._get_passthrough_device_candidates(
+            pool_type, iommu_device_paths
+        )
+        if len(candidates) == 1 and allow_single_candidate_fallback:
+            resolved_bdf = candidates[0]
+            self.host_node.log.debug(
+                f"Requested PCI address '{requested_bdf}' was not found on the "
+                f"libvirt host; using the only available passthrough candidate "
+                f"'{resolved_bdf}' for pool type '{pool_type.value}'."
+            )
+            return resolved_bdf
+
+        if len(candidates) == 1:
+            raise LisaException(
+                f"Requested PCI address '{requested_bdf}' was not found on the "
+                f"libvirt host. Only one passthrough candidate '{candidates[0]}' "
+                f"is available for pool type '{pool_type.value}', but fallback "
+                "is disabled because multiple 'pci_bdf' values were configured "
+                "for this pool. Specify the nested or visible PCI BDFs "
+                "explicitly so each requested device maps unambiguously."
+            )
+
+        raise LisaException(
+            f"Requested PCI address '{requested_bdf}' was not found on the "
+            f"libvirt host. The PCI BDF inside L1 may differ from the original "
+            f"host BDF. Available passthrough candidates for pool type "
+            f"'{pool_type.value}': {', '.join(sorted(candidates)) or 'none'}. "
+            f"Available IOMMU devices: "
+            f"{', '.join(sorted(available_iommu_devices)) or 'none'}"
+        )
+
+    def _get_passthrough_device_candidates(
+        self,
+        pool_type: HostDevicePoolType,
+        iommu_device_paths: Optional[List[str]] = None,
+    ) -> List[str]:
+        lspci = self.host_node.tools[Lspci]
+        if pool_type == HostDevicePoolType.PCI_NIC:
+            pool_devices = lspci.get_devices_by_type(
+                constants.DEVICE_TYPE_SRIOV, force_run=True
+            )
+        elif pool_type == HostDevicePoolType.PCI_GPU:
+            pool_devices = lspci.get_gpu_devices(force_run=True)
+        else:
+            return []
+
+        primary_nic_iommu: Set[str] = (
+            set(self.get_primary_nic_id())
+            if pool_type == HostDevicePoolType.PCI_NIC
+            else set()
+        )
+        candidates: List[str] = []
+        for pool_device in pool_devices:
+            domain, bus, slot, fn = self._parse_pci_address_str(pool_device.slot)
+            device = self._get_pci_address_instance(domain, bus, slot, fn)
+            try:
+                iommu_group = self._get_device_iommu_group(device, iommu_device_paths)
+            except LisaException:
+                continue
+
+            if iommu_group in primary_nic_iommu:
+                continue
+
+            candidates.append(pool_device.slot)
+
+        return candidates
 
     def _create_pool(
         self,
@@ -379,9 +485,7 @@ class LibvirtDevicePool(BaseDevicePool):
             device_context.device_list = devices
             node_context.passthrough_devices.append(device_context)
 
-    def _get_device_iommu_group(self, device: DeviceAddressSchema) -> str:
-        iommu_pattern = re.compile(r"/sys/kernel/iommu_groups/(?P<id>\d+)/devices/.*")
-        device_id = self._get_pci_address_str(device)
+    def _get_iommu_group_device_paths(self) -> List[str]:
         command = "find /sys/kernel/iommu_groups/ -type l"
         err = "Command failed to list IOMMU Groups"
         result = self.host_node.execute(
@@ -391,9 +495,20 @@ class LibvirtDevicePool(BaseDevicePool):
             expected_exit_code=0,
             expected_exit_code_failure_message=err,
         )
+        return [line.strip() for line in result.stdout.strip().splitlines() if line]
+
+    def _get_device_iommu_group(
+        self,
+        device: DeviceAddressSchema,
+        iommu_device_paths: Optional[List[str]] = None,
+    ) -> str:
+        iommu_pattern = re.compile(r"/sys/kernel/iommu_groups/(?P<id>\d+)/devices/.*")
+        device_id = self._get_pci_address_str(device)
+        if iommu_device_paths is None:
+            iommu_device_paths = self._get_iommu_group_device_paths()
 
         iommu_grp = ""
-        for line in result.stdout.strip().splitlines():
+        for line in iommu_device_paths:
             if line.find(device_id) >= 0:
                 iommu_grp_res = find_group_in_lines(
                     lines=line,
@@ -401,5 +516,16 @@ class LibvirtDevicePool(BaseDevicePool):
                 )
                 iommu_grp = iommu_grp_res.get("id", "")
                 break
-        assert iommu_grp, f"Can not get IOMMU group for device: {device}"
+
+        if not iommu_grp:
+            available_iommu_devices = [
+                line.strip().split("/")[-1] for line in iommu_device_paths if line
+            ]
+            raise LisaException(
+                f"Can not get IOMMU group for device: {device}. Requested PCI "
+                f"address '{device_id}' was not found under "
+                "/sys/kernel/iommu_groups. Available IOMMU devices: "
+                f"{', '.join(sorted(available_iommu_devices)) or 'none'}"
+            )
+
         return f"iommu_grp_{iommu_grp}"

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -1,6 +1,7 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from lisa.sut_orchestrator.util.schema import (
+    DeviceLocationPathIdentifier,
     HostDevicePoolSchema,
     HostDevicePoolType,
     PciAddressIdentifier,
@@ -28,6 +29,20 @@ class BaseDevicePool:
     ) -> None:
         raise NotImplementedError()
 
+    def resolve_requested_pci_address(
+        self,
+        pool_type: HostDevicePoolType,
+        requested_bdf: str,
+    ) -> str:
+        return requested_bdf
+
+    def create_device_pool_from_location_paths(
+        self,
+        pool_type: HostDevicePoolType,
+        location_paths: List[str],
+    ) -> None:
+        raise NotImplementedError()
+
     def get_primary_nic_id(self) -> List[str]:
         raise NotImplementedError()
 
@@ -48,65 +63,162 @@ class BaseDevicePool:
         self,
         device_configs: Optional[List[HostDevicePoolSchema]],
     ) -> None:
-        if device_configs:
-            pool_types_from_runbook = [config.type for config in device_configs]
-            for pool_type in pool_types_from_runbook:
-                if pool_type not in self.supported_pool_type:
-                    raise LisaException(
-                        f"Pool type '{pool_type}' is not supported by platform"
-                    )
-            for config in device_configs:
-                devices = config.devices
-                if isinstance(devices, list) and all(
-                    isinstance(d, VendorDeviceIdIdentifier) for d in devices
-                ):
-                    if not devices:
-                        raise LisaException(
-                            "Device pool configuration has no vendor/device "
-                            "id entries for pool type"
-                        )
-                    if len(devices) > 1:
-                        raise LisaException(
-                            "Device Pool does not support more than one "
-                            "vendor/device id list for given pool type"
-                        )
+        if not device_configs:
+            return
 
-                    vendor_device_id = devices[0]
-                    vendor_id = vendor_device_id.vendor_id.strip()
-                    if not vendor_id:
-                        raise LisaException(
-                            "Device pool configuration has empty 'vendor_id'"
-                        )
-                    device_id = vendor_device_id.device_id.strip()
-                    if not device_id:
-                        raise LisaException(
-                            "Device pool configuration has empty 'device_id'"
-                        )
+        self._validate_supported_pool_types(device_configs)
+        for config in device_configs:
+            self._configure_passthrough_pool(config)
 
-                    self.create_device_pool(
-                        pool_type=config.type,
-                        vendor_id=vendor_id,
-                        device_id=device_id,
-                    )
-                elif isinstance(devices, (dict, PciAddressIdentifier)):
-                    if isinstance(devices, dict):
-                        if "pci_bdf" not in devices:
-                            raise LisaException(
-                                "Key not found in device configuration: 'pci_bdf'"
-                            )
-                        pci_addr_list: List[str] = devices["pci_bdf"]
-                    else:
-                        pci_addr_list = devices.pci_bdf
-                    if not pci_addr_list:
-                        raise LisaException(
-                            "PCI address list 'pci_bdf' must not be empty"
-                        )
-                    self.create_device_pool_from_pci_addresses(
-                        pool_type=config.type,
-                        pci_addr_list=pci_addr_list,
-                    )
-                else:
-                    raise LisaException(
-                        f"Unknown device identifier of type: {type(devices)}"
-                        f", value: {devices}"
-                    )
+    def _validate_supported_pool_types(
+        self,
+        device_configs: List[HostDevicePoolSchema],
+    ) -> None:
+        for config in device_configs:
+            if config.type not in self.supported_pool_type:
+                raise LisaException(
+                    f"Pool type '{config.type}' is not supported by platform"
+                )
+
+    def _configure_passthrough_pool(self, config: HostDevicePoolSchema) -> None:
+        devices = config.devices
+        if self._is_vendor_device_id_list(devices):
+            vendor_device_list = cast(List[VendorDeviceIdIdentifier], devices)
+            self._configure_vendor_device_id_pool(config, vendor_device_list)
+            return
+
+        if isinstance(
+            devices,
+            (dict, PciAddressIdentifier, DeviceLocationPathIdentifier),
+        ):
+            self._configure_identifier_pool(config, devices)
+            return
+
+        raise LisaException(
+            f"Unknown device identifier of type: {type(devices)}" f", value: {devices}"
+        )
+
+    def _is_vendor_device_id_list(self, devices: Any) -> bool:
+        return isinstance(devices, list) and all(
+            isinstance(device, VendorDeviceIdIdentifier) for device in devices
+        )
+
+    def _configure_vendor_device_id_pool(
+        self,
+        config: HostDevicePoolSchema,
+        devices: List[VendorDeviceIdIdentifier],
+    ) -> None:
+        if not devices:
+            raise LisaException(
+                "Device pool configuration has no vendor/device "
+                "id entries for pool type"
+            )
+        if len(devices) > 1:
+            raise LisaException(
+                "Device Pool does not support more than one "
+                "vendor/device id list for given pool type"
+            )
+
+        vendor_device_id = devices[0]
+        vendor_id = vendor_device_id.vendor_id.strip()
+        if not vendor_id:
+            raise LisaException("Device pool configuration has empty 'vendor_id'")
+
+        device_id = vendor_device_id.device_id.strip()
+        if not device_id:
+            raise LisaException("Device pool configuration has empty 'device_id'")
+
+        self.create_device_pool(
+            pool_type=config.type,
+            vendor_id=vendor_id,
+            device_id=device_id,
+        )
+
+    def _configure_identifier_pool(
+        self,
+        config: HostDevicePoolSchema,
+        devices: Any,
+    ) -> None:
+        if isinstance(devices, dict):
+            self._configure_dict_identifier_pool(config, devices)
+        elif isinstance(devices, PciAddressIdentifier):
+            self.create_device_pool_from_pci_addresses(
+                pool_type=config.type,
+                pci_addr_list=self._normalize_pci_address_list(devices.pci_bdf),
+            )
+        else:
+            self.create_device_pool_from_location_paths(
+                pool_type=config.type,
+                location_paths=self._normalize_location_path_list(
+                    devices.location_path
+                ),
+            )
+
+    def _configure_dict_identifier_pool(
+        self,
+        config: HostDevicePoolSchema,
+        devices: Dict[str, Any],
+    ) -> None:
+        if "pci_bdf" in devices:
+            self.create_device_pool_from_pci_addresses(
+                pool_type=config.type,
+                pci_addr_list=self._normalize_pci_address_list(devices["pci_bdf"]),
+            )
+            return
+
+        if "location_path" in devices:
+            self.create_device_pool_from_location_paths(
+                pool_type=config.type,
+                location_paths=self._normalize_location_path_list(
+                    devices["location_path"]
+                ),
+            )
+            return
+
+        raise LisaException(
+            "Key not found in device configuration: expected "
+            "'pci_bdf' or 'location_path'"
+        )
+
+    def _normalize_pci_address_list(self, pci_addr_value: Any) -> List[str]:
+        return self._normalize_string_list(
+            raw_value=pci_addr_value,
+            field_name="PCI address list 'pci_bdf'",
+        )
+
+    def _normalize_location_path_list(self, location_path_value: Any) -> List[str]:
+        return self._normalize_string_list(
+            raw_value=location_path_value,
+            field_name="Location path list 'location_path'",
+        )
+
+    def _normalize_string_list(self, raw_value: Any, field_name: str) -> List[str]:
+        if raw_value is None:
+            raise LisaException(f"{field_name} must not be null")
+
+        if isinstance(raw_value, str):
+            raw_values = [raw_value]
+        else:
+            try:
+                raw_values = list(raw_value)
+            except TypeError as identifier_error:
+                raise LisaException(
+                    f"{field_name} must be a string or an iterable of strings"
+                ) from identifier_error
+
+        normalized_values: List[str] = []
+        for raw_item in raw_values:
+            if not isinstance(raw_item, str):
+                raise LisaException(
+                    f"{field_name} must contain only strings; got "
+                    f"{type(raw_item).__name__}"
+                )
+
+            normalized_item = raw_item.strip()
+            if normalized_item:
+                normalized_values.append(normalized_item)
+
+        if not normalized_values:
+            raise LisaException(f"{field_name} must not be empty")
+
+        return normalized_values

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -24,14 +24,23 @@ class PciAddressIdentifier:
     pci_bdf: List[str] = field(default_factory=list)
 
 
+@dataclass_json()
+@dataclass
+class DeviceLocationPathIdentifier:
+    # List of Hyper-V DDA location paths like PCIROOT(20)#PCI(0300)#PCI(0000)
+    location_path: List[str] = field(default_factory=list)
+
+
 # Configuration options for device-passthrough for the VM.
 @dataclass_json()
 @dataclass
 class HostDevicePoolSchema:
     type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
-    devices: Union[List[VendorDeviceIdIdentifier], PciAddressIdentifier] = field(
-        default_factory=lambda: cast(List[VendorDeviceIdIdentifier], [])
-    )
+    devices: Union[
+        List[VendorDeviceIdIdentifier],
+        PciAddressIdentifier,
+        DeviceLocationPathIdentifier,
+    ] = field(default_factory=lambda: cast(List[VendorDeviceIdIdentifier], []))
 
 
 @dataclass_json()


### PR DESCRIPTION
Add location_path handling for Hyper-V DDA pool selection and recover assigned or disabled host devices before reuse.

Improve libvirt PCI passthrough handling by resolving requested BDFs to visible nested devices, tolerating non-PCI management NICs, and reusing that resolution in device passthrough validation for BDF-only pools.

Also harden passthrough runbook parsing by ignoring blank pci_bdf entries and make host/guest network passthrough cleanup skip unsupported Windows baremetal hosts while reducing noisy NIC selection logs.