### PR TITLE
Reduce number of iteration in stress_reboot test from 100 to 10

### DIFF
--- a/lisa/microsoft/testsuites/core/provisioning.py
+++ b/lisa/microsoft/testsuites/core/provisioning.py
@@ -353,12 +353,12 @@ class Provisioning(TestSuite):
     @TestCaseMetadata(
         description="""
         This case performs a reboot stress test on the node
-        and iterates smoke test 100 times.
+        and iterates smoke test 10 times.
         The test steps are almost the same as `smoke_test`.
         The reboot times is summarized after the test is run
         """,
         priority=3,
-        timeout=10800,
+        timeout=1800,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
         ),
@@ -366,15 +366,15 @@ class Provisioning(TestSuite):
     def stress_reboot(self, log: Logger, node: RemoteNode, log_path: Path) -> None:
         reboot_times = []
         try:
-            for i in range(100):
+            for i in range(10):
                 elapsed = self._smoke_test(log, node, log_path, "stress_reboot")
                 reboot_times.append((i + 1, elapsed))
-                log.debug(f"Reboot iterations {i + 1}/100 completed in {elapsed:.2f}s")
+                log.debug(f"Reboot iterations {i + 1}/10 completed in {elapsed:.2f}s")
         except PassedException as e:
             raise LisaException(e)
         finally:
             times = [time for _, time in reboot_times if isinstance(time, (int, float))]
-            log.info(f"completed {i + 1}/100 iterations;summary:")
+            log.info(f"completed {i + 1}/10 iterations;summary:")
             log.info(f"Min reboot time: {min(times):.2f}s")
             log.info(f"Max reboot time: {max(times):.2f}s")
             log.info(f"Average reboot time: {mean(times):.2f}s")

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -816,7 +816,7 @@ class Ntttcp(Tool):
             )
         if need_reboot:
             self._log.debug("reboot vm to make sure TasksMax change take effect")
-            self.node.reboot()
+            self.node.reboot(time_out=600)
 
 
 class BSDNtttcp(Ntttcp):


### PR DESCRIPTION
## Description

Reduce number of iteration in stress_reboot test from 100 to 10. Likely to hit issues which customers face in under 10 iterations.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
RedHat:RHEL:9_7:9.7.2025102907,canonical:ubuntu-24_04-lts:server:latest
-

## Test Results
https://microsoft.visualstudio.com/LSG/_build/results?buildId=143648896

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
