### PR TITLE
SKIP 'verify_hv_kvp_daemon_installed' on CVMs

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -19,6 +19,7 @@ from lisa import (
 )
 from lisa.base_tools.uname import Uname
 from lisa.features import Disk
+from lisa.features.security_profile import CvmDisabled
 from lisa.features.virtualization import HyperVHostType
 from lisa.operating_system import (
     BSD,
@@ -727,6 +728,9 @@ class AzureImageStandard(TestSuite):
         This test will check that kvp daemon is installed. This is an optional
         requirement for Debian based distros.
 
+        KVP daemon is not supported / disabled on CVMs (SNP/TDX) to restrict
+        host/guest interaction to minimize attack surface.
+
         Steps:
         1. Verify that list of running process matching name of kvp daemon
         has length greater than zero.
@@ -734,7 +738,7 @@ class AzureImageStandard(TestSuite):
         priority=2,
         requirement=simple_requirement(
             supported_platform_type=[AZURE, READY, HYPERV],
-            supported_features=[HyperVHostType()],
+            supported_features=[HyperVHostType(), CvmDisabled()],
         ),
     )
     def verify_hv_kvp_daemon_installed(self, node: Node) -> None:


### PR DESCRIPTION

## Description

KVP daemon is not supported / disabled on CVMs (SNP/TDX) to restrict host/guest interaction to minimize attack surface.
verify_hv_kvp_daemon_installed is passing on CVMs with message "warning: hv_kvp_daemon is not installed" which is incorrect behaviour
## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_hv_kvp_daemon_installed

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
canonical ubuntu-24_04-lts cvm latest
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical ubuntu-24_04-lts cvm latest|Standard_DC2es_v6| SKIPPED |
