### PR TITLE
BugFix: Detect NVMe support from Azure SKU capabilities for all VM families

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3163,6 +3163,7 @@ class Nvme(AzureFeatureMixin, features.Nvme):
     def create_setting(
         cls, *args: Any, **kwargs: Any
     ) -> Optional[schema.FeatureSettings]:
+        raw_capabilities: Any = kwargs.get("raw_capabilities")
         resource_sku: Any = kwargs.get("resource_sku")
         node_space: Any = kwargs.get("node_space")
 
@@ -3182,6 +3183,24 @@ class Nvme(AzureFeatureMixin, features.Nvme):
             ), f"actual: {node_space.core_count}"
             nvme.disk_count = int(node_space.core_count / 8)
             return nvme
+
+        # Detect NVMe support from raw capabilities for VMs not in the
+        # hardcoded family list (e.g. arm64 v6-series). Check both
+        # DiskControllerTypes and NvmeDiskSizeInMiB as NVMe indicators.
+        if raw_capabilities:
+            disk_controller_types = raw_capabilities.get(
+                "DiskControllerTypes", ""
+            )
+            nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")
+            has_nvme_controller = (
+                schema.DiskControllerType.NVME.value
+                in disk_controller_types.split(",")
+            )
+            has_nvme_disk = int(nvme_disk_size) > 0 if nvme_disk_size else False
+            if has_nvme_controller or has_nvme_disk:
+                nvme = features.NvmeSettings()
+                nvme.disk_count = search_space.IntRange(min=0)
+                return nvme
 
         return None
 

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3164,42 +3164,17 @@ class Nvme(AzureFeatureMixin, features.Nvme):
         cls, *args: Any, **kwargs: Any
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
-        resource_sku: Any = kwargs.get("resource_sku")
-        node_space: Any = kwargs.get("node_space")
 
-        assert isinstance(node_space, schema.NodeSpace), f"actual: {type(node_space)}"
-        # add vm which support nested virtualization
-        # https://docs.microsoft.com/en-us/azure/virtual-machines/acu
-        if resource_sku.family.casefold() in [
-            "standardlsv2family",
-            "standardlsv3family",
-            "standardlasv3family",
-        ]:
-            # refer https://docs.microsoft.com/en-us/azure/virtual-machines/lsv2-series # noqa: E501
-            # NVMe disk count = vCPU / 8
-            nvme = features.NvmeSettings()
-            assert isinstance(
-                node_space.core_count, int
-            ), f"actual: {node_space.core_count}"
-            nvme.disk_count = int(node_space.core_count / 8)
-            return nvme
-
-        # Detect NVMe support from raw capabilities for VMs not in the
-        # hardcoded family list (e.g. arm64 v6-series). Check both
-        # DiskControllerTypes and NvmeDiskSizeInMiB as NVMe indicators.
         if raw_capabilities:
-            disk_controller_types = raw_capabilities.get(
-                "DiskControllerTypes", ""
-            )
             nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")
-            has_nvme_controller = (
-                schema.DiskControllerType.NVME.value
-                in disk_controller_types.split(",")
+            nvme_size_per_disk = raw_capabilities.get("NvmeSizePerDiskInMiB", "0")
+            nvme_disk_size_int = int(nvme_disk_size) if nvme_disk_size else 0
+            nvme_size_per_disk_int = (
+                int(nvme_size_per_disk) if nvme_size_per_disk else 0
             )
-            has_nvme_disk = int(nvme_disk_size) > 0 if nvme_disk_size else False
-            if has_nvme_controller or has_nvme_disk:
+            if nvme_disk_size_int != 0 and nvme_size_per_disk_int != 0:
                 nvme = features.NvmeSettings()
-                nvme.disk_count = search_space.IntRange(min=0)
+                nvme.disk_count = nvme_disk_size_int // nvme_size_per_disk_int
                 return nvme
 
         return None

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3164,6 +3164,25 @@ class Nvme(AzureFeatureMixin, features.Nvme):
         cls, *args: Any, **kwargs: Any
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
+        resource_sku: Any = kwargs.get("resource_sku")
+        node_space: Any = kwargs.get("node_space")
+
+        assert isinstance(node_space, schema.NodeSpace), f"actual: {type(node_space)}"
+        # add vm which support nested virtualization
+        # https://docs.microsoft.com/en-us/azure/virtual-machines/acu
+        if resource_sku.family.casefold() in [
+            "standardlsv2family",
+            "standardlsv3family",
+            "standardlasv3family",
+        ]:
+            # refer https://docs.microsoft.com/en-us/azure/virtual-machines/lsv2-series # noqa: E501
+            # NVMe disk count = vCPU / 8
+            nvme = features.NvmeSettings()
+            assert isinstance(
+                node_space.core_count, int
+            ), f"actual: {node_space.core_count}"
+            nvme.disk_count = int(node_space.core_count / 8)
+            return nvme
 
         if raw_capabilities:
             nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3164,28 +3164,8 @@ class Nvme(AzureFeatureMixin, features.Nvme):
         cls, *args: Any, **kwargs: Any
     ) -> Optional[schema.FeatureSettings]:
         raw_capabilities: Any = kwargs.get("raw_capabilities")
-        resource_sku: Any = kwargs.get("resource_sku")
-        node_space: Any = kwargs.get("node_space")
 
