### PR TITLE
CUDA installation fix for Ubuntu1604

### DIFF
--- a/lisa/tools/gpu_drivers.py
+++ b/lisa/tools/gpu_drivers.py
@@ -481,10 +481,11 @@ class NvidiaCudaDriver(GpuDriver):
 
             assert isinstance(self.node.os, Ubuntu), "Ubuntu installation expected"
 
-            # Install CUDA keyring
+            # Install CUDA keyring from NVIDIA repository
+            # https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/
             cuda_keyring_url = (
                 f"{self.NVIDIA_CUDA_REPO_BASE_URL}/"
-                f"ubuntu{release}/x86_64/cuda-keyring_1.1-1_all.deb"
+                f"ubuntu{release}/x86_64/cuda-keyring_1.0-1_all.deb"
             )
             self.node.os.install_package_from_url(
                 cuda_keyring_url,


### PR DESCRIPTION
cuda-keyring_1.1-1_all.deb for Ubuntu 1604 is not available at given url. Modified it to cuda-keyring_1.0-1_all.deb which is available on path.