### PR TITLE
BugFix: Raise on unexpected zypper exit codes in _install_packages

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2410,9 +2410,10 @@ class Suse(Linux):
         elif install_result.exit_code == 0:
             self._log.debug(f"{packages} is/are installed successfully.")
         else:
-            self._log.debug(
-                f"{packages} is/are installed."
-                " A system reboot or package manager restart might be required."
+            raise LisaException(
+                f"Failed to install {packages}. "
+                f"Unexpected exit_code: {install_result.exit_code}, "
+                f"stderr: {install_result.stderr}"
             )
 
     def _update_packages(self, packages: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
The else branch in Suse._install_packages silently logged 'packages is/are installed' for any zypper exit code not in {0, 1, 4, 100}, masking installation failures (e.g. when a package is not found in repos). Now raises LisaException for unexpected exit codes instead of silently continuing.