### PR TITLE
Fix invaild template issue

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -136,13 +136,11 @@ func getAttachDisk(disk object, diskName string, index int) object => {
   createOption: 'attach'
   caching: disk.caching_type
   managedDisk: {
-      id: resourceId('Microsoft.Compute/disks', diskName)
+      id: '${resourceGroup().id}/providers/Microsoft.Compute/disks/${diskName}'
   }
 }
 
-func getDataDisk(nodeName string, dataDisk object, index int) object => (dataDisk.type == 'UltraSSD_LRS' || (!empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
-? getAttachDisk(dataDisk, '${nodeName}-data-disk-${index}', index)
-: getCreateDisk(dataDisk, '${nodeName}-data-disk-${index}', index)
+func shouldAttachDataDisk(dataDisk object) bool => bool(dataDisk.type == 'UltraSSD_LRS' || (dataDisk.vhd_details != null && !empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
 
 func getOsDiskSharedGallery(shared_gallery object) object => {
   id: resourceId(shared_gallery.subscription_id, empty(shared_gallery.resource_group_name) ? 'None' : shared_gallery.resource_group_name, 'Microsoft.Compute/galleries/images/versions', shared_gallery.image_gallery, shared_gallery.image_definition, shared_gallery.image_version)
@@ -411,8 +409,10 @@ resource nodes_data_disks 'Microsoft.Compute/disks@2022-03-02' = [
   /*
     Create ultra data disks with setting iops and throughput, and attach them to the VMs.
     There is no way to use getCreateDisk with setting iops and throughput.
+    Use conditional count (0 when not ultra) instead of loop-level 'if' condition,
+    so ARM won't register resource names or evaluate body expressions when not needed.
   */
-  for i in range(0, (length(data_disks) * node_count)): if (is_ultradisk) {
+  for i in range(0, is_ultradisk ? (length(data_disks) * node_count) : 0): {
     name: '${nodes[(i / length(data_disks))].name}-data-disk-${(i % length(data_disks))}'
     location: location
     tags: tags
@@ -432,8 +432,10 @@ resource nodes_data_disks 'Microsoft.Compute/disks@2022-03-02' = [
 ]
 
 // Create managed disks from data VHD URIs
+// Use conditional count so ARM won't evaluate body expressions (like resourceId on
+// null vhd_details) when not needed.
 resource nodes_data_disks_with_vhds 'Microsoft.Compute/disks@2022-03-02' = [
-  for i in range(0, (length(data_disks) * node_count)): if (is_data_disk_with_vhd && !is_ultradisk) {
+  for i in range(0, (is_data_disk_with_vhd && !is_ultradisk) ? (length(data_disks) * node_count) : 0): {
     name: '${nodes[(i / length(data_disks))].name}-data-disk-${(i % length(data_disks))}'
     location: location
     tags: tags
@@ -466,7 +468,16 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
       imageReference: getImageReference(nodes[i])
       osDisk:  getVMOsDisk(nodes[i])
       diskControllerType: (nodes[i].disk_controller_type == 'SCSI') ? null : nodes[i].disk_controller_type
-      dataDisks: [for (item, j) in data_disks: getDataDisk(nodes[i].name, item, j)]
+      dataDisks: concat(
+        map(
+          filter(range(0, length(data_disks)), j => !shouldAttachDataDisk(data_disks[j])),
+          j => getCreateDisk(data_disks[j], '${nodes[i].name}-data-disk-${j}', j)
+        ),
+        map(
+          filter(range(0, length(data_disks)), j => shouldAttachDataDisk(data_disks[j])),
+          j => getAttachDisk(data_disks[j], '${nodes[i].name}-data-disk-${j}', j)
+        )
+      )
     }
     networkProfile: {
       networkInterfaces: [for j in range(0, nodes[i].nic_count): {
@@ -493,6 +504,7 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
     nodes_nics
     virtual_network_name_resource
     nodes_disk
+    nodes_data_disks
     nodes_data_disks_with_vhds
   ]
 }]

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.36.177.2456",
-      "templateHash": "18099469189437246926"
+      "version": "0.41.2.15936",
+      "templateHash": "16442678695930802815"
     }
   },
   "functions": [
@@ -172,29 +172,21 @@
               "createOption": "attach",
               "caching": "[parameters('disk').caching_type]",
               "managedDisk": {
-                "id": "[resourceId('Microsoft.Compute/disks', parameters('diskName'))]"
+                "id": "[format('{0}/providers/Microsoft.Compute/disks/{1}', resourceGroup().id, parameters('diskName'))]"
               }
             }
           }
         },
-        "getDataDisk": {
+        "shouldAttachDataDisk": {
           "parameters": [
-            {
-              "type": "string",
-              "name": "nodeName"
-            },
             {
               "type": "object",
               "name": "dataDisk"
-            },
-            {
-              "type": "int",
-              "name": "index"
             }
           ],
           "output": {
-            "type": "object",
-            "value": "[if(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(not(empty(parameters('dataDisk').vhd_details)), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
+            "type": "bool",
+            "value": "[bool(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(and(not(equals(parameters('dataDisk').vhd_details, null())), not(empty(parameters('dataDisk').vhd_details))), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))))]"
           }
         },
         "getOsDiskSharedGallery": {
@@ -770,47 +762,45 @@
     "nodes_data_disks": {
       "copy": {
         "name": "nodes_data_disks",
-        "count": "[length(range(0, mul(length(parameters('data_disks')), variables('node_count'))))]"
+        "count": "[length(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0)))]"
       },
-      "condition": "[parameters('is_ultradisk')]",
       "type": "Microsoft.Compute/disks",
       "apiVersion": "2022-03-02",
-      "name": "[format('{0}-data-disk-{1}', parameters('nodes')[div(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].name, mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks'))))]",
+      "name": "[format('{0}-data-disk-{1}', parameters('nodes')[div(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].name, mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks'))))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "properties": {
-        "diskSizeGB": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].size]",
+        "diskSizeGB": "[parameters('data_disks')[mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].size]",
         "creationData": {
-          "createOption": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].create_option]"
+          "createOption": "[parameters('data_disks')[mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].create_option]"
         },
-        "diskIOPSReadWrite": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].iops]",
-        "diskMBpsReadWrite": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].throughput]"
+        "diskIOPSReadWrite": "[parameters('data_disks')[mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].iops]",
+        "diskMBpsReadWrite": "[parameters('data_disks')[mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].throughput]"
       },
       "sku": {
-        "name": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].type]"
+        "name": "[parameters('data_disks')[mod(range(0, if(parameters('is_ultradisk'), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].type]"
       },
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]"
     },
     "nodes_data_disks_with_vhds": {
       "copy": {
         "name": "nodes_data_disks_with_vhds",
-        "count": "[length(range(0, mul(length(parameters('data_disks')), variables('node_count'))))]"
+        "count": "[length(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0)))]"
       },
-      "condition": "[and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk')))]",
       "type": "Microsoft.Compute/disks",
       "apiVersion": "2022-03-02",
-      "name": "[format('{0}-data-disk-{1}', parameters('nodes')[div(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].name, mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks'))))]",
+      "name": "[format('{0}-data-disk-{1}', parameters('nodes')[div(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].name, mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks'))))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
       "properties": {
         "creationData": {
-          "createOption": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].create_option]",
-          "storageAccountId": "[resourceId(parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_resource_group_name, 'Microsoft.Storage/storageAccounts', parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_account_name)]",
-          "sourceUri": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].vhd_details.vhd_uri]"
+          "createOption": "[parameters('data_disks')[mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].create_option]",
+          "storageAccountId": "[resourceId(parameters('data_disks')[mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_resource_group_name, 'Microsoft.Storage/storageAccounts', parameters('data_disks')[mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].vhd_details.storage_account_name)]",
+          "sourceUri": "[parameters('data_disks')[mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].vhd_details.vhd_uri]"
         }
       },
       "sku": {
-        "name": "[parameters('data_disks')[mod(range(0, mul(length(parameters('data_disks')), variables('node_count')))[copyIndex()], length(parameters('data_disks')))].type]"
+        "name": "[parameters('data_disks')[mod(range(0, if(and(parameters('is_data_disk_with_vhd'), not(parameters('is_ultradisk'))), mul(length(parameters('data_disks')), variables('node_count')), 0))[copyIndex()], length(parameters('data_disks')))].type]"
       },
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]"
     },
