### PR TITLE
[AI Generated] BugFix: Replace RHEL version-based NFS UDP skip with generic server-side portlist check

### DIFF
--- a/lisa/microsoft/testsuites/performance/storageperf.py
+++ b/lisa/microsoft/testsuites/performance/storageperf.py
@@ -538,6 +538,34 @@ class StoragePerformance(TestSuite):
             [client.internal_address], server_raid_disk_mount_dir
         )
 
+        # Check if the NFS server supports the requested protocol.
+        # /proc/fs/nfsd/portlist lists the protocols the NFS daemon is
+        # actually listening on (e.g. "udp 2049", "tcp 2049"). On newer
+        # kernels/distros (RHEL 8+, SUSE 15 SP4+, etc.) the NFS server
+        # no longer binds to UDP, so mounting with proto=udp will fail.
+        # This check is distro-agnostic: it works on any Linux kernel
+        # where the nfsd module exposes the portlist procfs entry.
+        # A short retry loop handles the case where the portlist is not
+        # yet populated immediately after the NFS service restart.
+        if "udp" in protocol:
+            portlist_result = server.execute(
+                "for i in 1 2 3 4 5; do "
+                "content=$(cat /proc/fs/nfsd/portlist 2>/dev/null) && "
+                '[ -n "$content" ] && echo "$content" && exit 0; '
+                "sleep 1; done; exit 1",
+                sudo=True,
+                shell=True,
+            )
+            if (
+                portlist_result.exit_code == 0
+                and portlist_result.stdout.strip()
+                and "udp" not in portlist_result.stdout.lower()
+            ):
+                raise SkippedException(
+                    "NFS server does not support UDP. "
+                    f"Server portlist: {portlist_result.stdout.strip()}"
+                )
+
         # setup raid on client
         client.tools[NFSClient].setup(
             server.internal_address,
@@ -609,18 +637,6 @@ class StoragePerformance(TestSuite):
             and not isinstance(server_node.os, Suse)
         ):
             raise SkippedException(f"{server_node.os.name} not supported")
-
-        # refer below link, in RHEL 8, NFS over UDP is no longer supported.
-        # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/exporting-nfs-shares_deploying-different-types-of-servers#the-tcp-and-udp-protocols-in-nfsv3-and-nfsv4_exporting-nfs-shares  # noqa: E501
-        if (
-            "udp" == protocol
-            and isinstance(server_node.os, Redhat)
-            and server_node.os.information.version >= "8.0.0"
-        ):
-            raise SkippedException(
-                f"udp mode not supported on {server_node.os.information.vendor} "
-                f"{server_node.os.information.release}"
-            )
 
         # Each fio process start jobs equal to the iodepth to read/write from
         # the disks. The max number of jobs can be equal to the core count of


### PR DESCRIPTION
## Summary
Replace the RHEL 8+ version-specific NFS UDP skip with a generic server-side check that reads `/proc/fs/nfsd/portlist` after NFS server setup. This covers all distros (SUSE, Ubuntu, RHEL, etc.) where the NFS server no longer binds to UDP.

The existing RHEL version check was distro-specific and did not cover other distributions (e.g. SUSE 15 SP4+, Ubuntu 24.04+) where the NFS server also no longer binds to UDP. The new check reads the kernel procfs entry that lists the protocols the NFS daemon is actually listening on. If the file exists and does not contain `udp`, the test is skipped with a clear message. If the file does not exist (old kernel, nfsd not loaded), the test proceeds normally — and the existing client-side `CONFIG_NFS_DISABLE_UDP_SUPPORT` kernel config check in `nfs_client.py` serves as a second layer of defense.

Also simplified `VirtualizationSettings.__eq__` to a single expression (same logic, no behavior change).

## Validation Results
| Test | Image | VM Size | Location | Result |
|------|-------|---------|----------|--------|
| perf_storage_over_nfs_sriov_tcp_4k | canonical ubuntu-25_10 server 25.10.202510070 | Standard_D4ds_v6 | westus2 | PASSED |
| perf_storage_over_nfs_sriov_udp_4k | canonical ubuntu-25_10 server 25.10.202510070 | Standard_D4ds_v6 | westus2 | SKIPPED (portlist: tcp 2049 — no UDP) |
| perf_storage_over_nfs_sriov_udp_4k | suse sles-15-sp6 gen2 2025.10.22 | Standard_DS3_v2 | westus3 | SKIPPED (portlist: tcp 2049 — no UDP) |
| perf_storage_over_nfs_sriov_udp_4k | redhat rhel 9_7 9.7.2026031115 | Standard_DS3_v2 | westus3 | SKIPPED (portlist: rdma 20049, tcp 2049 — no UDP) |
| perf_storage_over_nfs_sriov_udp_4k | canonical ubuntu-24_04-lts server 24.04.202601300 | Standard_D8ds_v6 | westus3 | SKIPPED (portlist: tcp 2049 — no UDP) |
| perf_storage_over_nfs_sriov_udp_4k | canonical ubuntu-24_04-lts server 24.04.202601300 | Standard_D8ds_v6 | westus3 | SKIPPED (kernel UDP disabled) |

Pre-fix baseline: SLES 15 SP6 FAILED with `mount -o proto=udp` exit code 32.