### PR TITLE
Nested: use host connection address instead of public_address

### DIFF
--- a/lisa/microsoft/testsuites/nested/common.py
+++ b/lisa/microsoft/testsuites/nested/common.py
@@ -188,8 +188,10 @@ def qemu_connect_nested_vm(
         )
 
     # setup connection to nested vm
+    # Use the host's connection address which respects use_public_address setting.
+    host_address = host.connection_info["address"]
     connection_info = schema.ConnectionInfo(
-        address=host.public_address,
+        address=host_address,
         port=guest_port,
         username=guest_username,
         password=guest_password,
@@ -246,8 +248,9 @@ def hyperv_connect_nested_vm(
     hyperv.setup_port_forwarding(nat_name, port, local_ip)
 
     # setup connection to nested vm
+    host_address = host.connection_info["address"]
     connection_info = schema.ConnectionInfo(
-        address=host.public_address,
+        address=host_address,
         port=port,
         username=guest_username,
         password=guest_password,


### PR DESCRIPTION
## Description

`qemu_connect_nested_vm()` and `hyperv_connect_nested_vm()` used `host.public_address` to build the SSH connection to the nested VM. When `use_public_address` is set to `false` in the runbook (e.g., in private VNet environments), the public IP may not have the forwarded nested-VM port (60024) open, causing SSH timeouts.

This changes both functions to use `host.connection_info[address]` instead, which respects the `use_public_address` setting and returns the appropriate address (public or private) based on the runbook configuration.

## Related Issue

Nested KVM tests (`verify_nested_kvm_basic`) fail with SSH connection timeout when running in environments where `use_public_address: false` and the public IP's NSG blocks port 60024.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:** `verify_nested_kvm_basic` (QEMU nested KVM)

**Impacted LISA Features:** Nested VM connection (QEMU and Hyper-V)

**Tested Azure Marketplace Images:**
- RHEL 9.0 — PASSED
- Ubuntu 22.04 — PASSED
- CBL-Mariner 2.0 — SKIPPED (does not support nested KVM)