### PR TITLE
Fix vdso compilation issues on Ubuntu2510

### DIFF
--- a/lisa/tools/vdsotest.py
+++ b/lisa/tools/vdsotest.py
@@ -73,14 +73,11 @@ class Vdsotest(Tool):
         make = self.node.tools[Make]
         code_path = tool_path.joinpath("vdsotest")
         self.node.execute("./autogen.sh", cwd=code_path).assert_exit_code()
-        # Fedora requires explicit C11 standard flag to avoid compilation errors.
-        # Using -std=gnu11 ensures compatibility with the vdsotest source code while
-        # avoiding issues with stricter compiler enforcement on newer GCC versions.
-        if type(self.node.os) is Fedora:
-            self.node.execute(
-                "./configure CFLAGS='-std=gnu11'", cwd=code_path
-            ).assert_exit_code()
-        else:
-            self.node.execute("./configure", cwd=code_path).assert_exit_code()
+        # Use -std=gnu11 to avoid compilation errors on newer GCC versions that
+        # default to C23, where 'nullptr' is a reserved keyword conflicting with
+        # the vdsotest source code (src/getcpu.c).
+        self.node.execute(
+            "./configure CFLAGS='-std=gnu11'", cwd=code_path
+        ).assert_exit_code()
         make.make_install(cwd=code_path)
         return self._check_exists()


### PR DESCRIPTION
## Description

Use -std=gnu11 to avoid compilation errors on newer GCC versions that default to C23, where 'nullptr' is a reserved keyword conflicting with the vdsotest source code (src/getcpu.c). This is the solution already used for Fedora, but can be used for all distros without any issue.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_vdso

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
almalinux almalinux-x86_64 9-gen2 latest
canonical 0001-com-ubuntu-pro-microsoft 18_04-lts latest
canonical 0001-com-ubuntu-pro-microsoft 18_04-lts-arm64 latest
canonical 0001-com-ubuntu-pro-microsoft 18_04-lts-gen1 latest
canonical 0001-com-ubuntu-pro-microsoft pro-fips-18_04 latest
canonical 0001-com-ubuntu-pro-microsoft pro-fips-20_04 latest
canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest
canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04-arm64 latest
canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04-gen1 latest
canonical 0001-com-ubuntu-server-focal 20_04-lts latest
canonical 0001-com-ubuntu-server-focal 20_04-lts-arm64 latest
canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest
canonical 0001-com-ubuntu-server-jammy 22_04-lts latest
canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest
canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
canonical ubuntu-24_04-lts server latest
canonical ubuntu-24_04-lts server-arm64 latest
canonical ubuntu-24_04-lts server-gen1 latest
canonical ubuntu-25_04 server latest
canonical ubuntu-25_04 server-arm64 latest
canonical ubuntu-25_04 server-gen1 latest
canonical ubuntu-25_10 server latest
canonical ubuntu-25_10 server-arm64 latest
canonical ubuntu-25_10 server-gen1 latest
canonical ubuntuserver 16_04-lts-gen2 latest
canonical ubuntuserver 16.04-lts latest
debian debian-12 12-gen2 latest
microsoftcblmariner azure-linux-3 azure-linux-3-gen2 latest
microsoftcblmariner cbl-mariner cbl-mariner-2-gen2 latest
oracle oracle-linux ol95-lvm-gen2 latest
redhat rhel 10-lvm-gen2 latest
redhat rhel 101-gen2 latest
resf rockylinux-x86_64 9-base latest
suse sles-sap-15-sp7 gen2 latest


## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|almalinux almalinux-x86_64 9-gen2 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft 18_04-lts latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft 18_04-lts-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft 18_04-lts-gen1 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft pro-fips-18_04 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft pro-fips-20_04 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04-gen1 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-server-focal 20_04-lts latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-server-focal 20_04-lts-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-server-jammy 22_04-lts latest |Standard_D2ads_v7|PASSED |
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-24_04-lts server latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-24_04-lts server-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical ubuntu-24_04-lts server-gen1 latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-25_04 server latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-25_04 server-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical ubuntu-25_04 server-gen1 latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-25_10 server latest |Standard_D2ads_v7|PASSED |
|canonical ubuntu-25_10 server-arm64 latest |Standard_D2plds_v5|PASSED |
|canonical ubuntu-25_10 server-gen1 latest |Standard_D2ads_v7|PASSED |
|canonical ubuntuserver 16_04-lts-gen2 latest |Standard_D2ads_v7|PASSED |
|canonical ubuntuserver 16.04-lts latest |Standard_D2ads_v7|PASSED |
|debian debian-12 12-gen2 latest |Standard_D2ads_v7|PASSED |
|microsoftcblmariner azure-linux-3 azure-linux-3-gen2 latest |Standard_D2ads_v7|PASSED |
|microsoftcblmariner cbl-mariner cbl-mariner-2-gen2 latest |Standard_D2ads_v7|PASSED |
|oracle oracle-linux ol95-lvm-gen2 latest |Standard_D2ads_v7|PASSED |
|redhat rhel 10-lvm-gen2 latest |Standard_D2ads_v7|PASSED |
|redhat rhel 101-gen2 latest |Standard_D2ads_v7|PASSED |
|resf rockylinux-x86_64 9-base latest |Standard_D2ads_v7|PASSED |
|suse sles-sap-15-sp7 gen2 latest |Standard_D2ads_v7|PASSED |

