### PR TITLE
platform_utils: retry vmm version detection after unknown cache

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1346,10 +1346,24 @@ exit $ec
         This is called automatically after the tool is installed, ensuring
         the version is available for platform information hooks.
         """
-        from lisa.sut_orchestrator.platform_utils import get_vmm_version
+        from lisa.sut_orchestrator.platform_utils import (
+            KEY_VMM_VERSION,
+            get_vmm_version,
+        )
 
         try:
-            vmm_version = get_vmm_version(self.node, refresh_unknown_cache=True)
+            # Clear any previously cached UNKNOWN so detection is retried now
+            # that cloud-hypervisor has been installed.
+            extended_resources = getattr(
+                self.node.capability, "extended_resources", None
+            )
+            if (
+                extended_resources
+                and str(extended_resources.get(KEY_VMM_VERSION, "")).upper()
+                == "UNKNOWN"
+            ):
+                extended_resources.pop(KEY_VMM_VERSION)
+            vmm_version = get_vmm_version(self.node)
             if vmm_version and vmm_version != "UNKNOWN":
                 self._log.info(f"Cloud-Hypervisor version detected: {vmm_version}")
                 # get_vmm_version() already caches the version in extended_resources

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1349,7 +1349,7 @@ exit $ec
         from lisa.sut_orchestrator.platform_utils import get_vmm_version
 
         try:
-            vmm_version = get_vmm_version(self.node)
+            vmm_version = get_vmm_version(self.node, refresh_unknown_cache=True)
             if vmm_version and vmm_version != "UNKNOWN":
                 self._log.info(f"Cloud-Hypervisor version detected: {vmm_version}")
                 # get_vmm_version() already caches the version in extended_resources

--- a/lisa/sut_orchestrator/platform_utils.py
+++ b/lisa/sut_orchestrator/platform_utils.py
@@ -38,7 +38,7 @@ def _cache_vmm_version_in_node(node: Node, version: str) -> None:
     extended_resources[KEY_VMM_VERSION] = version
 
 
-def get_vmm_version(node: Node) -> str:
+def get_vmm_version(node: Node, refresh_unknown_cache: bool = False) -> str:
     """
     Detects cloud-hypervisor VMM version from cached value, local binary,
     or git repository.
@@ -61,8 +61,14 @@ def get_vmm_version(node: Node) -> str:
         if extended_resources and KEY_VMM_VERSION in extended_resources:
             cached_version = extended_resources.get(KEY_VMM_VERSION)
             if cached_version:
-                node.log.debug(f"Using cached VMM version: {cached_version}")
-                return str(cached_version)
+                cached_version_str = str(cached_version)
+                if cached_version_str.upper() != "UNKNOWN" or not refresh_unknown_cache:
+                    node.log.debug(f"Using cached VMM version: {cached_version_str}")
+                    return cached_version_str
+                node.log.debug(
+                    "Cached VMM version is UNKNOWN; retrying detection because "
+                    "refresh_unknown_cache=True"
+                )
 
         # If there is no cached value, only proceed with SSH-based detection
         # when the node is connected and running a POSIX-compatible OS.
@@ -81,6 +87,7 @@ def get_vmm_version(node: Node) -> str:
             match = re.search(VMM_VERSION_PATTERN, output.strip())
             if match:
                 result = match.group("ch_version")
+                _cache_vmm_version_in_node(node, result)
                 node.log.debug(
                     f"Successfully detected VMM version from local binary: {result}"
                 )
@@ -90,12 +97,10 @@ def get_vmm_version(node: Node) -> str:
         # For Docker-based tests where cloud-hypervisor is compiled from source
         node.log.debug("Local binary not found, trying git repository...")
 
