### PR TITLE
[AI Generated] BugFix: fix package installation on CentOS 7/8 by redirecting repos to vault.centos.org

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2036,12 +2036,43 @@ class CentOs(Redhat):
 
     def _initialize_package_installation(self) -> None:
         information = self._get_information()
-        if 8 == information.version.major:
-            # refer https://www.centos.org/centos-linux-eol/ CentOS 8 is EOL,
-            # old repo mirror was moved to vault.centos.org
-            # CentOS-AppStream.repo, CentOS-Base.repo may contain non-existed
-            # repo use skip_if_unavailable to avoid installation issues brought
-            #  in by above issue
+        if information.version.major in (7, 8):
+            # refer https://www.centos.org/centos-linux-eol/ - both CentOS 7
+            # and CentOS 8 are EOL and their repo mirrors were moved to
+            # vault.centos.org. mirror.centos.org returns 404 and
+            # olcentgbl.trafficmanager.net no longer resolves, so rewrite the
+            # stock repo files to point at vault.centos.org before any package
+            # operation. Use "|| true" so a missing repo file does not fail
+            # the whole command.
+            fix_commands = [
+                # Disable mirrorlist entries (vault does not serve mirrorlist)
+                "sed -i 's/^mirrorlist=/#mirrorlist=/g' "
+                "/etc/yum.repos.d/CentOS-*.repo || true",
+                # Point baseurl to vault.centos.org. Preserve the original
+                # scheme (http or https) via back-reference so images that
+                # ship with either scheme are handled correctly.
+                "sed -i -E 's|^#?baseurl=(https?)://mirror.centos.org|"
+                "baseurl=\\1://vault.centos.org|g' "
+                "/etc/yum.repos.d/CentOS-*.repo || true",
+                # Some CentOS images ship a second baseurl pointing at
+                # olcentgbl.trafficmanager.net which no longer resolves. The
+                # URL often appears on a continuation line (no "baseurl="
+                # prefix), may live in a file that does not match
+                # CentOS-*.repo (e.g. OpenLogic.repo), and on CentOS 8 uses
+                # the $contentdir variable in place of a literal "centos"
+                # path component, so rewrite just the host globally across
+                # every repo file. Paths with no vault equivalent (e.g.
+                # /openlogic/*) will be silently skipped via
+                # skip_if_unavailable below.
+                "sed -i -E "
+                "'s|olcentgbl\\.trafficmanager\\.net|vault.centos.org|g' "
+                "/etc/yum.repos.d/*.repo || true",
+            ]
+            for cmd in fix_commands:
+                self._node.execute(cmd, shell=True, sudo=True, timeout=30)
+            # Some stock repo files still reference unreachable hosts
+            # (e.g. olcentgbl.trafficmanager.net); allow yum to skip them so a
+            # single broken repo does not block the whole install.
             cmd_results = self._node.execute("yum repolist -v", sudo=True)
             if 0 != cmd_results.exit_code:
                 self._node.tools[YumConfigManager].set_opt("skip_if_unavailable=true")


### PR DESCRIPTION
## Summary

Both CentOS 7 (EOL June 2024) and CentOS 8 (EOL Dec 2021) have had their `mirror.centos.org` repositories retired. `olcentgbl.trafficmanager.net` no longer resolves either. As a result, any package installation via `yum`/`dnf` on stock Azure marketplace CentOS 7/8 images fails.

## Fix

Before any package operation on CentOS 7 or 8, rewrite the stock `/etc/yum.repos.d/CentOS-*.repo` files to point `baseurl` at `http://vault.centos.org` and disable `mirrorlist` entries (vault does not serve mirrorlist). `|| true` is used so a missing repo file does not fail the whole command.

## Validation

Validated end-to-end on Azure (westus3, Standard_D2ds_v5):

| Image | Test | Result |
|---|---|---|
| `openlogic:centos:8_3:8.3.2020120900` | `HvModule.verify_initrd_modules` | PASSED |
| `openlogic:centos:8_3:8.3.2020120900` | `Utilities.utility_tools_install` (Fio) | PASSED |
| `openlogic:centos:7_9:7.9.2022101800` | `HvModule.verify_initrd_modules` | PASSED |
| `openlogic:centos:7_9:7.9.2022101800` | `Utilities.utility_tools_install` (Fio) | PASSED |

Logs confirm `sed` executes, `baseurl` becomes `http://vault.centos.org/centos/{7,8}/...`, and packages install successfully (e.g. `fio-3.7-2.el7.x86_64` on CentOS 7, `fio-3.19-3.el8.x86_64` on CentOS 8).

## Note

This PR was generated by an AI coding agent and validated on live Azure VMs.
