### PR TITLE
[AI Generated] BugFix: Fix intermittent InvalidTemplate error for data disk deployments

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -131,17 +131,17 @@ func getCreateDisk(disk object, diskName string, index int) object => {
   }
 }
 
-func getAttachDisk(disk object, diskName string, index int) object => {
+func getAttachDisk(disk object, diskName string, index int, rgId string) object => {
   lun: index
   createOption: 'attach'
   caching: disk.caching_type
   managedDisk: {
-      id: resourceId('Microsoft.Compute/disks', diskName)
+      id: '${rgId}/providers/Microsoft.Compute/disks/${diskName}'
   }
 }
 
-func getDataDisk(nodeName string, dataDisk object, index int) object => (dataDisk.type == 'UltraSSD_LRS' || (!empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
-? getAttachDisk(dataDisk, '${nodeName}-data-disk-${index}', index)
+func getDataDisk(nodeName string, dataDisk object, index int, rgId string) object => (dataDisk.type == 'UltraSSD_LRS' || (!empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
+? getAttachDisk(dataDisk, '${nodeName}-data-disk-${index}', index, rgId)
 : getCreateDisk(dataDisk, '${nodeName}-data-disk-${index}', index)
 
 func getOsDiskSharedGallery(shared_gallery object) object => {
@@ -466,7 +466,7 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
       imageReference: getImageReference(nodes[i])
       osDisk:  getVMOsDisk(nodes[i])
       diskControllerType: (nodes[i].disk_controller_type == 'SCSI') ? null : nodes[i].disk_controller_type
-      dataDisks: [for (item, j) in data_disks: getDataDisk(nodes[i].name, item, j)]
+      dataDisks: [for (item, j) in data_disks: getDataDisk(nodes[i].name, item, j, resourceGroup().id)]
     }
     networkProfile: {
       networkInterfaces: [for j in range(0, nodes[i].nic_count): {
@@ -493,6 +493,7 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
     nodes_nics
     virtual_network_name_resource
     nodes_disk
+    nodes_data_disks
     nodes_data_disks_with_vhds
   ]
 }]

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.177.2456",
-      "templateHash": "18099469189437246926"
+      "version": "0.41.2.15936",
+      "templateHash": "4344046724676715403"
     }
   },
   "functions": [
@@ -163,6 +163,10 @@
             {
               "type": "int",
               "name": "index"
+            },
+            {
+              "type": "string",
+              "name": "rgId"
             }
           ],
           "output": {
@@ -172,7 +176,7 @@
               "createOption": "attach",
               "caching": "[parameters('disk').caching_type]",
               "managedDisk": {
-                "id": "[resourceId('Microsoft.Compute/disks', parameters('diskName'))]"
+                "id": "[format('{0}/providers/Microsoft.Compute/disks/{1}', parameters('rgId'), parameters('diskName'))]"
               }
             }
           }
@@ -190,11 +194,15 @@
             {
               "type": "int",
               "name": "index"
+            },
+            {
+              "type": "string",
+              "name": "rgId"
             }
           ],
           "output": {
             "type": "object",
-            "value": "[if(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(not(empty(parameters('dataDisk').vhd_details)), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
+            "value": "[if(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(not(empty(parameters('dataDisk').vhd_details)), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index'), parameters('rgId')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
           }
         },
         "getOsDiskSharedGallery": {
@@ -836,7 +844,7 @@
             {
               "name": "dataDisks",
               "count": "[length(parameters('data_disks'))]",
-              "input": "[__bicep.getDataDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, parameters('data_disks')[copyIndex('dataDisks')], copyIndex('dataDisks'))]"
+              "input": "[__bicep.getDataDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, parameters('data_disks')[copyIndex('dataDisks')], copyIndex('dataDisks'), resourceGroup().id)]"
             }
           ],
           "imageReference": "[__bicep.getImageReference(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
@@ -870,6 +878,7 @@
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]",
       "dependsOn": [
         "availability_set",
+        "nodes_data_disks",
         "nodes_data_disks_with_vhds",
         "nodes_disk",
         "nodes_image",
@@ -883,7 +892,7 @@
         "count": "[length(range(0, variables('node_count')))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-nics', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -929,8 +938,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "15654609969338604205"
+              "version": "0.41.2.15936",
+              "templateHash": "2282563054596282747"
             }
           },
           "functions": [

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2471,7 +2471,7 @@ class AzurePlatform(Platform):
                             0,
                             azure_node_runbook.data_disk_type,
                             DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_FROM_IMAGE,
-                            None,
+                            VhdDetails(),
                         )
                     )
         assert isinstance(
@@ -2495,7 +2495,7 @@ class AzurePlatform(Platform):
                     node.capability.disk.data_disk_throughput,
                     azure_node_runbook.data_disk_type,
                     DataDiskCreateOption.DATADISK_CREATE_OPTION_TYPE_EMPTY,
-                    None,
+                    VhdDetails(),
                 )
             )
         runbook = node.capability.get_extended_runbook(AzureNodeSchema)


### PR DESCRIPTION
## Summary

Replace `resourceId()` with `format()` string interpolation in the ARM template `getAttachDisk` function to fix intermittent `InvalidTemplate` deployment failures.

ARM template validation evaluates both branches of `if()` expressions. When `getDataDisk` selects the `getCreateDisk` branch for regular (non-UltraSSD, non-VHD) data disks, the validator still evaluates the `getAttachDisk` branch which contained `resourceId('Microsoft.Compute/disks', name)`. Since no disk resource is defined when both `is_ultradisk` and `is_data_disk_with_vhd` are false, validation intermittently fails.

Also adds `nodes_data_disks` to VM `dependsOn` (was missing, latent race condition for UltraSSD deployments) and initializes `vhd_details` with empty `VhdDetails()` instead of `None` to prevent null property access in conditional ARM expressions.

## Validation Results
| Image | Result |
|-------|--------|
| Pending | Running after PR creation |