### PR TITLE
[AI Generated] BugFix: Skip resource disk readme check when cloud-init manages the disk

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -41,6 +41,7 @@ from lisa.operating_system import (
     Ubuntu,
 )
 from lisa.sut_orchestrator import AZURE, HYPERV, QEMU, READY
+from lisa.sut_orchestrator.azure.common import is_cloud_init_enabled
 from lisa.sut_orchestrator.azure.features import AzureDiskOptionSettings
 from lisa.sut_orchestrator.azure.tools import Waagent
 from lisa.tools import (
@@ -1463,8 +1464,16 @@ class AzureImageStandard(TestSuite):
             assert_that(folder_exists, f"{fold_path} should be present").is_true()
 
         # verify DATALOSS_WARNING_README.txt file exists
+        # This file is created by waagent, not cloud-init. When cloud-init
+        # manages the resource disk, the file will not be present.
         file_path = f"{resource_disk_mount_point}/DATALOSS_WARNING_README.txt"
         file_exists = node.tools[Ls].path_exists(file_path, sudo=True)
+        if not file_exists and is_cloud_init_enabled(node):
+            raise SkippedException(
+                f"{file_path} is not present. DATALOSS_WARNING_README.txt is"
+                " created by waagent, not cloud-init. Skipping on cloud-init"
+                " managed resource disk."
+            )
         assert_that(file_exists, f"{file_path} should be present").is_true()
 
         # verify 'WARNING: THIS IS A TEMPORARY DISK' contained in


### PR DESCRIPTION
## Summary
When cloud-init manages the resource disk (e.g. on Debian 12, SUSE), it does not create the `DATALOSS_WARNING_README.txt` file — only waagent does. This caused `verify_resource_disk_readme_file` to fail with an assertion error on cloud-init managed distros.

The fix checks whether the readme file is absent **and** cloud-init is managing the resource disk. If so, the test is skipped with a descriptive message instead of failing.

## Validation Results
| Image | Result |
|-------|--------|
| Debian debian-12 12 latest | SKIPPED (expected — cloud-init managed) |
| Canonical ubuntu-24_04-lts server latest | PASSED |