### PR TITLE
[AI Generated] BugFix: filter resize candidates by actual disk controller type

### DIFF
--- a/lisa/microsoft/testsuites/core/vm_resize.py
+++ b/lisa/microsoft/testsuites/core/vm_resize.py
@@ -144,6 +144,7 @@ class VmResize(TestSuite):
                     or "AllocationFailed" in str(e)
                     or "PropertyChangeNotAllowed" in str(e)
                     or "cannot boot Hypervisor Generation" in str(e)
+                    or "cannot boot with DiskControllerType" in str(e)
                     or "due to different CPU Architectures" in str(e)
                     or "An existing connection was forcibly closed by the remote host"
                     in str(e)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -188,9 +188,9 @@ class StartStop(AzureFeatureMixin, features.StartStop):
         node_info = self._node.connection_info
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_PUBLIC_ADDRESS] = public_ip
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS] = private_ip
-        node_info[constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS] = (
-            platform._azure_runbook.use_public_address
-        )
+        node_info[
+            constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS
+        ] = platform._azure_runbook.use_public_address
         self._node.set_connection_info(**node_info)
         self._node._is_initialized = False
         self._node.initialize()
@@ -2562,9 +2562,7 @@ class Resize(AzureFeatureMixin, features.Resize):
             )
             and self._compare_size_generation(candidate_size, current_vm_size)
             and self._compare_network_interface(candidate_size, current_vm_size)
