### PR TITLE
DPDK: Add symmetric_mp hotplug test

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -147,6 +147,7 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
         ),
+        timeout=1200,
     )
     def verify_dpdk_symmetric_mp_hotplug(
         self,
@@ -155,7 +156,35 @@ class Dpdk(TestSuite):
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        run_dpdk_symmetric_mp(node, log, variables, trigger_hotplug=True)
+        run_dpdk_symmetric_mp(
+            node, log, variables, trigger_hotplug=True, hotplug_times=10
+        )
+
+    @TestCaseMetadata(
+        description="""
+            netvsc pmd version.
+            This test case checks dpdk symmetic mp app, plus an sriov hotplug.
+            More details refer https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#prerequisites # noqa: E501
+        """,
+        priority=4,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+        timeout=6000,
+    )
+    def stress_dpdk_symmetric_mp_hotplug(
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        run_dpdk_symmetric_mp(
+            node, log, variables, trigger_hotplug=True, hotplug_times=100
+        )
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -147,7 +147,7 @@ class Dpdk(TestSuite):
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
         ),
-        timeout=1200,
+        timeout=600,
     )
     def verify_dpdk_symmetric_mp_hotplug(
         self,
@@ -157,7 +157,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         run_dpdk_symmetric_mp(
-            node, log, variables, trigger_hotplug=True, hotplug_times=10
+            node, log, variables, trigger_hotplug=True, hotplug_times=3
         )
 
     @TestCaseMetadata(
@@ -183,7 +183,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         run_dpdk_symmetric_mp(
-            node, log, variables, trigger_hotplug=True, hotplug_times=100
+            node, log, variables, trigger_hotplug=True, hotplug_times=40
         )
 
     @TestCaseMetadata(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -136,6 +136,29 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
+            netvsc pmd version.
+            This test case checks dpdk symmetic mp app, plus an sriov hotplug.
+            More details refer https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#prerequisites # noqa: E501
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=3,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+        ),
+    )
+    def verify_dpdk_symmetric_mp_hotplug(
+        self,
+        node: Node,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        run_dpdk_symmetric_mp(node, log, variables, trigger_hotplug=True)
+
+    @TestCaseMetadata(
+        description="""
             netvsc pmd version with 1GiB hugepages
             This test case checks DPDK can be built and installed correctly.
             Prerequisites, accelerated networking must be enabled.

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -137,7 +137,7 @@ class Dpdk(TestSuite):
     @TestCaseMetadata(
         description="""
             netvsc pmd version.
-            This test case checks dpdk symmetic mp app, plus an sriov hotplug.
+            This test case checks dpdk symmetric mp app, plus an sriov hotplug.
             More details refer https://docs.microsoft.com/en-us/azure/virtual-network/setup-dpdk#prerequisites # noqa: E501
         """,
         priority=2,

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -157,7 +157,7 @@ class Dpdk(TestSuite):
         result: TestResult,
     ) -> None:
         run_dpdk_symmetric_mp(
-            node, log, variables, trigger_hotplug=True, hotplug_times=3
+            node, log, variables, trigger_hotplug=True, hotplug_times=1
         )
 
     @TestCaseMetadata(

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1718,6 +1718,8 @@ def run_dpdk_symmetric_mp(
     - count packets received on tx/rx side of each process and port
 
     """
+
+    test_timeout = 60 * hotplug_times if trigger_hotplug else 35
     # setup and unwrap the resources for this test
     # get a list of the upper non-primary nics and select two of them
     test_nics = [
@@ -1790,9 +1792,9 @@ def run_dpdk_symmetric_mp(
             f"{str(symmetric_mp_path)} -l 1 --proc-type auto "
             f"{symmetric_mp_args} --proc-id 0"
         ),
-        timeout=1200,
+        timeout=test_timeout,
         signal=SIGINT,
-        kill_timeout=1200,
+        kill_timeout=test_timeout + 5,
     )
 
     # wait for it to start
@@ -1804,9 +1806,9 @@ def run_dpdk_symmetric_mp(
             f"{str(symmetric_mp_path)} -l 2 --proc-type secondary "
             f"{symmetric_mp_args} --proc-id 1"
         ),
-        timeout=600,
+        timeout=test_timeout,
         signal=SIGINT,
-        kill_timeout=1200,
+        kill_timeout=test_timeout + 5,
     )
     secondary.wait_output("APP: Finished Process Init", timeout=20)
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1790,9 +1790,9 @@ def run_dpdk_symmetric_mp(
             f"{str(symmetric_mp_path)} -l 1 --proc-type auto "
             f"{symmetric_mp_args} --proc-id 0"
         ),
-        timeout=660,
+        timeout=1200,
         signal=SIGINT,
-        kill_timeout=30,
+        kill_timeout=1200,
     )
 
     # wait for it to start
@@ -1806,7 +1806,7 @@ def run_dpdk_symmetric_mp(
         ),
         timeout=600,
         signal=SIGINT,
-        kill_timeout=35,
+        kill_timeout=1200,
     )
     secondary.wait_output("APP: Finished Process Init", timeout=20)
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1845,7 +1845,7 @@ def run_dpdk_symmetric_mp(
                 "Device notification type=1",  # RTE_DEV_EVENT_REMOVE
                 delta_only=True,
             )  # relying on compiler defaults here, not great.
