### PR TITLE
Fix verify_sriov_reload_modules failure on HPC images with broken mana_ib

### DIFF
--- a/lisa/microsoft/testsuites/network/sriov.py
+++ b/lisa/microsoft/testsuites/network/sriov.py
@@ -506,8 +506,8 @@ class Sriov(TestSuite):
         sriov_basic_test(environment)
 
         module_in_used: Dict[str, List[str]] = {}
-        module_name_list: List[str] = []
         for node in environment.nodes.list():
+            module_name_list: List[str] = []
             for module_name in node.nics.get_used_modules(["hv_netvsc"]):
                 if node.nics.is_module_reloadable(module_name):
                     module_name_list.extend(node.nics.unload_module(module_name))

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -682,7 +682,7 @@ class Nics(InitializableMixin):
         module_list = [
             m
             for m in self._device_module_map[module_name].drivers
-            if modprobe.module_exists(m)
+            if modprobe.is_module_loaded(m, force_run=True)
         ]
         modprobe.remove(module_list)
         return module_list


### PR DESCRIPTION
## Problem

`verify_sriov_reload_modules` fails on AlmaLinux 9 HPC (9.7.2026010601) with:
`
modprobe: ERROR: could not insert 'mana_ib': Invalid argument
`

## Root Cause

`unload_module()` in `nic.py` uses `module_exists()` (`modprobe --dry-run`) to filter the MANA driver list before unloading. On HPC images, `mana_ib.ko` exists on disk but was **never loaded at boot** due to symbol version mismatches with IB core modules:
`
mana_ib: disagrees about version of symbol ib_register_device
mana_ib: Unknown symbol ib_set_device_ops (err -22)
`

The test unloads the filtered list (including `mana_ib` as a no-op), then tries to reload each module. `modprobe mana_ib` fails with `Invalid argument` because the kernel can't resolve the IB symbols.

## Fix

1. **`nic.py`**: Change filter from `module_exists()` to `is_module_loaded()` in `unload_module()`. Only modules that are actually loaded get included in the unload/reload list.
2. **`sriov.py`**: Move `module_name_list` initialization inside the node loop (secondary bug — all nodes previously shared the same growing list reference).

## Validation

Ran `verify_sriov_reload_modules` on the same image/VM/region:
- **Before fix**: FAILED (`modprobe mana_ib` returns exit code 1)
- **After fix**: PASSED (`mana_ib` excluded from unload/reload list since it was never loaded)

Fixes: AB#61531354