### PR TITLE
[AI Generated] BugFix: add securityProfile to ephemeral OS disk for ConfidentialVM deployments

### DIFF
--- a/lisa/microsoft/testsuites/core/provisioning.py
+++ b/lisa/microsoft/testsuites/core/provisioning.py
@@ -211,7 +211,6 @@ class Provisioning(TestSuite):
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
             disk=DiskEphemeral(),
-            supported_features=[CvmDisabled()],  # TODO: Fix disk deployment for CVM
         ),
     )
     def verify_deployment_provision_ephemeral_managed_disk(

--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -111,6 +111,9 @@ func getLinuxConfiguration(keyPath string, publicKeyData string, disable_passwor
 
 func getEphemeralOSImage(node object) object => {
   name: '${node.name}-osDisk'
+  managedDisk: {
+    securityProfile: (empty(node.security_profile) || (node.security_profile.security_type != 'ConfidentialVM')) ? null : getSecurityProfileForOSDisk(node)
+  }
   diffDiskSettings: {
       option: 'local'
       placement: node.ephemeral_disk_placement_type

--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -111,9 +111,11 @@ func getLinuxConfiguration(keyPath string, publicKeyData string, disable_passwor
 
 func getEphemeralOSImage(node object) object => {
   name: '${node.name}-osDisk'
-  managedDisk: {
-    securityProfile: (empty(node.security_profile) || (node.security_profile.security_type != 'ConfidentialVM')) ? null : getSecurityProfileForOSDisk(node)
-  }
+  ...((empty(node.security_profile) || (node.security_profile.security_type != 'ConfidentialVM')) ? {} : {
+    managedDisk: {
+      securityProfile: getSecurityProfileForOSDisk(node)
+    }
+  })
   diffDiskSettings: {
       option: 'local'
       placement: node.ephemeral_disk_placement_type

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -111,6 +111,9 @@
             "type": "object",
             "value": {
               "name": "[format('{0}-osDisk', parameters('node').name)]",
+              "managedDisk": {
+                "securityProfile": "[if(or(empty(parameters('node').security_profile), not(equals(parameters('node').security_profile.security_type, 'ConfidentialVM'))), null(), __bicep.getSecurityProfileForOSDisk(parameters('node')))]"
+              },
               "diffDiskSettings": {
                 "option": "local",
                 "placement": "[parameters('node').ephemeral_disk_placement_type]"

--- a/lisa/sut_orchestrator/azure/autogen_arm_template.json
+++ b/lisa/sut_orchestrator/azure/autogen_arm_template.json
@@ -109,19 +109,7 @@
           ],
           "output": {
             "type": "object",
-            "value": {
-              "name": "[format('{0}-osDisk', parameters('node').name)]",
-              "managedDisk": {
-                "securityProfile": "[if(or(empty(parameters('node').security_profile), not(equals(parameters('node').security_profile.security_type, 'ConfidentialVM'))), null(), __bicep.getSecurityProfileForOSDisk(parameters('node')))]"
-              },
-              "diffDiskSettings": {
-                "option": "local",
-                "placement": "[parameters('node').ephemeral_disk_placement_type]"
-              },
-              "caching": "ReadOnly",
-              "createOption": "FromImage",
-              "diskSizeGB": "[parameters('node').osdisk_size_in_gb]"
-            }
+            "value": "[shallowMerge(createArray(createObject('name', format('{0}-osDisk', parameters('node').name)), if(or(empty(parameters('node').security_profile), not(equals(parameters('node').security_profile.security_type, 'ConfidentialVM'))), createObject(), createObject('managedDisk', createObject('securityProfile', __bicep.getSecurityProfileForOSDisk(parameters('node'))))), createObject('diffDiskSettings', createObject('option', 'local', 'placement', parameters('node').ephemeral_disk_placement_type), 'caching', 'ReadOnly', 'createOption', 'FromImage', 'diskSizeGB', parameters('node').osdisk_size_in_gb)))]"
           }
         },
         "getCreateDisk": {


### PR DESCRIPTION
Confidential VM deployments failed with an error indicating that managedDisk.securityProfile.securityEncryptionType was missing for the OS disk.

**Root cause**
There was an inconsistency in the Azure template logic:

The standard OS disk path included managedDisk.securityProfile.
The ephemeral OS disk path did not include it.
As a result, CVM + ephemeral OS disk deployments generated an invalid disk payload for Azure.

**What this PR changes**
Added managedDisk.securityProfile handling to the ephemeral OS disk path in the Bicep template.
Kept the same null-safe logic pattern used by the standard OS disk path.
Regenerated the corresponding ARM JSON template to keep generated artifacts in sync.

**Validation**
The fix was validated with 3 runs:

CVM + ephemeral OS disk: Passed (original failing scenario).
Standard SSD provisioning regression: Passed.
Non-CVM + ephemeral OS disk regression: Passed.