### PR TITLE
'verify_cdrom_device_status_code' install issues fix for Ubuntu2510+

### DIFF
--- a/lisa/microsoft/testsuites/cdrom/cdrom.py
+++ b/lisa/microsoft/testsuites/cdrom/cdrom.py
@@ -6,7 +6,7 @@ from typing import Any
 from assertpy import assert_that
 
 from lisa import Node, SkippedException, TestCaseMetadata, TestSuite, TestSuiteMetadata
-from lisa.operating_system import CBLMariner, Debian, Linux
+from lisa.operating_system import CBLMariner, Debian, Linux, Ubuntu
 from lisa.sut_orchestrator import AZURE, HYPERV
 from lisa.testsuite import simple_requirement
 from lisa.tools import Gcc
@@ -91,6 +91,10 @@ class CdromSuite(TestSuite):
         # Mariner doesn't ship with many dev tools. Install build tools and headers
         if isinstance(distro, CBLMariner):
             distro.install_packages(["kernel-headers", "binutils-devel", "glibc-devel"])
+        # Starting from Ubuntu 2510 'build-essential' package is not available by
+        # default. It needs to be installed when needed.
+        elif isinstance(distro, Ubuntu):
+            distro.install_packages(["build-essential"])
         # debian ships with headers, no setup needed
         elif isinstance(distro, Debian):
             ...


### PR DESCRIPTION

## Description

<!-- Briefly describe what this PR does and why. -->
Starting from Ubuntu 2510 'build-essential' package is not available by default. It needs to be installed when needed.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [X] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X ] Description is filled in above
- [ X] No credentials, secrets, or internal details are included
- [ X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_cdrom_device_status_code

**Impacted LISA Features:**
cdrom

**Tested Azure Marketplace Images:**
- Canonical ubuntu-25_10 server latest
- Canonical ubuntu-25_10 server-arm64 latest

## Test Results


| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-25_10 server latest |Standard_D2ads_v5| PASSED |
| Canonical ubuntu-25_10 server-arm64 latest|Standard_D2pds_v5|PASSED |