-
+            sleep(1)
             # turn SRIOV on
             node.features[NetworkInterface].switch_sriov(
                 enable=True, wait=False, reset_connections=False

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -478,7 +478,7 @@ def initialize_node_resources(
     hugepages = node.tools[Hugepages]
     numa_nodes = node.tools[Lscpu].get_numa_node_count()
     try:
-        hugepages.init_hugepages(hugepage_size, minimum_gb=8 * numa_nodes)
+        hugepages.init_hugepages(hugepage_size, minimum_gb=4 * numa_nodes)
     except NotEnoughMemoryException as err:
         raise SkippedException(err)
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -95,6 +95,7 @@ from lisa.util import (
     generate_random_chars,
     get_matched_str,
     set_filtered_fields,
+    sleep,
 )
 
 if TYPE_CHECKING:
@@ -1008,6 +1009,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     f"now set its status into [{enable}]."
                 )
                 updated_nic.enable_accelerated_networking = enable
+
                 network_client.network_interfaces.begin_create_or_update(
                     self._resource_group_name, updated_nic.name, updated_nic
                 )
@@ -1019,6 +1021,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     f"networking into status [{enable}]"
                 ).is_equal_to(enable)
                 status_changed = True
+                sleep(0.5)
 
         # wait settings effective
         if wait and status_changed:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1010,18 +1010,15 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                 )
                 updated_nic.enable_accelerated_networking = enable
 
-                network_client.network_interfaces.begin_create_or_update(
+                poller = network_client.network_interfaces.begin_create_or_update(
                     self._resource_group_name, updated_nic.name, updated_nic
                 )
-                updated_nic = network_client.network_interfaces.get(
-                    self._resource_group_name, nic_name
-                )
+                updated_nic = poller.result()
                 assert_that(updated_nic.enable_accelerated_networking).described_as(
                     f"fail to set network interface {nic_name}'s accelerated "
                     f"networking into status [{enable}]"
                 ).is_equal_to(enable)
                 status_changed = True
-                sleep(0.5)
 
         # wait settings effective
         if wait and status_changed:


### PR DESCRIPTION
Adds the dpdk symmetric_mp test with hotplugging, stress and regular.

Passing this test on MANA is unreliable without some patches from Long Li. These have merged into dpdk-next-net and will make their way into the next release.
https://git.dpdk.org/next/dpdk-next-net/commit/?id=ea9d4ee993eec0123b0e1cd227cb5743876ae677

This test will fail all versions below the next release 26.07. I have a seperate patch for LISA's pipeline which will allow testing upstream versions of DPDK easily; this will be required for running validation on this test.