### PR TITLE
Fixing incorrect variable name 'size_gb' which actually represents 'size_mb'

### DIFF
--- a/lisa/microsoft/testsuites/cpu/cpusuite.py
+++ b/lisa/microsoft/testsuites/cpu/cpusuite.py
@@ -111,7 +111,7 @@ class CPUSuite(TestSuite):
                 numjob=10,
                 time=fio_run_time,
                 block_size="1M",
-                size_gb=fio_data_size_in_gb,
+                size_mb=fio_data_size_in_gb,
                 group_reporting=False,
                 overwrite=True,
                 time_based=True,

--- a/lisa/microsoft/testsuites/cpu/cpusuite.py
+++ b/lisa/microsoft/testsuites/cpu/cpusuite.py
@@ -98,9 +98,9 @@ class CPUSuite(TestSuite):
     )
     def verify_cpu_offline_storage_workload(self, log: Logger, node: Node) -> None:
         # run fio process asynchronously on the node
-        fio_data_size_in_gb = 1
+        fio_data_size_in_mb = 1
         try:
-            image_folder_path = node.find_partition_with_freespace(fio_data_size_in_gb)
+            image_folder_path = node.find_partition_with_freespace(fio_data_size_in_mb)
             # Each CPU takes ~10 seconds to toggle offline-online
             fio_run_time = 300 + (node.tools[Lscpu].get_thread_count() * 10)
             fio_process = node.tools[Fio].launch_async(
@@ -111,7 +111,7 @@ class CPUSuite(TestSuite):
                 numjob=10,
                 time=fio_run_time,
                 block_size="1M",
-                size_mb=fio_data_size_in_gb,
+                size_mb=fio_data_size_in_mb,
                 group_reporting=False,
                 overwrite=True,
                 time_based=True,

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -156,7 +156,7 @@ def perf_disk(
                 filename=filename,
                 mode=mode.name,
                 time=time,
-                size_gb=size_mb,
+                size_mb=size_mb,
                 block_size=f"{block_size}K",
                 iodepth=iodepth,
                 overwrite=overwrite,

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -365,7 +365,7 @@ def run_storage_workload(node: Node) -> Decimal:
         time=120,
         block_size="1M",
         overwrite=True,
-        size_gb=1,
+        size_mb=1,
     )
     return fio_result.iops
 

--- a/lisa/microsoft/testsuites/storage/storagesuite.py
+++ b/lisa/microsoft/testsuites/storage/storagesuite.py
@@ -153,7 +153,7 @@ class StorageTest(TestSuite):
                     numjob=0,
                     time=0,
                     block_size="",
-                    size_gb=100,
+                    size_mb=100,
                     group_reporting=False,
                     do_verify=True,
                     bsrange="512-256K",

--- a/lisa/tools/fio.py
+++ b/lisa/tools/fio.py
@@ -96,7 +96,7 @@ class Fio(Tool):
         time: int = 120,
         ssh_timeout: int = 6400,
         block_size: str = "4K",
-        size_gb: int = 0,
+        size_mb: int = 0,
         direct: bool = True,
         gtod_reduce: bool = False,
         group_reporting: bool = True,
@@ -118,7 +118,7 @@ class Fio(Tool):
             numjob,
             time,
             block_size,
-            size_gb,
+            size_mb,
             direct,
             gtod_reduce,
             group_reporting,
@@ -154,7 +154,7 @@ class Fio(Tool):
         numjob: int,
         time: int = 120,
         block_size: str = "4K",
-        size_gb: int = 0,
+        size_mb: int = 0,
         direct: bool = True,
         gtod_reduce: bool = False,
         group_reporting: bool = True,
@@ -176,7 +176,7 @@ class Fio(Tool):
             numjob,
             time,
             block_size,
-            size_gb,
+            size_mb,
             direct,
             gtod_reduce,
             group_reporting,
@@ -326,7 +326,7 @@ class Fio(Tool):
         numjob: int = 0,
         time: int = 120,
         block_size: str = "4K",
-        size_gb: int = 0,
+        size_mb: int = 0,
         direct: bool = True,
         gtod_reduce: bool = False,
         group_reporting: bool = True,
@@ -358,8 +358,8 @@ class Fio(Tool):
             cmd += " --direct=1"
         if gtod_reduce:
             cmd += " --gtod_reduce=1"
-        if size_gb:
-            cmd += f" --size={size_gb}M"
+        if size_mb:
+            cmd += f" --size={size_mb}M"
         if group_reporting:
             cmd += " --group_reporting"
         if overwrite:


### PR DESCRIPTION
## Description
Fixing incorrect variable name 'size_gb' which actually represents 'size_mb'

## Related Issue
size_gb is misleading variable name.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
perf_nvme
perf_premium_datadisks_4k
perf_premium_datadisks_1024k


**Impacted LISA Features:**
None

**Tested Azure Marketplace Images:**
-  canonical ubuntu-24_04-lts server latest


## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical ubuntu-24_04-lts server latest|Standard_D32s_v5| PASSED  |
