### PR TITLE
[AI Generated] BugFix: Add encoding='utf-8' to file writes that handle command output

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -730,7 +730,7 @@ class CloudHypervisorTests(Tool):
     def _write_testcase_log(self, log_path: Path, testcase: str, trace: str) -> None:
         """Write testcase log to file."""
         testcase_log_file = log_path.joinpath(f"{testcase}.log")
-        with open(testcase_log_file, "w") as f:
+        with open(testcase_log_file, "w", encoding="utf-8") as f:
             if hasattr(self, "_last_result") and self._last_result is not None:
                 if self._last_result.stdout:
                     f.write(self._last_result.stdout)

--- a/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
+++ b/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
@@ -68,7 +68,7 @@ class RustVmmTestSuite(TestSuite):
         testcase_log = log_path / "rust_vmm_mshv.log"
         cargo = node.tools[Cargo]
         test_result: ExecutableResult = cargo.test(cwd=repo_root, sudo=True)
-        with open(testcase_log, "w") as f:
+        with open(testcase_log, "w", encoding="utf-8") as f:
             f.write(f"{test_result.stdout} {test_result.stderr}")
         self.__process_result(
             test_result.stdout,

--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -1446,7 +1446,7 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
             libvirt_log = self.host_node.tools[Journalctl].logs_for_unit(
                 "libvirtd", sudo=self.host_node.is_remote
             )
-            with open(str(libvirt_log_local_path), "w") as f:
+            with open(str(libvirt_log_local_path), "w", encoding="utf-8") as f:
                 f.write(libvirt_log)
 
     def _expand_nodes_os_partition(self, environment: Environment, log: Logger) -> None:

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -102,7 +102,7 @@ class ExecutableResult:
         return assert_that(expected_exit_codes, message).contains(self.exit_code)
 
     def save_stdout_to_file(self, saved_path: Path) -> "ExecutableResult":
-        with open(saved_path, "w") as f:
+        with open(saved_path, "w", encoding="utf-8") as f:
             f.write(self.stdout)
         return self
 


### PR DESCRIPTION
## Summary
Add explicit encoding='utf-8' to open() calls that write command output to log files. On Windows with cp1252 locale, writing Unicode characters (e.g. arrow symbols from Rust test output) raises UnicodeEncodeError.

## Validation Results
| Image | Result |
|-------|--------|
| Canonical ubuntu-24_04-lts server 24.04.202408210 | PASSED (165/166 subtests passed, 1 pre-existing VDPA env issue filed separately) |