### PR TITLE
BugFix: Skip verify_cifs_basic on FIPS-enabled images

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -689,7 +689,7 @@ class Storage(TestSuite):
             force_run=True,
             no_error_log=True,
         )
-        if fips_result.exit_code == 0 and fips_result.stdout.strip() == "1":
+        if fips_result.exit_code == 0 and (fips_result.stdout or "").strip() == "1":
             raise SkippedException(
                 "This test mounts Azure Files over SMB using shared-key/"
                 "NTLMSSP authentication, which is not FIPS-compliant."

--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -682,6 +682,19 @@ class Storage(TestSuite):
         priority=5,
     )
     def verify_cifs_basic(self, node: Node, environment: Environment) -> None:
+        # FIPS mode disallows the MD5-based NTLMSSP signing that CIFS/SMB
+        # mounts rely on by default, so skip rather than fail on FIPS images.
+        fips_result = node.tools[Cat].run(
+            "/proc/sys/crypto/fips_enabled",
+            force_run=True,
+            no_error_log=True,
+        )
+        if fips_result.exit_code == 0 and fips_result.stdout.strip() == "1":
+            raise SkippedException(
+                "This test mounts Azure Files over SMB using shared-key/"
+                "NTLMSSP authentication, which is not FIPS-compliant."
+            )
+
         if not node.tools[KernelConfig].is_enabled("CONFIG_CIFS"):
             raise LisaException("CIFS module must be present in Azure Endorsed Distros")
         test_folder = "/root/test"


### PR DESCRIPTION
`verify_cifs_basic` was failing on FIPS-enabled images because Azure Files SMB mounts rely on shared-key/NTLMSSP authentication (MD5-based signing), which is disallowed in FIPS mode.

## Changes

- **FIPS detection**: Reads `/proc/sys/crypto/fips_enabled` via `node.tools[Cat]` at the start of `verify_cifs_basic`
- **Skip on FIPS**: Raises `SkippedException` when FIPS is active, with a message scoped to this test's auth mechanism (shared-key/NTLMSSP) to avoid implying CIFS/SMB is universally incompatible with FIPS
- **Null-safe stdout check**: Uses `(fips_result.stdout or "").strip() == "1"` to guard against `None` stdout

```python
fips_result = node.tools[Cat].run(
    "/proc/sys/crypto/fips_enabled",
    force_run=True,
    no_error_log=True,
)
if fips_result.exit_code == 0 and (fips_result.stdout or "").strip() == "1":
    raise SkippedException(
        "This test mounts Azure Files over SMB using shared-key/"
        "NTLMSSP authentication, which is not FIPS-compliant."
    )
```