### PR TITLE
[AI Generated] BugFix: expand clang version detection for XDP tools on newer Ubuntu

### DIFF
--- a/lisa/microsoft/testsuites/xdp/xdptools.py
+++ b/lisa/microsoft/testsuites/xdp/xdptools.py
@@ -121,12 +121,18 @@ class XdpTool(Tool):
                         package_list.append(package)
             else:
                 package_list.append("gcc-multilib")
-            if self.node.os.is_package_in_repo("clang-11"):
-                package_list.append("clang-11")
-                config_envs.update({"CLANG": "clang-11", "LLC": "llc-11"})
-            elif self.node.os.is_package_in_repo("clang-10"):
-                package_list.append("clang-10")
-                config_envs.update({"CLANG": "clang-10", "LLC": "llc-10"})
+            for ver in range(18, 9, -1):
+                clang_pkg = f"clang-{ver}"
+                if self.node.os.is_package_in_repo(clang_pkg):
+                    package_list.append(clang_pkg)
+                    config_envs.update({"CLANG": clang_pkg, "LLC": f"llc-{ver}"})
+                    break
+            else:
+                raise UnsupportedDistroException(
+                    self.node.os,
+                    "No clang package (clang-18 through clang-10) found in "
+                    "any configured repository.",
+                )
             self.node.os.install_packages(package_list)
 
         elif isinstance(self.node.os, Fedora):


### PR DESCRIPTION
## Summary
The XDP tool install only checked for clang-11 and clang-10, which are unavailable on Ubuntu 23.10+ (ships clang-17/18). This caused `./configure` to fail with `could not find tool clang`.

Expanded the search to clang-18 through clang-10 (descending order) and added a terminal error if no clang version is found.

## Validation Results
| Image | Result |
|-------|--------|
| Canonical ubuntu-24_04-lts server 24.04.202408210 | PASSED (configure + build succeeded; 2 unrelated upstream xdp-tools test failures) |