### PR TITLE
BugFix: Compare disks by name in hot_add_disk tests

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -817,10 +817,11 @@ class Storage(TestSuite):
             # verify that partition count is increased by 1
             # and the size of partition is correct
             partitons_after_adding_disk = lsblk.get_disks(force_run=True)
+            before_names = {d.name for d in partitions_before_adding_disk}
             added_partitions = [
                 item
                 for item in partitons_after_adding_disk
-                if item not in partitions_before_adding_disk
+                if item.name not in before_names
             ]
             log.debug(f"added_partitions: {added_partitions}")
             assert_that(added_partitions, "Data disk should be added").is_length(
@@ -853,10 +854,11 @@ class Storage(TestSuite):
 
         # verify that all the attached disks are removed
         partitions_after_removing_disks = lsblk.get_disks(force_run=True)
+        after_names = {d.name for d in partitions_after_removing_disks}
         partitions_available = [
             item
             for item in partitions_before_adding_disk
-            if item not in partitions_after_removing_disks
+            if item.name not in after_names
         ]
         assert_that(partitions_available, "data disks should not be present").is_length(
             0
@@ -903,10 +905,11 @@ class Storage(TestSuite):
         timer = create_timer()
         while timeout > timer.elapsed(False):
             partitons_after_adding_disks = lsblk.get_disks(force_run=True)
+            before_names = {d.name for d in partitions_before_adding_disks}
             added_partitions = [
                 item
                 for item in partitons_after_adding_disks
-                if item not in partitions_before_adding_disks
+                if item.name not in before_names
             ]
             if len(added_partitions) == disks_to_add:
                 break
@@ -928,10 +931,11 @@ class Storage(TestSuite):
 
         # verify that partition count is decreased by disks_to_add
         partition_after_removing_disk = lsblk.get_disks(force_run=True)
+        after_names = {d.name for d in partition_after_removing_disk}
         added_partitions = [
             item
             for item in partitions_before_adding_disks
-            if item not in partition_after_removing_disk
+            if item.name not in after_names
         ]
         assert_that(added_partitions, "data disks should not be present").is_length(0)
 

--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -831,10 +831,11 @@ class Storage(TestSuite):
             # verify that partition count is increased by 1
             # and the size of partition is correct
             partitons_after_adding_disk = lsblk.get_disks(force_run=True)
+            before_names = {d.name for d in partitions_before_adding_disk}
             added_partitions = [
                 item
                 for item in partitons_after_adding_disk
-                if item not in partitions_before_adding_disk
+                if item.name not in before_names
             ]
             log.debug(f"added_partitions: {added_partitions}")
             assert_that(added_partitions, "Data disk should be added").is_length(
@@ -897,10 +898,11 @@ class Storage(TestSuite):
 
         # verify that all the attached disks are removed
         partitions_after_removing_disks = lsblk.get_disks(force_run=True)
+        after_names = {d.name for d in partitions_after_removing_disks}
         partitions_available = [
             item
             for item in partitions_before_adding_disk
-            if item not in partitions_after_removing_disks
+            if item.name not in after_names
         ]
         assert_that(partitions_available, "data disks should not be present").is_length(
             0
@@ -947,10 +949,11 @@ class Storage(TestSuite):
         timer = create_timer()
         while timeout > timer.elapsed(False):
             partitons_after_adding_disks = lsblk.get_disks(force_run=True)
+            before_names = {d.name for d in partitions_before_adding_disks}
             added_partitions = [
                 item
                 for item in partitons_after_adding_disks
-                if item not in partitions_before_adding_disks
+                if item.name not in before_names
             ]
             if len(added_partitions) == disks_to_add:
                 break
@@ -972,10 +975,11 @@ class Storage(TestSuite):
 
         # verify that partition count is decreased by disks_to_add
         partition_after_removing_disk = lsblk.get_disks(force_run=True)
+        after_names = {d.name for d in partition_after_removing_disk}
         added_partitions = [
             item
             for item in partitions_before_adding_disks
-            if item not in partition_after_removing_disk
+            if item.name not in after_names
         ]
         assert_that(added_partitions, "data disks should not be present").is_length(0)
 


### PR DESCRIPTION
## Summary

Fixes false failures in all hot_add_disk test cases on Azure Linux 3.

## Root Cause

`DiskInfo` is a `@dataclass` so its auto-generated `__eq__` compares ALL fields including `mountpoint`. On Azure Linux 3, the EFI boot partition auto-unmounts when idle, causing the before/after disk comparison to see unchanged disks as "new".

## Fix

Changed all 4 comparison sites in `_hot_add_disk_serial` and `_hot_add_disk_parallel` to use name-based comparison (`item.name not in before_names`) instead of full dataclass equality.

## Validation

- `verify_hot_add_disk_serial` PASSED on Azure Linux 3 / Standard_D2ds_v5 / westus3