### PR TITLE
Fix HTML notifier masking for structured runbooks

### DIFF
--- a/lisa/notifiers/html.py
+++ b/lisa/notifiers/html.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from pprint import pformat
 from string import Template
 from typing import Any, Dict, List, Type, cast
 
@@ -66,7 +67,7 @@ class Html(Notifier):
                 "test pass": message.test_pass,
                 "tags": message.tags,
                 "runbook_path": constants.RUNBOOK_FILE,
-                "runbook": mask(constants.RUNBOOK),
+                "runbook": mask(self._stringify_runbook(constants.RUNBOOK)),
             }
             # Filter out None/empty values
             self._metadata = OrderedDict(
@@ -92,6 +93,13 @@ class Html(Notifier):
         self._title = "LISA Test Report"
         self._metadata = OrderedDict()
         self._start_time = datetime.now(timezone.utc)
+
+    def _stringify_runbook(self, runbook: Any) -> str:
+        if isinstance(runbook, str):
+            return runbook
+        if runbook is None:
+            return ""
+        return pformat(runbook, sort_dicts=False, width=120)
 
     def _write_html_report(self) -> None:
         """Generate and write the HTML report."""

--- a/lisa/util/constants.py
+++ b/lisa/util/constants.py
@@ -3,6 +3,7 @@
 
 import re
 from pathlib import Path, PurePath
+from typing import Any
 
 # config types
 CONFIG_RUNBOOK = "runbook"
@@ -18,7 +19,7 @@ CONCURRENCY = "concurrency"
 
 RUNBOOK_FILE: Path
 RUNBOOK_PATH: Path
-RUNBOOK: str = ""
+RUNBOOK: Any = ""
 # a global cache path for all runs
 CACHE_PATH: Path
 # The physical path of current run.

--- a/selftests/test_html_notifier.py
+++ b/selftests/test_html_notifier.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from pathlib import Path
 from unittest import TestCase
 
+from lisa.messages import TestRunMessage, TestRunStatus
 from lisa.notifiers.html import Html, HtmlSchema
 from lisa.secret import add_secret, mask, reset
 from lisa.util import constants
@@ -97,3 +98,105 @@ class HtmlMetadataSecretTestCase(TestCase):
         self.assertNotIn("late-secret", result)
         self.assertIn("***early***", result)
         self.assertIn("***late***", result)
+
+
+class HtmlStructuredRunbookTestCase(TestCase):
+    """Regression tests: dict/list-backed constants.RUNBOOK must not raise TypeError."""
+
+    def setUp(self) -> None:
+        reset()
+        self._original_runbook = constants.RUNBOOK
+        self._original_log_path = constants.RUN_LOCAL_LOG_PATH
+        self._had_runbook_file = hasattr(constants, "RUNBOOK_FILE")
+        self._original_runbook_file = getattr(constants, "RUNBOOK_FILE", None)
+
+        constants.RUN_LOCAL_LOG_PATH = Path("/tmp/lisa_test")
+        constants.RUNBOOK_FILE = Path("/tmp/lisa_test/runbook.yml")
+
+        runbook = HtmlSchema(type="html")
+        self._notifier = Html(runbook=runbook)
+        self._notifier._initialize()
+
+    def tearDown(self) -> None:
+        reset()
+        constants.RUNBOOK = self._original_runbook
+        constants.RUN_LOCAL_LOG_PATH = self._original_log_path
+        if self._had_runbook_file:
+            constants.RUNBOOK_FILE = self._original_runbook_file
+        elif hasattr(constants, "RUNBOOK_FILE"):
+            del constants.RUNBOOK_FILE
+
+    def _send_initializing_message(self) -> None:
+        msg = TestRunMessage(
+            status=TestRunStatus.INITIALIZING,
+            run_name="test-run",
+        )
+        self._notifier._received_test_run(msg)
+
+    def test_dict_runbook_does_not_raise(self) -> None:
+        """A dict-backed RUNBOOK must not raise TypeError during message handling."""
+        constants.RUNBOOK = {
+            "notifier": [{"type": "html"}],
+            "platform": [{"type": "mock"}],
+        }
+        # Must not raise TypeError when mask() is called on the stringified runbook
+        try:
+            self._send_initializing_message()
+        except TypeError as e:
+            self.fail(f"_received_test_run raised TypeError for dict runbook: {e}")
+
+        result = self._notifier._generate_metadata_rows()
+        self.assertIn("notifier", result)
+        self.assertIn("html", result)
+
+    def test_list_runbook_does_not_raise(self) -> None:
+        """A list-backed RUNBOOK must not raise TypeError during message handling."""
+        constants.RUNBOOK = [
+            {"notifier": [{"type": "html"}]},
+            {"platform": [{"type": "mock"}]},
+        ]
+        try:
+            self._send_initializing_message()
+        except TypeError as e:
+            self.fail(f"_received_test_run raised TypeError for list runbook: {e}")
+
+        result = self._notifier._generate_metadata_rows()
+        self.assertIn("notifier", result)
+
+    def test_none_runbook_does_not_raise(self) -> None:
+        """A None RUNBOOK must not raise and should produce no runbook metadata row."""
+        constants.RUNBOOK = None
+        try:
+            self._send_initializing_message()
+        except Exception as e:
+            self.fail(f"_received_test_run raised {type(e).__name__} for None runbook: {e}")
+
+        result = self._notifier._generate_metadata_rows()
+        # No runbook key should be present when value is empty/None
+        self.assertNotIn(">runbook<", result)
+
+    def test_dict_runbook_secrets_are_masked(self) -> None:
+        """Secrets inside a dict-backed RUNBOOK are masked in the metadata output."""
+        constants.RUNBOOK = {
+            "platform": [{"admin_password": "dict-secret-password"}],
+        }
+        add_secret("dict-secret-password", sub="***masked***")
+        self._send_initializing_message()
+
+        result = self._notifier._generate_metadata_rows()
+
+        self.assertNotIn("dict-secret-password", result)
+        self.assertIn("***masked***", result)
+
+    def test_list_runbook_secrets_are_masked(self) -> None:
+        """Secrets inside a list-backed RUNBOOK are masked in the metadata output."""
+        constants.RUNBOOK = [
+            {"credential": {"token": "list-secret-token"}},
+        ]
+        add_secret("list-secret-token", sub="***tok***")
+        self._send_initializing_message()
+
+        result = self._notifier._generate_metadata_rows()
+
+        self.assertNotIn("list-secret-token", result)
+        self.assertIn("***tok***", result)

--- a/selftests/test_html_notifier.py
+++ b/selftests/test_html_notifier.py
@@ -169,7 +169,9 @@ class HtmlStructuredRunbookTestCase(TestCase):
         try:
             self._send_initializing_message()
         except Exception as e:
-            self.fail(f"_received_test_run raised {type(e).__name__} for None runbook: {e}")
+            self.fail(
+                f"_received_test_run raised {type(e).__name__} for None runbook: {e}"
+            )
 
         result = self._notifier._generate_metadata_rows()
         # No runbook key should be present when value is empty/None


### PR DESCRIPTION
RootRunner stores constants.RUNBOOK as the resolved raw runbook object after variable replacement, so the value can be a dict or list instead of a rendered string.

The HTML notifier still passed constants.RUNBOOK directly into secret.mask() when recording run metadata. secret.mask() uses regex search/substitution and expects text, so a dict-backed runbook raised TypeError during notification flush and caused the test run to fail after execution completed.

Stringify non-string runbooks before masking in the HTML notifier and update the RUNBOOK constant typing to reflect the structured data that runner assigns today.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
