### PR TITLE
upgrade simpleeval package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests ~= 2.32.4",
     "retry ~= 0.9.2",
     "semver ~= 2.13.0",
-    "simpleeval ~= 0.9.12",
+    "simpleeval ~= 1.0.7",
     "spurplus ~= 2.3.5",
     "websockets ~= 15.0.1",
 ]


### PR DESCRIPTION
## Description

The current simpleeval (0.9.12) uses some deprecated features in python. This has been fixed in recent simpleeval package. 
And to use the existing (0.9.*) simpleeval with python 3.14 will cause a runtime error.

## Related Issue

Fixes #4388 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

n/a

**Key Test Cases:**
n/a

**Impacted LISA Features:**
n/a

**Tested Azure Marketplace Images:**
n/a

-

## Test Results

n/a

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