@@ -832,16 +822,10 @@
         },
         "osProfile": "[__bicep.getOsProfile(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]], parameters('admin_username'), parameters('admin_password'), parameters('admin_key_data'))]",
         "storageProfile": {
-          "copy": [
-            {
-              "name": "dataDisks",
-              "count": "[length(parameters('data_disks'))]",
-              "input": "[__bicep.getDataDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, parameters('data_disks')[copyIndex('dataDisks')], copyIndex('dataDisks'))]"
-            }
-          ],
           "imageReference": "[__bicep.getImageReference(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
           "osDisk": "[__bicep.getVMOsDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
-          "diskControllerType": "[if(equals(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type, 'SCSI'), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type)]"
+          "diskControllerType": "[if(equals(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type, 'SCSI'), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type)]",
+          "dataDisks": "[concat(map(filter(range(0, length(parameters('data_disks'))), lambda('j', not(__bicep.shouldAttachDataDisk(parameters('data_disks')[lambdaVariables('j')])))), lambda('j', __bicep.getCreateDisk(parameters('data_disks')[lambdaVariables('j')], format('{0}-data-disk-{1}', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, lambdaVariables('j')), lambdaVariables('j')))), map(filter(range(0, length(parameters('data_disks'))), lambda('j', __bicep.shouldAttachDataDisk(parameters('data_disks')[lambdaVariables('j')]))), lambda('j', __bicep.getAttachDisk(parameters('data_disks')[lambdaVariables('j')], format('{0}-data-disk-{1}', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, lambdaVariables('j')), lambdaVariables('j')))))]"
         },
         "networkProfile": {
           "copy": [
@@ -870,6 +854,7 @@
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]",
       "dependsOn": [
         "availability_set",
+        "nodes_data_disks",
         "nodes_data_disks_with_vhds",
         "nodes_disk",
         "nodes_image",
@@ -883,7 +868,7 @@
         "count": "[length(range(0, variables('node_count')))]"
       },
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "[format('{0}-nics', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name)]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -929,8 +914,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.36.177.2456",
-              "templateHash": "15654609969338604205"
+              "version": "0.41.2.15936",
+              "templateHash": "2282563054596282747"
             }
           },
           "functions": [


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
Probably it is a regression issue of https://github.com/microsoft/lisa/pull/4200
And recently we found ```deployment failed. LisaException: InvalidTemplate: Deployment template validation failed: 'The resource 'Microsoft.Compute/disks/lisa-Chaos-Monkey-Test-20260228-010303-739-e0-n0-data-disk-0' is not defined in the template. Please see https://aka.ms/arm-syntax for usage details.'.``` exception during deployment.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_deployment_provision_premiumv2_disk|verify_disk_with_fio_verify_option|verify_nested_kvm_basic

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
No features impacted, but impact deployment.

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops 2023-03-27-twas-single-server-base-image 2023-03-27-twas-single-server-base-image 9.0.20250429 (need attach data disks during deployment) + any test cases - repro 100%

Any images + verify_deployment_provision_premiumv2_disk|verify_disk_with_fio_verify_option|verify_nested_kvm_basic, not repro 100%, but if run in high concurrency, it may repro.

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|     ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops 2023-03-27-twas-single-server-base-image 2023-03-27-twas-single-server-base-image 9.0.20250429  + smoketest |      Any   | (before fix) FAILED |
|     ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops 2023-03-27-twas-single-server-base-image 2023-03-27-twas-single-server-base-image 9.0.20250429 + smoketest |      Any   | (after fix) PASSED |

Baihua has validated the vhd + vhd data disks scenario on her end.

I have run P3 against microsoftcblmariner azure-linux-3 azure-linux-3-gen2 3.20260304.01, didn't see this issue.
