### PR TITLE
[AI Generated] BugFix: ensure tar package is installed before use

### DIFF
--- a/lisa/tools/tar.py
+++ b/lisa/tools/tar.py
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Callable, List, Optional, Type
+from typing import Callable, List, Optional, Type, cast
 
 from assertpy import assert_that
 
 from lisa.executable import Tool
-from lisa.operating_system import Suse
+from lisa.operating_system import Posix, Suse
 from lisa.tools.bzip2 import Bzip2
 from lisa.tools.mkdir import Mkdir
 
@@ -16,12 +16,22 @@ class Tar(Tool):
     def command(self) -> str:
         return "tar"
 
+    @property
+    def can_install(self) -> bool:
+        return True
+
     def _check_exists(self) -> bool:
         if isinstance(self.node.os, Suse):
             # ensure that bzip2 is installed on Suse
             _ = self.node.tools[Bzip2]
 
-        return True
+        exists, self._use_sudo = self.command_exists(self.command)
+        return exists
+
+    def _install(self) -> bool:
+        posix_os: Posix = cast(Posix, self.node.os)
+        posix_os.install_packages("tar")
+        return self._check_exists()
 
     @classmethod
     def _windows_tool(cls) -> Optional[Type[Tool]]:
@@ -135,6 +145,12 @@ class Tar(Tool):
 
 
 class WindowsTar(Tar):
+    @property
+    def can_install(self) -> bool:
+        # tar ships with modern Windows; do not attempt the POSIX
+        # package install path inherited from Tar.
+        return False
+
     def extract(
         self,
         file: str,


### PR DESCRIPTION
## Summary

On distro images that do not ship the GNU `tar` binary by default (e.g. Oracle Linux 10), the `Tar` tool's `_check_exists()` returned `True` unconditionally and `_install()` was not implemented. Any caller (such as `Texinfo._install_from_src`) hit `tar: command not found` (exit 127) when invoking `tar.extract()`, surfacing as:

```
AssertionError: [Failed to extract file to ...] tar: command not found
```

## Fix

`lisa/tools/tar.py`:

- `_check_exists()` now actually probes for the `tar` binary via `command_exists()` instead of always returning `True`.
- `_install()` installs the `tar` package via the Posix OS package manager.
- `can_install` is set to `True` so the framework triggers `_install` when the binary is missing.

The existing Suse-specific `bzip2` dependency check is preserved.

## Validation

| Item | Detail |
|---|---|
| Test case | `NetworkPerformace.perf_tcp_max_pps_synthetic` |
| Image | `oracle oracle-linux ol10-lvm-gen2 10.0.1` |
| VM size | `Standard_D2ds_v5` |
| Region | `westus3` |
| Result | **PASSED** (was previously failing in `Texinfo._install_from_src` → `tar.extract`) |
| Lint | `black` ✓ `flake8` ✓ `pylint` 10/10 ✓ |
