### PR TITLE
[AI Generated] Azure: surface per-resource errors on truncated DeploymentFailed

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1870,6 +1870,30 @@ class AzurePlatform(Platform):
             assert e.error, f"HttpResponseError: {e}"
 
             error_message = "\n".join(self._parse_detail_errors(e.error))
+            # When Azure returns a generic deployment failure message without
+            # actionable per-resource details (e.g. truncated aggregated error,
+            # ResourceDeploymentFailure with only a tracking id, or any other
+            # *DeploymentFailed* code with no nested details), fall back to
+            # listing deployment operations to surface the real sub-resource
+            # errors.
+            top_code = getattr(e.error, "code", "") or ""
+            if (
+                "aggregated deployment error is too large" in error_message
+                or "ResourceDeploymentFailure" in top_code
+                or (
+                    "DeploymentFailed" in top_code
+                    and not getattr(e.error, "details", None)
+                )
+            ):
+                op_errors = self._collect_deployment_operation_errors(
+                    resource_group_name, log
+                )
+                if op_errors:
+                    log.error(
+                        "deployment failed sub-resource errors:\n"
+                        + "\n".join(op_errors)
+                    )
+                    error_message = error_message + "\n" + "\n".join(op_errors)
             if (
                 self._azure_runbook.ignore_provisioning_error
                 and "OSProvisioningTimedOut: OS Provisioning for VM" in error_message
@@ -1929,6 +1953,40 @@ class AzurePlatform(Platform):
             except Exception:
                 # load failed, it should be a real error message string
                 errors = [f"{error.code}: {error.message}"]
+        return errors
+
+    def _collect_deployment_operation_errors(
+        self, resource_group_name: str, log: Logger
+    ) -> List[str]:
+        """Fetch per-resource errors from a failed ARM deployment.
+
+        Used when the top-level HttpResponseError only carries the aggregated
+        "deployment error is too large" message and no nested details.
+        """
+        errors: List[str] = []
+        try:
+            operations = self._rm_client.deployment_operations.list(
+                resource_group_name=resource_group_name,
+                deployment_name=AZURE_DEPLOYMENT_NAME,
+            )
+            for op in operations:
+                props = getattr(op, "properties", None)
+                if not props or props.provisioning_state != "Failed":
+                    continue
+                target = getattr(props, "target_resource", None)
+                resource_type = getattr(target, "resource_type", "") if target else ""
+                resource_name = getattr(target, "resource_name", "") if target else ""
+                status = getattr(props, "status_message", None)
+                inner = getattr(status, "error", None) if status else None
+                if inner is not None:
+                    errors.extend(
+                        f"{resource_type}/{resource_name}: {msg}"
+                        for msg in self._parse_detail_errors(inner)
+                    )
+                else:
+                    errors.append(f"{resource_type}/{resource_name}: {status}")
+        except Exception as ex:
+            log.debug(f"failed to list deployment operations: {ex}")
         return errors
 
     # the VM may not be queried after deployed. use retry to mitigate it.

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -32,7 +32,7 @@ from typing import (
 )
 
 import requests
-from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.core.exceptions import AzureError, HttpResponseError, ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.compute.models import (
     CommunityGalleryImage,
@@ -1877,12 +1877,12 @@ class AzurePlatform(Platform):
             # listing deployment operations to surface the real sub-resource
             # errors.
             top_code = getattr(e.error, "code", "") or ""
-            if (
-                "aggregated deployment error is too large" in error_message
-                or "ResourceDeploymentFailure" in top_code
-                or (
-                    "DeploymentFailed" in top_code
-                    and not getattr(e.error, "details", None)
+            has_details = bool(getattr(e.error, "details", None))
+            if "aggregated deployment error is too large" in error_message or (
+                not has_details
+                and (
+                    "ResourceDeploymentFailure" in top_code
+                    or "DeploymentFailed" in top_code
                 )
             ):
                 op_errors = self._collect_deployment_operation_errors(
@@ -1960,18 +1960,43 @@ class AzurePlatform(Platform):
     ) -> List[str]:
         """Fetch per-resource errors from a failed ARM deployment.
 
-        Used when the top-level HttpResponseError only carries the aggregated
-        "deployment error is too large" message and no nested details.
+        Used as a fallback when the top-level HttpResponseError does not
+        already carry actionable per-resource details. Callers in ``_deploy``
+        invoke this helper for any of the following cases:
+
+        * The aggregated "deployment error is too large" message, where ARM
+          truncates the nested error tree.
+        * ``ResourceDeploymentFailure`` errors with no nested
+          ``error.details`` (e.g. transient internal server errors that
+          carry only a tracking id).
+        * ``DeploymentFailed`` errors that arrive without any nested
+          ``details`` populated.
+
+        When the top-level error already carries actionable nested
+        ``details``, callers skip this helper to avoid an extra ARM call
+        and duplicated/noisy output.
+
+        In all of these cases, listing the deployment operations is the
+        only way to surface the underlying per-resource failure messages.
         """
         errors: List[str] = []
         try:
-            operations = self._rm_client.deployment_operations.list(
-                resource_group_name=resource_group_name,
-                deployment_name=AZURE_DEPLOYMENT_NAME,
-            )
+            # Azure SDK calls share auth state via files on disk; serialize
+            # access to avoid intermittent failures during parallel runs.
+            # See common.py global_credential_access_lock for context.
+            with global_credential_access_lock:
+                operations = list(
+                    self._rm_client.deployment_operations.list(
+                        resource_group_name=resource_group_name,
+                        deployment_name=AZURE_DEPLOYMENT_NAME,
+                    )
+                )
             for op in operations:
                 props = getattr(op, "properties", None)
-                if not props or props.provisioning_state != "Failed":
+                if not props:
+                    continue
+                provisioning_state = getattr(props, "provisioning_state", None) or ""
+                if provisioning_state.lower() != "failed":
                     continue
                 target = getattr(props, "target_resource", None)
                 resource_type = getattr(target, "resource_type", "") if target else ""
@@ -1985,8 +2010,17 @@ class AzurePlatform(Platform):
                     )
                 else:
                     errors.append(f"{resource_type}/{resource_name}: {status}")
-        except Exception as ex:
-            log.debug(f"failed to list deployment operations: {ex}")
+        except (AzureError, ValueError, TypeError, AttributeError) as ex:
+            # Keep the original error path intact: never let this helper raise.
+            # Catch Azure SDK errors (AzureError covers HttpResponseError /
+            # ResourceNotFoundError) plus common parsing/shape mismatches
+            # (ValueError, TypeError, AttributeError). Programming errors
+            # outside this set will still propagate so they remain visible.
+            # Log with traceback so failures here are still debuggable.
+            log.debug(
+                f"failed to collect deployment operation errors: {ex}",
+                exc_info=True,
+            )
         return errors
 
     # the VM may not be queried after deployed. use retry to mitigate it.


### PR DESCRIPTION
## Summary

When an Azure ARM deployment fails, LISA currently only surfaces the top-level `HttpResponseError`. In several common cases the top-level message is unactionable:

- `DeploymentFailed` with the body `"aggregated deployment error is too large"` (Azure truncates the inner details when there are many failed sub-operations).
- `ResourceDeploymentFailure: Encountered internal server error. Diagnostic information: timestamp '...', subscription id '...', tracking id '...'` — only a tracking id is returned, no per-resource error.
- `DeploymentFailed` with no nested `details`.

In these cases users have to re-run with `keep_environment:always` and dig through the Portal / `az deployment operation group list` to find which resource actually failed and why.

## Change

In `lisa/sut_orchestrator/azure/platform_.py`:

- Add `_collect_deployment_operation_errors()` which calls `self._rm_client.deployment_operations.list(resource_group_name, AZURE_DEPLOYMENT_NAME)` after a failed deploy and extracts per-resource `targetResource` + nested `statusMessage.error` for every operation whose `provisioningState == "Failed"`.
- In `_deploy()`'s `HttpResponseError` handler, call this helper as a fallback when the top-level message looks aggregated/truncated, the code is `ResourceDeploymentFailure`, or `DeploymentFailed` has no nested `details`. Append the collected sub-resource errors to both the log and the raised `LisaException`.
- Behavior is unchanged for normal deployment failures that already carry per-resource details. The fallback is wrapped in `try/except` and logs at debug on failure, so this never makes diagnostics worse.

After this change a previously opaque error becomes:

```
ResourceDeploymentFailure: Encountered internal server error. ...tracking id '...'.
Microsoft.Compute/virtualMachines/<name>: AllocationFailed: ...
Microsoft.Network/networkInterfaces/<name>: NetworkInterfaceCountExceeded: ...
```

## Validation

Before fix the exception is 
```
2026-04-29 08:10:07.153[8168][ERROR] lisa.env[generated_0] case failed
Traceback (most recent call last):
  File "C:\Python\Lib\site-packages\azure\core\polling\base_polling.py", line 950, in run
    self._poll()
  File "C:\Python\Lib\site-packages\azure\core\polling\base_polling.py", line 982, in _poll
    raise OperationFailed("Operation failed or canceled")
azure.core.polling.base_polling.OperationFailed: Operation failed or canceled

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\app\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 1845, in _deploy
    wait_operation(
  File "C:\app\lsg-lisa\lisa\lisa\sut_orchestrator\azure\common.py", line 1805, in wait_operation
    wait_result = operation.wait(1)
                  ^^^^^^^^^^^^^^^^^
  File "C:\Python\Lib\site-packages\azure\core\tracing\decorator.py", line 119, in wrapper_use_tracer
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python\Lib\site-packages\azure\core\polling\_poller.py", line 342, in wait
    raise self._exception  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python\Lib\site-packages\azure\core\polling\_poller.py", line 247, in _start
    self._polling_method.run()
  File "C:\Python\Lib\site-packages\azure\core\polling\base_polling.py", line 965, in run
    raise HttpResponseError(response=self._pipeline_response.http_response, error=err) from err
azure.core.exceptions.HttpResponseError: (DeploymentFailed) The aggregated deployment error is too large. Please list deployment operations to get the deployment details. Please see https://aka.ms/arm-deployment-operations for usage details.
Code: DeploymentFailed

```

After fixing, the exception is
```

  File "C:\app\lsg-lisa\lisa\lisa\runners\lisa_runner.py", line 297, in _deploy_environment_task
    self.platform.deploy_environment(environment)
  File "C:\app\lsg-lisa\lisa\lisa\platform_.py", line 189, in deploy_environment
    raise identifier
  File "C:\app\lsg-lisa\lisa\lisa\platform_.py", line 186, in deploy_environment
    self._deploy_environment(environment, log)
  File "C:\app\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 713, in _deploy_environment
    raise e
  File "C:\app\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 708, in _deploy_environment
    self._deploy(location, deployment_parameters, log, environment)
  File "C:\app\lsg-lisa\lisa\lisa\sut_orchestrator\azure\platform_.py", line 1938, in _deploy
    raise LisaException(error_message)
lisa.util.LisaException: DeploymentFailed: The aggregated deployment error is too large. Please list deployment operations to get the deployment details. Please see https://aka.ms/arm-deployment-operations for usage details.
Microsoft.Compute/virtualMachines/lisa-Azure-fleet-smoke-20260429-071421-703-e0-n0: InvalidParameter: The requested VM size Standard_L16aous_v4 is not available in the current region. The sizes available in the current region are: ExtraSmall_Internal,Small_Internal,Medium_Internal,Large_Internal,ExtraLarge_Internal,NetworkMonitor_x64_v1,Standard_NC24ads_A100_v4,Standard_NC48ads_A100_v4,Standard_NC96ads_A100_v4,Standard_D2ls_v6,Standard_D4ls_v6,Standard_D8ls_v6,Standard_D16ls_v6,Standard_D32ls_v6,Standard_D48ls_v6,Standard_D64ls_v6,Standard_D96ls_v6,Standard_D128ls_v6,Standard_D2lds_v6,Standard_D4lds_v6,Standard_D8lds_v6,Standard_D16lds_v6,Standard_D32lds_v6,Standard_D48lds_v6,Standard_D64lds_v6,Standard_D96lds_v6,Standard_D128lds_v6,Standard_D2s_v6,Standard_D4s_v6,Standard_D8s_v6,Standard_D16s_v6,Standard_D32s_v6,Standard_D48s_v6,Standard_D64s_v6,Standard_D96s_v6,Standard_D128s_v6,Standard_D192s_v6,Standard_D2ds_v6,Standard_D4ds_v6,Standard_D8ds_v6,Standard_D16ds_v6,Standard_D32ds_v6,Standard_D48ds_v6,Standard_D64ds_v6,Standard_D96ds_v6,Standard_D128ds_v6,Standard_D192ds_v6,Standard_E2s_v6,Standard_E4-2s_v6,Standard_E4s_v6,Standard_E8-2s_v6,Standard_E8-4s_v6,Standard_E8s_v6,Standard_E16-4s_v6,Standard_E16-8s_v6,Standard_E16s_v6,Standard_E20s_v6,Standard_E32-8s_v6,Standard_E32-16s_v6,Standard_E32s_v6,Standard_E48s_v6,Standard_E64-16s_v6,Standard_E64-32s_v6,Standard_E64s_v6,Standard_E96-24s_v6,Standard_E96-48s_v6,Standard_E96s_v6,Standard_E2ds_v6,Standard_E4-2ds_v6,Standard_E4ds_v6,Standard_E8-2ds_v6,Standard_E8-4ds_v6,Standard_E8ds_v6,Standard_E16-4ds_v6,Standard_E16-8ds_v6,Standard_E16ds_v6,Standard_E20ds_v6,Standard_E32-8ds_v6,Standard_E32-16ds_v6,Standard_E32ds_v6,Standard_E48ds_v6,Standard_E64-16ds_v6,Standard_E64-32ds_v6,Standard_E64ds_v6,Standard_E96-24ds_v6,Standard_E96-48ds_v6,Standard_E96ds_v6,Internal_GPGen10MM_208ids,Internal_GPGen10NPMMG5C_2ds,Internal_GPGen10NPMMG5C_4ds,Internal_GPGen10NPMMG5C_8ds,Internal_GPGen10NPMMG5C_16ds,Internal_GPGen10NPMMG5C_24ds,Internal_GPGen10NPMMG5C_32ds,Internal_GPGen10NPMMG5C_40ds,Internal_GPGen10NPMMG5C_64ds,Internal_GPGen10NPMMG5C_80ds,Internal_GPGen10NPMMG5C_128ds,Internal_GPGen10NPMMG5C_208ids,Internal_GPGen10NPMM_2ds,Internal_GPGen10NPMM_4ds,Internal_GPGen10NPMM_8ds,Internal_GPGen10NPMM_16ds,Internal_GPGen10NPMM_24ds,Internal_GPGen10NPMM_32ds,Internal_GPGen10NPMM_40ds,Internal_GPGen10NPMM_64ds,Internal_GPGen10NPMM_80ds,Internal_GPGen10NPMM_208ids,Experimental_Boost4,Experimental_Boost8,Experimental_Boost32,Experimental_Boost64,Experimental_Boost192,NetworkMonitor_x64_v2,Standard_E2bs_v6,Standard_E4bs_v6,Standard_E8bs_v6,Standard_E16bs_v6,Standard_E20bs_v6,Standard_E32bs_v6,Standard_E48bs_v6,Standard_E64bs_v6,Standard_E96bs_v6,Standard_E2bds_v6,Standard_E4bds_v6,Standard_E8bds_v6,Standard_E16bds_v6,Standard_E20bds_v6,Standard_E32bds_v6,Standard_E48bds_v6,Standard_E64bds_v6,Standard_E96bds_v6,Standard_D2nls_v6,Standard_D2nls_v6_manadirect_experimental,Standard_D4nls_v6,Standard_D4nls_v6_manadirect_experimental,Standard_D8nls_v6,Standard_D16nls_v6,Standard_D16nls_v6_manadirect_experimental,Standard_D32nls_v6,Standard_D48nls_v6,Standard_D64nls_v6,Standard_D64nls_v6_manadirect_experimental,Standard_D96nls_v6,Standard_D128nls_v6,Standard_D192nls_v6_manadirect_experimental,Standard_D2ns_v6,Standard_D4ns_v6,Standard_D8ns_v6,Standard_D16ns_v6,Standard_D32ns_v6,Standard_D48ns_v6,Standard_D64ns_v6,Standard_D96ns_v6,Standard_D128ns_v6,Standard_E2ns_v6,Standard_E4ns_v6,Standard_E8ns_v6,Standard_E16ns_v6,Standard_E32ns_v6,Standard_E48ns_v6,Standard_E64ns_v6,Standard_E96ns_v6,Standard_D2nlds_v6,Standard_D4nlds_v6,Standard_D8nlds_v6,Standard_D16nlds_v6,Standard_D32nlds_v6,Standard_D48nlds_v6,Standard_D64nlds_v6,Standard_D96nlds_v6,Standard_D128nlds_v6,Standard_D2nds_v6,Standard_D4nds_v6,Standard_D8nds_v6,Standard_D16nds_v6,Standard_D32nds_v6,Standard_D48nds_v6,Standard_D64nds_v6,Standard_D96nds_v6,Standard_D128nds_v6,Standard_E2nds_v6,Standard_E4nds_v6,Standard_E8nds_v6,Standard_E16nds_v6,Standard_E32nds_v6,Standard_E48nds_v6,Standard_E64nds_v6,Standard_E96nds_v6,D2_Flex,D2_Flex_Prime,D4_Flex,D4_Flex_Prime,D8_Flex,D8_Flex_Prime,D16_Flex,D16_Flex_Prime,D32_Flex,D32_Flex_Prime,D48_Flex_Prime,D64_Flex,D64_Flex_Prime,D2s_Flex,D2s_Flex_Prime,D4s_Flex,D4s_Flex_Prime,D8s_Flex,D8s_Flex_Prime,D16s_Flex,D16s_Flex_Prime,D32s_Flex,D32s_Flex_Prime,D48s_Flex_Prime,D64s_Flex,D64s_Flex_Prime,E2_Flex,E2_Flex_Prime,E4_Flex,E4_Flex_Prime,E8_Flex,E8_Flex_Prime,E16_Flex,E16_Flex_Prime,E20_Flex,E20_Flex_Prime,E32_Flex,E32_Flex_Prime,E48_Flex_Prime,E64_Flex,E64_Flex_Prime,E2s_Flex,E2s_Flex_Prime,E4s_Flex,E4s_Flex_Prime,E8s_Flex,E8s_Flex_Prime,E16s_Flex,E16s_Flex_Prime,E20s_Flex,E20s_Flex_Prime,E32s_Flex,E32s_Flex_Prime,E48s_Flex_Prime,E64s_Flex,E64s_Flex_Prime,F2_Flex,F2_Flex_Prime,F4_Flex,F4_Flex_Prime,F8_Flex,F8_Flex_Prime,F16_Flex,F16_Flex_Prime,F32_Flex,F32_Flex_Prime,F64_Flex,F64_Flex_Prime,F2s_Flex,F2s_Flex_Prime,F4s_Flex,F4s_Flex_Prime,F8s_Flex,F8s_Flex_Prime,F16s_Flex,F16s_Flex_Prime,F32s_Flex,F32s_Flex_Prime,F64s_Flex,F64s_Flex_Prime,Standard_D2a_v4,Standard_D4a_v4,Standard_D8a_v4,Standard_D16a_v4,Standard_D32a_v4,Standard_D48a_v4,Standard_D64a_v4,Standard_D96a_v4,Standard_D2ahs_v4,Standard_D2as_v4,Standard_D4ahs_v4,Standard_D4as_v4,Standard_D8ahs_v4,Standard_D8as_v4,Standard_D16as_v4,Standard_D32as_v4,Standard_D48as_v4,Standard_D64as_v4,Standard_D96as_v4,Internal_D2as_v4_NoDwnclk,Internal_D4as_v4_NoDwnclk,Internal_D8as_v4_NoDwnclk,Internal_D16as_v4_NoDwnclk,Internal_D32as_v4_NoDwnclk,Internal_D48as_v4_NoDwnclk,Internal_D64as_v4_NoDwnclk,Internal_D96as_v4_NoDwnclk,Standard_E2a_v4,Standard_E4a_v4,Standard_E8a_v4,Standard_E16a_v4,Standard_E20a_v4,Standard_E32a_v4,Standard_E48a_v4,Standard_E64a_v4,Standard_E96a_v4,Standard_E2as_v4,Standard_E4-2as_v4,Standard_E4as_v4,Standard_E8-2as_v4,Standard_E8-4as_v4,Standard_E8as_v4,Standard_E16-4as_v4,Standard_E16-8as_v4,Standard_E16as_v4,Standard_E20as_v4,Standard_E32-8as_v4,Standard_E32-16as_v4,Standard_E32as_v4,Standard_E48as_v4,Standard_E64-16as_v4,Standard_E64-32as_v4,Standard_E64as_v4,Standard_E96-24as_v4,Standard_E96-48as_v4,Standard_E96as_v4,Standard_D2als_v5,Standard_D4als_v5,Standard_D8als_v5,Standard_D16als_v5,Standard_D32als_v5,Standard_D48als_v5,Standard_D64als_v5,Standard_D96als_v5,Standard_D2as_v5_Promo,Standard_D4as_v5_Promo,Standard_D8as_v5_Promo,Standard_D16as_v5_Promo,Standard_D32as_v5_Promo,Standard_D48as_v5_Promo,Standard_D64as_v5_Promo,Standard_D96as_v5_Promo,Internal_D2als_v5,Internal_D4als_v5,Internal_D8als_v5,Internal_D16als_v5,Internal_D32als_v5,Internal_D48als_v5,Internal_D64als_v5,Internal_D96als_v5,Internal_D2as_v5,Internal_D4as_v5,Internal_D8as_v5,Internal_D16as_v5,Internal_D32as_v5,Internal_D48as_v5,Internal_D64as_v5,Internal_D96as_v5,Internal_E2as_v5,Internal_E4as_v5,Internal_E8as_v5,Internal_E16as_v5,Internal_E20as_v5,Internal_E32as_v5,Internal_E48as_v5,Internal_E64as_v5,Internal_E96as_v5,Internal_D2alds_v5,Internal_D4alds_v5,Internal_D8alds_v5,Internal_D16alds_v5,Internal_D32alds_v5,Internal_D48alds_v5,Internal_D64alds_v5,Internal_D96alds_v5,Internal_D2ads_v5,Internal_D4ads_v5,Internal_D8ads_v5,Internal_D16ads_v5,Internal_D32ads_v5,Internal_D48ads_v5,Internal_D64ads_v5,Internal_D96ads_v5,Internal_E2ads_v5,Internal_E4ads_v5,Internal_E8ads_v5,Internal_E16ads_v5,Internal_E20ads_v5,Internal_E32ads_v5,Internal_E48ads_v5,Internal_E64ads_v5,Internal_E96ads_v5,Standard_E2as_v5_Promo,Standard_E4as_v5_Promo,Standard_E8as_v5_Promo,Standard_E16as_v5_Promo,Standard_E20as_v5_Promo,Standard_E32as_v5_Promo,Standard_E48as_v5_Promo,Standard_E64as_v5_Promo,Standard_E96as_v5_Promo,Standard_D2alds_v5,Standard_D4alds_v5,Standard_D8alds_v5,Standard_D16alds_v5,Standard_D32alds_v5,Standard_D48alds_v5,Standard_D64alds_v5,Standard_D96alds_v5,Standard_D2as_v5,Standard_D4as_v5,Standard_D8as_v5,Standard_D16as_v5,Standard_D32as_v5,Standard_D48as_v5,Standard_D64as_v5,Standard_D96as_v5,Standard_E2as_v5,Standard_E4-2as_v5,Standard_E4as_v5,Standard_E8-2as_v5,Standard_E8-4as_v5,Standard_E8as_v5,Standard_E16-4as_v5,Standard_E16-8as_v5,Standard_E16as_v5,Standard_E20as_v5,Standard_E32-8as_v5,Standard_E32-16as_v5,Standard_E32as_v5,Standard_E48as_v5,Standard_E64-16as_v5,Standard_E64-32as_v5,Standard_E64as_v5,Standard_E96-24as_v5,Standard_E96-48as_v5,Standard_E96as_v5,Standard_E96ias_v5,Standard_E112ias_v5,Standard_D2ads_v5,Standard_D4ads_v5,Standard_D8ads_v5,Standard_D16ads_v5,Standard_D32ads_v5,Standard_D48ads_v5,Standard_D64ads_v5,Standard_D96ads_v5,Standard_E2ads_v5,Standard_E4-2ads_v5,Standard_E4ads_v5,Standard_E8-2ads_v5,Standard_E8-4ads_v5,Standard_E8ads_v5,Standard_E16-4ads_v5,Standard_E16-8ads_v5,Standard_E16ads_v5,Standard_E20ads_v5,Standard_E32-8ads_v5,Standard_E32-16ads_v5,Standard_E32ads_v5,Standard_E48ads_v5,Standard_E64-16ads_v5,Standard_E64-32ads_v5,Standard_E64ads_v5,Standard_E96-24ads_v5,Standard_E96-48ads_v5,Standard_E96ads_v5,Standard_E96iads_v5,Standard_E112iads_v5,Internal_GPGen8MM_128iad,Internal_GPGen8MMv2_128iad,Standard_B2als_v2,Standard_B2as_v2,Standard_B2ats_v2,Standard_B4als_v2,Standard_B4as_v2,Standard_B8als_v2,Standard_B8as_v2,Standard_B16als_v2,Standard_B16as_v2,Standard_B32als_v2,Standard_B32as_v2,Standard_D2as_v6,Standard_D4as_v6,Standard_D8as_v6,Standard_D16as_v6,Standard_D32as_v6,Standard_D48as_v6,Standard_D64as_v6,Standard_D96as_v6,Standard_E2as_v6,Standard_E4-2as_v6,Standard_E4as_v6,Standard_E8-2as_v6,Standard_E8-4as_v6,Standard_E8as_v6,Standard_E16-4as_v6,Standard_E16-8as_v6,Standard_E16as_v6,Standard_E20as_v6,Standard_E32-8as_v6,Standard_E32-16as_v6,Standard_E32as_v6,Standard_E48as_v6,Standard_E64-16as_v6,Standard_E64-32as_v6,Standard_E64as_v6,Standard_E96-24as_v6,Standard_E96-48as_v6,Standard_E96as_v6,Standard_D2ads_v6,Standard_D4ads_v6,Standard_D8ads_v6,Standard_D16ads_v6,Standard_D32ads_v6,Standard_D48ads_v6,Standard_D64ads_v6,Standard_D96ads_v6,Standard_D2als_v6,Standard_D4als_v6,Standard_D8als_v6,Standard_D16als_v6,Standard_D32als_v6,Standard_D48als_v6,Standard_D64als_v6,Standard_D96als_v6,Standard_D2alds_v6,Standard_D4alds_v6,Standard_D8alds_v6,Standard_D16alds_v6,Standard_D32alds_v6,Standard_D48alds_v6,Standard_D64alds_v6,Standard_D96alds_v6,Standard_E2ads_v6,Standard_E4-2ads_v6,Standard_E4ads_v6,Standard_E8-2ads_v6,Standard_E8-4ads_v6,Standard_E8ads_v6,Standard_E16-4ads_v6,Standard_E16-8ads_v6,Standard_E16ads_v6,Standard_E20ads_v6,Standard_E32-8ads_v6,Standard_E32-16ads_v6,Standard_E32ads_v6,Standard_E48ads_v6,Standard_E64-16ads_v6,Standard_E64-32ads_v6,Standard_E64ads_v6,Standard_E96-24ads_v6,Standard_E96-48ads_v6,Standard_E96ads_v6,Standard_D2aods_v6,Standard_D4aods_v6,Standard_D8aods_v6,Standard_D16aods_v6,Standard_D32aods_v6,Standard_D48aods_v6,Standard_D64aods_v6,Standard_F1as_v6,Standard_F2as_v6,Standard_F4as_v6,Standard_F8as_v6,Standard_F16as_v6,Standard_F32as_v6,Standard_F48as_v6,Standard_F64as_v6,Standard_F72as_v6,Standard_F1ads_v6,Standard_F2ads_v6,Standard_F4ads_v6,Standard_F8ads_v6,Standard_F16ads_v6,Standard_F32ads_v6,Standard_F48ads_v6,Standard_F64ads_v6,Standard_F72ads_v6,Standard_F1als_v6,Standard_F2als_v6,Standard_F4als_v6,Standard_F8als_v6,Standard_F16als_v6,Standard_F32als_v6,Standard_F48als_v6,Standard_F64als_v6,Standard_F72als_v6,Standard_F1alds_v6,Standard_F2alds_v6,Standard_F4alds_v6,Standard_F8alds_v6,Standard_F16alds_v6,Standard_F32alds_v6,Standard_F48alds_v6,Standard_F64alds_v6,Standard_F72alds_v6,Standard_F1ams_v6,Standard_F2ams_v6,Standard_F4ams_v6,Standard_F8ams_v6,Standard_F16ams_v6,Standard_F32ams_v6,Standard_F48ams_v6,Standard_F64ams_v6,Standard_F72iams_v6,Standard_F1amds_v6,Standard_F2amds_v6,Standard_F4amds_v6,Standard_F8amds_v6,Standard_F16amds_v6,Standard_F32amds_v6,Standard_F48amds_v6,Standard_F64amds_v6,Standard_F72iamds_v6,Internal_GPGen9MM_160iads,Standard_L32als_v4,Standard_D32adus_v6,Standard_D64adus_v6,Standard_D96adus_v6,Standard_D32aldus_v6,Standard_D64aldus_v6,Standard_D96aldus_v6,Standard_E32adus_v6,Standard_E64adus_v6,Standard_E96adus_v6,Standard_A1Web35_v2,Standard_A1Web_v2,Standard_A1_v2,Standard_A1_v2_Gen2,Standard_A2Web45_v2,Standard_A2Web_v2,Standard_A2m_v2,Standard_A2m_v2_Gen2,Standard_A2_v2,Standard_A2_v2_Gen2,Standard_A4Web_v2,Standard_A4m_v2,Standard_A4m_v2_Gen2,Standard_A4_v2,Standard_A4_v2_Gen2,Standard_A8m_v2,Standard_A8m_v2_Gen2,Standard_A8_v2,Standard_A8_v2_Gen2,Internal_A1Web35_v2_Gen2,Internal_A2Web45_v2_Gen2,Internal_A4Web_v2_Gen2,Standard_B1ls,Standard_B1ms,Standard_B1s,Standard_B2hms,Standard_B2ms,Standard_B2s,Standard_B4hms,Standard_B4ms,Standard_B8ms,Standard_B12ms,Standard_B16ms,Standard_B20ms,Standard_D2ds_v4,Standard_D4ds_v4,Standard_D8ds_v4,Standard_D16ds_v4,Standard_D32ds_v4,Standard_D48ds_v4,Standard_D64ds_v4,Standard_D2ds_v5,Standard_D4ds_v5,Standard_D8ds_v5,Standard_D16ds_v5,Standard_D32ds_v5,Standard_D48ds_v5,Standard_D64ds_v5,Standard_D96ds_v5,Standard_D2d_v4,Standard_D4d_v4,Standard_D8d_v4,Standard_D16d_v4,Standard_D32d_v4,Standard_D48d_v4,Standard_D64d_v4,Standard_D2d_v5,Standard_D4d_v5,Standard_D8d_v5,Standard_D16d_v5,Standard_D32d_v5,Standard_D48d_v5,Standard_D64d_v5,Standard_D96d_v5,Standard_DS1_v2,Standard_DS2_v2,Standard_DS3_v2,Standard_DS4_v2,Standard_DS5_v2,Standard_DS11-1_v2,Standard_DS11_v2,Standard_DS12-1_v2,Standard_DS12-2_v2,Standard_DS12_v2,Standard_DS13-2_v2,Standard_DS13-4_v2,Standard_DS13_v2,Standard_DS14-4_v2,Standard_DS14-8_v2,Standard_DS14_v2,Standard_DS15i_v2,Standard_DS15_v2,Standard_DS2_v2_Promo,Standard_DS3_v2_Promo,Standard_DS4_v2_Promo,Standard_DS5_v2_Promo,Standard_DS11_v2_Promo,Standard_DS12_v2_Promo,Standard_DS13_v2_Promo,Standard_DS14_v2_Promo,Standard_D2hs_v3,Standard_D2s_v3,Standard_D4hs_v3,Standard_D4s_v3,Standard_D8hs_v3,Standard_D8s_v3,Standard_D16s_v3,Standard_D32-8s_v3,Standard_D32-16s_v3,Standard_D32s_v3,Standard_D48s_v3,Standard_D64-16s_v3,Standard_D64-32s_v3,Standard_D64s_v3,Internal_D2s_v3_NoDwnclk,Internal_D4s_v3_NoDwnclk,Internal_D8s_v3_NoDwnclk,Internal_D16s_v3_NoDwnclk,Internal_D32s_v3_NoDwnclk,Internal_D48s_v3_NoDwnclk,Internal_D64s_v3_NoDwnclk,Standard_D2s_v4,Standard_D4s_v4,Standard_D8s_v4,Standard_D16s_v4,Standard_D32s_v4,Standard_D48s_v4,Standard_D64s_v4,Standard_D2s_v5,Standard_D4s_v5,Standard_D8s_v5,Standard_D16s_v5,Standard_D32s_v5,Standard_D48s_v5,Standard_D64s_v5,Standard_D96s_v5,Standard_D1_v2,Standard_D2_v2,Standard_D3_v2,Standard_D4_v2,Standard_D5_v2,Standard_D11_v2,Standard_D12_v2,Standard_D13_v2,Standard_D14_v2,Standard_D15i_v2,Standard_D15_v2,Standard_D1_v2_Internal,Standard_D2_v2_Internal,Standard_D3_v2_Internal,Standard_D4_v2_Internal,Standard_D5_v2_Internal,Standard_D11_v2_Internal,Standard_D12_v2_Internal,Standard_D13_v2_Internal,Standard_D14_v2_Internal,Standard_D2_v2_Promo,Standard_D3_v2_Promo,Standard_D4_v2_Promo,Standard_D5_v2_Promo,Standard_D11_v2_Promo,Standard_D12_v2_Promo,Standard_D13_v2_Promo,Standard_D14_v2_Promo,Standard_D2_v3,Standard_D4_v3,Standard_D8_v3,Standard_D16_v3,Standard_D32_v3,Standard_D48_v3,Standard_D64_v3,Standard_D2_v4,Standard_D4_v4,Standard_D8_v4,Standard_D16_v4,Standard_D32_v4,Standard_D48_v4,Standard_D64_v4,Standard_D2_v5,Standard_D4_v5,Standard_D8_v5,Standard_D16_v5,Standard_D32_v5,Standard_D48_v5,Standard_D64_v5,Standard_D96_v5,Standard_E2ds_v4,Standard_E4-2ds_v4,Standard_E4ds_v4,Standard_E8-2ds_v4,Standard_E8-4ds_v4,Standard_E8ds_v4,Standard_E16-4ds_v4,Standard_E16-8ds_v4,Standard_E16ds_v4,Standard_E20ds_v4,Standard_E32-8ds_v4,Standard_E32-16ds_v4,Standard_E32ds_v4,Standard_E48ds_v4,Standard_E64-16ds_v4,Standard_E64-32ds_v4,Standard_E64ds_v4,Standard_E2ds_v5,Standard_E4-2ds_v5,Standard_E4ds_v5,Standard_E8-2ds_v5,Standard_E8-4ds_v5,Standard_E8ds_v5,Standard_E16-4ds_v5,Standard_E16-8ds_v5,Standard_E16ds_v5,Standard_E20ds_v5,Standard_E32-8ds_v5,Standard_E32-16ds_v5,Standard_E32ds_v5,Standard_E48ds_v5,Standard_E64-16ds_v5,Standard_E64-32ds_v5,Standard_E64ds_v5,Standard_E96-24ds_v5,Standard_E96-48ds_v5,Standard_E96ds_v5,Standard_E104ids_v5,Standard_E2d_v4,Standard_E4d_v4,Standard_E8d_v4,Standard_E16d_v4,Standard_E20d_v4,Standard_E32d_v4,Standard_E48d_v4,Standard_E64d_v4,Standard_E2d_v5,Standard_E4d_v5,Standard_E8d_v5,Standard_E16d_v5,Standard_E20d_v5,Standard_E32d_v5,Standard_E48d_v5,Standard_E64d_v5,Standard_E96d_v5,Standard_E104id_v5,Standard_E2s_v3,Standard_E4-2s_v3,Standard_E4s_v3,Standard_E8-2s_v3,Standard_E8-4s_v3,Standard_E8s_v3,Standard_E16-4s_v3,Standard_E16-8s_v3,Standard_E16s_v3,Standard_E20s_v3,Standard_E32-8s_v3,Standard_E32-16s_v3,Standard_E32s_v3,Standard_E48s_v3,Standard_E64-16s_v3,Standard_E64-32s_v3,Standard_E64s_v3,Harvest_E2s_v3,Harvest_E4s_v3,Harvest_E8s_v3,Standard_E2s_v4,Standard_E4-2s_v4,Standard_E4s_v4,Standard_E8-2s_v4,Standard_E8-4s_v4,Standard_E8s_v4,Standard_E16-4s_v4,Standard_E16-8s_v4,Standard_E16s_v4,Standard_E20s_v4,Standard_E32-8s_v4,Standard_E32-16s_v4,Standard_E32s_v4,Standard_E48s_v4,Standard_E64-16s_v4,Standard_E64-32s_v4,Standard_E64s_v4,Standard_E2s_v5,Standard_E4-2s_v5,Standard_E4s_v5,Standard_E8-2s_v5,Standard_E8-4s_v5,Standard_E8s_v5,Standard_E16-4s_v5,Standard_E16-8s_v5,Standard_E16s_v5,Standard_E20s_v5,Standard_E32-8s_v5,Standard_E32-16s_v5,Standard_E32s_v5,Standard_E48s_v5,Standard_E64-16s_v5,Standard_E64-32s_v5,Standard_E64s_v5,Standard_E96-24s_v5,Standard_E96-48s_v5,Standard_E96s_v5,Standard_E104is_v5,Standard_E2_v3,Standard_E4_v3,Standard_E8_v3,Standard_E16_v3,Standard_E20_v3,Standard_E32_v3,Standard_E48_v3,Standard_E64_v3,Standard_E2_v4,Standard_E4_v4,Standard_E8_v4,Standard_E16_v4,Standard_E20_v4,Standard_E32_v4,Standard_E48_v4,Standard_E64_v4,Standard_E2_v5,Standard_E4_v5,Standard_E8_v5,Standard_E16_v5,Standard_E20_v5,Standard_E32_v5,Standard_E48_v5,Standard_E64_v5,Standard_E96_v5,Standard_E104i_v5,Standard_F1,Standard_F2,Standard_F4,Standard_F8,Standard_F16,Standard_F1s,Standard_F2s,Standard_F4s,Standard_F8s,Standard_F16s,Standard_F2hs_v2,Standard_F2s_v2,Standard_F4s_v2,Standard_F8s_v2,Standard_F16s_v2,Standard_F32s_v2,Standard_F48s_v2,Standard_F64s_v2,Standard_F72s_v2,Internal_GPGen8MM_128id,Internal_GPGen8MM_128id_IaaS,Internal_GPGen8MMv2_128id,Internal_NPG5C_2d,Internal_NPG5C_2ds,Internal_NPG5C_4d,Internal_NPG5C_4ds,Internal_NPG5C_8d,Internal_NPG5C_8ds,Internal_NPG5C_16d,Internal_NPG5C_16ds,Internal_NPG5C_24d,Internal_NPG5C_24ds,Internal_NPG5C_32d,Internal_NPG5C_32ds,Internal_NPG5C_40d,Internal_NPG5C_40ds,Internal_NPG5C_64d,Internal_NPG5C_64ds,Internal_NPG5C_80d,Internal_NPG5C_80ds,Internal_NPG5C_128d,Internal_NPG5C_128ds,Internal_NPG5C_128id,Internal_NPG5C_128id_IaaS,Internal_NPG5C_128ids,Internal_NPG5C_128ids_IaaS,Internal_NPMM_2ds,Internal_NPMM_4ds,Internal_NPMM_8ds,Internal_NPMM_16ds,Internal_NPMM_24ds,Internal_NPMM_32ds,Internal_NPMM_40ds,Internal_NPMM_64ds,Internal_NPMM_80ds,Internal_NPMM_128ds,Internal_NPMM_128ids,Internal_NPMM_128ids_IaaS,Standard_E2bs_v5,Standard_E4bs_v5,Standard_E8bs_v5,Standard_E16bs_v5,Standard_E32bs_v5,Standard_E48bs_v5,Standard_E64bs_v5,Standard_E96bs_v5,Standard_E112ibs_v5,Standard_E2bds_v5,Standard_E4bds_v5,Standard_E8bds_v5,Standard_E16bds_v5,Standard_E32bds_v5,Standard_E48bds_v5,Standard_E64bds_v5,Standard_E96bds_v5,Standard_E112ibds_v5,Standard_D2ls_v5,Standard_D4ls_v5,Standard_D8ls_v5,Standard_D16ls_v5,Standard_D32ls_v5,Standard_D48ls_v5,Standard_D64ls_v5,Standard_D96ls_v5,Standard_D2lds_v5,Standard_D4lds_v5,Standard_D8lds_v5,Standard_D16lds_v5,Standard_D32lds_v5,Standard_D48lds_v5,Standard_D64lds_v5,Standard_D96lds_v5,Standard_B2ls_v2,Standard_B2s_v2,Standard_B2ts_v2,Standard_B4ls_v2,Standard_B4s_v2,Standard_B8ls_v2,Standard_B8s_v2,Standard_B16ls_v2,Standard_B16s_v2,Standard_B32ls_v2,Standard_B32s_v2,Experimental_OVLTest_CurrentT0,Experimental_OVLTest_CurrentT1,Experimental_OVLTest_CurrentT2,Experimental_OVLTest_CurrentT3,Experimental_OVLTest_CurrentT4,Experimental_OVLTest_CurrentT5,Experimental_OVLTest_CurrentT6,Experimental_OVLTest_CurrentT7,Experimental_OVLTest_CurrentT8,Experimental_OVLTest_CurrentT9,Standard_L8as_v3,Standard_L16as_v3,Standard_L32as_v3,Standard_L48as_v3,Standard_L64as_v3,Standard_L80as_v3,Standard_L112ias_v3,Standard_E112iadms_v5,Internal_GPGen8HH_128iad,Internal_GPGen8HHv2_128iad,Standard_D2pls_v6,Standard_D4pls_v6,Standard_D8pls_v6,Standard_D16pls_v6,Standard_D32pls_v6,Standard_D48pls_v6,Standard_D64pls_v6,Standard_D96pls_v6,Standard_D2plds_v6,Standard_D4plds_v6,Standard_D8plds_v6,Standard_D16plds_v6,Standard_D32plds_v6,Standard_D48plds_v6,Standard_D64plds_v6,Standard_D96plds_v6,Standard_D2ps_v6,Standard_D4ps_v6,Standard_D8ps_v6,Standard_D16ps_v6,Standard_D32ps_v6,Standard_D48ps_v6,Standard_D64ps_v6,Internal_GPGen9LM_112ipds,Standard_D2pds_v6,Standard_D4pds_v6,Standard_D8pds_v6,Standard_D16pds_v6,Standard_D32pds_v6,Standard_D48pds_v6,Standard_D64pds_v6,Standard_E2ps_v6,Standard_E4ps_v6,Standard_E8ps_v6,Standard_E16ps_v6,Standard_E32ps_v6,Standard_E2pds_v6,Standard_E4pds_v6,Standard_E8pds_v6,Standard_E16pds_v6,Standard_E32pds_v6,NetworkMonitor_ARM_v1,Standard_D32pdus_v6,Standard_D64pdus_v6,Standard_D32pldus_v6,Standard_D64pldus_v6,Standard_D96pldus_v6,Standard_E32pdus_v6,SQLG6,SQLG6_IaaS,SQLG6_NP2,SQLG6_NP4,SQLG6_NP8,SQLG6_NP16,SQLG6_NP24,SQLG6_NP32,SQLG6_NP40,SQLG6_NP56,SQLG6_NP64,SQLG6_NP80,SQLG6_NP96,SQLG6_NP96s,Standard_DS1,Standard_DS2,Standard_DS3,Standard_DS4,Standard_DS11,Standard_DS12,Standard_DS13,Standard_DS14,Standard_D1,Standard_D2,Standard_D3,Standard_D4,Standard_D11,Standard_D12,Standard_D13,Standard_D14,Standard_G1,Standard_G2,Standard_G3,Standard_G4,Standard_G5,Standard_GS1,Standard_GS2,Standard_GS3,Standard_GS4,Standard_GS4-4,Standard_GS4-8,Standard_GS5,Standard_GS5-8,Standard_GS5-16,Standard_L4s,Standard_L8s,Standard_L16s,Standard_L32s,Standard_HC44-16rs,Standard_HC44-32rs,Standard_HC44rs,Standard_DC8_v2,Standard_DC1s_v2,Standard_DC2s_v2,Standard_DC4s_v2,SQLDCGen6_2,SQLG5,SQLG5Core,SQLG5_IaaS,SQLG5_NP2,SQLG5_NP4,SQLG5_NP8,SQLG5_NP16,SQLG5_NP24,SQLG5_NP32,SQLG5_NP40,SQLG5_NP64,SQLG5_NP80,SQLG5_NP80s,Special_D4_v2,FCA_E8-6s_v3,FCA_E16-10s_v3,FCA_E16-12s_v3,FCA_E16-14s_v3,FCA_E32-24s_v3,FCA_E32-26s_v3,FCA_E32-28s_v3,FCA_E64-52s_v3,Standard_E96ias_v4,SQLG7_AMD,SQLG7_AMD_IaaS,Internal_GPGen8LM_128iad,Standard_B2afs_v2,Standard_MSODSG5,Standard_E128-32s_v6,Standard_E128-64s_v6,Standard_E128s_v6,Standard_E192is_v6,Standard_E128-32ds_v6,Standard_E128-64ds_v6,Standard_E128ds_v6,Standard_E192ids_v6,Standard_FX2ms_v2,Standard_FX4-2ms_v2,Standard_FX4ms_v2,Standard_FX8-2ms_v2,Standard_FX8-4ms_v2,Standard_FX8ms_v2,Standard_FX12-6ms_v2,Standard_FX12ms_v2,Standard_FX16-4ms_v2,Standard_FX16-8ms_v2,Standard_FX16ms_v2,Standard_FX24-6ms_v2,Standard_FX24-12ms_v2,Standard_FX24ms_v2,Standard_FX32-8ms_v2,Standard_FX32-16ms_v2,Standard_FX32ms_v2,Standard_FX48-12ms_v2,Standard_FX48-24ms_v2,Standard_FX48ms_v2,Standard_FX64-16ms_v2,Standard_FX64-32ms_v2,Standard_FX64ms_v2,Standard_FX96-24ms_v2,Standard_FX96-48ms_v2,Standard_FX96ms_v2,Standard_FX2mds_v2,Standard_FX4-2mds_v2,Standard_FX4mds_v2,Standard_FX8-2mds_v2,Standard_FX8-4mds_v2,Standard_FX8mds_v2,Standard_FX12-6mds_v2,Standard_FX12mds_v2,Standard_FX16-4mds_v2,Standard_FX16-8mds_v2,Standard_FX16mds_v2,Standard_FX24-6mds_v2,Standard_FX24-12mds_v2,Standard_FX24mds_v2,Standard_FX32-8mds_v2,Standard_FX32-16mds_v2,Standard_FX32mds_v2,Standard_FX48-12mds_v2,Standard_FX48-24mds_v2,Standard_FX48mds_v2,Standard_FX64-16mds_v2,Standard_FX64-32mds_v2,Standard_FX64mds_v2,Standard_FX96-24mds_v2,Standard_FX96-48mds_v2,Standard_FX96mds_v2,Internal_GPGen10HH_208ids,Internal_GPGen10NPHHG5C_2ds,Internal_GPGen10NPHHG5C_4ds,Internal_GPGen10NPHHG5C_8ds,Internal_GPGen10NPHHG5C_16ds,Internal_GPGen10NPHHG5C_24ds,Internal_GPGen10NPHHG5C_32ds,Internal_GPGen10NPHHG5C_40ds,Internal_GPGen10NPHHG5C_64ds,Internal_GPGen10NPHHG5C_80ds,Internal_GPGen10NPHHG5C_128ds,Internal_GPGen10NPHHG5C_208ids,Internal_GPGen10NPHH_2ds,Internal_GPGen10NPHH_4ds,Internal_GPGen10NPHH_8ds,Internal_GPGen10NPHH_16ds,Internal_GPGen10NPHH_24ds,Internal_GPGen10NPHH_32ds,Internal_GPGen10NPHH_40ds,Internal_GPGen10NPHH_48ds,Internal_GPGen10NPHH_64ds,Internal_GPGen10NPHH_80ds,Internal_GPGen10NPHH_104ds,Internal_GPGen10NPHH_128ds,Internal_GPGen10NPHH_208ids,Internal_GPGen10HH_208ids_CVM,Standard_L2s_v4,Standard_L4s_v4,Standard_L8s_v4,Standard_L16s_v4,Standard_L32s_v4,Standard_L48s_v4,Standard_L64s_v4,Standard_L80s_v4,Standard_L96s_v4,Standard_L192is_v4,Standard_E128bs_v6,Standard_E192ibs_v6,Standard_E128bds_v6,Standard_E192ibds_v6,Standard_FX64-16mdus_v2,Standard_FX64-32mdus_v2,Standard_FX64mdus_v2,Standard_E128dus_v6,Standard_E192idus_v6,Standard_E128ndus_v6,Standard_E128bdus_v6,Standard_E192ibdus_v6,Standard_E128nds_v6,Standard_E128ns_v6,Standard_NC40ads_H100_v5,Standard_NC80adis_H100_v5,Standard_E128ads_v6,Standard_E144iads_v6,Standard_L2aos_v4,Standard_L4aos_v4,Standard_L8aos_v4,Standard_L12aos_v4,Standard_L16aos_v4,Standard_L24aos_v4,Standard_L32aos_v4,Standard_L2as_v4,Standard_L4as_v4,Standard_L8as_v4,Standard_L16as_v4,Standard_L32as_v4,Standard_L48as_v4,Standard_L64as_v4,Standard_L80as_v4,Standard_L96as_v4,Standard_D96aods_v6,Internal_GPGen9HH_160iads,SQLG7,SQLG7_DCLK,SQLG7_IaaS,Internal_Gen7_IaaS_LI,SQLG7_NP2,SQLG7_NP4,SQLG7_NP8,SQLG7_NP16,SQLG7_NP24,SQLG7_NP32,SQLG7_NP40,SQLG7_NP64,SQLG7_NP80,SQLG7_NP96,SQLG7_NP104,SQLG7_NP104s,Standard_E64i_v4_SPECIAL,Standard_E64is_v4_SPECIAL,Standard_E4s_v4_ADHType1,Standard_E8s_v4_ADHType1,Standard_E16s_v4_ADHType1,Standard_E32s_v4_ADHType1,Standard_E80is_v4,Standard_E4ds_v4_ADHType1,Standard_E8ds_v4_ADHType1,Standard_E16ds_v4_ADHType1,Standard_E32ds_v4_ADHType1,Standard_E80ids_v4,Special_CCX_DS13_v2,Special_CCX_DS14_v2,Internal_GPGen8LM_128id,Internal_GPGen8LM_128id_IaaS,Standard_NC6s_v3,Standard_NC12s_v3,Standard_NC24rs_v3,Standard_NC24s_v3,Standard_M896ixds_24_v3,Standard_M896ixds_32_v3,Standard_M896xds_16_v3,Standard_M1792ixds_32_v3,Standard_M208bs_2_v3,Standard_M312bs_3_v3,Standard_M416bs_4_v3,Standard_D2als_v7,Standard_D4als_v7,Standard_D8als_v7,Standard_D16als_v7,Standard_D32als_v7,Standard_D48als_v7,Standard_D64als_v7,Standard_D96als_v7,Standard_D128als_v7,Standard_D160als_v7,Standard_D2alds_v7,Standard_D4alds_v7,Standard_D8alds_v7,Standard_D16alds_v7,Standard_D32alds_v7,Standard_D48alds_v7,Standard_D64alds_v7,Standard_D96alds_v7,Standard_D128alds_v7,Standard_D160alds_v7,Standard_D2as_v7,Standard_D4as_v7,Standard_D8as_v7,Standard_D16as_v7,Standard_D32as_v7,Standard_D48as_v7,Standard_D64as_v7,Standard_D96as_v7,Standard_D128as_v7,Standard_D160as_v7,Standard_D2ads_v7,Standard_D4ads_v7,Standard_D8ads_v7,Standard_D16ads_v7,Standard_D32ads_v7,Standard_D48ads_v7,Standard_D64ads_v7,Standard_D96ads_v7,Standard_D128ads_v7,Standard_D160ads_v7,Standard_E2as_v7,Standard_E4-2as_v7,Standard_E4as_v7,Standard_E8-2as_v7,Standard_E8-4as_v7,Standard_E8as_v7,Standard_E16-4as_v7,Standard_E16-8as_v7,Standard_E16as_v7,Standard_E32-8as_v7,Standard_E32-16as_v7,Standard_E32as_v7,Standard_E48as_v7,Standard_E64-16as_v7,Standard_E64-32as_v7,Standard_E64as_v7,Standard_E96-24as_v7,Standard_E96-48as_v7,Standard_E96as_v7,Standard_E128-32as_v7,Standard_E128-64as_v7,Standard_E128as_v7,Standard_E2ads_v7,Standard_E4-2ads_v7,Standard_E4ads_v7,Standard_E8-2ads_v7,Standard_E8-4ads_v7,Standard_E8ads_v7,Standard_E16-4ads_v7,Standard_E16-8ads_v7,Standard_E16ads_v7,Standard_E32-8ads_v7,Standard_E32-16ads_v7,Standard_E32ads_v7,Standard_E48ads_v7,Standard_E64-16ads_v7,Standard_E64-32ads_v7,Standard_E64ads_v7,Standard_E96-24ads_v7,Standard_E96-48ads_v7,Standard_E96ads_v7,Standard_E128-32ads_v7,Standard_E128-64ads_v7,Standard_E128ads_v7,Standard_F1als_v7,Standard_F2als_v7,Standard_F4als_v7,Standard_F8als_v7,Standard_F16als_v7,Standard_F32als_v7,Standard_F48als_v7,Standard_F64als_v7,Standard_F80als_v7,Standard_F1alds_v7,Standard_F2alds_v7,Standard_F4alds_v7,Standard_F8alds_v7,Standard_F16alds_v7,Standard_F32alds_v7,Standard_F48alds_v7,Standard_F64alds_v7,Standard_F80alds_v7,Standard_F1as_v7,Standard_F2as_v7,Standard_F4as_v7,Standard_F8as_v7,Standard_F16as_v7,Standard_F32as_v7,Standard_F48as_v7,Standard_F64as_v7,Standard_F80as_v7,Standard_F1ads_v7,Standard_F2ads_v7,Standard_F4ads_v7,Standard_F8ads_v7,Standard_F16ads_v7,Standard_F32ads_v7,Standard_F48ads_v7,Standard_F64ads_v7,Standard_F80ads_v7,Standard_F1ams_v7,Standard_F2-1ams_v7,Standard_F2ams_v7,Standard_F4-1ams_v7,Standard_F4-2ams_v7,Standard_F4ams_v7,Standard_F8-2ams_v7,Standard_F8-4ams_v7,Standard_F8ams_v7,Standard_F16-4ams_v7,Standard_F16-8ams_v7,Standard_F16ams_v7,Standard_F32-8ams_v7,Standard_F32-16ams_v7,Standard_F32ams_v7,Standard_F48ams_v7,Standard_F64-16ams_v7,Standard_F64-32ams_v7,Standard_F64ams_v7,Standard_F80ams_v7,Standard_F1amds_v7,Standard_F2-1amds_v7,Standard_F2amds_v7,Standard_F4-1amds_v7,Standard_F4-2amds_v7,Standard_F4amds_v7,Standard_F8-2amds_v7,Standard_F8-4amds_v7,Standard_F8amds_v7,Standard_F16-4amds_v7,Standard_F16-8amds_v7,Standard_F16amds_v7,Standard_F32-8amds_v7,Standard_F32-16amds_v7,Standard_F32amds_v7,Standard_F48amds_v7,Standard_F64-16amds_v7,Standard_F64-32amds_v7,Standard_F64amds_v7,Standard_F80amds_v7,Internal_AMDGen10Test,Internal_GPGen10MM_192iads,Standard_D64adus_v7,Standard_D128adus_v7,Standard_D64aldus_v7,Standard_D128aldus_v7,Standard_E64-16adus_v7,Standard_E64-32adus_v7,Standard_E64adus_v7,Standard_E128-32adus_v7,Standard_E128-64adus_v7,Standard_E128adus_v7,Standard_F32adus_v7,Standard_F64adus_v7,Standard_F32aldus_v7,Standard_F64aldus_v7,Standard_F32-8amdus_v7,Standard_F32-16amdus_v7,Standard_F32amdus_v7,Standard_F64-16amdus_v7,Standard_F64-32amdus_v7,Standard_F64amdus_v7,Internal_GPGen10NPMMG5C_2ads,Internal_GPGen10NPMMG5C_4ads,Internal_GPGen10NPMMG5C_8ads,Internal_GPGen10NPMMG5C_16ads,Internal_GPGen10NPMMG5C_24ads,Internal_GPGen10NPMMG5C_32ads,Internal_GPGen10NPMMG5C_40ads,Internal_GPGen10NPMMG5C_48ads,Internal_GPGen10NPMMG5C_64ads,Internal_GPGen10NPMMG5C_80ads,Internal_GPGen10NPMMG5C_96ads,Internal_GPGen10NPMMG5C_128ads,Internal_GPGen10NPMMG5C_192iads,Internal_GPGen10NPMM_2ads,Internal_GPGen10NPMM_4ads,Internal_GPGen10NPMM_8ads,Internal_GPGen10NPMM_16ads,Internal_GPGen10NPMM_24ads,Internal_GPGen10NPMM_32ads,Internal_GPGen10NPMM_40ads,Internal_GPGen10NPMM_48ads,Internal_GPGen10NPMM_64ads,Internal_GPGen10NPMM_80ads,Internal_GPGen10NPMM_96ads,Internal_GPGen10NPMM_192iads,Standard_D96pds_v6,Standard_D96ps_v6,Standard_E48ps_v6,Standard_E64ps_v6,Standard_E96ps_v6,Standard_E48pds_v6,Standard_E64pds_v6,Standard_E96pds_v6,Internal_GPGen9MM_112ipds,Standard_D96pdus_v6,Standard_E64pdus_v6,Standard_E96pdus_v6,Standard_M64,Standard_M64m,Standard_M128,Standard_M128m,Standard_M8-2ms,Standard_M8-4ms,Standard_M8ms,Standard_M16-4ms,Standard_M16-8ms,Standard_M16ms,Standard_M32-8ms,Standard_M32-16ms,Standard_M32ls,Standard_M32ms,Standard_M32ts,Standard_M64-16ms,Standard_M64-32ms,Standard_M64ls,Standard_M64ms,Standard_M64s,Standard_M128-32ms,Standard_M128-64ms,Standard_M128ms,Standard_M128s,Standard_M8mds_v2,Standard_M8ms_v2,Standard_M16mds_v2,Standard_M16ms_v2,Standard_M32ls_v2,Standard_M32ms_v2,Standard_M32ts_v2,Standard_M64-32ms_v2,Standard_M64ls_v2,Standard_M64ms_v2,Standard_M64s_v2,Standard_M128ms_v2,Standard_M128s_v2,Standard_M192ims_v2,Standard_M192is_v2,Standard_M192ms_v2,Standard_M192s_v2,Standard_M32dms_v2,Standard_M32lds_v2,Standard_M32tds_v2,Standard_M64dms_v2,Standard_M64ds_v2,Standard_M64lds_v2,Standard_M128dms_v2,Standard_M128ds_v2,Standard_M192idms_v2,Standard_M192ids_v2,Standard_L8s_v3,Standard_L16s_v3,Standard_L32s_v3,Standard_L48s_v3,Standard_L64s_v3,Standard_L80s_v3,Standard_L104is_v3,Internal_GPGen8HH_128id,Internal_GPGen8HH_128id_IaaS,Internal_NPHH_2ds,Internal_NPHH_4ds,Internal_NPHH_8ds,Internal_NPHH_16ds,Internal_NPHH_24ds,Internal_NPHH_32ds,Internal_NPHH_40ds,Internal_NPHH_48ds,Internal_NPHH_64ds,Internal_NPHH_80ds,Internal_NPHH_104ds,Internal_NPHH_128ds,Internal_NPHH_128ids,Internal_NPHH_128ids_IaaS,Standard_NC4as_T4_v3,Standard_NC8as_T4_v3,Standard_NC16as_T4_v3,Standard_NC64as_T4_v3,Standard_HB120-16rs_v2,Standard_HB120-32rs_v2,Standard_HB120-64rs_v2,Standard_HB120-96rs_v2,Standard_HB120rs_v2,Standard_HB368FC-48rs_v5,Standard_HB368-48rs_v5,Standard_HB368FC-96rs_v5,Standard_HB368-96rs_v5,Standard_HB368FC-144rs_v5,Standard_HB368-144rs_v5,Standard_HB368FC-192rs_v5,Standard_HB368-192rs_v5,Standard_HB368FC-240rs_v5,Standard_HB368-240rs_v5,Standard_HB368FC-288rs_v5,Standard_HB368-288rs_v5,Standard_HB368FC-336rs_v5,Standard_HB368-336rs_v5,Standard_HB352FCrs_v5,Standard_HB352rs_v5,Standard_HB368FCrs_v5,Standard_HB368rs_v5,Standard_D2plds_v5,Standard_D4plds_v5,Standard_D8plds_v5,Standard_D16plds_v5,Standard_D32plds_v5,Standard_D48plds_v5,Standard_D64plds_v5,Standard_D2pls_v5,Standard_D4pls_v5,Standard_D8pls_v5,Standard_D16pls_v5,Standard_D32pls_v5,Standard_D48pls_v5,Standard_D64pls_v5,Standard_D2pds_v5,Standard_D4pds_v5,Standard_D8pds_v5,Standard_D16pds_v5,Standard_D32pds_v5,Standard_D48pds_v5,Standard_D64pds_v5,Standard_D2ps_v5,Standard_D4ps_v5,Standard_D8ps_v5,Standard_D16ps_v5,Standard_D32ps_v5,Standard_D48ps_v5,Standard_D64ps_v5,Standard_E2pds_v5,Standard_E4pds_v5,Standard_E8pds_v5,Standard_E16pds_v5,Standard_E20pds_v5,Standard_E32pds_v5,Standard_E2ps_v5,Standard_E4ps_v5,Standard_E8ps_v5,Standard_E16ps_v5,Standard_E20ps_v5,Standard_E32ps_v5,Standard_B2pfs_v2,Standard_B2pls_v2,Standard_B2ps_v2,Standard_B2pts_v2,Standard_B4pls_v2,Standard_B4ps_v2,Standard_B8pls_v2,Standard_B8ps_v2,Standard_B16pls_v2,Standard_B16ps_v2,Standard_B32pls_v2,Standard_B32ps_v2,SQLG4VM,Standard_NV6s_v2,Standard_NV12s_v2,Standard_NV24s_v2,Standard_NV12hs_v3,Standard_NV12s_v3,Standard_NV24ms_v3,Standard_NV24s_v3,Standard_NV32ms_v3,Standard_NV48s_v3,Standard_NV6ads_A10_v5,Standard_NV12ads_A10_v5,Standard_NV18ads_A10_v5,Standard_NV36adms_A10_v5,Standard_NV36ads_A10_v5,Standard_NV72ads_A10_v5,Standard_DC2as_v6,Standard_DC4as_v6,Standard_DC8as_v6,Standard_DC16as_v6,Standard_DC32as_v6,Standard_DC48as_v6,Standard_DC64as_v6,Standard_DC96as_v6,Standard_DC2ads_v6,Standard_DC4ads_v6,Standard_DC8ads_v6,Standard_DC16ads_v6,Standard_DC32ads_v6,Standard_DC48ads_v6,Standard_DC64ads_v6,Standard_DC96ads_v6,Standard_EC2as_v6,Standard_EC4as_v6,Standard_EC8as_v6,Standard_EC16as_v6,Standard_EC32as_v6,Standard_EC48as_v6,Standard_EC64as_v6,Standard_EC96as_v6,Standard_EC2ads_v6,Standard_EC4ads_v6,Standard_EC8ads_v6,Standard_EC16ads_v6,Standard_EC32ads_v6,Standard_EC48ads_v6,Standard_EC64ads_v6,Standard_EC96ads_v6,DC8ads_SPO_v6,DC16ads_SPO_v6,Standard_DC8as_cc_v6,Standard_DC32as_cc_v6,Standard_EC32as_cc_v6,Internal_GPGen9MM_160iads_CVM,Internal_DC2as_v6,Internal_DC4as_v6,Internal_DC8as_v6,Internal_DC16as_v6,Internal_DC32as_v6,Internal_DC48as_v6,Internal_DC64as_v6,Internal_DC96as_v6,Internal_DC2ads_v6,Internal_DC4ads_v6,Internal_DC8ads_v6,Internal_DC16ads_v6,Internal_DC32ads_v6,Internal_DC48ads_v6,Internal_DC64ads_v6,Internal_DC96ads_v6,Internal_EC2as_v6,Internal_EC4as_v6,Internal_EC8as_v6,Internal_EC16as_v6,Internal_EC32as_v6,Internal_EC48as_v6,Internal_EC64as_v6,Internal_EC96as_v6,Internal_EC2ads_v6,Internal_EC4ads_v6,Internal_EC8ads_v6,Internal_EC16ads_v6,Internal_EC32ads_v6,Internal_EC48ads_v6,Internal_EC64ads_v6,Internal_EC96ads_v6,Standard_HX176-24rs,Standard_HX176-48rs,Standard_HX176-96rs,Standard_HX176-144rs,Standard_HX176rs,Standard_HB176-24rs_v4,Standard_HB176-48rs_v4,Standard_HB176-96rs_v4,Standard_HB176-144rs_v4,Standard_HB176rs_v4,Standard_HX176-24s,Standard_HX176-48s,Standard_HX176-96s,Standard_HX176-144s,Standard_HX176s,Standard_HB176-24s_v4,Standard_HB176-48s_v4,Standard_HB176-96s_v4,Standard_HB176-144s_v4,Standard_HB176s_v4,Experimental_OVLTest_CurrentT12,Experimental_OVLTest_CurrentT13,Internal_GPGen9MM_208ids,MaxDisk_VM_2_64,MaxDisk_VM_4_64,Standard_M8s_v3,Standard_M12-6s_v3,Standard_M12s_v3,Standard_M16s_v3,Standard_M24-6s_v3,Standard_M24-12s_v3,Standard_M24s_v3,Standard_M32ms_v3,Standard_M32s_1_v3,Standard_M32ts_v3,Standard_M48-12s_1_v3,Standard_M48-24s_1_v3,Standard_M48s_1_v3,Standard_M64s_1_v3,Standard_M64s_2_v3,Standard_M64s_v3,Standard_M96-24s_1_v3,Standard_M96-24s_2_v3,Standard_M96-48s_1_v3,Standard_M96-48s_2_v3,Standard_M96s_1_v3,Standard_M96s_2_v3,Standard_M96s_v3,Standard_M128s_2_v3,Standard_M128s_4_v3,Standard_M176-44s_3_v3,Standard_M176-44s_4_v3,Standard_M176-88s_3_v3,Standard_M176-88s_4_v3,Standard_M176s_2_v3,Standard_M176s_3_v3,Standard_M176s_4_v3,Standard_M176s_v3,Standard_M8ds_v3,Standard_M12-6ds_v3,Standard_M12ds_v3,Standard_M16ds_v3,Standard_M24-6ds_v3,Standard_M24-12ds_v3,Standard_M24ds_v3,Standard_M32dms_v3,Standard_M32ds_1_v3,Standard_M32tds_v3,Standard_M48-12ds_1_v3,Standard_M48-24ds_1_v3,Standard_M48ds_1_v3,Standard_M64ds_1_v3,Standard_M64ds_2_v3,Standard_M64ds_v3,Standard_M96-24ds_1_v3,Standard_M96-24ds_2_v3,Standard_M96-48ds_1_v3,Standard_M96-48ds_2_v3,Standard_M96ds_1_v3,Standard_M96ds_2_v3,Standard_M96ds_v3,Standard_M128ds_2_v3,Standard_M128ds_4_v3,Standard_M176-44ds_3_v3,Standard_M176-44ds_4_v3,Standard_M176-88ds_3_v3,Standard_M176-88ds_4_v3,Standard_M176ds_2_v3,Standard_M176ds_3_v3,Standard_M176ds_4_v3,Standard_M176ds_v3,Standard_M144ds_2_v3,Standard_M144ds_4_v3,Standard_M144s_2_v3,Standard_M144s_4_v3,Standard_M16bs_v3,Standard_M32bs_v3,Standard_M48bs_v3,Standard_M64bs_v3,Standard_M96bs_v3,Standard_M128-64bs_v3,Standard_M128bs_v3,Standard_M176-88bs_v3,Standard_M176bs_3_v3,Standard_M176bs_v3,Standard_M16bds_v3,Standard_M32bds_v3,Standard_M48bds_v3,Standard_M64-32bds_1_v3,Standard_M64bds_1_v3,Standard_M64bds_v3,Standard_M96-48bds_2_v3,Standard_M96bds_2_v3,Standard_M96bds_v3,Standard_M128-64bds_3_v3,Standard_M128-64bds_v3,Standard_M128bds_3_v3,Standard_M128bds_v3,Standard_M176-88bds_4_v3,Standard_M176-88bds_v3,Standard_M176bds_3_v3,Standard_M176bds_4_v3,Standard_M176bds_v3,Standard_E2s_v7,Standard_E4s_v7,Standard_E8s_v7,Standard_E16s_v7,Standard_E20s_v7,Standard_E32s_v7,Standard_E48s_v7,Standard_E64s_v7,Standard_E96s_v7,Standard_E128s_v7,Standard_E192s_v7,Standard_E248s_v7,Standard_E256s_v7,Standard_E360is_v7,Standard_E360s_v7,Standard_E372is_v7,Standard_E2ds_v7,Standard_E4ds_v7,Standard_E8ds_v7,Standard_E16ds_v7,Standard_E20ds_v7,Standard_E32ds_v7,Standard_E48ds_v7,Standard_E64ds_v7,Standard_E96ds_v7,Standard_E128ds_v7,Standard_E192ds_v7,Standard_E248ds_v7,Standard_E256ds_v7,Standard_E360ds_v7,Standard_E360ids_v7,Standard_E372ids_v7,Standard_EC2es_v7,Standard_EC4es_v7,Standard_EC8es_v7,Standard_EC16es_v7,Standard_EC32es_v7,Standard_EC48es_v7,Standard_EC64es_v7,Standard_EC96es_v7,Standard_EC124es_v7,Standard_EC128es_v7,Standard_EC186es_v7,Standard_EC192es_v7,Standard_EC248es_v7,Standard_EC256es_v7,Standard_EC2eds_v7,Standard_EC4eds_v7,Standard_EC8eds_v7,Standard_EC16eds_v7,Standard_EC32eds_v7,Standard_EC48eds_v7,Standard_EC64eds_v7,Standard_EC96eds_v7,Standard_EC124eds_v7,Standard_EC128eds_v7,Standard_EC186eds_v7,Standard_EC192eds_v7,Standard_EC248eds_v7,Standard_EC256eds_v7,Standard_L2s_v5,Standard_L4s_v5,Standard_L8s_v5,Standard_L16s_v5,Standard_L32s_v5,Standard_L48s_v5,Standard_L64s_v5,Standard_L80s_v5,Standard_L96s_v5,Standard_L124s_v5,Standard_L128s_v5,Standard_L186s_v5,Standard_L192s_v5,Standard_L248is_v5,Standard_L248s_v5,Standard_L360is_v5,Standard_L372is_v5,Standard_L8s_v2,Standard_L16s_v2,Standard_L32s_v2,Standard_L48s_v2,Standard_L64s_v2,Standard_L80s_v2,Standard_L88is_v2,Internal_L128is_v2,Standard_M624-160ds_12_v3,Standard_M624-320ds_12_v3,Standard_M624ds_12_v3,Standard_M832-208ds_12_v3,Standard_M832-416ds_12_v3,Standard_M832ds_12_v3,Standard_M624-160s_12_v3,Standard_M624-320s_12_v3,Standard_M624s_12_v3,Standard_M832-208s_12_v3,Standard_M832-416s_12_v3,Standard_M832s_12_v3,Standard_M832-208ids_16_v3,Standard_M832-416ids_16_v3,Standard_M832ids_16_v3,Standard_M832-208is_16_v3,Standard_M832-416is_16_v3,Standard_M832is_16_v3,Standard_M208-52s_v2,Standard_M208-104ms_v2,Standard_M208-104s_v2,Standard_M208ms_v2,Standard_M208s_v2,Standard_M416-104ms_v2,Standard_M416-104s_v2,Standard_M416-208ms_v2,Standard_M416-208s_v2,Standard_M416ms_v2,Standard_M416s_8_v2,Standard_M416s_9_v2,Standard_M416s_10_v2,Standard_M416s_v2,Standard_M416-112ds_6_v3,Standard_M416-112ds_8_v3,Standard_M416-208ds_6_v3,Standard_M416-208ds_8_v3,Standard_M416ds_6_v3,Standard_M416ds_8_v3,Standard_M416-112s_6_v3,Standard_M416-112s_8_v3,Standard_M416-208s_6_v3,Standard_M416-208s_8_v3,Standard_M416s_6_v3,Standard_M416s_8_v3,Standard_M208bs_v3,Standard_M312bs_v3,Standard_M416bs_v3,Standard_ND40rs_v2,Standard_NV4ahs_v4,Standard_NV4as_v4,Standard_NV8ahs_v4,Standard_NV8as_v4,Standard_NV16ahs_v4,Standard_NV16as_v4,Standard_NV32ahs_v4,Standard_NV32as_v4,Standard_M208-52ms_v2,Standard_M416is_v2,Standard_M832ixs,Standard_M832ixs_v2,Standard_HB120-16rs_v3,Standard_HB120-32rs_v3,Standard_HB120-64rs_v3,Standard_HB120-96rs_v3,Standard_HB120rs_v3,Standard_ND96asr_v4,Standard_NV4ads_V710_v5,Standard_NV8ads_V710_v5,Standard_NV12ads_V710_v5,Standard_NV24ads_V710_v5,Standard_DC1s_v3,Standard_DC2s_v3,Standard_DC4s_v3,Standard_DC8s_v3,Standard_DC16s_v3,Standard_DC24s_v3,Standard_DC32s_v3,Standard_DC48s_v3,Standard_DC1ds_v3,Standard_DC2ds_v3,Standard_DC4ds_v3,Standard_DC8ds_v3,Standard_DC16ds_v3,Standard_DC24ds_v3,Standard_DC32ds_v3,Standard_DC48ds_v3,Internal_ACCGen8MM_64id,Standard_ND96isr_H100_v5,Standard_ND96is_H100_v5,Standard_ND96is_noIB_H100_v5,Internal_GPGen10HH_192iads,Internal_GPGen10NPHHG5C_2ads,Internal_GPGen10NPHHG5C_4ads,Internal_GPGen10NPHHG5C_8ads,Internal_GPGen10NPHHG5C_16ads,Internal_GPGen10NPHHG5C_24ads,Internal_GPGen10NPHHG5C_32ads,Internal_GPGen10NPHHG5C_40ads,Internal_GPGen10NPHHG5C_48ads,Internal_GPGen10NPHHG5C_64ads,Internal_GPGen10NPHHG5C_80ads,Internal_GPGen10NPHHG5C_96ads,Internal_GPGen10NPHHG5C_128ads,Internal_GPGen10NPHHG5C_192iads,Internal_GPGen10NPHH_2ads,Internal_GPGen10NPHH_4ads,Internal_GPGen10NPHH_8ads,Internal_GPGen10NPHH_16ads,Internal_GPGen10NPHH_24ads,Internal_GPGen10NPHH_32ads,Internal_GPGen10NPHH_40ads,Internal_GPGen10NPHH_48ads,Internal_GPGen10NPHH_64ads,Internal_GPGen10NPHH_80ads,Internal_GPGen10NPHH_96ads,Internal_GPGen10NPHH_112ads,Internal_GPGen10NPHH_128ads,Internal_GPGen10NPHH_192iads,Standard_E160as_v7,Standard_E160ads_v7,Standard_L2as_v5,Standard_L4as_v5,Standard_L8as_v5,Standard_L16as_v5,Standard_L32as_v5,Standard_L48as_v5,Standard_L64as_v5,Standard_L80as_v5,Standard_L96as_v5,Standard_L128as_v5,Standard_L160ias_v5,Standard_ND96amsr_A100_v4,Standard_ND96amsr_A100_internal_v4,CosmosDBG5_JBOD,Standard_NP10s,Standard_NP20s,Standard_NP40s,Standard_NP48. Find out more on the available VM sizes in each region at https://aka.ms/azure-regionservices.
2026-04-29 07:16:33.014[2160][DEBUG] lisa.env[generated_0].node[0] detecting hardware_disk_controller_type ..
```

---

🤖 Generated with the assistance of GitHub Copilot.