### PR TITLE
[AI Generated] BugFix: Filter MANA module list by existence before unload/reload

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -679,7 +679,11 @@ class Nics(InitializableMixin):
 
     def unload_module(self, module_name: str) -> List[str]:
         modprobe = self._node.tools[Modprobe]
-        module_list = self._device_module_map[module_name].drivers
+        module_list = [
+            m
+            for m in self._device_module_map[module_name].drivers
+            if modprobe.module_exists(m)
+        ]
         modprobe.remove(module_list)
         return module_list
 


### PR DESCRIPTION
## Summary

The `unload_module()` method in `nic.py` returns a hardcoded list of MANA drivers (`mana`, `mana_en`, `mana_ib`) regardless of which modules actually exist on the running kernel. On AlmaLinux/RHEL 9 kernels, `mana_en` does not exist — MANA Ethernet is provided by `mana.ko` only. This causes `verify_sriov_reload_modules` to fail when it attempts to reload `mana_en` via `modprobe`.

The fix filters the driver list using `modprobe.module_exists()` before unloading, so only modules that are actually present on the kernel are unloaded and subsequently reloaded.

## Validation Results

| Image | VM Size | Result |
|-------|---------|--------|
| almalinux almalinux-hpc 9-hpc-gen2 9.7.2026010601 | Standard_D8ds_v6 | FAILED (pre-existing mana_ib issue, mana_en fix confirmed) |
| Canonical ubuntu-24_04-lts server 24.04.202507080 | Standard_D8ds_v6 | PASSED |

Note: The AlmaLinux 9 HPC failure is a separate pre-existing issue where `mana_ib` cannot be reinserted after unload (`modprobe: ERROR: could not insert mana_ib: Invalid argument`). The original `mana_en` failure is resolved by this fix.