### PR TITLE
Delete the old environment before setting the status to NEW

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -311,6 +311,9 @@ class LisaRunner(BaseRunner):
                     environment.status = EnvironmentStatus.New
         except Exception as e:
             if self._need_retry(environment):
+                # if need retry, the environment should be deleted before setting the
+                # status to new, otherwise, the environment won't be cleaned up.
+                self._delete_environment_task(environment=environment, test_results=[])
                 environment.status = EnvironmentStatus.New
             else:
                 # Final attempt failed; handle the failure

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -639,17 +639,12 @@ class RunnerTestCase(TestCase):
                 "generated_2",
             ],
             expected_deployed_envs=[],
-            expected_deleted_envs=[
-                "generated_0",
-                "generated_0",
-                "generated_0",
-                "generated_1",
-                "generated_1",
-                "generated_1",
-                "generated_2",
-                "generated_2",
-                "generated_2",
-            ],
+            # Each environment is deleted once per failed deployment attempt:
+            # the initial attempt plus `env_runbook.retry` retries.
+            expected_deleted_envs=
+            ["generated_0"] * (env_runbook.retry + 1)
+            + ["generated_1"] * (env_runbook.retry + 1)
+            + ["generated_2"] * (env_runbook.retry + 1),
             runner=runner,
         )
         self.verify_test_results(

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -641,7 +641,13 @@ class RunnerTestCase(TestCase):
             expected_deployed_envs=[],
             expected_deleted_envs=[
                 "generated_0",
+                "generated_0",
+                "generated_0",
                 "generated_1",
+                "generated_1",
+                "generated_1",
+                "generated_2",
+                "generated_2",
                 "generated_2",
             ],
             runner=runner,

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -641,10 +641,11 @@ class RunnerTestCase(TestCase):
             expected_deployed_envs=[],
             # Each environment is deleted once per failed deployment attempt:
             # the initial attempt plus `env_runbook.retry` retries.
-            expected_deleted_envs=
-            ["generated_0"] * (env_runbook.retry + 1)
-            + ["generated_1"] * (env_runbook.retry + 1)
-            + ["generated_2"] * (env_runbook.retry + 1),
+            expected_deleted_envs=(
+                ["generated_0"] * (env_runbook.retry + 1)
+                + ["generated_1"] * (env_runbook.retry + 1)
+                + ["generated_2"] * (env_runbook.retry + 1)
+            ),
             runner=runner,
         )
         self.verify_test_results(


### PR DESCRIPTION
This change addresses the issue where environments were not cleaned up when the Environment retry count was greater than zero.

## Description

This change addresses the issue where environments were not cleaned up when the Environment retry count was greater than zero.
Previously, when a retry was triggered, only the latest environment was deleted, while older environments remained uncleared. This resulted in leftover resources after multiple retries.
To resolve this issue, the _delete_environment_task has been added during retry operations to ensure that all previously created environments are properly cleaned up.

## Related Issue
Before the fix
The related logs are:
```
2026-04-14 02:23:26.056[67164][INFO] lisa.env[generated_0].deploy creating or updating resource group: [lisa-None-20260414-022033-118-e0]
2026-04-14 02:23:28.331[67164][INFO] lisa.env[generated_0].deploy Creating Resource group: 'lisa-None-20260414-022033-118-e0'
2026-04-14 02:23:31.994[67164][DEBUG] lisa.env[generated_0].deploy validating deployment
2026-04-14 02:23:43.276[67164][DEBUG] lisa.env[generated_0].deploy found storage account: lisaswestus36a28e896
2026-04-14 02:23:43.277[67164][INFO] lisa.env[generated_0].deploy resource group 'lisa-None-20260414-022033-118-e0' deployment is in progress...
2026-04-14 02:44:36.079[67164][DEBUG] lisa.env[generated_0].deploy checking panic...
2026-04-14 02:44:36.083[67164][DEBUG] lisa.env[generated_0].deploy checking root filesystem mount failure...
2026-04-14 02:44:36.089[67164][INFO] lisa.runner[0] Retrying... (Attempt 1/2)
2026-04-14 02:44:36.096[64088][DEBUG] lisa.[azure].prepare[generated_0] allowed locations: ['westus3']
...
2026-04-14 02:44:41.205[67164][INFO] lisa.env[generated_0].deploy creating or updating resource group: [lisa-None-20260414-022033-118-e0-1]
2026-04-14 02:44:43.946[67164][INFO] lisa.env[generated_0].deploy Creating Resource group: 'lisa-None-20260414-022033-118-e0-1'
2026-04-14 02:44:47.818[67164][DEBUG] lisa.env[generated_0].deploy validating deployment
2026-04-14 02:44:59.625[67164][DEBUG] lisa.env[generated_0].deploy found storage account: lisaswestus36a28e896
2026-04-14 02:44:59.625[67164][INFO] lisa.env[generated_0].deploy resource group 'lisa-None-20260414-022033-118-e0-1' deployment is in progress...
2026-04-14 03:05:57.405[67164][DEBUG] lisa.env[generated_0].deploy checking panic...
2026-04-14 03:05:57.411[67164][DEBUG] lisa.env[generated_0].deploy checking root filesystem mount failure...
```

 Only the newest environment was deleted, while older environment lisa-None-20260414-022033-118-e0 is leftover.
`2026-04-14 03:27:54.743[67164][INFO] lisa.[azure].del[generated_0] deleting resource group: lisa-None-20260414-022033-118-e0-1, wait: False`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation
After the fix, all old environments are deleted as expected.
```
2026-04-14 04:01:19.710[67552][INFO] lisa.[azure].del[generated_0] deleting resource group: lisa-None-20260414-033738-838-e0, wait: False
2026-04-14 04:23:43.158[67552][INFO] lisa.[azure].del[generated_0] deleting resource group: lisa-None-20260414-033738-838-e0-1, wait: False
```

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
