### PR TITLE
Add MissingPackagesException for suse

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2432,9 +2432,9 @@ class Suse(Linux):
 
         # zypper exit codes:
         # 0: ZYPPER_EXIT_OK - Success
-        # 1: ZYPPER_EXIT_ERR_BUG - Unexpected situation
-        # 4: ZYPPER_EXIT_ERR_ZYPP - Capability not found or dependency problem
-        # 100: ZYPPER_EXIT_INF_UPDATE_NEEDED - Updates available
+        # 1: ZYPPER_EXIT_ERR_BUG - Unexpected situation (internal error)
+        # 4: ZYPPER_EXIT_ERR_ZYPP - A libzypp error (e.g. dependency conflict)
+        # 100: ZYPPER_EXIT_INF_UPDATE_NEEDED - Updates available (install may succeed)
         # 104: ZYPPER_EXIT_INF_CAP_NOT_FOUND - Requested package/capability not found
         # If installation failed due to dependency conflicts, retry with
         # --force-resolution to allow zypper to automatically resolve conflicts

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2430,10 +2430,12 @@ class Suse(Linux):
             command, shell=True, sudo=True, timeout=timeout
         )
 
-        # zypper exit codes that indicate dependency/resolution issues:
+        # zypper exit codes:
+        # 0: ZYPPER_EXIT_OK - Success
         # 1: ZYPPER_EXIT_ERR_BUG - Unexpected situation
-        # 4: ZYPPER_EXIT_INF_CAP_NOT_FOUND - Capability not found or dependency problem
+        # 4: ZYPPER_EXIT_ERR_ZYPP - Capability not found or dependency problem
         # 100: ZYPPER_EXIT_INF_UPDATE_NEEDED - Updates available
+        # 104: ZYPPER_EXIT_INF_CAP_NOT_FOUND - Requested package/capability not found
         # If installation failed due to dependency conflicts, retry with
         # --force-resolution to allow zypper to automatically resolve conflicts
         if install_result.exit_code in (1, 4, 100):

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2454,6 +2454,8 @@ class Suse(Linux):
                 f"Failed to install {packages}. exit_code: {install_result.exit_code}, "
                 f"stdout: {install_result.stdout}, stderr: {install_result.stderr}"
             )
+        elif install_result.exit_code == 104:
+            raise MissingPackagesException(packages)
         elif install_result.exit_code == 0:
             self._log.debug(f"{packages} is/are installed successfully.")
         else:


### PR DESCRIPTION
## Description

When zypper returns exit code 104 (package not found), the code now raises MissingPackagesException instead of a generic LisaException.
This makes missing-package failures clearer and easier to handle in higher-level test logic.

## Related Issue

Fix case verify_hyperv_platform_id

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_hyperv_platform_id

**Impacted LISA Features:**
None

**Tested Azure Marketplace Images:**
SUSE sles-15-sp6 gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|    SUSE sles-15-sp6 gen2 latest   |         |  FAILED (before fix) |
|    SUSE sles-15-sp6 gen2 latest   |         |  PASSED (after fix) |
