### PR TITLE
Fix for regression in modprobe script run

### DIFF
--- a/lisa/tools/modprobe.py
+++ b/lisa/tools/modprobe.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
 from lisa.executable import CustomScript, CustomScriptBuilder, ExecutableResult, Tool
-from lisa.tools import Cat, Chown, Dhclient
+from lisa.tools import Cat, Dhclient
 from lisa.tools.dmesg import Dmesg
 from lisa.tools.journalctl import Journalctl
 from lisa.tools.kernel_config import KLDStat
@@ -207,12 +207,6 @@ class Modprobe(Tool):
             include_output=True,
         )
 
-        original_user = self.node.tools[Whoami].get_username()
-        if original_user:
-            self.node.tools[Chown].change_owner(
-                file=Path(loop_process_pid_file_name), user=original_user
-            )
-
         cat = self.node.tools[Cat]
         tried_times: int = 0
         timer = create_timer()
@@ -220,7 +214,9 @@ class Modprobe(Tool):
         while (timer.elapsed(False) < timeout) or tried_times < 1:
             tried_times += 1
             try:
-                pid = cat.read(loop_process_pid_file_name, force_run=True)
+                pid = cat.read(
+                    loop_process_pid_file_name, force_run=True, sudo=True
+                ).strip()
                 r = self.node.execute(
                     f"ps -p {pid} > /dev/null && echo 'running' || echo 'not_running'",
                     sudo=True,


### PR DESCRIPTION
## Description

https://github.com/microsoft/lisa/pull/4152 this change had caused a regression where without waiting for hv_netvsc reload operation to complete and without waiting for the VM to come up, chown operation was attempted. This could be avoided by simply put a sudo true in the cat operation to handle mariner scenario. I had added a comment in that PR after it was merged and also informed the same to the author, yet it was not fixed, hence raised this PR.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
validate_netvsc_reload

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
