### PR TITLE
[AI Generated] BugFix: Skip ADE tests on ARM64 architecture

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/lisa/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -49,6 +49,8 @@ class AzureDiskEncryption(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
         node_arch = node.tools[Lscpu].get_architecture()
+        # ADE only supports x64 architecture. See supported VM configurations at:
+        # https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-overview#supported-vms-and-operating-systems
         if node_arch != CpuArchitecture.X64:
             raise SkippedException(
                 UnsupportedCpuArchitectureException(arch=str(node_arch.value))

--- a/lisa/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
+++ b/lisa/microsoft/testsuites/vm_extensions/azure_disk_encryption.py
@@ -24,8 +24,11 @@ from lisa.sut_orchestrator.azure.common import (
 from lisa.sut_orchestrator.azure.features import AzureExtension
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform, AzurePlatformSchema
 from lisa.testsuite import TestResult, simple_requirement
+from lisa.tools import Lscpu
+from lisa.tools.lscpu import CpuArchitecture
 from lisa.util import (
     SkippedException,
+    UnsupportedCpuArchitectureException,
     UnsupportedDistroException,
     generate_random_chars,
 )
@@ -45,6 +48,11 @@ UnsupportedVersionInfo = List[Dict[str, int]]
 class AzureDiskEncryption(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
+        node_arch = node.tools[Lscpu].get_architecture()
+        if node_arch != CpuArchitecture.X64:
+            raise SkippedException(
+                UnsupportedCpuArchitectureException(arch=str(node_arch.value))
+            )
         if not self._is_supported_linux_distro(node):
             raise SkippedException(UnsupportedDistroException(node.os))
         needed_packages = ["python-parted", "python3-parted"]


### PR DESCRIPTION
## Summary
Azure Disk Encryption (ADE) is not supported on ARM architecture ([docs](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption-overview#supported-vms-and-operating-systems)). Added a CPU architecture check in the `AzureDiskEncryption.before_case()` method to skip all ADE tests when running on non-x64 architectures, using the same pattern established in other LISA test suites.

## Validation Results
| Image | Test | Result |
|-------|------|--------|
| Canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 22.04.202503240 | verify_azure_disk_encryption_provisioned | SKIPPED (Unsupported CPU architecture aarch64) |
| canonical 0001-com-ubuntu-server-jammy 22_04-lts 22.04.202602250 | verify_azure_disk_encryption_provisioned | Executed (not skipped on x64; hit env auth issue unrelated to fix) |