### PR TITLE
[AI Generated] BugFix: Fix verify_sriov_reload_modules failure on HPC images with broken mana_ib

### DIFF
--- a/lisa/microsoft/testsuites/network/sriov.py
+++ b/lisa/microsoft/testsuites/network/sriov.py
@@ -506,8 +506,8 @@ class Sriov(TestSuite):
         sriov_basic_test(environment)
 
         module_in_used: Dict[str, List[str]] = {}
-        module_name_list: List[str] = []
         for node in environment.nodes.list():
+            module_name_list: List[str] = []
             for module_name in node.nics.get_used_modules(["hv_netvsc"]):
                 if node.nics.is_module_reloadable(module_name):
                     module_name_list.extend(node.nics.unload_module(module_name))

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -682,7 +682,7 @@ class Nics(InitializableMixin):
         module_list = [
             m
             for m in self._device_module_map[module_name].drivers
-            if modprobe.module_exists(m)
+            if modprobe.is_module_loaded(m, force_run=True)
         ]
         modprobe.remove(module_list)
         return module_list


### PR DESCRIPTION
## Summary
Fix verify_sriov_reload_modules failing on HPC images where mana_ib.ko exists but cannot load due to kernel symbol mismatches. Changed unload_module() to use is_module_loaded() instead of module_exists() so only actually-loaded modules are included in the unload/reload list. Also fixed module_name_list not being reset per node.

## Validation Results
| Image | Result |
|-------|--------|
| almalinux almalinux-hpc 9-hpc-gen2 9.7.2026010601 | PASSED |