-            and self._compare_core_count(
-                candidate_size, current_vm_size, resize_action
-            )
+            and self._compare_core_count(candidate_size, current_vm_size, resize_action)
         )
 
     def _select_vm_size(

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -565,7 +565,8 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         ]
     }
     """  # noqa: E501
-    _gpu_extension_nvidia_properties = json.loads("""
+    _gpu_extension_nvidia_properties = json.loads(
+        """
         {
             "publisher": "Microsoft.HpcCompute",
             "type": "NvidiaGpuDriverLinux",
@@ -574,7 +575,8 @@ class Gpu(AzureFeatureMixin, features.Gpu):
             "settings": {
             }
         }
-    """)
+    """
+    )
 
     def is_supported(self) -> bool:
         # TODO: The GPU Feature is supposed to handle cloud related

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2545,6 +2545,27 @@ class Resize(AzureFeatureMixin, features.Resize):
         ).is_instance_of(int)
         assert current_vm_size.capability.features
 
+        # Get the actual disk controller type the VM is using (from Azure API,
+        # works even when VM is stopped). This may differ from the VM SIZE's
+        # supported types — e.g. a size supports {SCSI, NVMe} but the deployed
+        # VM uses SCSI. We must ensure the candidate also supports the actual
+        # controller type, not just any overlapping type.
+        actual_disk_controller_type: Optional[schema.DiskControllerType] = None
+        try:
+            node_disk = self._node.features[features.Disk]
+            hw_dc_type = node_disk.get_hardware_disk_controller_type()
+            if hw_dc_type is not None:
+                actual_disk_controller_type = schema.DiskControllerType(hw_dc_type)
+                self._log.debug(
+                    f"actual hardware disk controller type: "
+                    f"{actual_disk_controller_type}"
+                )
+        except (LisaException, ValueError, AttributeError) as e:
+            self._log.debug(
+                f"could not determine actual disk controller type, "
+                f"falling back to VM size capability comparison: {e}"
+            )
+
         # Loop removes candidate vm sizes if they can't be resized to or if the
         # change in cores resulting from the resize is undesired
         for candidate_size in avail_eligible_intersect[:]:
@@ -2577,6 +2598,28 @@ class Resize(AzureFeatureMixin, features.Resize):
                 # Continue to the next candidate size in the loop
                 # without checking further
                 continue
+
+            # Check against the actual hardware disk controller type.
+            # The capability comparison above checks for overlap between VM SIZE
+            # capabilities (e.g. current supports {SCSI,NVMe} and candidate
+            # supports {NVMe} -> overlap exists). But if the VM is actually
+            # using SCSI, resizing to an NVMe-only size will fail.
+            if actual_disk_controller_type is not None:
+                candidate_dc_types = getattr(
+                    candidate_size.capability.disk, "disk_controller_type", None
+                )
+                if candidate_dc_types is not None:
+                    if isinstance(
+                        candidate_dc_types, search_space.SetSpace
+                    ) and actual_disk_controller_type not in candidate_dc_types:
+                        avail_eligible_intersect.remove(candidate_size)
+                        continue
+                    elif (
+                        isinstance(candidate_dc_types, schema.DiskControllerType)
+                        and candidate_dc_types != actual_disk_controller_type
+                    ):
+                        avail_eligible_intersect.remove(candidate_size)
+                        continue
 
             if not self._compare_size_generation(candidate_size, current_vm_size):
                 avail_eligible_intersect.remove(candidate_size)

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2489,6 +2489,84 @@ class Resize(AzureFeatureMixin, features.Resize):
             return False
         return True
 
+    def _get_actual_disk_controller_type(
+        self,
+    ) -> Optional[schema.DiskControllerType]:
+        # Get the actual disk controller type the VM is using (from Azure API,
+        # works even when VM is stopped). This may differ from the VM SIZE's
+        # supported types — e.g. a size supports {SCSI, NVMe} but the deployed
+        # VM uses SCSI. We must ensure the candidate also supports the actual
+        # controller type, not just any overlapping type.
+        try:
+            node_disk = self._node.features[features.Disk]
+            hw_dc_type = node_disk.get_hardware_disk_controller_type()
+            if hw_dc_type:
+                dc_type = schema.DiskControllerType(hw_dc_type)
+                self._log.debug(f"actual hardware disk controller type: {dc_type}")
+                return dc_type
+        except (
+            LisaException,
+            ValueError,
+            AttributeError,
+            HttpResponseError,
+            ResourceNotFoundError,
+            ClientAuthenticationError,
+        ) as e:
+            self._log.debug(
+                f"could not determine actual disk controller type, "
+                f"falling back to VM size capability comparison: {e}"
+            )
+        return None
+
+    def _check_actual_disk_controller_type(
+        self,
+        candidate_size: "AzureCapability",
+        actual_disk_controller_type: Optional[schema.DiskControllerType],
+    ) -> bool:
+        # Check against the actual hardware disk controller type.
+        # The capability comparison checks for overlap between VM SIZE
+        # capabilities (e.g. current supports {SCSI,NVMe} and candidate
+        # supports {NVMe} -> overlap exists). But if the VM is actually
+        # using SCSI, resizing to an NVMe-only size will fail.
+        if not actual_disk_controller_type:
+            return True
+
+        candidate_dc_types = getattr(
+            candidate_size.capability.disk, "disk_controller_type", None
+        )
+        if not candidate_dc_types:
+            return True
+
+        if isinstance(candidate_dc_types, search_space.SetSpace):
+            return actual_disk_controller_type in candidate_dc_types
+        if isinstance(candidate_dc_types, schema.DiskControllerType):
+            return candidate_dc_types == actual_disk_controller_type
+
+        return True
+
+    def _is_candidate_size_valid(
+        self,
+        candidate_size: "AzureCapability",
+        current_vm_size: "AzureCapability",
+        resize_action: ResizeAction,
+        actual_disk_controller_type: Optional[schema.DiskControllerType],
+    ) -> bool:
+        return (
+            self._compare_architecture(candidate_size, current_vm_size)
+            and all(
+                self._compare_disk_property(candidate_size, current_vm_size, prop)
+                for prop in ["disk_controller_type", "os_disk_type", "data_disk_type"]
+            )
+            and self._check_actual_disk_controller_type(
+                candidate_size, actual_disk_controller_type
+            )
+            and self._compare_size_generation(candidate_size, current_vm_size)
+            and self._compare_network_interface(candidate_size, current_vm_size)
+            and self._compare_core_count(
+                candidate_size, current_vm_size, resize_action
+            )
+        )
+
     def _select_vm_size(
         self, resize_action: ResizeAction = ResizeAction.IncreaseCoreCount
     ) -> Tuple[str, "AzureCapability"]:
@@ -2543,103 +2621,19 @@ class Resize(AzureFeatureMixin, features.Resize):
         ).is_instance_of(int)
         assert current_vm_size.capability.features
 
-        # Get the actual disk controller type the VM is using (from Azure API,
-        # works even when VM is stopped). This may differ from the VM SIZE's
-        # supported types — e.g. a size supports {SCSI, NVMe} but the deployed
-        # VM uses SCSI. We must ensure the candidate also supports the actual
-        # controller type, not just any overlapping type.
-        actual_disk_controller_type: Optional[schema.DiskControllerType] = None
-        try:
-            node_disk = self._node.features[features.Disk]
-            hw_dc_type = node_disk.get_hardware_disk_controller_type()
-            if hw_dc_type:
-                actual_disk_controller_type = schema.DiskControllerType(hw_dc_type)
-                self._log.debug(
-                    f"actual hardware disk controller type: "
-                    f"{actual_disk_controller_type}"
-                )
-        except (
-            LisaException,
-            ValueError,
-            AttributeError,
-            HttpResponseError,
-            ResourceNotFoundError,
-            ClientAuthenticationError,
-        ) as e:
-            self._log.debug(
-                f"could not determine actual disk controller type, "
-                f"falling back to VM size capability comparison: {e}"
+        actual_disk_controller_type = self._get_actual_disk_controller_type()
+
+        # Filter candidate vm sizes that can't be resized to
+        avail_eligible_intersect = [
+            candidate
+            for candidate in avail_eligible_intersect
+            if self._is_candidate_size_valid(
+                candidate,
+                current_vm_size,
+                resize_action,
+                actual_disk_controller_type,
             )
-
-        # Loop removes candidate vm sizes if they can't be resized to or if the
-        # change in cores resulting from the resize is undesired
-        for candidate_size in avail_eligible_intersect[:]:
-            if not self._compare_architecture(candidate_size, current_vm_size):
-                avail_eligible_intersect.remove(candidate_size)
-                continue
-
-            # List of disk properties to compare
-            disk_properties_to_compare = [
-                "disk_controller_type",
-                "os_disk_type",
-                "data_disk_type",
-            ]
-            # Flag to track whether the candidate passed all disk property checks
-            candidate_passed_all_checks = True
-            for prop in disk_properties_to_compare:
-                # compare the current property between the candidate size
-                # and the current VM size
-                if not self._compare_disk_property(
-                    candidate_size, current_vm_size, prop
-                ):
-                    # If the comparison fails (returns False)
-                    # mark the candidate as failing all checks
-                    candidate_passed_all_checks = False
-                    break
-            # If the candidate failed any of the checks (disk properties did not match)
-            if not candidate_passed_all_checks:
-                # Remove the candidate size from the list of available eligible sizes
-                avail_eligible_intersect.remove(candidate_size)
-                # Continue to the next candidate size in the loop
-                # without checking further
-                continue
-
-            # Check against the actual hardware disk controller type.
-            # The capability comparison above checks for overlap between VM SIZE
-            # capabilities (e.g. current supports {SCSI,NVMe} and candidate
-            # supports {NVMe} -> overlap exists). But if the VM is actually
-            # using SCSI, resizing to an NVMe-only size will fail.
-            if actual_disk_controller_type:
-                candidate_dc_types = getattr(
-                    candidate_size.capability.disk, "disk_controller_type", None
-                )
-                if candidate_dc_types:
-                    if (
-                        isinstance(candidate_dc_types, search_space.SetSpace)
-                        and actual_disk_controller_type not in candidate_dc_types
-                    ):
-                        avail_eligible_intersect.remove(candidate_size)
-                        continue
-                    if (
-                        isinstance(candidate_dc_types, schema.DiskControllerType)
-                        and candidate_dc_types != actual_disk_controller_type
-                    ):
-                        avail_eligible_intersect.remove(candidate_size)
-                        continue
-
-            if not self._compare_size_generation(candidate_size, current_vm_size):
-                avail_eligible_intersect.remove(candidate_size)
-                continue
-
-            if not self._compare_network_interface(candidate_size, current_vm_size):
-                avail_eligible_intersect.remove(candidate_size)
-                continue
-
-            if not self._compare_core_count(
-                candidate_size, current_vm_size, resize_action
-            ):
-                avail_eligible_intersect.remove(candidate_size)
-                continue
+        ]
 
         if not avail_eligible_intersect:
             raise LisaException(

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -188,9 +188,9 @@ class StartStop(AzureFeatureMixin, features.StartStop):
         node_info = self._node.connection_info
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_PUBLIC_ADDRESS] = public_ip
         node_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS] = private_ip
-        node_info[
-            constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS
-        ] = platform._azure_runbook.use_public_address
+        node_info[constants.ENVIRONMENTS_NODES_REMOTE_USE_PUBLIC_ADDRESS] = (
+            platform._azure_runbook.use_public_address
+        )
         self._node.set_connection_info(**node_info)
         self._node._is_initialized = False
         self._node.initialize()
@@ -565,8 +565,7 @@ class Gpu(AzureFeatureMixin, features.Gpu):
         ]
     }
     """  # noqa: E501
