### PR TITLE
libvirt: resolve passthrough BDFs from visible devices

### DIFF
--- a/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
+++ b/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-from typing import TYPE_CHECKING, Dict, cast
+from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 from lisa import Environment, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.base_tools import Cat
@@ -12,6 +12,7 @@ from lisa.util import LisaException, SkippedException
 
 if TYPE_CHECKING:
     from lisa.sut_orchestrator.libvirt.ch_platform import CloudHypervisorPlatform
+    from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 
 
 @TestSuiteMetadata(
@@ -94,16 +95,16 @@ class DevicePassthroughFunctionalTests(TestSuite):
                 if not pool.devices.pci_bdf:
                     raise LisaException(f"Pool '{pool_type}' has no pci_bdf entries")
                 vendor_device_id = self._vendor_device_from_host_bdf(
-                    platform, pool.devices.pci_bdf[0]
+                    platform, pool.type, pool.devices.pci_bdf[0]
                 )
             elif isinstance(pool.devices, dict):
                 # dataclasses_json fallback: raw dict form from runbook.
                 if "pci_bdf" in pool.devices:
-                    bdf_list = pool.devices["pci_bdf"]
-                    if not bdf_list:
-                        raise LisaException(f"Pool '{pool_type}' pci_bdf list is empty")
+                    bdf_list = self._normalize_pci_bdf_list(
+                        pool.devices["pci_bdf"], pool_type
+                    )
                     vendor_device_id = self._vendor_device_from_host_bdf(
-                        platform, bdf_list[0]
+                        platform, pool.type, bdf_list[0]
                     )
                 elif "vendor_id" in pool.devices and "device_id" in pool.devices:
                     vendor_device_id = {
@@ -156,13 +157,43 @@ class DevicePassthroughFunctionalTests(TestSuite):
     @staticmethod
     def _vendor_device_from_host_bdf(
         platform: "CloudHypervisorPlatform",
+        pool_type: "HostDevicePoolType",
         bdf: str,
     ) -> Dict[str, str]:
         """Read vendor_id and device_id for a BDF from host sysfs."""
+        resolved_bdf = platform.device_pool.resolve_requested_pci_address(
+            pool_type, bdf.strip()
+        )
         cat = platform.host_node.tools[Cat]
-        vendor_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/vendor", sudo=True).strip()
-        device_raw = cat.read(f"/sys/bus/pci/devices/{bdf}/device", sudo=True).strip()
+        vendor_raw = cat.read(
+            f"/sys/bus/pci/devices/{resolved_bdf}/vendor", sudo=True
+        ).strip()
+        device_raw = cat.read(
+            f"/sys/bus/pci/devices/{resolved_bdf}/device", sudo=True
+        ).strip()
         # Normalize to 4-digit lowercase hex used by lspci identifiers.
         vendor_id = vendor_raw.lower().replace("0x", "").zfill(4)
         device_id = device_raw.lower().replace("0x", "").zfill(4)
         return {"vendor_id": vendor_id, "device_id": device_id}
+
+    @staticmethod
+    def _normalize_pci_bdf_list(raw_value: Any, pool_type: str) -> List[str]:
+        if raw_value is None:
+            raise LisaException(f"Pool '{pool_type}' pci_bdf list is empty")
+
+        if isinstance(raw_value, str):
+            raw_values = [raw_value]
+        else:
+            try:
+                raw_values = list(raw_value)
+            except TypeError as identifier_error:
+                raise LisaException(
+                    f"Pool '{pool_type}' pci_bdf must be a string or iterable "
+                    "of strings"
+                ) from identifier_error
+
+        normalized_values = [value.strip() for value in raw_values if value.strip()]
+        if not normalized_values:
+            raise LisaException(f"Pool '{pool_type}' pci_bdf list is empty")
+
+        return normalized_values

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -4,13 +4,19 @@
 import re
 import xml.etree.ElementTree as ET  # noqa: N817
 from itertools import combinations
+from pathlib import PurePosixPath
 from typing import Any, Dict, List, Optional, cast
 
 from lisa.node import Node, RemoteNode
 from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
 from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
 from lisa.tools import Ls, Lspci, Modprobe
-from lisa.util import LisaException, ResourceAwaitableException, find_group_in_lines
+from lisa.util import (
+    LisaException,
+    ResourceAwaitableException,
+    constants,
+    find_group_in_lines,
+)
 
 from .context import DevicePassthroughContext, NodeContext
 from .schema import (
@@ -141,38 +147,32 @@ class LibvirtDevicePool(BaseDevicePool):
 
         assert interface_name, "Can not find interface name"
         result = self.host_node.execute(
-            cmd=f"find /sys/devices/ -name *{interface_name}*",
+            cmd=f"readlink -f /sys/class/net/{interface_name}/device",
             sudo=True,
             shell=True,
         )
         stdout = result.stdout.strip()
-        assert len(stdout.splitlines()) == 1
-        pci_address_pattern = re.compile(
-            r"/(?P<root>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
-            r"(?P<id>[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])/"
-        )
-        match = find_group_in_lines(
-            lines=stdout,
-            pattern=pci_address_pattern,
-            single_line=False,
-        )
-        if match:
-            pci_address = match.get("id", "")
-            assert pci_address, "Can not get primary NIC IOMMU Group"
-            device = DeviceAddressSchema()
-            domain, bus, slot, fn = self._parse_pci_address_str(addr=pci_address)
-            device.domain = domain
-            device.bus = bus
-            device.slot = slot
-            device.function = fn
-
-            iommu_grp = self._get_device_iommu_group(device)
-            return [iommu_grp]
-        else:
-            raise LisaException(
-                f"Can't find pci address of for: {interface_name}, "
-                f"stdout for command: {stdout}"
+        pci_address = PurePosixPath(stdout).name
+        if not re.fullmatch(
+            r"[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]",
+            pci_address,
+        ):
+            self.host_node.log.debug(
+                f"Primary interface '{interface_name}' is not backed by a PCI "
+                f"device on the libvirt host; skipping primary NIC IOMMU "
+                f"exclusion. Sysfs device path: {stdout or '<empty>'}"
             )
+            return []
+
+        device = DeviceAddressSchema()
+        domain, bus, slot, fn = self._parse_pci_address_str(addr=pci_address)
+        device.domain = domain
+        device.bus = bus
+        device.slot = slot
+        device.function = fn
+
+        iommu_grp = self._get_device_iommu_group(device)
+        return [iommu_grp]
 
     def create_device_pool(
         self,
@@ -195,10 +195,35 @@ class LibvirtDevicePool(BaseDevicePool):
         pci_addr_list: List[str],
     ) -> None:
         self.available_host_devices[pool_type] = {}
-        for bdf in pci_addr_list:
-            domain, bus, slot, fn = self._parse_pci_address_str(bdf)
+        stripped_bdfs = [bdf.strip() for bdf in pci_addr_list]
+        if not stripped_bdfs:
+            raise LisaException(
+                f"No PCI addresses provided for pool {pool_type}. "
+                "Please specify at least one PCI address."
+            )
+
+        if any(not bdf for bdf in stripped_bdfs):
+            raise LisaException(
+                f"Empty or whitespace-only PCI address entry found for pool "
+                f"{pool_type}. Please fix the runbook configuration."
+            )
+
+        iommu_device_paths = self._get_iommu_group_device_paths()
+        passthrough_candidates = self._get_passthrough_device_candidates(
+            pool_type, iommu_device_paths
+        )
+        allow_single_candidate_fallback = len(stripped_bdfs) == 1
+        for requested_bdf in stripped_bdfs:
+            resolved_bdf = self._resolve_requested_pci_address(
+                pool_type,
+                requested_bdf,
+                iommu_device_paths=iommu_device_paths,
+                passthrough_candidates=passthrough_candidates,
+                allow_single_candidate_fallback=allow_single_candidate_fallback,
+            )
+            domain, bus, slot, fn = self._parse_pci_address_str(resolved_bdf)
             device = self._get_pci_address_instance(domain, bus, slot, fn)
-            iommu_group = self._get_device_iommu_group(device)
+            iommu_group = self._get_device_iommu_group(device, iommu_device_paths)
 
             # Strip the pool-key prefix to get the raw numeric id for sysfs.
             sysfs_iommu_group = (
@@ -210,12 +235,107 @@ class LibvirtDevicePool(BaseDevicePool):
             iommu_path = f"/sys/kernel/iommu_groups/{sysfs_iommu_group}/devices"
             # Ls.list() returns full paths; extract the basename (bare BDF).
             bdf_list = [
-                i.strip().split("/")[-1]
+                PurePosixPath(i.strip()).name
                 for i in self.host_node.tools[Ls].list(iommu_path)
             ]
-            bdf_list.append(bdf.strip())
+            if resolved_bdf not in bdf_list:
+                bdf_list.append(resolved_bdf)
 
             self._create_pool(pool_type, bdf_list)
+
+    def resolve_requested_pci_address(
+        self,
+        pool_type: HostDevicePoolType,
+        requested_bdf: str,
+    ) -> str:
+        return self._resolve_requested_pci_address(pool_type, requested_bdf)
+
+    def _resolve_requested_pci_address(
+        self,
+        pool_type: HostDevicePoolType,
+        requested_bdf: str,
+        iommu_device_paths: Optional[List[str]] = None,
+        passthrough_candidates: Optional[List[str]] = None,
+        allow_single_candidate_fallback: bool = True,
+    ) -> str:
+        if iommu_device_paths is None:
+            iommu_device_paths = self._get_iommu_group_device_paths()
+        available_iommu_devices = [
+            PurePosixPath(line.strip()).name
+            for line in iommu_device_paths
+            if line.strip()
+        ]
+
+        if requested_bdf in available_iommu_devices:
+            return requested_bdf
+
+        if passthrough_candidates is None:
+            passthrough_candidates = self._get_passthrough_device_candidates(
+                pool_type, iommu_device_paths
+            )
+
+        candidates = passthrough_candidates
+        if len(candidates) == 1 and allow_single_candidate_fallback:
+            resolved_bdf = candidates[0]
+            self.host_node.log.debug(
+                f"Requested PCI address '{requested_bdf}' was not found on the "
+                f"libvirt host; using the only available passthrough candidate "
+                f"'{resolved_bdf}' for pool type '{pool_type.value}'."
+            )
+            return resolved_bdf
+
+        if len(candidates) == 1:
+            raise LisaException(
+                f"Requested PCI address '{requested_bdf}' was not found on the "
+                f"libvirt host. Only one passthrough candidate '{candidates[0]}' "
+                f"is available for pool type '{pool_type.value}', but fallback "
+                "is disabled because multiple 'pci_bdf' values were configured "
+                "for this pool. Specify the nested or visible PCI BDFs "
+                "explicitly so each requested device maps unambiguously."
+            )
+
+        raise LisaException(
+            f"Requested PCI address '{requested_bdf}' was not found on the "
+            f"libvirt host. The PCI BDF inside L1 may differ from the original "
+            f"host BDF. Available passthrough candidates for pool type "
+            f"'{pool_type.value}': {', '.join(sorted(candidates)) or 'none'}. "
+            f"Available IOMMU devices: "
+            f"{', '.join(sorted(available_iommu_devices)) or 'none'}"
+        )
+
+    def _get_passthrough_device_candidates(
+        self,
+        pool_type: HostDevicePoolType,
+        iommu_device_paths: Optional[List[str]] = None,
+    ) -> List[str]:
+        lspci = self.host_node.tools[Lspci]
+        if pool_type == HostDevicePoolType.PCI_NIC:
+            pool_devices = lspci.get_devices_by_type(
+                constants.DEVICE_TYPE_SRIOV, force_run=True
+            )
+        elif pool_type == HostDevicePoolType.PCI_GPU:
+            pool_devices = lspci.get_gpu_devices(force_run=True)
+        else:
+            return []
+
+        primary_nic_iommu = (
+            self.get_primary_nic_id() if pool_type == HostDevicePoolType.PCI_NIC else []
+        )
+        candidates: List[str] = []
+        for pool_device in pool_devices:
+            domain, bus, slot, fn = self._parse_pci_address_str(pool_device.slot)
+            device = self._get_pci_address_instance(domain, bus, slot, fn)
+            try:
+                iommu_group = self._get_device_iommu_group(device, iommu_device_paths)
+            except LisaException:
+                continue
+
+            if iommu_group in primary_nic_iommu:
+                continue
+
+            candidates.append(pool_device.slot)
+
+        return candidates
 
     def _create_pool(
         self,
@@ -379,9 +499,7 @@ class LibvirtDevicePool(BaseDevicePool):
             device_context.device_list = devices
             node_context.passthrough_devices.append(device_context)
 
-    def _get_device_iommu_group(self, device: DeviceAddressSchema) -> str:
-        iommu_pattern = re.compile(r"/sys/kernel/iommu_groups/(?P<id>\d+)/devices/.*")
-        device_id = self._get_pci_address_str(device)
+    def _get_iommu_group_device_paths(self) -> List[str]:
         command = "find /sys/kernel/iommu_groups/ -type l"
         err = "Command failed to list IOMMU Groups"
         result = self.host_node.execute(
@@ -391,9 +509,20 @@ class LibvirtDevicePool(BaseDevicePool):
             expected_exit_code=0,
             expected_exit_code_failure_message=err,
         )
+        return [line.strip() for line in result.stdout.strip().splitlines() if line]
+
+    def _get_device_iommu_group(
+        self,
+        device: DeviceAddressSchema,
+        iommu_device_paths: Optional[List[str]] = None,
+    ) -> str:
+        iommu_pattern = re.compile(r"/sys/kernel/iommu_groups/(?P<id>\d+)/devices/.*")
+        device_id = self._get_pci_address_str(device)
+        if iommu_device_paths is None:
+            iommu_device_paths = self._get_iommu_group_device_paths()
 
         iommu_grp = ""
-        for line in result.stdout.strip().splitlines():
+        for line in iommu_device_paths:
             if line.find(device_id) >= 0:
                 iommu_grp_res = find_group_in_lines(
                     lines=line,
@@ -401,5 +530,18 @@ class LibvirtDevicePool(BaseDevicePool):
                 )
                 iommu_grp = iommu_grp_res.get("id", "")
                 break
-        assert iommu_grp, f"Can not get IOMMU group for device: {device}"
+
+        if not iommu_grp:
+            available_iommu_devices = [
+                PurePosixPath(line.strip()).name
+                for line in iommu_device_paths
+                if line.strip()
+            ]
+            raise LisaException(
+                f"Can not get IOMMU group for device: {device}. Requested PCI "
+                f"address '{device_id}' was not found under "
+                "/sys/kernel/iommu_groups. Available IOMMU devices: "
+                f"{', '.join(sorted(available_iommu_devices)) or 'none'}"
+            )
+
         return f"iommu_grp_{iommu_grp}"


### PR DESCRIPTION
Improve libvirt PCI passthrough handling by resolving requested BDFs to visible nested devices before building IOMMU-backed pools.

This commit also tolerates non-PCI management NICs when determining the primary NIC exclusion set and reuses the same BDF resolution path in device passthrough functional validation for BDF-only pools so host sysfs lookup follows the resolved passthrough device.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_device_passthrough_on_guest

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
NIC Passthrough

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-Local HyperV VHD

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->
verify_device_passthrough_on_guest
| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED  |
