### PR TITLE
Fix ARM data-disk copy-loop validation error

### DIFF
--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -65,6 +65,7 @@ param source_address_prefixes array
 param create_public_address bool
 
 var vnet_id = virtual_network_name_resource.id
+var rg_id = resourceGroup().id
 var node_count = length(nodes)
 var availability_set_name_value = 'lisa-availabilitySet'
 var existing_subnet_ref = (empty(virtual_network_resource_group) ? '' : resourceId(virtual_network_resource_group, 'Microsoft.Network/virtualNetworks/subnets', virtual_network_name, subnet_prefix))
@@ -131,16 +132,18 @@ func getCreateDisk(disk object, diskName string, index int) object => {
   }
 }
 
-func getAttachDisk(disk object, diskName string, index int) object => {
+func getAttachDisk(disk object, diskName string, index int, rgId string) object => {
   lun: index
   createOption: 'attach'
   caching: disk.caching_type
   managedDisk: {
-      id: '${resourceGroup().id}/providers/Microsoft.Compute/disks/${diskName}'
+      id: '${rgId}/providers/Microsoft.Compute/disks/${diskName}'
   }
 }
 
-func shouldAttachDataDisk(dataDisk object) bool => bool(dataDisk.type == 'UltraSSD_LRS' || (dataDisk.vhd_details != null && !empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
+func getDataDisk(nodeName string, dataDisk object, index int, rgId string) object => (dataDisk.type == 'UltraSSD_LRS' || (!empty(dataDisk.vhd_details) && (!empty(dataDisk.vhd_details.vhd_uri))))
+? getAttachDisk(dataDisk, '${nodeName}-data-disk-${index}', index, rgId)
+: getCreateDisk(dataDisk, '${nodeName}-data-disk-${index}', index)
 
 func getOsDiskSharedGallery(shared_gallery object) object => {
   id: resourceId(shared_gallery.subscription_id, empty(shared_gallery.resource_group_name) ? 'None' : shared_gallery.resource_group_name, 'Microsoft.Compute/galleries/images/versions', shared_gallery.image_gallery, shared_gallery.image_definition, shared_gallery.image_version)
@@ -409,8 +412,10 @@ resource nodes_data_disks 'Microsoft.Compute/disks@2022-03-02' = [
   /*
     Create ultra data disks with setting iops and throughput, and attach them to the VMs.
     There is no way to use getCreateDisk with setting iops and throughput.
-    Use conditional count (0 when not ultra) instead of loop-level 'if' condition,
-    so ARM won't register resource names or evaluate body expressions when not needed.
+    The condition is folded into the range count so that the copy loop produces
+    0 iterations when is_ultradisk is false. Using `for...if` with a non-zero
+    count but false condition leaves phantom resources in the ARM dependency
+    graph, causing validation errors in dependsOn references.
   */
   for i in range(0, is_ultradisk ? (length(data_disks) * node_count) : 0): {
     name: '${nodes[(i / length(data_disks))].name}-data-disk-${(i % length(data_disks))}'
@@ -431,9 +436,8 @@ resource nodes_data_disks 'Microsoft.Compute/disks@2022-03-02' = [
   }
 ]
 
-// Create managed disks from data VHD URIs
-// Use conditional count so ARM won't evaluate body expressions (like resourceId on
-// null vhd_details) when not needed.
+// Create managed disks from data VHD URIs.
+// Condition folded into range count ??? see nodes_data_disks comment above.
 resource nodes_data_disks_with_vhds 'Microsoft.Compute/disks@2022-03-02' = [
   for i in range(0, (is_data_disk_with_vhd && !is_ultradisk) ? (length(data_disks) * node_count) : 0): {
     name: '${nodes[(i / length(data_disks))].name}-data-disk-${(i % length(data_disks))}'
@@ -468,16 +472,7 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
       imageReference: getImageReference(nodes[i])
       osDisk:  getVMOsDisk(nodes[i])
       diskControllerType: (nodes[i].disk_controller_type == 'SCSI') ? null : nodes[i].disk_controller_type
-      dataDisks: concat(
-        map(
-          filter(range(0, length(data_disks)), j => !shouldAttachDataDisk(data_disks[j])),
-          j => getCreateDisk(data_disks[j], '${nodes[i].name}-data-disk-${j}', j)
-        ),
-        map(
-          filter(range(0, length(data_disks)), j => shouldAttachDataDisk(data_disks[j])),
-          j => getAttachDisk(data_disks[j], '${nodes[i].name}-data-disk-${j}', j)
-        )
-      )
+      dataDisks: [for (item, j) in data_disks: getDataDisk(nodes[i].name, item, j, rg_id)]
     }
     networkProfile: {
       networkInterfaces: [for j in range(0, nodes[i].nic_count): {
@@ -504,7 +499,6 @@ resource nodes_vms 'Microsoft.Compute/virtualMachines@2024-03-01' = [for i in ra
     nodes_nics
     virtual_network_name_resource
     nodes_disk
-    nodes_data_disks
     nodes_data_disks_with_vhds
   ]
 }]

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "16442678695930802815"
+      "version": "0.42.1.51946",
+      "templateHash": "6854296261882341012"
     }
   },
   "functions": [
@@ -163,6 +163,10 @@
             {
               "type": "int",
               "name": "index"
+            },
+            {
+              "type": "string",
+              "name": "rgId"
             }
           ],
           "output": {
@@ -172,21 +176,33 @@
               "createOption": "attach",
               "caching": "[parameters('disk').caching_type]",
               "managedDisk": {
-                "id": "[format('{0}/providers/Microsoft.Compute/disks/{1}', resourceGroup().id, parameters('diskName'))]"
+                "id": "[format('{0}/providers/Microsoft.Compute/disks/{1}', parameters('rgId'), parameters('diskName'))]"
               }
             }
           }
         },
-        "shouldAttachDataDisk": {
+        "getDataDisk": {
           "parameters": [
+            {
+              "type": "string",
+              "name": "nodeName"
+            },
             {
               "type": "object",
               "name": "dataDisk"
+            },
+            {
+              "type": "int",
+              "name": "index"
+            },
+            {
+              "type": "string",
+              "name": "rgId"
             }
           ],
           "output": {
-            "type": "bool",
-            "value": "[bool(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(and(not(equals(parameters('dataDisk').vhd_details, null())), not(empty(parameters('dataDisk').vhd_details))), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))))]"
+            "type": "object",
+            "value": "[if(or(equals(parameters('dataDisk').type, 'UltraSSD_LRS'), and(not(empty(parameters('dataDisk').vhd_details)), not(empty(parameters('dataDisk').vhd_details.vhd_uri)))), __bicep.getAttachDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index'), parameters('rgId')), __bicep.getCreateDisk(parameters('dataDisk'), format('{0}-data-disk-{1}', parameters('nodeName'), parameters('index')), parameters('index')))]"
           }
         },
         "getOsDiskSharedGallery": {
@@ -555,6 +571,7 @@
       }
     ],
     "vnet_id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtual_network_name'))]",
+    "rg_id": "[resourceGroup().id]",
     "node_count": "[length(parameters('nodes'))]",
     "availability_set_name_value": "lisa-availabilitySet",
     "existing_subnet_ref": "[if(empty(parameters('virtual_network_resource_group')), '', resourceId(parameters('virtual_network_resource_group'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtual_network_name'), parameters('subnet_prefix')))]",
@@ -822,10 +839,16 @@
         },
         "osProfile": "[__bicep.getOsProfile(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]], parameters('admin_username'), parameters('admin_password'), parameters('admin_key_data'))]",
         "storageProfile": {
+          "copy": [
+            {
+              "name": "dataDisks",
+              "count": "[length(parameters('data_disks'))]",
+              "input": "[__bicep.getDataDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, parameters('data_disks')[copyIndex('dataDisks')], copyIndex('dataDisks'), variables('rg_id'))]"
+            }
+          ],
           "imageReference": "[__bicep.getImageReference(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
           "osDisk": "[__bicep.getVMOsDisk(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]])]",
-          "diskControllerType": "[if(equals(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type, 'SCSI'), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type)]",
-          "dataDisks": "[concat(map(filter(range(0, length(parameters('data_disks'))), lambda('j', not(__bicep.shouldAttachDataDisk(parameters('data_disks')[lambdaVariables('j')])))), lambda('j', __bicep.getCreateDisk(parameters('data_disks')[lambdaVariables('j')], format('{0}-data-disk-{1}', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, lambdaVariables('j')), lambdaVariables('j')))), map(filter(range(0, length(parameters('data_disks'))), lambda('j', __bicep.shouldAttachDataDisk(parameters('data_disks')[lambdaVariables('j')]))), lambda('j', __bicep.getAttachDisk(parameters('data_disks')[lambdaVariables('j')], format('{0}-data-disk-{1}', parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].name, lambdaVariables('j')), lambdaVariables('j')))))]"
+          "diskControllerType": "[if(equals(parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type, 'SCSI'), null(), parameters('nodes')[range(0, variables('node_count'))[copyIndex()]].disk_controller_type)]"
         },
         "networkProfile": {
           "copy": [
@@ -854,7 +877,6 @@
       "zones": "[if(variables('use_availability_zones'), variables('availability_zones'), null())]",
       "dependsOn": [
         "availability_set",
-        "nodes_data_disks",
         "nodes_data_disks_with_vhds",
         "nodes_disk",
         "nodes_image",
@@ -914,8 +936,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2282563054596282747"
+              "version": "0.42.1.51946",
+              "templateHash": "14513471577247856783"
             }
           },
           "functions": [


### PR DESCRIPTION
With Bicep languageVersion 2.0, 'for...if(condition)' in copy loops creates phantom resource entries in the ARM dependency graph even when the condition is false, causing InvalidTemplate errors.

- Fold loop conditions into range count (condition ? N : 0) to avoid phantom entries when condition is false
- Replace resourceId() with string interpolation to prevent implicit dependsOn references that trigger validation errors
- Update getDataDisk/getAttachDisk functions to accept rgId parameter

No behavioral change - only eliminates phantom dependency graph entries.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
