### PR TITLE
[AI Generated] BugFix: fix IndexError in _hot_add_disk_serial when no new device appears

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -847,16 +847,22 @@ class Storage(TestSuite):
 
             # verify the lun number from linux VM
             linux_device_luns_after = disk.get_luns()
-            linux_device_lun_diff = [
-                linux_device_luns_after[k]
-                for k in set(linux_device_luns_after) - set(linux_device_luns)
-            ][0]
             log.debug(f"linux_device_luns: {linux_device_luns}")
             log.debug(f"linux_device_luns_after: {linux_device_luns_after}")
-            log.debug(f"linux_device_lun_diff: {linux_device_lun_diff}")
+            new_device_keys = set(linux_device_luns_after) - set(linux_device_luns)
             assert_that(
-                linux_device_lun_diff, "No new device lun found on VM"
-            ).is_equal_to(lun)
+                list(new_device_keys),
+                f"Expected new device at lun {lun} but no new device "
+                f"appeared. Before: {linux_device_luns}, "
+                f"After: {linux_device_luns_after}. This may indicate "
+                f"the VM size does not support this many data disks "
+                f"(max_data_disk_count={max_data_disk_count}).",
+            ).is_not_empty()
+            linux_device_lun_diff = linux_device_luns_after[next(iter(new_device_keys))]
+            log.debug(f"linux_device_lun_diff: {linux_device_lun_diff}")
+            assert_that(linux_device_lun_diff, "New device lun mismatch").is_equal_to(
+                lun
+            )
 
         # Remove all attached data disks
         for disk_added in disks_added:


### PR DESCRIPTION
## Summary

Fix an `IndexError: list index out of range` crash in `_hot_add_disk_serial()` when a hot-added data disk does not appear as a new Linux block device after attachment.

## Root Cause

The method computed the set difference of device keys before vs. after hot-add, then immediately indexed `[0]` on the resulting list without checking whether it was empty. If the disk was not yet visible (timing race) or failed to appear, the empty-list access raised `IndexError`.

## Fix

- Replace the bare `[0]` indexing with an explicit `assert_that(...).is_not_empty()` assertion that produces a clear diagnostic message including the expected LUN number.
- Use `next(iter(...))` to retrieve the first element safely after the assertion guarantees non-emptiness.

## Validation

Tested on 3 distro families with `verify_hot_add_disk_serial_premium_ssd`:

| Distro | Kernel | VM Size | Region | Result |
|--------|--------|---------|--------|--------|
| Ubuntu 22.04 LTS | 6.x | Standard_D2s_v3 | westus2 | PASSED |
| RHEL 9.7 | 5.14.0-611.45.1.el9_7 | Standard_D2s_v3 | westus2 | PASSED |
| SLES 15 SP5 | 5.14.21-150500.33.75-azure | Standard_D2s_v3 | westus2 | PASSED |

All lint checks pass (black, flake8, mypy).