### PR TITLE
Reload netvsc 3 times should be enough

### DIFF
--- a/lisa/microsoft/testsuites/network/netinterface.py
+++ b/lisa/microsoft/testsuites/network/netinterface.py
@@ -30,7 +30,7 @@ from lisa.util import perf_timer
     """,
 )
 class NetInterface(TestSuite):
-    NETVSC_RELOAD_TEST_COUNT = 10
+    NETVSC_RELOAD_TEST_COUNT = 3
     NET_INTERFACE_RELOAD_TEST_COUNT = 4
     DHCLIENT_TIMEOUT = 15
 


### PR DESCRIPTION
If there is a kernel issue, the module reload test typically fails on the first run, so running it once is usually sufficient. Running it three times is only for additional confidence. Running it ten times is unnecessary, as it significantly increases the test duration, and most failures that occur only after many reloads are not real issues.