### PR TITLE
Add generic VM extension case

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
@@ -1,0 +1,139 @@
+from typing import Any, Dict
+
+from assertpy import assert_that
+from retry import retry
+
+from lisa import (
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.sut_orchestrator.azure.features import AzureExtension
+
+
+@TestSuiteMetadata(
+    area="vm_extension",
+    category="functional",
+    description=(
+        "Generic test for validating VM extension install and uninstall. "
+        "Extension publisher, type, and version are provided via runbook variables."
+    ),
+    tags=["VM_Extension"],
+)
+class GenericVmExtension(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        Generic test case that installs a VM extension specified via runbook
+        variables, verifies provisioning succeeds, uninstalls the extension,
+        and confirms the VM is still reachable afterwards.
+
+        Required runbook variables:
+          - extension_publisher  (e.g. "Microsoft.Azure.Monitor")
+          - extension_type       (e.g. "AzureMonitorLinuxAgent")
+          - extension_version    (e.g. "1.0")
+        """,
+        priority=2,
+        requirement=simple_requirement(supported_features=[AzureExtension]),
+    )
+    def verify_vm_extension_install_uninstall(
+        self,
+        log: Logger,
+        node: Node,
+        variables: Dict[str, Any],
+    ) -> None:
+        publisher: str = variables["extension_publisher"]
+        type_: str = variables["extension_type"]
+        version: str = variables["extension_version"]
+
+        extension = node.features[AzureExtension]
+        extension_name = f"{publisher}.{type_}-{version}"
+
+        # Remove any existing extension with the same handler type to avoid
+        # conflicts (Azure forbids two extensions with the same publisher+type
+        # but different versions on the same VM).
+        self._cleanup_existing_extensions(extension, publisher, type_, log)
+
+        extension_result = self._install_extension(
+            extension, extension_name, publisher, type_, version
+        )
+
+        assert_that(extension_result["provisioning_state"]).described_as(
+            "Found the extension provisioning state unexpectedly not Succeeded"
+        ).is_equal_to("Succeeded")
+
+        assert_that(self._check_exist(extension, extension_name)).described_as(
+            "Found the VM Extension unexpectedly not exists on the VM after"
+            "installation"
+        ).is_true()
+
+        # Verify the VM is still reachable after extension operations.
+        assert_that(node.test_connection()).described_as(
+            "Found the VM unexpectedly not reachable via SSH after extension install"
+        ).is_true()
+
+        # if extension installed by test then delete the extension
+        self._delete_extension(extension, extension_name)
+
+        assert_that(self._check_exist(extension, extension_name)).described_as(
+            "Found the VM Extension still unexpectedly exists on the VM after deletion"
+        ).is_false()
+
+        # Verify the VM is still reachable after extension operations.
+        assert_that(node.test_connection()).described_as(
+            "Found the VM unexpectedly not reachable via SSH after extension uninstall"
+        ).is_true()
+
+    @retry(tries=3, delay=10)  # type: ignore
+    def _cleanup_existing_extensions(
+        self,
+        extension: AzureExtension,
+        publisher: str,
+        type_: str,
+        log: Logger,
+    ) -> None:
+        for ext in extension.list_all():
+            if (
+                getattr(ext, "publisher", None) == publisher
+                and getattr(ext, "type_properties_type", None) == type_
+            ):
+                log.info(
+                    f"Deleting pre-existing extension '{ext.name}' "
+                    f"with same handler type '{publisher}.{type_}'."
+                )
+                extension.delete(name=ext.name)
+
+    @retry(tries=3, delay=10)  # type: ignore
+    def _install_extension(
+        self,
+        extension: AzureExtension,
+        name: str,
+        publisher: str,
+        type_: str,
+        version: str,
+    ) -> Any:
+        return extension.create_or_update(
+            name=name,
+            publisher=publisher,
+            type_=type_,
+            type_handler_version=version,
+        )
+
+    @retry(tries=3, delay=10)  # type: ignore
+    def _delete_extension(
+        self,
+        extension: AzureExtension,
+        name: str,
+        ignore_not_found: bool = False,
+    ) -> None:
+        extension.delete(name=name, ignore_not_found=ignore_not_found)
+
+    @retry(tries=3, delay=10)  # type: ignore
+    def _check_exist(
+        self,
+        extension: AzureExtension,
+        name: str,
+    ) -> bool:
+        return extension.check_exist(name)

--- a/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
@@ -6,6 +6,7 @@ from retry import retry
 from lisa import (
     Logger,
     Node,
+    SkippedException,
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
@@ -44,9 +45,18 @@ class GenericVmExtension(TestSuite):
         node: Node,
         variables: Dict[str, Any],
     ) -> None:
-        publisher: str = variables["extension_publisher"]
-        type_: str = variables["extension_type"]
-        version: str = variables["extension_version"]
+        publisher: str = variables.get("extension_publisher", "")
+        type_: str = variables.get("extension_type", "")
+        version: str = variables.get("extension_version", "")
+
+        if not publisher or not type_ or not version:
+            raise SkippedException(
+                "Required runbook variable(s) are missing or empty: "
+                f"extension_publisher='{publisher}', "
+                f"extension_type='{type_}', "
+                f"extension_version='{version}'. "
+                "Please set them in the runbook before running this test case."
+            )
 
         extension = node.features[AzureExtension]
         extension_name = f"{publisher}.{type_}-{version}"
@@ -61,29 +71,28 @@ class GenericVmExtension(TestSuite):
         )
 
         assert_that(extension_result["provisioning_state"]).described_as(
-            "Found the extension provisioning state unexpectedly not Succeeded"
+            "Expected extension provisioning state to be Succeeded"
         ).is_equal_to("Succeeded")
 
         assert_that(self._check_exist(extension, extension_name)).described_as(
-            "Found the VM Extension unexpectedly not exists on the VM after"
-            "installation"
+            "Expected VM extension to exist after installation"
         ).is_true()
 
         # Verify the VM is still reachable after extension operations.
         assert_that(node.test_connection()).described_as(
-            "Found the VM unexpectedly not reachable via SSH after extension install"
+            "Expected VM to be reachable via SSH after extension installation"
         ).is_true()
 
         # if extension installed by test then delete the extension
         self._delete_extension(extension, extension_name)
 
         assert_that(self._check_exist(extension, extension_name)).described_as(
-            "Found the VM Extension still unexpectedly exists on the VM after deletion"
+            "Expected VM extension to be removed after deletion"
         ).is_false()
 
         # Verify the VM is still reachable after extension operations.
         assert_that(node.test_connection()).described_as(
-            "Found the VM unexpectedly not reachable via SSH after extension uninstall"
+            "Expected VM to be reachable via SSH after extension uninstallation"
         ).is_true()
 
     @retry(tries=3, delay=10)  # type: ignore

--- a/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
@@ -36,7 +36,7 @@ class GenericVmExtension(TestSuite):
           - extension_type       (e.g. "AzureMonitorLinuxAgent")
           - extension_version    (e.g. "1.0")
         """,
-        priority=2,
+        priority=3,
         requirement=simple_requirement(supported_features=[AzureExtension]),
     )
     def verify_vm_extension_install_uninstall(


### PR DESCRIPTION
## Description

Add a generic test for validating VM extension install and uninstall. Extension publisher, type, and version are provided via runbook variables.
## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->
Runbook:
```
variable:
  - name: extension_publisher
    value: "Microsoft.Azure.Monitor"
    is_case_visible: true
  - name: extension_type
    value: "AzureMonitorLinuxAgent"
    is_case_visible: true
  - name: extension_version
    value: "1.7"
    is_case_visible: true
```

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_vm_extension_install_uninstall

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
None

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
Canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner GenericVmExtension.verify_vm_extension_install_uninstall: PASSED   
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner test result summary
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner     TOTAL    : 1
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner     QUEUED   : 0
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner     ASSIGNED : 0
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner     RUNNING  : 0
2026-04-16 09:44:24.353[29068][INFO] lisa.RootRunner     FAILED   : 0
2026-04-16 09:44:24.354[29068][INFO] lisa.RootRunner     PASSED   : 1
2026-04-16 09:44:24.354[29068][INFO] lisa.RootRunner     SKIPPED  : 0

| Image | VM Size | Result |
|-------|---------|--------|
|    Canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest   |     Standard_D2s_v3    | PASSED  |