-    _gpu_extension_nvidia_properties = json.loads(
-        """
+    _gpu_extension_nvidia_properties = json.loads("""
         {
             "publisher": "Microsoft.HpcCompute",
             "type": "NvidiaGpuDriverLinux",
@@ -575,8 +574,7 @@ class Gpu(AzureFeatureMixin, features.Gpu):
             "settings": {
             }
         }
-    """
-    )
+    """)
 
     def is_supported(self) -> bool:
         # TODO: The GPU Feature is supposed to handle cloud related
@@ -2021,9 +2019,9 @@ class Disk(AzureFeatureMixin, features.Disk):
             cmd_result = self._node.execute(
                 f"readlink -f {disk}", shell=True, sudo=True
             )
-            disk_array[
-                int(disk.split("/")[-1].replace("lun", ""))
-            ] = cmd_result.stdout.strip()
+            disk_array[int(disk.split("/")[-1].replace("lun", ""))] = (
+                cmd_result.stdout.strip()
+            )
         return disk_array
 
     def get_all_disks(self) -> List[str]:
@@ -2554,13 +2552,20 @@ class Resize(AzureFeatureMixin, features.Resize):
         try:
             node_disk = self._node.features[features.Disk]
             hw_dc_type = node_disk.get_hardware_disk_controller_type()
