### PR TITLE
BugFix: Skip azsecpack test for unsupported distros

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/azsecpack.py
+++ b/lisa/microsoft/testsuites/vm_extensions/azsecpack.py
@@ -380,3 +380,10 @@ class AzSecPack(TestSuite):
                             node.os, "AzSecPack doesn't support this Distro version."
                         )
                     )
+                return
+
+        raise SkippedException(
+            UnsupportedDistroException(
+                node.os, "AzSecPack doesn't support this distro."
+            )
+        )


### PR DESCRIPTION
The _is_supported() method only rejected known distros with wrong versions but silently allowed distros not in the supported list (e.g. SLES on ARM64). Added early return for valid distro+version and a fallthrough SkippedException for unlisted distros.