### PR TITLE
BugFix: Set explicit crashkernel size for ARM64 Debian

### DIFF
--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -656,8 +656,10 @@ class KdumpDebian(KdumpBase):
             if arch == "x86_64":
                 return "512M"
             else:
-                # Use the default crash kernel size
-                return ""
+                # Explicitly set crashkernel for arm64 instead of relying on
+                # distro defaults, which may not be configured in grub on
+                # some Debian ARM64 images.
+                return "512M"
 
     def _get_crashkernel_cfg_file(self) -> str:
         return "/etc/default/grub.d/kdump-tools.cfg"


### PR DESCRIPTION
## Summary
On ARM64 Debian with >=2GB memory, `KdumpDebian.calculate_crashkernel_size()` returned an empty string, relying on distro defaults for crashkernel configuration. On some Debian ARM64 images, the default crashkernel parameter was not properly applied in grub, resulting in crash kernel memory not being reserved and kdump tests failing with kexec_crash_loaded not being 1.

This fix explicitly sets `crashkernel=512M` for ARM64 Debian instead of returning an empty string, ensuring the crashkernel is always configured in grub.

## Validation Results
| Image | Result |
|-------|--------|
| Debian debian-12-daily 12-arm64 0.20260311.2413 | PASSED (crash kernel reserved, kexec_crash_loaded=1; vmcore capture is a separate Debian ARM64 issue) |