-        # Construct path dynamically using node's working path
-        # CloudHypervisorTests tool clones repo to:
-        # <lisa_working_path>/tool/<tool_name>/cloud-hypervisor
-        git_repo_path = (
-            f"{node.get_pure_path(str(node.working_path))}/tool/"
-            "cloudhypervisortests/cloud-hypervisor"
+        # CloudHypervisorTests installs into the global tool cache via
+        global_working_root = node.get_working_path().parent.parent
+        git_repo_path = str(
+            global_working_root / "tool" / "cloudhypervisortests" / "cloud-hypervisor"
         )
         git_cmd = (
             f"cd {git_repo_path} 2>/dev/null && "
@@ -116,6 +121,7 @@ def get_vmm_version(node: Node) -> str:
             version_match = re.search(r"(?:msft/)?v?([\d.]+)", version_str)
             if version_match:
                 result = version_match.group(1)
+                _cache_vmm_version_in_node(node, result)
                 node.log.debug(
                     f"Successfully detected VMM version from git repository: {result}"
                 )

--- a/lisa/sut_orchestrator/platform_utils.py
+++ b/lisa/sut_orchestrator/platform_utils.py
@@ -38,7 +38,7 @@ def _cache_vmm_version_in_node(node: Node, version: str) -> None:
     extended_resources[KEY_VMM_VERSION] = version
 
 
-def get_vmm_version(node: Node, refresh_unknown_cache: bool = False) -> str:
+def get_vmm_version(node: Node) -> str:
     """
     Detects cloud-hypervisor VMM version from cached value, local binary,
     or git repository.
@@ -51,6 +51,14 @@ def get_vmm_version(node: Node, refresh_unknown_cache: bool = False) -> str:
     Returns the version string as reported by ``cloud-hypervisor --version`` after
     the ``cloud-hypervisor `` prefix (for example, ``"v41.0.0-41.0.120.g4ea35aaf"``
     or ``"48.0.235"``), or ``"UNKNOWN"`` if detection fails.
+
+    To force re-detection after a previous failure (e.g., when
+    cloud-hypervisor is installed after an initial detection attempt),
+    clear the cached value first::
+
+        extended_resources = getattr(node.capability, "extended_resources", None)
+        if extended_resources:
+            extended_resources.pop(KEY_VMM_VERSION, None)
     """
     result: str = "UNKNOWN"
     try:
@@ -62,13 +70,8 @@ def get_vmm_version(node: Node, refresh_unknown_cache: bool = False) -> str:
             cached_version = extended_resources.get(KEY_VMM_VERSION)
             if cached_version:
                 cached_version_str = str(cached_version)
-                if cached_version_str.upper() != "UNKNOWN" or not refresh_unknown_cache:
-                    node.log.debug(f"Using cached VMM version: {cached_version_str}")
-                    return cached_version_str
-                node.log.debug(
-                    "Cached VMM version is UNKNOWN; retrying detection because "
-                    "refresh_unknown_cache=True"
-                )
+                node.log.debug(f"Using cached VMM version: {cached_version_str}")
+                return cached_version_str
 
         # If there is no cached value, only proceed with SSH-based detection
         # when the node is connected and running a POSIX-compatible OS.
@@ -97,7 +100,10 @@ def get_vmm_version(node: Node, refresh_unknown_cache: bool = False) -> str:
         # For Docker-based tests where cloud-hypervisor is compiled from source
         node.log.debug("Local binary not found, trying git repository...")
 
-        # CloudHypervisorTests installs into the global tool cache via
+        # CloudHypervisorTests installs into the global tool cache rooted at
+        # node.get_working_path().parent.parent (the same hierarchy used by
+        # Tool.get_tool_path(use_global=True)), so reconstruct the git repository
+        # path from that global working root.
         global_working_root = node.get_working_path().parent.parent
         git_repo_path = str(
             global_working_root / "tool" / "cloudhypervisortests" / "cloud-hypervisor"


### PR DESCRIPTION


## Description

Do not treat cached UNKNOWN as a terminal vmm_version value. If an earlier detection attempt failed before cloud-hypervisor was available, later calls should retry live detection instead of reusing UNKNOWN forever.

Also cache successful detections from both the local binary path and the git-describe fallback so later lookups reuse the resolved version.

## Related Issue



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
CH integration test

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Dom0 Image

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED  |
