### PR TITLE
[AI Generated] BugFix: iperf3 force source build for versions >= 3.14 to avoid UDP segfault

### DIFF
--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -4,9 +4,10 @@ import json
 import re
 import time
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, List, Pattern, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Type, cast
 
 from retry import retry
+from semver import VersionInfo
 
 from lisa.executable import Tool
 from lisa.messages import (
@@ -70,6 +71,13 @@ IPERF_UDP_CONCURRENCY = [
 class Iperf3(Tool):
     _repo = "https://github.com/esnet/iperf"
     _branch = "3.10.1"
+    # iperf3 versions 3.14+ have a known segfault in UDP mode with high
+    # parallelism (-P 64+). Force a source build from _branch when the
+    # distro-installed version falls in this buggy range.
+    _buggy_version_min = VersionInfo(3, 14, 0)
+    _version_pattern = re.compile(
+        r"iperf\s+(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<patch>\d*)"
+    )
     _sender_pattern = re.compile(
         r"(([\w\W]*?)[SUM].* (?P<bandwidth>[0-9]+.[0-9]+)"
         r" Gbits/sec.*sender([\w\W]*?))",
@@ -100,6 +108,17 @@ class Iperf3(Tool):
     def help(self) -> ExecutableResult:
         return self.run("-h", force_run=True)
 
+    def get_version(self) -> Optional[VersionInfo]:
+        result = self.run("-v", force_run=True)
+        matched = self._version_pattern.search(result.stdout)
+        if matched:
+            major = int(matched.group("major"))
+            minor = int(matched.group("minor"))
+            patch_str = matched.group("patch")
+            patch = int(patch_str) if patch_str.isdigit() else 0
+            return VersionInfo(major, minor, patch)
+        return None
+
     def install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
         try:
@@ -110,6 +129,16 @@ class Iperf3(Tool):
         if self._check_exists():
             if "--logfile" not in self.help().stdout:
                 install_from_src = True
+            else:
+                # iperf3 >= 3.14 segfaults in UDP mode with high parallelism.
+                # Force a source build from a known-good version.
+                version = self.get_version()
+                if version and version >= self._buggy_version_min:
+                    self._log.info(
+                        f"iperf3 {version} has known UDP segfault, "
+                        f"rebuilding from source ({self._branch})"
+                    )
+                    install_from_src = True
         else:
             install_from_src = True
         if install_from_src:
@@ -577,7 +606,7 @@ class Iperf3(Tool):
     def _install_from_src(self) -> None:
         tool_path = self.get_tool_path()
         git = self.node.tools[Git]
-        git.clone(self._repo, tool_path)
+        git.clone(self._repo, tool_path, ref=self._branch)
         code_path = tool_path.joinpath("iperf")
         make = self.node.tools[Make]
         self.node.execute("./configure", cwd=code_path).assert_exit_code()
@@ -597,5 +626,9 @@ class Iperf3(Tool):
     def _pre_handle(self, result: str) -> str:
         result = result.replace("-nan", "0")
         result_matched = get_matched_str(result, self._json_pattern)
-        assert result_matched, "fail to find json format results"
+        if not result_matched:
+            raise LisaException(
+                f"Failed to parse iperf3 JSON output. "
+                f"Raw output (first 500 chars): {result[:500]}"
+            )
         return result_matched

--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -72,14 +72,14 @@ class Iperf3(Tool):
     _repo = "https://github.com/esnet/iperf"
     _branch = "3.10.1"
     # iperf3 versions >= 3.14.0 have been observed to segfault in UDP mode
-    # with high parallelism (-P 64+), so versions in that range are replaced
-    # with a source build from _branch (the last known-good release for the
-    # workloads exercised by LISA).
+    # with high parallelism (-P 64+) on the workloads LISA exercises. Such
+    # versions are replaced with a source build from _branch (the last
+    # known-good release).
     #
-    # Upstream tracking: https://github.com/esnet/iperf/issues  (link the
-    # specific issue/commit here once filed).
-    # First fixed release: TBD - bump _buggy_version_min to that version, or
-    # remove this workaround entirely, once the upstream fix is confirmed.
+    # TODO: file an upstream issue at https://github.com/esnet/iperf and
+    # replace this TODO with the specific issue link plus the first-fixed
+    # release. When the fix is confirmed, bump _buggy_version_min to that
+    # release (or remove this workaround entirely).
     _buggy_version_min = VersionInfo(3, 14, 0)
     _version_pattern = re.compile(
         r"iperf\s+(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<patch>\d*)"

--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -73,8 +73,13 @@ class Iperf3(Tool):
     _branch = "3.10.1"
     # iperf3 versions >= 3.14.0 have been observed to segfault in UDP mode
     # with high parallelism (-P 64+), so versions in that range are replaced
-    # with a source build from _branch.  When the upstream fix is confirmed,
-    # update or remove this workaround.
+    # with a source build from _branch (the last known-good release for the
+    # workloads exercised by LISA).
+    #
+    # Upstream tracking: https://github.com/esnet/iperf/issues  (link the
+    # specific issue/commit here once filed).
+    # First fixed release: TBD - bump _buggy_version_min to that version, or
+    # remove this workaround entirely, once the upstream fix is confirmed.
     _buggy_version_min = VersionInfo(3, 14, 0)
     _version_pattern = re.compile(
         r"iperf\s+(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<patch>\d*)"
@@ -132,9 +137,19 @@ class Iperf3(Tool):
                 install_from_src = True
             else:
                 # iperf3 >= 3.14 segfaults in UDP mode with high parallelism.
-                # Force a source build from a known-good version.
+                # Force a source build from a known-good version. If the
+                # version cannot be parsed, fail safe and rebuild so the
+                # mitigation cannot be silently bypassed by an unexpected
+                # `iperf3 -v` output format.
                 version = self.get_version()
-                if version and version >= self._buggy_version_min:
+                if version is None:
+                    self._log.warning(
+                        "could not parse iperf3 version output; "
+                        f"rebuilding from source ({self._branch}) as a "
+                        "precaution against the known UDP segfault"
+                    )
+                    install_from_src = True
+                elif version >= self._buggy_version_min:
                     self._log.info(
                         f"iperf3 {version} has known UDP segfault, "
                         f"rebuilding from source ({self._branch})"
@@ -634,7 +649,12 @@ class Iperf3(Tool):
         result_matched = get_matched_str(result, self._json_pattern)
         if not result_matched:
             raise LisaException(
-                f"Failed to parse iperf3 JSON output. "
+                "Failed to parse iperf3 JSON output. This usually means "
+                "iperf3 produced non-JSON output - common causes include "
+                "the command not being invoked with -J / JSON mode, an "
+                "iperf3 crash or segfault (check the exit code and "
+                "stderr/logfile), or truncated output. Verify the iperf3 "
+                "command and version, and inspect the full stdout/stderr.\n"
                 f"Raw output (first 500 chars): {result[:500]}"
             )
         return result_matched

--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -4,9 +4,10 @@ import json
 import re
 import time
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, List, Pattern, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Type, cast
 
 from retry import retry
+from semver import VersionInfo
 
 from lisa.executable import Tool
 from lisa.messages import (
@@ -70,6 +71,14 @@ IPERF_UDP_CONCURRENCY = [
 class Iperf3(Tool):
     _repo = "https://github.com/esnet/iperf"
     _branch = "3.10.1"
+    # iperf3 versions >= 3.14.0 have been observed to segfault in UDP mode
+    # with high parallelism (-P 64+), so versions in that range are replaced
+    # with a source build from _branch.  When the upstream fix is confirmed,
+    # update or remove this workaround.
+    _buggy_version_min = VersionInfo(3, 14, 0)
+    _version_pattern = re.compile(
+        r"iperf\s+(?P<major>\d+)\.(?P<minor>\d+)\.?(?P<patch>\d*)"
+    )
     _sender_pattern = re.compile(
         r"(([\w\W]*?)[SUM].* (?P<bandwidth>[0-9]+.[0-9]+)"
         r" Gbits/sec.*sender([\w\W]*?))",
@@ -100,6 +109,17 @@ class Iperf3(Tool):
     def help(self) -> ExecutableResult:
         return self.run("-h", force_run=True)
 
+    def get_version(self) -> Optional[VersionInfo]:
+        result = self.run("-v", force_run=True)
+        matched = self._version_pattern.search(result.stdout)
+        if matched:
+            major = int(matched.group("major"))
+            minor = int(matched.group("minor"))
+            patch_str = matched.group("patch")
+            patch = int(patch_str) if patch_str.isdigit() else 0
+            return VersionInfo(major, minor, patch)
+        return None
+
     def install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
         try:
@@ -110,6 +130,21 @@ class Iperf3(Tool):
         if self._check_exists():
             if "--logfile" not in self.help().stdout:
                 install_from_src = True
+            else:
+                # iperf3 >= 3.14 segfaults in UDP mode with high parallelism.
+                # Force a source build from a known-good version.
+                version = self.get_version()
+                if version and version >= self._buggy_version_min:
+                    self._log.info(
+                        f"iperf3 {version} has known UDP segfault, "
+                        f"rebuilding from source ({self._branch})"
+                    )
+                    install_from_src = True
+                else:
+                    self._log.debug(
+                        f"iperf3 {version} is below buggy threshold "
+                        f"{self._buggy_version_min}, keeping distro version"
+                    )
         else:
             install_from_src = True
         if install_from_src:
@@ -577,7 +612,7 @@ class Iperf3(Tool):
     def _install_from_src(self) -> None:
         tool_path = self.get_tool_path()
         git = self.node.tools[Git]
-        git.clone(self._repo, tool_path)
+        git.clone(self._repo, tool_path, ref=self._branch)
         code_path = tool_path.joinpath("iperf")
         make = self.node.tools[Make]
         self.node.execute("./configure", cwd=code_path).assert_exit_code()
@@ -597,5 +632,9 @@ class Iperf3(Tool):
     def _pre_handle(self, result: str) -> str:
         result = result.replace("-nan", "0")
         result_matched = get_matched_str(result, self._json_pattern)
-        assert result_matched, "fail to find json format results"
+        if not result_matched:
+            raise LisaException(
+                f"Failed to parse iperf3 JSON output. "
+                f"Raw output (first 500 chars): {result[:500]}"
+            )
         return result_matched


### PR DESCRIPTION
## Summary
Force source build of iperf3 from tag 3.10.1 when the distro-installed version is >= 3.14, which has a known segfault in UDP mode with high parallelism (-P 64+). Also passes ref to git.clone() and replaces bare assert with LisaException for better diagnostics.

## Validation Results
| Image | Result |
|-------|--------|
| canonical ubuntu-24_04-lts server 24.04.202404230 | PASSED |