### PR TITLE
hyperv: fix assignable device check syntax

### DIFF
--- a/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
+++ b/lisa/sut_orchestrator/hyperv/get_assignable_devices.py
@@ -159,10 +159,11 @@ ForEach-Object {
     $instanceId = $_.InstanceId
     $locationPaths = $null
     try {
-        $locationPaths = (
-            Get-PnpDeviceProperty -InstanceId $instanceId
-                'DEVPKEY_Device_LocationPaths' -ErrorAction Stop
-        ).Data
+        $locationPathProperty = Get-PnpDeviceProperty `
+            -InstanceId $instanceId `
+            -KeyName 'DEVPKEY_Device_LocationPaths' `
+            -ErrorAction Stop
+        $locationPaths = $locationPathProperty.Data
     } catch {
         Write-Verbose (
             "Failed to read DEVPKEY_Device_LocationPaths for device '{0}': {1}" -f

--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -175,7 +175,9 @@ class HyperVDevicePool(BaseDevicePool):
 $instanceId = '{escaped_instance_id}'
 $deadline = (Get-Date).AddSeconds({self.PNP_ENABLE_TIMEOUT_SECONDS})
 do {{
-    $device = Get-PnpDevice -PresentOnly -InstanceId $instanceId \
+    $device = Get-PnpDevice `
+        -PresentOnly `
+        -InstanceId $instanceId `
         -ErrorAction SilentlyContinue
     if ($null -ne $device) {{
         $code = "$($device.ConfigManagerErrorCode)".Trim()
@@ -187,7 +189,9 @@ do {{
     Start-Sleep -Seconds {self.PNP_ENABLE_POLL_INTERVAL_SECONDS}
 }} while ((Get-Date) -lt $deadline)
 
-$finalDevice = Get-PnpDevice -PresentOnly -InstanceId $instanceId \
+$finalDevice = Get-PnpDevice `
+    -PresentOnly `
+    -InstanceId $instanceId `
     -ErrorAction SilentlyContinue
 if ($null -eq $finalDevice) {{
     Write-Output 'device_not_present'
@@ -220,10 +224,11 @@ exit 1
 $target = '{escaped_location_path}'
 Get-VM | ForEach-Object {{
     $vmName = $_.Name
-    if (
-        Get-VMAssignableDevice -VMName $vmName -LocationPath $target
-            -ErrorAction SilentlyContinue
-    ) {{
+    $assignedDevice = Get-VMAssignableDevice `
+        -VMName $vmName `
+        -LocationPath $target `
+        -ErrorAction SilentlyContinue
+    if ($assignedDevice) {{
         Write-Output $vmName
     }}
 }}

--- a/lisa/tools/powershell.py
+++ b/lisa/tools/powershell.py
@@ -58,7 +58,7 @@ class PowerShell(Tool):
         no_debug_log: bool = True,
     ) -> Any:
         if output_json:
-            cmdlet = f"{cmdlet} | ConvertTo-Json"
+            cmdlet = f"{cmdlet.rstrip()} | ConvertTo-Json"
         process = self.run_cmdlet_async(
             cmdlet=cmdlet, force_run=force_run, sudo=sudo, no_debug_log=no_debug_log
         )


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
