### PR TITLE
[AI Generated] BugFix: Retry zypper operations on lock contention (exit code 7)

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2406,23 +2406,21 @@ class Suse(Linux):
         """
         result: ExecutableResult
         for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
+            self.wait_running_process("zypper")
             result = self._node.execute(cmd, **execute_kwargs)
             if result.exit_code != self._ZYPPER_EXIT_LOCK:
                 return result
-            self._log.debug(
+            self._log.warning(
                 f"zypper lock contention (exit code 7) during {operation_name}, "
                 f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
             )
-            self.wait_running_process("zypper")
             time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
-        if result.exit_code == self._ZYPPER_EXIT_LOCK:
-            raise LisaException(
-                f"zypper {operation_name} failed due to persistent lock contention "
-                f"(exit code 7) after {self._ZYPPER_LOCK_MAX_RETRIES} retries "
-                f"with {self._ZYPPER_LOCK_RETRY_DELAY}s delay between retries. "
-                f"stdout: {result.stdout!r}. stderr: {result.stderr!r}."
-            )
-        return result
+        raise LisaException(
+            f"zypper {operation_name} failed due to persistent lock contention "
+            f"(exit code 7) after {self._ZYPPER_LOCK_MAX_RETRIES} retries "
+            f"with {self._ZYPPER_LOCK_RETRY_DELAY}s delay between retries. "
+            f"stdout: {result.stdout!r}. stderr: {result.stderr!r}."
+        )
 
     def _initialize_package_installation(self) -> None:
         self.wait_running_process("zypper")
@@ -2434,8 +2432,11 @@ class Suse(Linux):
                 if service.is_service_inactive("guestregister"):
                     break
                 time.sleep(1)
-        output = self._node.execute(
-            "zypper --non-interactive --gpg-auto-import-keys refresh", sudo=True
+        output = self._execute_zypper_with_lock_retry(
+            "zypper --non-interactive --gpg-auto-import-keys refresh",
+            operation_name="refresh",
+            sudo=True,
+            timeout=600,
         ).stdout
         if self._no_repo_defined.search(output):
             raise RepoNotExistException(
@@ -2456,7 +2457,6 @@ class Suse(Linux):
             command += " --no-gpg-checks "
         remove_packages = " ".join(packages)
         command += f" rm {remove_packages}"
-        self.wait_running_process("zypper")
         uninstall_result = self._execute_zypper_with_lock_retry(
             command,
             operation_name="uninstall",
@@ -2483,7 +2483,6 @@ class Suse(Linux):
         if not signed:
             command += " --no-gpg-checks "
         command += f" in {' '.join(packages)}"
-        self.wait_running_process("zypper")
         install_result = self._execute_zypper_with_lock_retry(
             command,
             operation_name="install",
@@ -2507,8 +2506,12 @@ class Suse(Linux):
             if not signed:
                 command_with_force += " --no-gpg-checks "
             command_with_force += f" in --force-resolution {' '.join(packages)}"
-            install_result = self._node.execute(
-                command_with_force, shell=True, sudo=True, timeout=timeout
+            install_result = self._execute_zypper_with_lock_retry(
+                command_with_force,
+                operation_name="install (force-resolution)",
+                shell=True,
+                sudo=True,
+                timeout=timeout,
             )
 
         if install_result.exit_code in (1, 4, 100):
@@ -2529,7 +2532,9 @@ class Suse(Linux):
         command = "zypper --non-interactive --gpg-auto-import-keys update "
         if packages:
             command += " ".join(packages)
-        self._node.execute(command, sudo=True, timeout=3600)
+        self._execute_zypper_with_lock_retry(
+            command, operation_name="update", sudo=True, timeout=3600
+        )
 
     def _package_exists(self, package: str) -> bool:
         command = f"zypper search --installed-only --match-exact {package}"

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -227,7 +227,8 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None: ...
+    def capture_system_information(self, saved_path: Path) -> None:
+        ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -737,7 +738,8 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix): ...
+class BSD(Posix):
+    ...
 
 
 class BMC(Posix):
@@ -758,7 +760,8 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix): ...
+class Linux(Posix):
+    ...
 
 
 class CoreOs(Linux):
@@ -1608,7 +1611,8 @@ class FreeBSD(BSD):
         )
 
 
-class OpenBSD(BSD): ...
+class OpenBSD(BSD):
+    ...
 
 
 @dataclass

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -227,8 +227,7 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None:
-        ...
+    def capture_system_information(self, saved_path: Path) -> None: ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -738,8 +737,7 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix):
-    ...
+class BSD(Posix): ...
 
 
 class BMC(Posix):
@@ -760,8 +758,7 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix):
-    ...
+class Linux(Posix): ...
 
 
 class CoreOs(Linux):
@@ -1611,8 +1608,7 @@ class FreeBSD(BSD):
         )
 
 
-class OpenBSD(BSD):
-    ...
+class OpenBSD(BSD): ...
 
 
 @dataclass
@@ -2304,6 +2300,12 @@ class Suse(Linux):
 
     # zypper exit code 7: ZYPPER_EXIT_ERR_ZYPP — another zypper instance holds
     # the system management lock.  This is transient and retryable.
+    # Retries are tuned to balance resilience and test runtime:
+    # - In practice, zypper locks are typically released within a few seconds
+    #   once the competing process exits.
+    # - 5 attempts with a 10-second delay cap the worst-case wait at ~50s,
+    #   which is long enough for transient locks to clear without noticeably
+    #   extending overall LISA test runs.
     _ZYPPER_EXIT_LOCK = 7
     _ZYPPER_LOCK_MAX_RETRIES = 5
     _ZYPPER_LOCK_RETRY_DELAY = 10  # seconds
@@ -2359,17 +2361,9 @@ class Suse(Linux):
         if no_gpgcheck:
             cmd += " -G "
         cmd += f" {repo} {repo_name}"
-        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
-            cmd_result = self._node.execute(cmd=cmd, sudo=True)
-            if cmd_result.exit_code == self._ZYPPER_EXIT_LOCK:
-                self._log.debug(
-                    f"zypper lock contention (exit code 7), "
-                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
-                )
-                self.wait_running_process("zypper")
-                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
-                continue
-            break
+        cmd_result = self._execute_zypper_with_lock_retry(
+            cmd, operation_name="add_repository", sudo=True
+        )
         if "already exists. Please use another alias." not in cmd_result.stdout:
             cmd_result.assert_exit_code(0, f"fail to add repo {repo}")
         else:
@@ -2385,6 +2379,46 @@ class Suse(Linux):
             repo="https://packages.microsoft.com/yumrepos/azurecore/",
             repo_name="packages-microsoft-com-azurecore",
         )
+
+    def _execute_zypper_with_lock_retry(
+        self,
+        cmd: str,
+        operation_name: str,
+        **execute_kwargs: Any,
+    ) -> ExecutableResult:
+        """Execute a zypper command, retrying on lock contention (exit code 7).
+
+        Args:
+            cmd: The zypper command string to execute.
+            operation_name: Human-readable label used in log/error messages.
+            **execute_kwargs: Additional keyword arguments forwarded to
+                ``node.execute`` (e.g. ``sudo``, ``shell``, ``timeout``).
+
+        Returns:
+            The ``ExecutableResult`` of the last successful (non-lock) execution.
+
+        Raises:
+            LisaException: If lock contention persists after all retries.
+        """
+        result: ExecutableResult
+        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
+            result = self._node.execute(cmd, **execute_kwargs)
+            if result.exit_code != self._ZYPPER_EXIT_LOCK:
+                return result
+            self._log.debug(
+                f"zypper lock contention (exit code 7) during {operation_name}, "
+                f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
+            )
+            self.wait_running_process("zypper")
+            time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
+        if result.exit_code == self._ZYPPER_EXIT_LOCK:
+            raise LisaException(
+                f"zypper {operation_name} failed due to persistent lock contention "
+                f"(exit code 7) after {self._ZYPPER_LOCK_MAX_RETRIES} retries "
+                f"with {self._ZYPPER_LOCK_RETRY_DELAY}s delay between retries. "
+                f"stdout: {result.stdout!r}. stderr: {result.stderr!r}."
+            )
+        return result
 
     def _initialize_package_installation(self) -> None:
         self.wait_running_process("zypper")
@@ -2419,19 +2453,13 @@ class Suse(Linux):
         remove_packages = " ".join(packages)
         command += f" rm {remove_packages}"
         self.wait_running_process("zypper")
-        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
-            uninstall_result = self._node.execute(
-                command, shell=True, sudo=True, timeout=timeout
-            )
-            if uninstall_result.exit_code == self._ZYPPER_EXIT_LOCK:
-                self._log.debug(
-                    f"zypper lock contention (exit code 7), "
-                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
-                )
-                self.wait_running_process("zypper")
-                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
-                continue
-            break
+        uninstall_result = self._execute_zypper_with_lock_retry(
+            command,
+            operation_name="uninstall",
+            shell=True,
+            sudo=True,
+            timeout=timeout,
+        )
         uninstall_result.assert_exit_code(
             expected_exit_code=0,
             message=f"Could not uninstall package(s): {remove_packages}",
@@ -2452,19 +2480,13 @@ class Suse(Linux):
             command += " --no-gpg-checks "
         command += f" in {' '.join(packages)}"
         self.wait_running_process("zypper")
-        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
-            install_result = self._node.execute(
-                command, shell=True, sudo=True, timeout=timeout
-            )
-            if install_result.exit_code == self._ZYPPER_EXIT_LOCK:
-                self._log.debug(
-                    f"zypper lock contention (exit code 7), "
-                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
-                )
-                self.wait_running_process("zypper")
-                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
-                continue
-            break
+        install_result = self._execute_zypper_with_lock_retry(
+            command,
+            operation_name="install",
+            shell=True,
+            sudo=True,
+            timeout=timeout,
+        )
 
         # zypper exit codes that indicate dependency/resolution issues:
         # 1: ZYPPER_EXIT_ERR_BUG - Unexpected situation

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2302,6 +2302,12 @@ class Suse(Linux):
     )
     _ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
+    # zypper exit code 7: ZYPPER_EXIT_ERR_ZYPP — another zypper instance holds
+    # the system management lock.  This is transient and retryable.
+    _ZYPPER_EXIT_LOCK = 7
+    _ZYPPER_LOCK_MAX_RETRIES = 5
+    _ZYPPER_LOCK_RETRY_DELAY = 10  # seconds
+
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
         return re.compile("^SUSE|opensuse-leap$")
@@ -2353,7 +2359,17 @@ class Suse(Linux):
         if no_gpgcheck:
             cmd += " -G "
         cmd += f" {repo} {repo_name}"
-        cmd_result = self._node.execute(cmd=cmd, sudo=True)
+        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
+            cmd_result = self._node.execute(cmd=cmd, sudo=True)
+            if cmd_result.exit_code == self._ZYPPER_EXIT_LOCK:
+                self._log.debug(
+                    f"zypper lock contention (exit code 7), "
+                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
+                )
+                self.wait_running_process("zypper")
+                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
+                continue
+            break
         if "already exists. Please use another alias." not in cmd_result.stdout:
             cmd_result.assert_exit_code(0, f"fail to add repo {repo}")
         else:
@@ -2403,9 +2419,19 @@ class Suse(Linux):
         remove_packages = " ".join(packages)
         command += f" rm {remove_packages}"
         self.wait_running_process("zypper")
-        uninstall_result = self._node.execute(
-            command, shell=True, sudo=True, timeout=timeout
-        )
+        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
+            uninstall_result = self._node.execute(
+                command, shell=True, sudo=True, timeout=timeout
+            )
+            if uninstall_result.exit_code == self._ZYPPER_EXIT_LOCK:
+                self._log.debug(
+                    f"zypper lock contention (exit code 7), "
+                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
+                )
+                self.wait_running_process("zypper")
+                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
+                continue
+            break
         uninstall_result.assert_exit_code(
             expected_exit_code=0,
             message=f"Could not uninstall package(s): {remove_packages}",
@@ -2426,9 +2452,19 @@ class Suse(Linux):
             command += " --no-gpg-checks "
         command += f" in {' '.join(packages)}"
         self.wait_running_process("zypper")
-        install_result = self._node.execute(
-            command, shell=True, sudo=True, timeout=timeout
-        )
+        for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
+            install_result = self._node.execute(
+                command, shell=True, sudo=True, timeout=timeout
+            )
+            if install_result.exit_code == self._ZYPPER_EXIT_LOCK:
+                self._log.debug(
+                    f"zypper lock contention (exit code 7), "
+                    f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
+                )
+                self.wait_running_process("zypper")
+                time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
+                continue
+            break
 
         # zypper exit codes that indicate dependency/resolution issues:
         # 1: ZYPPER_EXIT_ERR_BUG - Unexpected situation

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2302,17 +2302,28 @@ class Suse(Linux):
     )
     _ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
-    # zypper exit code 7: ZYPPER_EXIT_ERR_ZYPP — another zypper instance holds
-    # the system management lock.  This is transient and retryable.
+    # Zypper lock contention can manifest in two ways:
+    #   1. Exit code 7 (ZYPPER_EXIT_ERR_ZYPP) — another zypper instance holds
+    #      the system management lock.
+    #   2. Exit code 8 (ZYPPER_EXIT_ERR_COMMIT) — zypper resolved packages but
+    #      the RPM transaction failed because another process holds
+    #      /usr/lib/sysimage/rpm/.rpm.lock. The stdout will contain
+    #      "can't create transaction lock on ...rpm.lock".
+    # Both conditions are transient and retryable.
     # Retries are tuned to balance resilience and test runtime:
-    # - In practice, zypper locks are typically released within a few seconds
+    # - In practice, locks are typically released within a few seconds
     #   once the competing process exits.
     # - 5 attempts with a 10-second delay cap the worst-case wait at ~50s,
     #   which is long enough for transient locks to clear without noticeably
     #   extending overall LISA test runs.
     _ZYPPER_EXIT_LOCK = 7
+    _ZYPPER_EXIT_COMMIT = 8
     _ZYPPER_LOCK_MAX_RETRIES = 5
     _ZYPPER_LOCK_RETRY_DELAY = 10  # seconds
+    _rpm_lock_pattern = re.compile(
+        r"can't create transaction lock on.*\.rpm\.lock",
+        re.I,
+    )
 
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
@@ -2384,13 +2395,32 @@ class Suse(Linux):
             repo_name="packages-microsoft-com-azurecore",
         )
 
+    def _is_zypper_lock_error(self, result: ExecutableResult) -> bool:
+        """Check if a zypper result indicates lock contention.
+
+        Detects two lock scenarios:
+        - Exit code 7: zypper-level lock (another zypper instance running).
+        - Exit code 8 with RPM lock message: zypper resolved dependencies but
+          the RPM transaction failed on /usr/lib/sysimage/rpm/.rpm.lock.
+        """
+        if result.exit_code == self._ZYPPER_EXIT_LOCK:
+            return True
+        if result.exit_code == self._ZYPPER_EXIT_COMMIT:
+            output = f"{result.stdout}\n{result.stderr}"
+            if self._rpm_lock_pattern.search(output):
+                return True
+        return False
+
     def _execute_zypper_with_lock_retry(
         self,
         cmd: str,
         operation_name: str,
         **execute_kwargs: Any,
     ) -> ExecutableResult:
-        """Execute a zypper command, retrying on lock contention (exit code 7).
+        """Execute a zypper command, retrying on lock contention.
+
+        Retries on zypper exit code 7 (zypper lock) and exit code 8 when
+        the RPM transaction lock (.rpm.lock) is held by another process.
 
         Args:
             cmd: The zypper command string to execute.
@@ -2408,16 +2438,18 @@ class Suse(Linux):
         for retry_num in range(self._ZYPPER_LOCK_MAX_RETRIES):
             self.wait_running_process("zypper")
             result = self._node.execute(cmd, **execute_kwargs)
-            if result.exit_code != self._ZYPPER_EXIT_LOCK:
+            if not self._is_zypper_lock_error(result):
                 return result
             self._log.warning(
-                f"zypper lock contention (exit code 7) during {operation_name}, "
+                f"zypper lock contention (exit code {result.exit_code}) "
+                f"during {operation_name}, "
                 f"retry {retry_num + 1}/{self._ZYPPER_LOCK_MAX_RETRIES}"
             )
             time.sleep(self._ZYPPER_LOCK_RETRY_DELAY)
         raise LisaException(
             f"zypper {operation_name} failed due to persistent lock contention "
-            f"(exit code 7) after {self._ZYPPER_LOCK_MAX_RETRIES} retries "
+            f"(exit code {result.exit_code}) "
+            f"after {self._ZYPPER_LOCK_MAX_RETRIES} retries "
             f"with {self._ZYPPER_LOCK_RETRY_DELAY}s delay between retries. "
             f"stdout: {result.stdout!r}. stderr: {result.stderr!r}."
         )


### PR DESCRIPTION
## Summary

Zypper exits with code 7 (ZYPPER_EXIT_ERR_ZYPP) when another process holds the system management lock. This is a transient condition, but `add_repository()`, `_install_packages()`, and `_uninstall_packages()` in the `Suse` class all treated it as a hard failure.

Adds retry logic (up to 5 attempts with 10s delay + `wait_running_process`) that detects exit code 7, waits for the competing zypper process to finish, then retries the command.

## Validation Results
| Image | Result |
|-------|--------|
| SUSE sles-15-sp6 gen2 2026.01.23 | PASSED |