### PR TITLE
Use extension version 1.8 for GPU

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -62,7 +62,7 @@ from lisa.features.security_profile import (
 )
 from lisa.features.startstop import VMStatus
 from lisa.node import Node, RemoteNode
-from lisa.operating_system import BSD, CBLMariner, CentOs, Redhat, Suse, Ubuntu
+from lisa.operating_system import BSD, CBLMariner, Redhat, Suse, Ubuntu
 from lisa.search_space import RequirementMethod, decode_set_space_by_type
 from lisa.secret import add_secret
 from lisa.tools import (
@@ -652,7 +652,6 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         supported_versions: Dict[Any, List[str]] = {
             Redhat: ["7.9", "8.2"],
             Ubuntu: ["20.04", "22.04", "24.04"],
-            CentOs: ["7.3", "7.4", "7.5", "7.6", "7.7", "7.8"],
         }
         release = self._node.os.information.release
         if release not in supported_versions.get(type(self._node.os), []):
@@ -661,11 +660,20 @@ class Gpu(AzureFeatureMixin, features.Gpu):
             self._node.os.handle_rhui_issue()
         extension = self._node.features[AzureExtension]
         try:
+            # type_handler_version 1.8 is the latest version at the time of this change.
+            # Below is the command to check available versions in Azure.
+            # az vm extension image list `
+            #   --publisher Microsoft.HpcCompute `
+            #   --name NvidiaGpuDriverLinux `
+            #   --location westus2 `
+            #   -o table
+
             result = extension.create_or_update(
                 type_="NvidiaGpuDriverLinux",
                 publisher="Microsoft.HpcCompute",
                 auto_upgrade_minor_version=True,
                 settings={},
+                type_handler_version="1.8",
             )
         except Exception as e:
             if (


### PR DESCRIPTION
Use extension version 1.8 for GPU.
CentOS is no longer supported hence removed.
Reference: https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/hpccompute-gpu-linux#operating-system

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_gpu_extension_installation
**Impacted LISA Features:**
GPU
**Tested Azure Marketplace Images:**
- Canonical ubuntu-24_04-lts server latest
- canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
- redhat rhel 82gen2 latest
- RedHat RHEL 79-gen2 latest

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-24_04-lts server latest|Standard_NC24ads_A100_v4| PASSED|
|canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest|Standard_NC24ads_A100_v4| FAILED |
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_NC24ads_A100_v4| PASSED |
|redhat rhel 82gen2 latest|Standard_NC24ads_A100_v4| FAILED |
|RedHat RHEL 79-gen2 latest|Standard_NC24ads_A100_v4| FAILED |

