### PR TITLE
[AI Generated] BugFix: Skip verify_sgx test on non-x64 architectures

### DIFF
--- a/lisa/microsoft/testsuites/acc/bvt.py
+++ b/lisa/microsoft/testsuites/acc/bvt.py
@@ -10,8 +10,13 @@ from lisa import (
 )
 from lisa.features import acc
 from lisa.operating_system import Ubuntu
-from lisa.tools import Dmesg, Make, Wget, Whoami
-from lisa.util import SkippedException, UnsupportedDistroException
+from lisa.tools import Dmesg, Lscpu, Make, Wget, Whoami
+from lisa.tools.lscpu import CpuArchitecture
+from lisa.util import (
+    SkippedException,
+    UnsupportedCpuArchitectureException,
+    UnsupportedDistroException,
+)
 
 
 @TestSuiteMetadata(
@@ -42,6 +47,11 @@ class ACCBasicTest(TestSuite):
         ),
     )
     def verify_sgx(self, log: Logger, node: Node) -> None:
+        node_arch = node.tools[Lscpu].get_architecture()
+        if node_arch != CpuArchitecture.X64:
+            raise SkippedException(
+                UnsupportedCpuArchitectureException(arch=str(node_arch.value))
+            )
         if isinstance(node.os, Ubuntu) and (node.os.information.version >= "18.4.0"):
             os_version = node.os.information.release
         else:


### PR DESCRIPTION
## Summary
Add an x86_64 architecture guard to the `verify_sgx` test case in `ACCBasicTest`. SGX is an Intel-only feature and the test should be skipped on ARM64 VMs instead of failing with a 404 when downloading the x64 Intel SGX driver.

The fix checks the CPU architecture using `Lscpu.get_architecture()` at the start of `verify_sgx()` and raises `SkippedException(UnsupportedCpuArchitectureException(...))` for non-x64 architectures, following the same pattern used in DPDK and other LISA test suites.

## Validation Results
| Image | VM Size | Location | Result |
|-------|---------|----------|--------|
| Canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest | Standard_DC2s_v3 | eastus2 | PASSED |
| Canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest | Standard_D2pds_v5 | eastus2 | SKIPPED (no ACC feature on ARM64 - correct) |