### PR TITLE
[AI Generated] BugFix: compute ringbuffer tolerance from PAGE_SIZE

### DIFF
--- a/lisa/microsoft/testsuites/network/networksettings.py
+++ b/lisa/microsoft/testsuites/network/networksettings.py
@@ -119,7 +119,14 @@ class NetworkSettings(TestSuite):
         # systems with 64 KiB pages (common on ARM64) the delta can be
         # much larger than the old hard-coded ±5.  Compute a tolerance
         # based on the real page size: ceil(PAGE_SIZE / section_size).
-        page_size = int(node.execute("getconf PAGE_SIZE", shell=True).stdout)
+        page_size_result = node.execute(
+            "getconf PAGE_SIZE",
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "Failed to determine PAGE_SIZE using 'getconf PAGE_SIZE'"
+            ),
+        )
+        page_size = int(page_size_result.stdout.strip())
         # ceil division: -(-a // b) == ceil(a / b)
         rx_tolerance = -(-page_size // NETVSC_RECV_SECTION_SIZE)
         tx_tolerance = -(-page_size // NETVSC_SEND_SECTION_SIZE)

--- a/lisa/microsoft/testsuites/network/networksettings.py
+++ b/lisa/microsoft/testsuites/network/networksettings.py
@@ -110,6 +110,18 @@ class NetworkSettings(TestSuite):
         except UnsupportedOperationException as e:
             raise SkippedException(e)
 
+        # The netvsc driver rounds buffer sizes up to PAGE_SIZE, so the
+        # actual section count can differ from the requested value.  On
+        # systems with 64 KiB pages (common on ARM64) the delta can be
+        # much larger than the old hard-coded ±5.  Compute a tolerance
+        # based on the real page size: ceil(PAGE_SIZE / section_size).
+        NETVSC_RECV_SECTION_SIZE = 1728
+        NETVSC_SEND_SECTION_SIZE = 6144
+        page_size = int(node.execute("getconf PAGE_SIZE", shell=True).stdout)
+        # ceil division: -(-a // b) == ceil(a / b)
+        rx_tolerance = -(-page_size // NETVSC_RECV_SECTION_SIZE)
+        tx_tolerance = -(-page_size // NETVSC_SEND_SECTION_SIZE)
+
         for interface_settings in devices_settings:
             interface = interface_settings.device_name
             original_rx = int(interface_settings.current_ring_buffer_settings["RX"])
@@ -144,7 +156,7 @@ class NetworkSettings(TestSuite):
                 interface, expected_rx, expected_tx
             )
 
-            # The buffer size gets rounded up per PAGE_size
+            # The buffer size gets rounded up per PAGE_SIZE
             # so the expected_rx and expected_tx can vary in a range
             #  /* Get receive buffer area. */
             # buf_size = device_info->recv_sections * device_info->recv_section_size;
@@ -156,11 +168,15 @@ class NetworkSettings(TestSuite):
             assert_that(
                 int(actual_settings.current_ring_buffer_settings["RX"]),
                 "Changing RX Ringbuffer setting didn't succeed",
-            ).is_between(expected_rx - 5, expected_rx + 5)
+            ).is_between(
+                expected_rx - rx_tolerance, expected_rx + rx_tolerance
+            )
             assert_that(
                 int(actual_settings.current_ring_buffer_settings["TX"]),
                 "Changing TX Ringbuffer setting didn't succeed",
-            ).is_between(expected_tx - 5, expected_rx + 5)
+            ).is_between(
+                expected_tx - tx_tolerance, expected_tx + tx_tolerance
+            )
 
             # Revert the settings back to original values
             reverted_settings = ethtool.change_device_ring_buffer_settings(

--- a/lisa/microsoft/testsuites/network/networksettings.py
+++ b/lisa/microsoft/testsuites/network/networksettings.py
@@ -30,6 +30,10 @@ from lisa.operating_system import BSD, Debian, Redhat, Suse, Ubuntu, Windows
 from lisa.tools import Ethtool, Iperf3, KernelConfig, Ls, Modinfo, Nm
 from lisa.util import parse_version
 
+# section sizes for netvsc buffers in bytes (from netvsc driver)
+NETVSC_RECV_SECTION_SIZE = 1728
+NETVSC_SEND_SECTION_SIZE = 6144
+
 
 @TestSuiteMetadata(
     area="network",
@@ -115,8 +119,6 @@ class NetworkSettings(TestSuite):
         # systems with 64 KiB pages (common on ARM64) the delta can be
         # much larger than the old hard-coded ±5.  Compute a tolerance
         # based on the real page size: ceil(PAGE_SIZE / section_size).
-        NETVSC_RECV_SECTION_SIZE = 1728
-        NETVSC_SEND_SECTION_SIZE = 6144
         page_size = int(node.execute("getconf PAGE_SIZE", shell=True).stdout)
         # ceil division: -(-a // b) == ceil(a / b)
         rx_tolerance = -(-page_size // NETVSC_RECV_SECTION_SIZE)
@@ -135,8 +137,12 @@ class NetworkSettings(TestSuite):
             # Send Buffer, TX
             # NETVSC_SEND_BUFFER_DEFAULT =  (1024 * 1024 * 1)
             # NETVSC_SEND_SECTION_SIZE = 6144
-            original_rxbuffer = round((original_rx * 1728) / (1024 * 1024))
-            original_txbuffer = round((original_tx * 6144) / (1024 * 1024))
+            original_rxbuffer = round(
+                (original_rx * NETVSC_RECV_SECTION_SIZE) / (1024 * 1024)
+            )
+            original_txbuffer = round(
+                (original_tx * NETVSC_SEND_SECTION_SIZE) / (1024 * 1024)
+            )
 
             rxbuffer = (
                 (original_rxbuffer - 2)
@@ -150,8 +156,8 @@ class NetworkSettings(TestSuite):
                 else (original_txbuffer + 2)
             )
 
-            expected_rx = int((rxbuffer * 1024 * 1024) / 1728)
-            expected_tx = int((txbuffer * 1024 * 1024) / 6144)
+            expected_rx = int((rxbuffer * 1024 * 1024) / NETVSC_RECV_SECTION_SIZE)
+            expected_tx = int((txbuffer * 1024 * 1024) / NETVSC_SEND_SECTION_SIZE)
             actual_settings = ethtool.change_device_ring_buffer_settings(
                 interface, expected_rx, expected_tx
             )
@@ -168,15 +174,11 @@ class NetworkSettings(TestSuite):
             assert_that(
                 int(actual_settings.current_ring_buffer_settings["RX"]),
                 "Changing RX Ringbuffer setting didn't succeed",
-            ).is_between(
-                expected_rx - rx_tolerance, expected_rx + rx_tolerance
-            )
+            ).is_between(expected_rx - rx_tolerance, expected_rx + rx_tolerance)
             assert_that(
                 int(actual_settings.current_ring_buffer_settings["TX"]),
                 "Changing TX Ringbuffer setting didn't succeed",
-            ).is_between(
-                expected_tx - tx_tolerance, expected_tx + tx_tolerance
-            )
+            ).is_between(expected_tx - tx_tolerance, expected_tx + tx_tolerance)
 
             # Revert the settings back to original values
             reverted_settings = ethtool.change_device_ring_buffer_settings(


### PR DESCRIPTION
## Summary

The netvsc driver rounds buffer sizes up to `PAGE_SIZE`, causing the actual RX/TX section count to differ from the requested value. On ARM64 systems with 64 KiB pages, the delta can be up to `ceil(65536/1728) = 38` for RX and `ceil(65536/6144) = 11` for TX, which exceeds the previous hard-coded tolerance of ±5.

This PR:
- Queries the guest `PAGE_SIZE` via `getconf PAGE_SIZE`
- Computes tolerance dynamically: `ceil(PAGE_SIZE / section_size)`
- Fixes a copy-paste typo in the TX assertion that used `expected_rx` instead of `expected_tx`

## Validation Results

| Image | Result |
|-------|--------|
| almalinux almalinux-arm 10-arm64-64k-gen2 latest (64K pages) | PASSED |
| canonical ubuntu-24_04-lts server-arm64 latest (4K pages) | PASSED |
| almalinux almalinux-arm 9-arm-gen2 latest (4K pages, pre-fix baseline) | PASSED |