### PR TITLE
Check the installed verson when extension has patch version

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
@@ -45,9 +45,9 @@ class GenericVmExtension(TestSuite):
         node: Node,
         variables: Dict[str, Any],
     ) -> None:
-        publisher: str = variables.get("extension_publisher", "")
-        type_: str = variables.get("extension_type", "")
-        version: str = variables.get("extension_version", "")
+        publisher: str = variables.get("extension_publisher", "").strip()
+        type_: str = variables.get("extension_type", "").strip()
+        version: str = variables.get("extension_version", "").strip()
 
         if not publisher or not type_ or not version:
             raise SkippedException(
@@ -60,6 +60,9 @@ class GenericVmExtension(TestSuite):
 
         extension = node.features[AzureExtension]
         extension_name = f"{publisher}.{type_}-{version}"
+        install_version, is_patch_version = extension.normalize_type_handler_version(
+            version
+        )
 
         # Remove any existing extension with the same handler type to avoid
         # conflicts (Azure forbids two extensions with the same publisher+type
@@ -67,7 +70,7 @@ class GenericVmExtension(TestSuite):
         self._cleanup_existing_extensions(extension, publisher, type_, log)
 
         extension_result = self._install_extension(
-            extension, extension_name, publisher, type_, version
+            extension, extension_name, publisher, type_, install_version
         )
 
         assert_that(extension_result["provisioning_state"]).described_as(
@@ -77,6 +80,18 @@ class GenericVmExtension(TestSuite):
         assert_that(self._check_exist(extension, extension_name)).described_as(
             "Expected VM extension to exist after installation"
         ).is_true()
+
+        installed_version = extension.get_installed_type_handler_version(extension_name)
+        if is_patch_version:
+            assert_that(installed_version).described_as(
+                f"Installed extension '{extension_name}' version mismatch: expected "
+                f"'{version}', actual '{installed_version}'. Verify which patch "
+                f"version Azure delivers for the requested major.minor version and "
+                f"check whether this extension version is published in the current "
+                f"region."
+            ).is_equal_to(version)
+
+        log.info(f"Installed extension '{extension_name}' version: {installed_version}")
 
         # Verify the VM is still reachable after extension operations.
         assert_that(node.test_connection()).described_as(

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3340,6 +3340,9 @@ class Nfs(AzureFeatureMixin, features.Nfs):
 
 class AzureExtension(AzureFeatureMixin, Feature):
     RESOURCE_NOT_FOUND = re.compile(r"ResourceNotFound", re.M)
+    _TYPE_HANDLER_VERSION_PATTERN = re.compile(
+        r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?$"
+    )
 
     @classmethod
     def create_setting(
@@ -3360,6 +3363,41 @@ class AzureExtension(AzureFeatureMixin, Feature):
             expand="instanceView",
         )
         return extension
+
+    def normalize_type_handler_version(self, version: str) -> Tuple[str, bool]:
+        """
+        Normalize a requested extension version for installation.
+
+        Returns:
+            Tuple[str, bool]:
+            - normalized Major.Minor version for installation
+            - True if the original version was Major.Minor.Patch
+        """
+        requested_version = version.strip()
+        matched = self._TYPE_HANDLER_VERSION_PATTERN.fullmatch(requested_version)
+        if not matched:
+            raise LisaException(
+                "Invalid extension_version format. Expected 'Major.Minor' "
+                f"or 'Major.Minor.Patch', got '{version}'."
+            )
+
+        normalized_version = f"{matched.group('major')}.{matched.group('minor')}"
+        is_patch_version = matched.group("patch") is not None
+        return normalized_version, is_patch_version
+
+    def get_installed_type_handler_version(self, name: str) -> str:
+        extension_obj = self.get(name=name)
+
+        instance_view = getattr(extension_obj, "instance_view", None)
+        version = getattr(instance_view, "type_handler_version", None)
+        if version:
+            return str(version)
+
+        version = getattr(extension_obj, "type_handler_version", None)
+        if version:
+            return str(version)
+
+        return str(getattr(extension_obj, "type_handler_version_name", "unknown"))
 
     def create_or_update(
         self,


### PR DESCRIPTION
## Description
When installing a VM extension using the Python SDK or an ARM template, there is only a single parameter available for version control: typeHandlerVersion. This parameter only supports the Major.Minor format. However, for the pre-publish validation scenario, the version is in Major.Minor.Patch format.

Azure platform has the following behavior:
Customers are only able to specify the Major.Minor version during deployment of an extension.  When AutoUpgradeMinorVersion is set "True", then the platform will deliver the latest Minor.Patch.Hotfix version of that Major version.  If this value is set to "False" then the platform will deliver the latest Patch.Hotfix of the Major.Minor pair. 

This PR adds a check for the installed version if the extension version passed in the case is Major.Minor.Patch format.  From the response of GET VM extension, we can get the installed version from the instance_view.type_handler_version. Then check if the installed version same as the expected version. If yes, then the case is passed. If not, the case is failed.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->
Test for the following runbooks:
1. Case verify_vm_extension_install_uninstall should be PASSED.
variable:
  - name: extension_publisher
    value: "Microsoft.Azure.Monitor"
    is_case_visible: true
  - name: extension_type
    value: "AzureMonitorLinuxAgent"
    is_case_visible: true
  - name: extension_version
    value: "**1.7.1**"
    is_case_visible: true
2. Case verify_vm_extension_install_uninstall should be PASSED.
variable:
  - name: extension_publisher
    value: "Microsoft.Azure.Monitor"
    is_case_visible: true
  - name: extension_type
    value: "AzureMonitorLinuxAgent"
    is_case_visible: true
  - name: extension_version
    value: "**1.7**"
    is_case_visible: true

3. Case verify_vm_extension_install_uninstall should be FAILED.
variable:
  - name: extension_publisher
    value: "Microsoft.Azure.Monitor"
    is_case_visible: true
  - name: extension_type
    value: "AzureMonitorLinuxAgent"
    is_case_visible: true
  - name: extension_version
    value: "**1.7.0**"
    is_case_visible: true

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_vm_extension_install_uninstall
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
VM Extension
**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-Canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
