### PR TITLE
[AI Generated] Fix Azure VM size mismatch skip reason message

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -2958,7 +2958,7 @@ class AzurePlatform(Platform):
                         seen.add(r)
                         unique_reasons.append(r)
                 error = "Requirement mismatch: " + "; ".join(unique_reasons)
-            else:
+            elif not error:
                 error = (
                     f"Test skipped on '{location}' for an unknown reason. "
                     "This could be due to insufficient quota, unmet hardware "
@@ -3021,7 +3021,14 @@ class AzurePlatform(Platform):
         )
 
         if not allowed_capabilities:
-            error = f"no vm size found in '{location}' for {allowed_vm_sizes}."
+            if node_runbook.vm_size:
+                error = (
+                    "Requirement mismatch: requested VM size "
+                    f"'{node_runbook.vm_size}' is unavailable in '{location}' "
+                    "or incompatible with current test requirements."
+                )
+            else:
+                error = f"no vm size found in '{location}' for {allowed_vm_sizes}."
 
         return allowed_capabilities, error
 


### PR DESCRIPTION
## Problem

When a test is run with a specific VM size that is incompatible with the requested image (e.g., x86-only `Standard_HC44-16rs` with an Arm64 Ubuntu image), LISA showed a misleading skip reason:

> "Test skipped on 'westus3' for an unknown reason. This could be due to insufficient quota..."

## Root Cause

In `_get_allowed_capabilities()`, when `not allowed_capabilities` and a specific `vm_size` was set, the error was a generic "no vm size found..." message. Then in `_get_azure_capabilities()`, the `else:` branch unconditionally overwrote any specific error set earlier with the generic "unknown reason" fallback.

## Fix

1. **`_get_allowed_capabilities()`**: When `not allowed_capabilities` and `node_runbook.vm_size` is explicitly set, emit a clear message: `"Requirement mismatch: requested VM size '<size>' is unavailable in '<location>' or incompatible with current test requirements."`

2. **`_get_azure_capabilities()`**: Changed `else:` → `elif not error:` so the generic "unknown reason" fallback only fires when no specific error was already populated.

## Validation

Repro with `Standard_HC44-16rs` + `22_04-lts-arm64` image in `westus3` now shows:

> "Requirement mismatch: requested VM size 'Standard_HC44-16rs' is unavailable in 'westus3' or incompatible with current test requirements."