### PR TITLE
hyperv: avoid stale VMs in case of VM setup failures

### DIFF
--- a/lisa/sut_orchestrator/hyperv/platform_.py
+++ b/lisa/sut_orchestrator/hyperv/platform_.py
@@ -348,41 +348,47 @@ class HypervPlatform(Platform):
                 extra_args=extra_args,
                 attach_offline_disks=False,
             )
-            # perform device passthrough for the VM
-            self.device_pool._set_device_passthrough_node_context(
-                node_context=node_context,
-                node_runbook=node_runbook,
-                hv=hv,
-                vm_name=vm_name,
-            )
 
             try:
+                # perform device passthrough for the VM
+                self.device_pool._set_device_passthrough_node_context(
+                    node_context=node_context,
+                    node_runbook=node_runbook,
+                    hv=hv,
+                    vm_name=vm_name,
+                )
+
                 # Start the VM
                 hv.start_vm(name=vm_name, extra_args=extra_args)
+                ip_addr = hv.get_ip_address(vm_name)
+                port = 22
+
+                # If the switch type is internal, we need to add a NAT mapping to
+                # access the VM from the outside of HyperV host.
+                if default_switch.type == HypervSwitchType.INTERNAL:
+                    port = hv.add_nat_mapping(
+                        nat_name=default_switch.name,
+                        internal_ip=ip_addr,
+                    )
+                    ip_addr = node_context.host.public_address
+
+                username = self.runbook.admin_username
+                password = self.runbook.admin_password
+                node.set_connection_info(
+                    address=ip_addr,
+                    username=username,
+                    password=password,
+                    public_port=port,
+                )
+
+                # In some cases, we observe that resize vhd resizes the entire disk
+                # but fails to expand the partition size.
+                resize = node.tools[ResizePartition]
+                resize.expand_os_partition()
             except Exception as ex:
                 # avoid stale VMs; delete the VM before raising exception
                 self._delete_node(node_context, wait_delete=False, log=log)
                 raise ex
-
-            ip_addr = hv.get_ip_address(vm_name)
-            port = 22
-            # If the switch type is internal, we need to add a NAT mapping to access the
-            # VM from the outside of HyperV host.
-            if default_switch.type == HypervSwitchType.INTERNAL:
-                port = hv.add_nat_mapping(
-                    nat_name=default_switch.name,
-                    internal_ip=ip_addr,
-                )
-                ip_addr = node_context.host.public_address
-            username = self.runbook.admin_username
-            password = self.runbook.admin_password
-            node.set_connection_info(
-                address=ip_addr, username=username, password=password, public_port=port
-            )
-            # In some cases, we observe that resize vhd resizes the entire disk
-            # but fails to expand the partition size.
-            resize = node.tools[ResizePartition]
-            resize.expand_os_partition()
 
     def _resize_vhd_if_needed(
         self, vhd_path: PurePath, node_runbook: HypervNodeSchema


### PR DESCRIPTION
## Description

Failures during initial VM setup steps such as adding NAT mapping, getting IP address, resizing partition, setting up device passthrough etc. would currently result in a stale VM left behind on the host. Catch these failures and clean up the VMs before returning/raising from _deploy_environment().

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
