### PR TITLE
[AI Generated] BugFix: Add retry loop for LUN detection in hot_add_disk_serial test

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -4,7 +4,7 @@ import random
 import re
 import string
 import time
-from typing import Any, Pattern, cast
+from typing import Any, Dict, List, Pattern, cast
 
 from assertpy.assertpy import assert_that
 
@@ -50,6 +50,7 @@ from lisa.util import (
     BadEnvironmentStateException,
     LisaException,
     SkippedException,
+    check_till_timeout,
     constants,
     generate_random_chars,
     get_matched_str,
@@ -846,19 +847,43 @@ class Storage(TestSuite):
             ).is_equal_to(size)
 
             # verify the lun number from linux VM
+            # Retry to allow udev to create the LUN symlink after disk attach
             linux_device_luns_after = disk.get_luns()
-            log.debug(f"linux_device_luns: {linux_device_luns}")
-            log.debug(f"linux_device_luns_after: {linux_device_luns_after}")
-            new_device_keys = set(linux_device_luns_after) - set(linux_device_luns)
+
+            def _new_lun_detected(
+                _baseline: Dict[str, int] = linux_device_luns,
+            ) -> bool:
+                nonlocal linux_device_luns_after
+                linux_device_luns_after = disk.get_luns()
+                new_keys = set(linux_device_luns_after) - set(_baseline)
+                return len(new_keys) > 0
+
+            # 30s matches the disk-detection timeout used in
+            # _hot_add_disk_parallel for partition appearance after attach.
+            check_till_timeout(
+                _new_lun_detected,
+                timeout_message=(
+                    f"new LUN not detected after disk attach at lun {lun}, "
+                    f"luns_before: {linux_device_luns}, "
+                    f"luns_after: {linux_device_luns_after}"
+                ),
+                timeout=30,
+                interval=1,
+            )
+            new_device_keys: List[str] = list(
+                set(linux_device_luns_after) - set(linux_device_luns)
+            )
             assert_that(
-                list(new_device_keys),
-                f"Expected new device at lun {lun} but no new device "
-                f"appeared. Before: {linux_device_luns}, "
+                new_device_keys,
+                f"Expected exactly one new device at lun {lun} but found "
+                f"{len(new_device_keys)}. Before: {linux_device_luns}, "
                 f"After: {linux_device_luns_after}. This may indicate "
                 f"the VM size does not support this many data disks "
                 f"(max_data_disk_count={max_data_disk_count}).",
-            ).is_not_empty()
-            linux_device_lun_diff = linux_device_luns_after[next(iter(new_device_keys))]
+            ).is_length(1)
+            linux_device_lun_diff = linux_device_luns_after[new_device_keys[0]]
+            log.debug(f"linux_device_luns: {linux_device_luns}")
+            log.debug(f"linux_device_luns_after: {linux_device_luns_after}")
             log.debug(f"linux_device_lun_diff: {linux_device_lun_diff}")
             assert_that(linux_device_lun_diff, "New device lun mismatch").is_equal_to(
                 lun


### PR DESCRIPTION
## Summary

After a data disk is attached via hot-add, the udev symlink under `/dev/disk/azure/scsi1/` may not appear immediately. The previous code called `get_luns()` once and indexed into the result with `[0]`, causing an `IndexError: list index out of range` when the set difference was empty.

Added a 30-second retry loop (matching the existing disk detection pattern in the same `_hot_add_disk_serial` method) that polls `get_luns()` until the new LUN symlink appears or times out with a clear assertion error.

## Validation Results

| Image | Result |
|-------|--------|
| MicrosoftCBLMariner azure-linux-3 azure-linux-3-gen2 3.20260401.01 | PASSED |
| canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest | PASSED |