-            if hw_dc_type is not None:
+            if hw_dc_type:
                 actual_disk_controller_type = schema.DiskControllerType(hw_dc_type)
                 self._log.debug(
                     f"actual hardware disk controller type: "
                     f"{actual_disk_controller_type}"
                 )
-        except (LisaException, ValueError, AttributeError) as e:
+        except (
+            LisaException,
+            ValueError,
+            AttributeError,
+            HttpResponseError,
+            ResourceNotFoundError,
+            ClientAuthenticationError,
+        ) as e:
             self._log.debug(
                 f"could not determine actual disk controller type, "
                 f"falling back to VM size capability comparison: {e}"
@@ -2604,17 +2609,18 @@ class Resize(AzureFeatureMixin, features.Resize):
             # capabilities (e.g. current supports {SCSI,NVMe} and candidate
             # supports {NVMe} -> overlap exists). But if the VM is actually
             # using SCSI, resizing to an NVMe-only size will fail.
-            if actual_disk_controller_type is not None:
+            if actual_disk_controller_type:
                 candidate_dc_types = getattr(
                     candidate_size.capability.disk, "disk_controller_type", None
                 )
-                if candidate_dc_types is not None:
-                    if isinstance(
-                        candidate_dc_types, search_space.SetSpace
-                    ) and actual_disk_controller_type not in candidate_dc_types:
+                if candidate_dc_types:
+                    if (
+                        isinstance(candidate_dc_types, search_space.SetSpace)
+                        and actual_disk_controller_type not in candidate_dc_types
+                    ):
                         avail_eligible_intersect.remove(candidate_size)
                         continue
-                    elif (
+                    if (
                         isinstance(candidate_dc_types, schema.DiskControllerType)
                         and candidate_dc_types != actual_disk_controller_type
                     ):
@@ -2877,9 +2883,9 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                     )
 
             # Disk Encryption Set ID
-            node_parameters.security_profile[
-                "disk_encryption_set_id"
-            ] = settings.disk_encryption_set_id
+            node_parameters.security_profile["disk_encryption_set_id"] = (
+                settings.disk_encryption_set_id
+            )
 
             # Return Skipped Exception if security profile is set on Gen 1 VM
             if node_parameters.security_profile["security_type"] == "":

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -2021,9 +2021,9 @@ class Disk(AzureFeatureMixin, features.Disk):
             cmd_result = self._node.execute(
                 f"readlink -f {disk}", shell=True, sudo=True
             )
-            disk_array[int(disk.split("/")[-1].replace("lun", ""))] = (
-                cmd_result.stdout.strip()
-            )
+            disk_array[
+                int(disk.split("/")[-1].replace("lun", ""))
+            ] = cmd_result.stdout.strip()
         return disk_array
 
     def get_all_disks(self) -> List[str]:
@@ -2877,9 +2877,9 @@ class SecurityProfile(AzureFeatureMixin, features.SecurityProfile):
                     )
 
             # Disk Encryption Set ID
-            node_parameters.security_profile["disk_encryption_set_id"] = (
-                settings.disk_encryption_set_id
-            )
+            node_parameters.security_profile[
+                "disk_encryption_set_id"
+            ] = settings.disk_encryption_set_id
 
             # Return Skipped Exception if security profile is set on Gen 1 VM
             if node_parameters.security_profile["security_type"] == "":


### PR DESCRIPTION
## Summary
When selecting a VM size for resize, `_select_vm_size()` previously only checked for overlap between VM size capability sets for `disk_controller_type`. This allowed NVMe-only candidates to pass the filter when the VM was actually deployed with SCSI, causing Azure to reject the resize with `cannot boot with DiskControllerType SCSI`.

Now queries the actual hardware disk controller type via Azure API and filters out candidates that don't support it. Also added the DiskControllerType error pattern to the resize retry list as defense-in-depth.

## Validation Results
| Image | VM Size | Location | Result |
|-------|---------|----------|--------|
| canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest | Standard_D2ds_v5 -> Standard_E96-48s_v5 | centralus | PASSED |