### PR TITLE
ch_tests_tool: increase perf tests timeout

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -51,8 +51,8 @@ class CloudHypervisorTests(Tool):
     # - list subtests before running the tests.
     # - extract sub test results from stdout and report them.
     CASE_TIME_OUT = CMD_TIME_OUT + 1200
-    # 2 Hrs of timeout for perf tests and 2400 seconds for other operations
-    PERF_CASE_TIME_OUT = 7200 + 2400
+    # 6 Hrs of timeout for perf tests and 2400 seconds for other operations
+    PERF_CASE_TIME_OUT = 21600 + 2400
     PERF_CMD_TIME_OUT = 1200
 
     upstream_repo = "https://github.com/cloud-hypervisor/cloud-hypervisor.git"


### PR DESCRIPTION
## Description

Lots of new tests have been added to the perf metrics suite in Cloud Hypervisor. Increase the timeout to accommodate them.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