-        assert isinstance(node_space, schema.NodeSpace), f"actual: {type(node_space)}"
-        # add vm which support nested virtualization
-        # https://docs.microsoft.com/en-us/azure/virtual-machines/acu
-        if resource_sku.family.casefold() in [
-            "standardlsv2family",
-            "standardlsv3family",
-            "standardlasv3family",
-        ]:
-            # refer https://docs.microsoft.com/en-us/azure/virtual-machines/lsv2-series # noqa: E501
-            # NVMe disk count = vCPU / 8
-            nvme = features.NvmeSettings()
-            assert isinstance(
-                node_space.core_count, int
-            ), f"actual: {node_space.core_count}"
-            nvme.disk_count = int(node_space.core_count / 8)
-            return nvme
-
-        # For VM families not covered above, derive NVMe disk count directly
-        # from Azure SKU capabilities:
+        # Derive NVMe disk count directly from Azure SKU capabilities:
         #   NvmeDiskSizeInMiB     - total NVMe storage capacity across all disks
         #   NvmeSizePerDiskInMiB  - capacity of a single NVMe disk
         # disk_count = NvmeDiskSizeInMiB // NvmeSizePerDiskInMiB

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3192,11 +3192,11 @@ class Nvme(AzureFeatureMixin, features.Nvme):
         if raw_capabilities:
             nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")
             nvme_size_per_disk = raw_capabilities.get("NvmeSizePerDiskInMiB", "0")
-            nvme_disk_size_int = int(nvme_disk_size) if nvme_disk_size else 0
+            nvme_disk_size_int = int(nvme_disk_size) if nvme_disk_size.isdigit() else 0
             nvme_size_per_disk_int = (
-                int(nvme_size_per_disk) if nvme_size_per_disk else 0
+                int(nvme_size_per_disk) if nvme_size_per_disk.isdigit() else 0
             )
-            if nvme_disk_size_int != 0 and nvme_size_per_disk_int != 0:
+            if nvme_disk_size_int and nvme_size_per_disk_int:
                 nvme = features.NvmeSettings()
                 nvme.disk_count = nvme_disk_size_int // nvme_size_per_disk_int
                 return nvme

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3184,6 +3184,11 @@ class Nvme(AzureFeatureMixin, features.Nvme):
             nvme.disk_count = int(node_space.core_count / 8)
             return nvme
 
+        # For VM families not covered above, derive NVMe disk count directly
+        # from Azure SKU capabilities:
+        #   NvmeDiskSizeInMiB     - total NVMe storage capacity across all disks
+        #   NvmeSizePerDiskInMiB  - capacity of a single NVMe disk
+        # disk_count = NvmeDiskSizeInMiB // NvmeSizePerDiskInMiB
         if raw_capabilities:
             nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")
             nvme_size_per_disk = raw_capabilities.get("NvmeSizePerDiskInMiB", "0")


### PR DESCRIPTION
## Summary

The `Nvme.create_setting()` method only recognized 3 hardcoded Ls-series VM families (`standardlsv2family`, `standardlsv3family`, `standardlasv3family`). VMs with NVMe support in other families (e.g. arm64 v6-series like `StandardDpdsv6Family`) were not getting the NVMe feature added to their capability, causing all NVMe tests to skip with `Requirement mismatch: no feature Nvme found in capability`.

## Changes

- **Removed** the hardcoded VM family list (`standardlsv2family`, `standardlsv3family`, `standardlasv3family`) and the `vCPU / 8` disk count heuristic
- **Removed** `DiskControllerTypes` NVMe controller check
- **Added** capability-driven detection using `NvmeDiskSizeInMiB` and `NvmeSizePerDiskInMiB` for all VM families: if both are present and non-zero, `disk_count = NvmeDiskSizeInMiB // NvmeSizePerDiskInMiB`
- **Added** safe string-to-int conversion using `.isdigit()` before parsing capability values

```python
# Derive NVMe disk count directly from Azure SKU capabilities:
#   NvmeDiskSizeInMiB     - total NVMe storage capacity across all disks
#   NvmeSizePerDiskInMiB  - capacity of a single NVMe disk
# disk_count = NvmeDiskSizeInMiB // NvmeSizePerDiskInMiB
if raw_capabilities:
    nvme_disk_size = raw_capabilities.get("NvmeDiskSizeInMiB", "0")
    nvme_size_per_disk = raw_capabilities.get("NvmeSizePerDiskInMiB", "0")
    nvme_disk_size_int = int(nvme_disk_size) if nvme_disk_size.isdigit() else 0
    nvme_size_per_disk_int = int(nvme_size_per_disk) if nvme_size_per_disk.isdigit() else 0
    if nvme_disk_size_int and nvme_size_per_disk_int:
        nvme = features.NvmeSettings()
        nvme.disk_count = nvme_disk_size_int // nvme_size_per_disk_int
        return nvme
```

The capability-based detection derives the correct disk count directly from Azure SKU capabilities, covering all VM families uniformly (including Ls-series and arm64 v6-series) without any hardcoded family-specific special cases.

## Validation Results

| Image | VM Size | Result |
|-------|---------|--------|
| Canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 22.04.202503240 | Standard_D2pds_v6 | PASSED |
| Canonical ubuntu-24_04-lts server-arm64 24.04.202507080 | Standard_D2pds_v6 | PASSED |

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.