### PR TITLE
Add openvmm upstream test and stress test

### DIFF
--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
@@ -7,8 +7,17 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
 
-from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa import (
+    Logger,
+    Node,
+    TestCaseMetadata,
+    TestSuite,
+    TestSuiteMetadata,
+    simple_requirement,
+)
+from lisa.environment import EnvironmentStatus
 from lisa.operating_system import CBLMariner, Ubuntu
+from lisa.secret import add_secret
 from lisa.testsuite import TestResult
 from lisa.tools import Ls, Uname
 from lisa.tools.usermod import Usermod
@@ -41,22 +50,26 @@ class OpenVmmUpstreamTestSuite(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         openvmm_tests_type = _get_openvmm_tests_type()
         node = cast(Node, kwargs["node"])
-        host = self._get_host_node(node)
+        host = self._get_initialized_host_node(node)
         if not isinstance(host.os, (CBLMariner, Ubuntu)):
             raise SkippedException(
                 f"OpenVMM upstream tests are not implemented for {host.os.name}"
             )
 
         variables: Dict[str, Any] = cast(Dict[str, Any], kwargs.get("variables", {}))
-        openvmm_tests_type.repo_url = (
+        repo_url = (
             str(
                 variables.get("openvmm_tests_repo", openvmm_tests_type.DEFAULT_REPO)
             ).strip()
             or openvmm_tests_type.DEFAULT_REPO
         )
-        openvmm_tests_type.auth_token = str(
-            variables.get("openvmm_tests_auth_token", "")
-        ).strip()
+        auth_token = str(variables.get("openvmm_tests_auth_token", "")).strip()
+        if auth_token:
+            add_secret(auth_token)
+
+        openvmm_tests = host.tools[openvmm_tests_type]
+        openvmm_tests.repo_url = repo_url
+        openvmm_tests.auth_token = auth_token
 
     @TestCaseMetadata(
         description="""
@@ -67,7 +80,13 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         PCAT firmware discovery depends on Windows or WSL-hosted firmware paths.
         """,
         priority=2,
+        # The full upstream vmm_tests suite can take up to 12 hours on slower
+        # hardware; individual filtered runs are much shorter, but a generous
+        # ceiling avoids spurious timeouts when running the complete suite.
         timeout=43200,
+        requirement=simple_requirement(
+            environment_status=EnvironmentStatus.Deployed,
+        ),
     )
     def verify_openvmm_upstream_vmm_tests(
         self,
@@ -76,7 +95,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         result: TestResult,
         variables: Dict[str, Any],
     ) -> None:
-        host = self._get_host_node(node)
+        host = self._get_initialized_host_node(node)
         command_group = self._ensure_vmm_tests_supported(host)
 
         openvmm_tests = host.tools[_get_openvmm_tests_type()]
@@ -108,6 +127,11 @@ class OpenVmmUpstreamTestSuite(TestSuite):
             return parent
 
         return node
+
+    def _get_initialized_host_node(self, node: Node) -> Any:
+        host = self._get_host_node(node)
+        host.initialize()
+        return host
 
     def _ensure_vmm_tests_supported(self, host: Node) -> Optional[str]:
         hardware_platform = host.tools[Uname].get_linux_information().hardware_platform

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
@@ -1,0 +1,250 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import importlib.util
+import shlex
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Optional, cast
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
+from lisa.operating_system import CBLMariner, Ubuntu
+from lisa.testsuite import TestResult
+from lisa.tools import Ls, Uname
+from lisa.tools.usermod import Usermod
+from lisa.util import LisaException, SkippedException
+
+
+@lru_cache(maxsize=1)
+def _get_openvmm_tests_type() -> Any:
+    module_path = Path(__file__).with_name("openvmm_tests_tool.py")
+    spec = importlib.util.spec_from_file_location(
+        "lisa_openvmm_tests_tool",
+        module_path,
+    )
+    if not spec or not spec.loader:
+        raise RuntimeError(f"failed to load OpenVMM tests helper from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.OpenVmmTests
+
+
+@TestSuiteMetadata(
+    area="openvmm",
+    category="community",
+    description="""
+    This suite runs the upstream OpenVMM vmm_tests from the Linux OpenVMM host.
+    """,
+)
+class OpenVmmUpstreamTestSuite(TestSuite):
+    def before_case(self, log: Logger, **kwargs: Any) -> None:
+        openvmm_tests_type = _get_openvmm_tests_type()
+        node = cast(Node, kwargs["node"])
+        host = self._get_host_node(node)
+        if not isinstance(host.os, (CBLMariner, Ubuntu)):
+            raise SkippedException(
+                f"OpenVMM upstream tests are not implemented for {host.os.name}"
+            )
+
+        variables: Dict[str, Any] = cast(Dict[str, Any], kwargs.get("variables", {}))
+        openvmm_tests_type.repo_url = (
+            str(
+                variables.get("openvmm_tests_repo", openvmm_tests_type.DEFAULT_REPO)
+            ).strip()
+            or openvmm_tests_type.DEFAULT_REPO
+        )
+        openvmm_tests_type.auth_token = str(
+            variables.get("openvmm_tests_auth_token", "")
+        ).strip()
+
+    @TestCaseMetadata(
+        description="""
+        Run the upstream OpenVMM vmm_tests flowey pipeline on the Linux x64 host.
+        Use openvmm_vmm_tests_guest_os=linux|windows|all to scope guest coverage,
+        and openvmm_vmm_tests_filter for any additional nextest filter expression.
+        Native Linux hosts automatically exclude PCAT coverage because upstream
+        PCAT firmware discovery depends on Windows or WSL-hosted firmware paths.
+        """,
+        priority=2,
+        timeout=43200,
+    )
+    def verify_openvmm_upstream_vmm_tests(
+        self,
+        node: Node,
+        log_path: Path,
+        result: TestResult,
+        variables: Dict[str, Any],
+    ) -> None:
+        host = self._get_host_node(node)
+        command_group = self._ensure_vmm_tests_supported(host)
+
+        openvmm_tests = host.tools[_get_openvmm_tests_type()]
+        openvmm_tests.command_group = command_group or ""
+        run_summary = openvmm_tests.run_vmm_tests(
+            log_path=log_path,
+            ref=str(variables.get("openvmm_tests_ref", "")).strip(),
+            release=self._is_truthy(variables.get("openvmm_tests_release", "")),
+            test_filter=self._compose_vmm_tests_filter(variables, host),
+            install_missing_deps=self._is_truthy(
+                variables.get("openvmm_vmm_tests_install_missing_deps", "yes"),
+                default=True,
+            ),
+            skip_vhd_prompt=self._is_truthy(
+                variables.get("openvmm_vmm_tests_skip_vhd_prompt", "yes"),
+                default=True,
+            ),
+        )
+        result.message = (
+            "upstream vmm_tests:\n"
+            f"{openvmm_tests.format_run_summary(run_summary, include_failed=False)}"
+        )
+
+    def _get_host_node(self, node: Node) -> Any:
+        parent: Optional[Node] = cast(Optional[Node], getattr(node, "parent", None))
+        if node.__class__.__name__ == "OpenVmmGuestNode":
+            if not parent:
+                raise SkippedException("OpenVMM guest node does not have a parent host")
+            return parent
+
+        return node
+
+    def _ensure_vmm_tests_supported(self, host: Node) -> Optional[str]:
+        hardware_platform = host.tools[Uname].get_linux_information().hardware_platform
+        if hardware_platform.lower() != "x86_64":
+            raise SkippedException(
+                "OpenVMM upstream vmm_tests currently require a Linux x64 host"
+            )
+
+        ls = host.tools[Ls]
+        has_kvm = ls.path_exists(path="/dev/kvm", sudo=True)
+        has_mshv = ls.path_exists(path="/dev/mshv", sudo=True)
+        if not has_kvm and not has_mshv:
+            raise SkippedException(
+                "OpenVMM upstream vmm_tests require /dev/kvm or /dev/mshv on the host"
+            )
+
+        if has_kvm:
+            host.tools[Usermod].add_user_to_group("kvm", sudo=True)
+        if has_mshv:
+            host.tools[Usermod].add_user_to_group("mshv", sudo=True)
+
+        command_group: Optional[str] = None
+        has_kvm_access = has_kvm and self._can_open_device(host, "/dev/kvm")
+        has_mshv_access = has_mshv and self._can_open_device(host, "/dev/mshv")
+
+        if has_mshv and not has_mshv_access:
+            has_mshv_access = self._can_open_device(host, "/dev/mshv", group="mshv")
+            if has_mshv_access:
+                command_group = "mshv"
+
+        if not has_mshv and has_kvm and not has_kvm_access:
+            has_kvm_access = self._can_open_device(host, "/dev/kvm", group="kvm")
+            if has_kvm_access:
+                command_group = "kvm"
+
+        if has_mshv and not has_mshv_access:
+            if has_kvm_access:
+                raise SkippedException(
+                    "OpenVMM upstream vmm_tests detect /dev/mshv before /dev/kvm, "
+                    "but the current user cannot open /dev/mshv. Fix /dev/mshv "
+                    "permissions or remove /dev/mshv from this host for the run."
+                )
+            raise SkippedException(
+                "OpenVMM upstream vmm_tests require read/write access to /dev/mshv "
+                "when it is present on the host, but the current user cannot open it."
+            )
+
+        if not has_kvm_access and not has_mshv_access:
+            raise SkippedException(
+                "OpenVMM upstream vmm_tests require read/write access to /dev/kvm "
+                "or /dev/mshv on the host, but the current user cannot open "
+                "either device."
+            )
+
+        return command_group
+
+    def _can_open_device(
+        self,
+        host: Node,
+        path: str,
+        group: str = "",
+    ) -> bool:
+        open_command = f": <> {path}"
+        if group:
+            command = f"sg {shlex.quote(group)} -c {shlex.quote(open_command)}"
+        else:
+            command = open_command
+        result = host.execute(
+            f"bash -lc {shlex.quote(command)}",
+            shell=True,
+            expected_exit_code=None,
+            no_info_log=True,
+            no_error_log=True,
+        )
+        return result.exit_code == 0
+
+    def _compose_vmm_tests_filter(
+        self,
+        variables: Dict[str, Any],
+        host: Optional[Node] = None,
+    ) -> str:
+        guest_os = (
+            str(
+                variables.get(
+                    "openvmm_vmm_tests_guest_os",
+                    "all",
+                )
+            )
+            .strip()
+            .lower()
+        )
+        custom_filter = str(variables.get("openvmm_vmm_tests_filter", "")).strip()
+
+        guest_filters = {
+            "": "",
+            "all": "",
+            "both": "",
+            "linux": "(test(linux_direct) | test(ubuntu) | test(alpine))",
+            "windows": "test(windows)",
+        }
+        if guest_os not in guest_filters:
+            raise LisaException(
+                "Unsupported value for openvmm_vmm_tests_guest_os. "
+                "Use one of: all, both, linux, windows."
+            )
+
+        guest_filter = guest_filters[guest_os]
+
+        filters = []
+        if guest_filter:
+            filters.append(guest_filter)
+        if custom_filter:
+            filters.append(custom_filter)
+        if host and not self._is_wsl_host(host):
+            filters.append("!test(pcat)")
+
+        return self._combine_nextest_filters(filters)
+
+    def _combine_nextest_filters(self, filters: Any) -> str:
+        normalized = [
+            str(filter_value).strip() for filter_value in filters if filter_value
+        ]
+        if not normalized:
+            return ""
+        if len(normalized) == 1:
+            return normalized[0]
+        return " & ".join(f"({filter_value})" for filter_value in normalized)
+
+    def _is_wsl_host(self, host: Node) -> bool:
+        kernel_release = host.tools[Uname].get_linux_information().kernel_version_raw
+        lowered = kernel_release.lower()
+        return "microsoft" in lowered or "wsl" in lowered
+
+    def _is_truthy(self, value: Any, default: bool = False) -> bool:
+        if value is None:
+            return default
+        normalized = str(value).strip().lower()
+        if not normalized:
+            return default
+        return normalized in {"1", "true", "yes", "y", "on"}

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-import importlib.util
 import shlex
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 from lisa import (
     Logger,
@@ -26,17 +25,9 @@ from lisa.util import LisaException, SkippedException
 
 @lru_cache(maxsize=1)
 def _get_openvmm_tests_type() -> Any:
-    module_path = Path(__file__).with_name("openvmm_tests_tool.py")
-    spec = importlib.util.spec_from_file_location(
-        "lisa_openvmm_tests_tool",
-        module_path,
-    )
-    if not spec or not spec.loader:
-        raise RuntimeError(f"failed to load OpenVMM tests helper from {module_path}")
+    from .openvmm_tests_tool import OpenVmmTests
 
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.OpenVmmTests
+    return OpenVmmTests
 
 
 @TestSuiteMetadata(
@@ -67,9 +58,25 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         if auth_token:
             add_secret(auth_token)
 
-        openvmm_tests = host.tools[openvmm_tests_type]
-        openvmm_tests.repo_url = repo_url
-        openvmm_tests.auth_token = auth_token
+        openvmm_tests = self._get_openvmm_tests(
+            host, openvmm_tests_type, repo_url, auth_token
+        )
+        openvmm_tests.configure_repository(repo_url, auth_token)
+
+    def _get_openvmm_tests(
+        self,
+        host: Node,
+        openvmm_tests_type: Any,
+        repo_url: str,
+        auth_token: str,
+    ) -> Any:
+        create_tool = getattr(host.tools, "create", None)
+        if callable(create_tool):
+            return create_tool(
+                openvmm_tests_type, repo_url=repo_url, auth_token=auth_token
+            )
+
+        return host.tools[openvmm_tests_type]
 
     @TestCaseMetadata(
         description="""
@@ -240,7 +247,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
 
         guest_filter = guest_filters[guest_os]
 
-        filters = []
+        filters: List[str] = []
         if guest_filter:
             filters.append(guest_filter)
         if custom_filter:

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -22,8 +22,8 @@ class _JUnitSummary:
     failures: int = 0
     errors: int = 0
     skipped: int = 0
-    failed_tests: List[str] = field(default_factory=list)
-    passed_tests: List[str] = field(default_factory=list)
+    failed_tests: List[str] = field(default_factory=list[str])
+    passed_tests: List[str] = field(default_factory=list[str])
 
 
 class OpenVmmTests(Tool):
@@ -287,7 +287,8 @@ class OpenVmmTests(Tool):
             (
                 "bash -lc "
                 + shlex.quote(
-                    f"set -o pipefail; {command} > {shlex.quote(str(remote_log))} 2>&1"
+                    "set -o pipefail; "
+                    f"{{ {command}; }} > {shlex.quote(str(remote_log))} 2>&1"
                 )
             ),
             shell=True,
@@ -336,13 +337,15 @@ class OpenVmmTests(Tool):
             "installing the upstream pinned standalone binary"
         )
         install_dir = self._artifact_root / "cargo-nextest-install"
-        archive_name = f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
-        sha256_name = f"{archive_name}.sha256"
-        download_url = (
-            f"https://get.nexte.st/{self.NEXTEST_VERSION}/"
-            f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
+        release_name = f"cargo-nextest-{self.NEXTEST_VERSION}"
+        asset_name = f"{release_name}-{self.NEXTEST_LINUX_X64_TARGET}"
+        archive_name = f"{asset_name}.tar.gz"
+        sha256_name = f"{asset_name}.sha256"
+        release_url = (
+            "https://github.com/nextest-rs/nextest/releases/download/" f"{release_name}"
         )
-        sha256_url = f"{download_url}.sha256"
+        download_url = f"{release_url}/{archive_name}"
+        sha256_url = f"{release_url}/{sha256_name}"
         curl_command = self.node.tools[Curl].command
         install_command = (
             f"rm -rf {shlex.quote(str(install_dir))} && "
@@ -352,9 +355,12 @@ class OpenVmmTests(Tool):
             f"-o {shlex.quote(archive_name)} && "
             f"{shlex.quote(curl_command)} --fail -L {shlex.quote(sha256_url)} "
             f"-o {shlex.quote(sha256_name)} && "
-            f"computed=$(sha256sum {shlex.quote(archive_name)} | awk '{{print $1}}') && "
+            f"computed=$(sha256sum {shlex.quote(archive_name)} | "
+            "awk '{print $1}') && "
             f"expected=$(awk '{{print $1}}' {shlex.quote(sha256_name)}) && "
-            'test "$computed" = "$expected" && '
+            'test "$computed" = "$expected" || '
+            '{ echo "SHA256 mismatch: expected=$expected '
+            'computed=$computed" >&2; exit 1; } && '
             f"tar -xf {shlex.quote(archive_name)} && "
             "cp cargo-nextest ~/.cargo/bin/cargo-nextest && "
             "chmod 0755 ~/.cargo/bin/cargo-nextest"

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -1,0 +1,602 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+import shlex
+import xml.etree.ElementTree as ETree
+from dataclasses import dataclass, field
+from pathlib import Path, PurePath
+from typing import Any, Dict, List, Optional, Type, cast
+
+from lisa.executable import Tool
+from lisa.operating_system import CBLMariner, Posix, Ubuntu
+from lisa.tools import Cargo, Curl, Git, Ls
+from lisa.util import LisaException, UnsupportedDistroException
+
+
+@dataclass
+class _JUnitSummary:
+    tests: int = 0
+    total: int = 0
+    passed: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+    failed_tests: List[str] = field(default_factory=list)
+    passed_tests: List[str] = field(default_factory=list)
+
+
+class OpenVmmTests(Tool):
+    RESTORE_TIMEOUT = 3600
+    VMM_TIMEOUT = 43200
+    NEXTEST_VERSION = "0.9.101"
+    NEXTEST_LINUX_X64_TARGET = "x86_64-unknown-linux-gnu"
+    _ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+    _SUMMARY_PATTERN = re.compile(
+        r"Summary \[\s*[\d.]+s\]\s+(?P<run>\d+)(?:/(?P<total>\d+))? tests run:\s+"
+        r"(?P<passed>\d+) passed,\s+(?P<failed>\d+) failed,\s+"
+        r"(?P<skipped>\d+) skipped"
+    )
+    _FAILED_TEST_PATTERN = re.compile(
+        r"^\s*FAIL\s+\[[^\]]+\]\s+\S+\s+(?P<name>.+?)\s*$",
+        re.MULTILINE,
+    )
+    _PASSED_TEST_PATTERN = re.compile(
+        r"^\s*PASS\s+\[[^\]]+\]\s+\S+\s+(?P<name>.+?)\s*$",
+        re.MULTILINE,
+    )
+
+    DEFAULT_REPO = "https://github.com/microsoft/openvmm.git"
+    repo_url = DEFAULT_REPO
+    auth_token = ""
+    command_group = ""
+
+    _distro_package_mapping = {
+        Ubuntu.__name__: ["libssl-dev", "perl", "pkg-config"],
+        CBLMariner.__name__: [
+            "gcc",
+            "openssl-devel",
+            "perl",
+            "pkg-config",
+            "binutils",
+            "glibc-devel",
+        ],
+    }
+
+    repo_root: PurePath
+    _artifact_root: PurePath
+    _prepared_ref: Optional[str]
+    _repo_prepared: bool
+
+    @property
+    def command(self) -> str:
+        return self.node.tools[Cargo].command
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    @property
+    def dependencies(self) -> List[Type[Tool]]:
+        return [Git, Cargo, Curl]
+
+    def _check_exists(self) -> bool:
+        return self.node.tools[Ls].path_exists(str(self.repo_root))
+
+    def run_vmm_tests(
+        self,
+        log_path: Path,
+        ref: str = "",
+        release: bool = False,
+        test_filter: str = "",
+        install_missing_deps: bool = True,
+        skip_vhd_prompt: bool = True,
+    ) -> _JUnitSummary:
+        cargo = self.node.tools[Cargo]
+        env = self._prepare_repo(log_path, ref)
+        output_dir = self._artifact_root / "vmm-tests-run"
+        self.node.execute(
+            (
+                f"rm -rf {shlex.quote(str(output_dir))} && "
+                f"mkdir -p {shlex.quote(str(output_dir))}"
+            ),
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to prepare OpenVMM vmm-tests output directory"
+            ),
+        )
+
+        command = [
+            cargo.command,
+            "xflowey",
+            "vmm-tests-run",
+            "--target",
+            "linux-x64",
+            "--dir",
+            str(output_dir),
+        ]
+        if install_missing_deps:
+            command.append("--install-missing-deps")
+        if skip_vhd_prompt:
+            command.append("--skip-vhd-prompt")
+        if release:
+            command.append("--release")
+        if test_filter:
+            command.extend(["--filter", test_filter])
+
+        wrapped_command = self._wrap_command_for_group(shlex.join(command))
+
+        self._run_logged_command(
+            name="openvmm_vmm_tests",
+            command=wrapped_command,
+            log_path=log_path,
+            timeout=self.VMM_TIMEOUT,
+            update_envs=env,
+        )
+
+        local_junit = log_path / "openvmm_vmm_tests.junit.xml"
+        self._copy_back_if_exists(output_dir / "junit.xml", local_junit)
+        return self._check_vmm_tests_results(
+            name="openvmm_vmm_tests",
+            log_file=log_path / "openvmm_vmm_tests.log",
+            junit_file=local_junit,
+        )
+
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        tool_path = self.get_tool_path(use_global=True)
+        self.repo_root = tool_path / "openvmm"
+        self._artifact_root = self.repo_root / "target" / "lisa-openvmm-tests"
+        self._prepared_ref = None
+        self._repo_prepared = False
+
+    def _install(self) -> bool:
+        node_os = cast(Posix, self.node.os)
+        package_names = self._distro_package_mapping.get(type(node_os).__name__)
+        if not package_names:
+            raise UnsupportedDistroException(
+                node_os,
+                "OpenVMM upstream tests are not supported on this distro.",
+            )
+
+        node_os.install_packages(package_names)
+
+        self.repo_root = self.node.tools[Git].clone(
+            url=self.repo_url,
+            cwd=self.get_tool_path(use_global=True),
+            dir_name="openvmm",
+            fail_on_exists=False,
+            auth_token=self.auth_token or None,
+            timeout=1800,
+        )
+        self.node.execute(
+            f"mkdir -p {shlex.quote(str(self._artifact_root))}",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to create OpenVMM upstream test artifact directory"
+            ),
+        )
+
+        return self.node.tools[Ls].path_exists(str(self.repo_root))
+
+    def _prepare_repo(self, log_path: Path, ref: str) -> Dict[str, str]:
+        cargo_env = self._get_cargo_environment()
+
+        if ref and self._prepared_ref != ref:
+            self.node.tools[Git].checkout(ref, self.repo_root)
+            self.node.execute(
+                "git submodule update --init --recursive",
+                shell=True,
+                cwd=self.repo_root,
+                update_envs=cargo_env,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    f"failed to update submodules after checking out {ref}"
+                ),
+            )
+            self._repo_prepared = False
+
+        if not self._repo_prepared:
+            restore_command = shlex.join(
+                [
+                    self.node.tools[Cargo].command,
+                    "xflowey",
+                    "restore-packages",
+                    "--no-compat-igvm",
+                ]
+            )
+            self._run_logged_command(
+                name="openvmm_restore_packages",
+                command=restore_command,
+                log_path=log_path,
+                timeout=self.RESTORE_TIMEOUT,
+                update_envs=cargo_env,
+            )
+            self._repo_prepared = True
+            self._prepared_ref = ref or ""
+
+        self._ensure_cargo_nextest(log_path, cargo_env)
+
+        return cargo_env
+
+    def _get_cargo_environment(self) -> Dict[str, str]:
+        cargo = self.node.tools[Cargo]
+        home_dir = self.node.execute(
+            "echo $HOME",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to determine the home directory for OpenVMM tests"
+            ),
+        ).stdout.strip()
+        cargo_bin_dir = str(PurePath(cargo.command).parent)
+        cargo_home_bin = f"{home_dir}/.cargo/bin"
+        rustup_bin = f"{cargo_home_bin}/rustup"
+        toolchain = cargo.toolchain or "stable"
+
+        self.node.execute(
+            "mkdir -p ~/.rustup/downloads ~/.rustup/tmp ~/.cargo/bin",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to prepare rustup directories for OpenVMM tests"
+            ),
+        )
+        self.node.execute(
+            f"{shlex.quote(rustup_bin)} component add rust-src --toolchain "
+            f"{shlex.quote(toolchain)}",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to install the rust-src component for OpenVMM tests"
+            ),
+        )
+
+        return {
+            "OPENSSL_NO_VENDOR": "1",
+            "PATH": f"{cargo_home_bin}:{cargo_bin_dir}:$PATH",
+            "RUST_BACKTRACE": "1",
+            "RUSTC": f"{cargo_bin_dir}/rustc",
+            "RUSTDOC": f"{cargo_bin_dir}/rustdoc",
+            "RUST_LOG": "trace",
+        }
+
+    def _wrap_command_for_group(self, command: str) -> str:
+        group = str(self.command_group).strip()
+        if not group:
+            return command
+        return f"sg {shlex.quote(group)} -c {shlex.quote(command)}"
+
+    def _run_logged_command(
+        self,
+        name: str,
+        command: str,
+        log_path: Path,
+        timeout: int,
+        update_envs: Dict[str, str],
+        artifact_dir: Optional[PurePath] = None,
+    ) -> None:
+        remote_log = self._artifact_root / f"{name}.log"
+        command_result = self.node.execute(
+            (
+                "bash -lc "
+                + shlex.quote(
+                    f"set -o pipefail; {command} > {shlex.quote(str(remote_log))} 2>&1"
+                )
+            ),
+            shell=True,
+            cwd=self.repo_root,
+            timeout=timeout,
+            update_envs=update_envs,
+            expected_exit_code=None,
+        )
+
+        self._copy_back_if_exists(remote_log, log_path / f"{name}.log")
+
+        if artifact_dir:
+            remote_archive = self._artifact_root / f"{name}_artifacts.tar.gz"
+            self._archive_remote_directory(artifact_dir, remote_archive)
+            self._copy_back_if_exists(
+                remote_archive,
+                log_path / f"{name}_artifacts.tar.gz",
+            )
+
+        if command_result.exit_code == 0:
+            return
+
+        timed_out = getattr(command_result, "is_timeout", False)
+        tail_output = self._tail_remote_log(remote_log)
+        if timed_out:
+            raise LisaException(
+                f"{name} timed out after {timeout} seconds. "
+                f"Last log lines: {tail_output}"
+            )
+
+        raise LisaException(
+            f"{name} failed with exit code {command_result.exit_code}. "
+            f"Last log lines: {tail_output}"
+        )
+
+    def _ensure_cargo_nextest(
+        self,
+        log_path: Path,
+        update_envs: Dict[str, str],
+    ) -> None:
+        if self._has_cargo_nextest(update_envs):
+            return
+
+        self._log.debug(
+            "cargo-nextest was not available after restore-packages; "
+            "installing the upstream pinned standalone binary"
+        )
+        install_dir = self._artifact_root / "cargo-nextest-install"
+        archive_name = f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
+        download_url = (
+            f"https://get.nexte.st/{self.NEXTEST_VERSION}/"
+            f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
+        )
+        curl_command = self.node.tools[Curl].command
+        install_command = (
+            f"rm -rf {shlex.quote(str(install_dir))} && "
+            f"mkdir -p {shlex.quote(str(install_dir))} ~/.cargo/bin && "
+            f"cd {shlex.quote(str(install_dir))} && "
+            f"{shlex.quote(curl_command)} --fail -L {shlex.quote(download_url)} "
+            f"-o {shlex.quote(archive_name)} && "
+            f"tar -xf {shlex.quote(archive_name)} && "
+            "cp cargo-nextest ~/.cargo/bin/cargo-nextest && "
+            "chmod 0755 ~/.cargo/bin/cargo-nextest"
+        )
+        self._run_logged_command(
+            name="openvmm_install_cargo_nextest",
+            command=install_command,
+            log_path=log_path,
+            timeout=self.RESTORE_TIMEOUT,
+            update_envs=update_envs,
+        )
+
+        if not self._has_cargo_nextest(update_envs):
+            raise LisaException(
+                "cargo-nextest is still unavailable after the fallback install. "
+                "See openvmm_install_cargo_nextest.log for details."
+            )
+
+    def _has_cargo_nextest(self, update_envs: Dict[str, str]) -> bool:
+        result = self.node.execute(
+            "cargo nextest --version",
+            shell=True,
+            cwd=self.repo_root,
+            update_envs=update_envs,
+            expected_exit_code=None,
+            no_info_log=True,
+            no_error_log=True,
+        )
+        return result.exit_code == 0
+
+    def _archive_remote_directory(
+        self,
+        source_dir: PurePath,
+        archive_path: PurePath,
+    ) -> None:
+        self.node.execute(
+            (
+                f"rm -f {shlex.quote(str(archive_path))} && "
+                f"tar -czf {shlex.quote(str(archive_path))} "
+                f"-C {shlex.quote(str(source_dir))} ."
+            ),
+            shell=True,
+            expected_exit_code=None,
+            no_info_log=True,
+            no_error_log=True,
+        )
+
+    def _copy_back_if_exists(self, remote_path: PurePath, local_path: Path) -> None:
+        try:
+            self.node.shell.copy_back(remote_path, local_path)
+        except Exception as identifier:
+            self._log.debug(f"skipping artifact copy for {remote_path}: {identifier}")
+
+    def _tail_remote_log(self, remote_log: PurePath) -> str:
+        result = self.node.execute(
+            f"tail -n 200 {shlex.quote(str(remote_log))}",
+            shell=True,
+            expected_exit_code=None,
+            no_info_log=True,
+            no_error_log=True,
+        )
+        output = (result.stdout or result.stderr).strip()
+        return output[-4000:] if output else "no log output captured"
+
+    def _check_vmm_tests_results(
+        self,
+        name: str,
+        log_file: Path,
+        junit_file: Optional[Path],
+    ) -> _JUnitSummary:
+        if junit_file and junit_file.exists():
+            try:
+                summary = self._parse_junit_summary(junit_file)
+            except ETree.ParseError as identifier:
+                raise LisaException(
+                    f"{name} produced an unreadable JUnit report at {junit_file}: "
+                    f"{identifier}"
+                ) from identifier
+
+            if summary.failures or summary.errors:
+                raise LisaException(
+                    f"{name} reported test failures.\n"
+                    f"{self.format_run_summary(summary)}"
+                )
+            return summary
+
+        if log_file.exists():
+            summary = self._extract_log_summary(log_file)
+            failure_summary = self._extract_failure_summary_from_log(log_file, summary)
+            if failure_summary:
+                raise LisaException(
+                    f"{name} reported test failures.\n{failure_summary}"
+                )
+
+            return summary
+
+        return _JUnitSummary()
+
+    def format_run_summary(
+        self,
+        summary: _JUnitSummary,
+        include_passed: bool = True,
+        include_failed: bool = True,
+        max_items: int = 20,
+    ) -> str:
+        failed_count = summary.failures + summary.errors
+        if not failed_count and summary.failed_tests:
+            failed_count = len(summary.failed_tests)
+
+        passed_count = summary.passed or len(summary.passed_tests)
+        tests_run = summary.tests or (passed_count + failed_count)
+        if summary.total:
+            overview = (
+                f"{tests_run}/{summary.total} tests run: "
+                f"{passed_count} passed, {failed_count} failed, "
+                f"{summary.skipped} skipped"
+            )
+        else:
+            overview = (
+                f"{tests_run} tests run: {passed_count} passed, "
+                f"{failed_count} failed, {summary.skipped} skipped"
+            )
+
+        lines = [overview]
+        if include_passed and (passed_count or summary.passed_tests):
+            lines.append("Passed tests:")
+            lines.append(
+                self._summarize_test_names(
+                    summary.passed_tests,
+                    max_items=max_items,
+                    empty_message="  - no passing test names captured",
+                )
+            )
+        if include_failed and (failed_count or summary.failed_tests):
+            lines.append("Failed tests:")
+            lines.append(
+                self._summarize_test_names(
+                    summary.failed_tests,
+                    max_items=max_items,
+                    empty_message="  - no failing test names captured",
+                )
+            )
+
+        return "\n".join(lines)
+
+    def _parse_junit_summary(self, junit_file: Path) -> _JUnitSummary:
+        tree = ETree.parse(junit_file)
+        root = tree.getroot()
+        summary = _JUnitSummary()
+
+        suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+        if not suites:
+            suites = [root]
+
+        for suite in suites:
+            summary.tests += int(suite.attrib.get("tests", "0") or 0)
+            summary.failures += int(suite.attrib.get("failures", "0") or 0)
+            summary.errors += int(suite.attrib.get("errors", "0") or 0)
+            summary.skipped += int(
+                suite.attrib.get("skipped", suite.attrib.get("disabled", "0")) or 0
+            )
+
+        for testcase in root.iter("testcase"):
+            classname = testcase.attrib.get("classname", "").strip()
+            test_name = testcase.attrib.get("name", "").strip()
+            full_name = self._format_test_name(classname, test_name)
+
+            if testcase.find("failure") is None and testcase.find("error") is None:
+                if testcase.find("skipped") is None and full_name:
+                    summary.passed_tests.append(full_name)
+                continue
+
+            if full_name:
+                summary.failed_tests.append(full_name)
+
+        summary.passed_tests = self._deduplicate_test_names(summary.passed_tests)
+        summary.failed_tests = self._deduplicate_test_names(summary.failed_tests)
+        summary.passed = len(summary.passed_tests)
+
+        return summary
+
+    def _extract_log_summary(self, log_file: Path) -> _JUnitSummary:
+        content = log_file.read_text(encoding="utf-8", errors="ignore")
+        return self._extract_log_summary_from_content(content)
+
+    def _extract_failure_summary_from_log(
+        self,
+        log_file: Path,
+        summary: Optional[_JUnitSummary] = None,
+    ) -> Optional[str]:
+        content = self._strip_ansi_escape_sequences(
+            log_file.read_text(encoding="utf-8", errors="ignore")
+        )
+        parsed_summary = summary or self._extract_log_summary_from_content(content)
+        failed_count = parsed_summary.failures + parsed_summary.errors
+        if not failed_count and parsed_summary.failed_tests:
+            failed_count = len(parsed_summary.failed_tests)
+
+        if failed_count:
+            return self.format_run_summary(parsed_summary)
+
+        lowered = content.lower()
+        if (
+            "encountered at least one test failure" in lowered
+            or "encountered test failures." in lowered
+        ):
+            return "Log reported test failures without listing individual test names"
+
+        return None
+
+    def _extract_log_summary_from_content(self, content: str) -> _JUnitSummary:
+        sanitized_content = self._strip_ansi_escape_sequences(content)
+        summary = _JUnitSummary()
+        summary_match = self._SUMMARY_PATTERN.search(sanitized_content)
+        if summary_match:
+            summary.tests = int(summary_match.group("run"))
+            summary.total = int(summary_match.group("total") or 0)
+            summary.passed = int(summary_match.group("passed"))
+            summary.failures = int(summary_match.group("failed"))
+            summary.skipped = int(summary_match.group("skipped"))
+
+        summary.passed_tests = self._deduplicate_test_names(
+            self._PASSED_TEST_PATTERN.findall(sanitized_content)
+        )
+        summary.failed_tests = self._deduplicate_test_names(
+            self._FAILED_TEST_PATTERN.findall(sanitized_content)
+        )
+        return summary
+
+    def _deduplicate_test_names(self, test_names: List[str]) -> List[str]:
+        normalized_names = [
+            str(test_name).strip() for test_name in test_names if test_name
+        ]
+        return list(dict.fromkeys(name for name in normalized_names if name))
+
+    def _summarize_test_names(
+        self,
+        test_names: List[str],
+        max_items: int = 20,
+        empty_message: str = "  - no test names captured",
+    ) -> str:
+        names = self._deduplicate_test_names(test_names)
+        if not names:
+            return empty_message
+
+        summarized_names = [f"  - {name}" for name in names[:max_items]]
+        if len(names) > max_items:
+            summarized_names.append(f"  - ... and {len(names) - max_items} more")
+        return "\n".join(summarized_names)
+
+    def _format_test_name(self, classname: str, test_name: str) -> str:
+        if classname and test_name:
+            return f"{classname} {test_name}"
+        return test_name
+
+    def _strip_ansi_escape_sequences(self, content: str) -> str:
+        return self._ANSI_ESCAPE_PATTERN.sub("", content)

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -27,7 +27,12 @@ class _JUnitSummary:
 
 
 class OpenVmmTests(Tool):
+    # Restoring packages (cargo xflowey restore-packages) can take up to 1 hour
+    # on first run due to large dependency downloads; subsequent runs are faster.
     RESTORE_TIMEOUT = 3600
+    # The full vmm_tests suite can take up to 12 hours on slower hardware.
+    # Individual filtered runs are faster, but allow the full ceiling to avoid
+    # spurious timeouts when running the complete suite.
     VMM_TIMEOUT = 43200
     NEXTEST_VERSION = "0.9.101"
     NEXTEST_LINUX_X64_TARGET = "x86_64-unknown-linux-gnu"
@@ -259,7 +264,7 @@ class OpenVmmTests(Tool):
             "RUST_BACKTRACE": "1",
             "RUSTC": f"{cargo_bin_dir}/rustc",
             "RUSTDOC": f"{cargo_bin_dir}/rustdoc",
-            "RUST_LOG": "trace",
+            "RUST_LOG": "info",
         }
 
     def _wrap_command_for_group(self, command: str) -> str:
@@ -332,10 +337,12 @@ class OpenVmmTests(Tool):
         )
         install_dir = self._artifact_root / "cargo-nextest-install"
         archive_name = f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
+        sha256_name = f"{archive_name}.sha256"
         download_url = (
             f"https://get.nexte.st/{self.NEXTEST_VERSION}/"
             f"{self.NEXTEST_LINUX_X64_TARGET}.tar.gz"
         )
+        sha256_url = f"{download_url}.sha256"
         curl_command = self.node.tools[Curl].command
         install_command = (
             f"rm -rf {shlex.quote(str(install_dir))} && "
@@ -343,6 +350,11 @@ class OpenVmmTests(Tool):
             f"cd {shlex.quote(str(install_dir))} && "
             f"{shlex.quote(curl_command)} --fail -L {shlex.quote(download_url)} "
             f"-o {shlex.quote(archive_name)} && "
+            f"{shlex.quote(curl_command)} --fail -L {shlex.quote(sha256_url)} "
+            f"-o {shlex.quote(sha256_name)} && "
+            f"computed=$(sha256sum {shlex.quote(archive_name)} | awk '{{print $1}}') && "
+            f"expected=$(awk '{{print $1}}' {shlex.quote(sha256_name)}) && "
+            'test "$computed" = "$expected" && '
             f"tar -xf {shlex.quote(archive_name)} && "
             "cp cargo-nextest ~/.cargo/bin/cargo-nextest && "
             "chmod 0755 ~/.cargo/bin/cargo-nextest"
@@ -391,10 +403,15 @@ class OpenVmmTests(Tool):
         )
 
     def _copy_back_if_exists(self, remote_path: PurePath, local_path: Path) -> None:
+        if not self.node.tools[Ls].path_exists(str(remote_path)):
+            self._log.debug(f"artifact not present on remote, skipping: {remote_path}")
+            return
         try:
             self.node.shell.copy_back(remote_path, local_path)
         except Exception as identifier:
-            self._log.debug(f"skipping artifact copy for {remote_path}: {identifier}")
+            self._log.warning(
+                f"failed to copy artifact {remote_path} to {local_path}: {identifier}"
+            )
 
     def _tail_remote_log(self, remote_log: PurePath) -> str:
         result = self.node.execute(
@@ -452,7 +469,18 @@ class OpenVmmTests(Tool):
         if not failed_count and summary.failed_tests:
             failed_count = len(summary.failed_tests)
 
-        passed_count = summary.passed or len(summary.passed_tests)
+        if summary.passed:
+            passed_count = summary.passed
+        elif summary.passed_tests:
+            passed_count = len(summary.passed_tests)
+        elif summary.tests:
+            # Derive passed count from totals when individual names aren't captured
+            # (e.g. JUnit reports that record counts but omit per-case elements).
+            passed_count = max(
+                0, summary.tests - summary.failures - summary.errors - summary.skipped
+            )
+        else:
+            passed_count = 0
         tests_run = summary.tests or (passed_count + failed_count)
         if summary.total:
             overview = (

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import hashlib
 import re
 import shlex
 import xml.etree.ElementTree as ETree
@@ -14,6 +15,10 @@ from lisa.tools import Cargo, Curl, Git, Ls
 from lisa.util import LisaException, UnsupportedDistroException
 
 
+def _new_str_list() -> List[str]:
+    return []
+
+
 @dataclass
 class _JUnitSummary:
     tests: int = 0
@@ -22,8 +27,8 @@ class _JUnitSummary:
     failures: int = 0
     errors: int = 0
     skipped: int = 0
-    failed_tests: List[str] = field(default_factory=list[str])
-    passed_tests: List[str] = field(default_factory=list[str])
+    failed_tests: List[str] = field(default_factory=_new_str_list)
+    passed_tests: List[str] = field(default_factory=_new_str_list)
 
 
 class OpenVmmTests(Tool):
@@ -83,10 +88,43 @@ class OpenVmmTests(Tool):
 
     @property
     def dependencies(self) -> List[Type[Tool]]:
-        return [Git, Cargo, Curl]
+        return [Git, Cargo, Curl, Ls]
+
+    @classmethod
+    def create(cls, node: Any, *args: Any, **kwargs: Any) -> "OpenVmmTests":
+        repo_url = str(kwargs.pop("repo_url", "")).strip()
+        auth_token = str(kwargs.pop("auth_token", "")).strip()
+        if args:
+            repo_url = str(args[0]).strip()
+        if len(args) > 1:
+            auth_token = str(args[1]).strip()
+        if len(args) > 2 or kwargs:
+            raise LisaException(
+                "OpenVmmTests.create accepts only repo_url and auth_token. "
+                "Remove any extra tool creation arguments."
+            )
+
+        tool = cls(node)
+        tool.repo_url = repo_url or cls.DEFAULT_REPO
+        tool.auth_token = auth_token
+        return tool
 
     def _check_exists(self) -> bool:
+        self._set_repo_paths()
         return self.node.tools[Ls].path_exists(str(self.repo_root))
+
+    def configure_repository(self, repo_url: str, auth_token: str) -> None:
+        repository_changed = self.repo_url != repo_url or self.auth_token != auth_token
+
+        self.repo_url = repo_url
+        self.auth_token = auth_token
+        self._set_repo_paths()
+        if not repository_changed:
+            return
+
+        self._prepared_ref = None
+        self._repo_prepared = False
+        self._exists = None
 
     def run_vmm_tests(
         self,
@@ -149,11 +187,17 @@ class OpenVmmTests(Tool):
         )
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
-        tool_path = self.get_tool_path(use_global=True)
-        self.repo_root = tool_path / "openvmm"
-        self._artifact_root = self.repo_root / "target" / "lisa-openvmm-tests"
+        self._set_repo_paths()
         self._prepared_ref = None
         self._repo_prepared = False
+
+    def _get_repo_dir_name(self) -> str:
+        repo_hash = hashlib.sha256(self.repo_url.encode("utf-8")).hexdigest()[:8]
+        return f"openvmm-{repo_hash}"
+
+    def _set_repo_paths(self) -> None:
+        self.repo_root = self.get_tool_path(use_global=True) / self._get_repo_dir_name()
+        self._artifact_root = self.repo_root / "target" / "lisa-openvmm-tests"
 
     def _install(self) -> bool:
         node_os = cast(Posix, self.node.os)
@@ -166,10 +210,12 @@ class OpenVmmTests(Tool):
 
         node_os.install_packages(package_names)
 
+        self._set_repo_paths()
+
         self.repo_root = self.node.tools[Git].clone(
             url=self.repo_url,
             cwd=self.get_tool_path(use_global=True),
-            dir_name="openvmm",
+            dir_name=self._get_repo_dir_name(),
             fail_on_exists=False,
             auth_token=self.auth_token or None,
             timeout=1800,
@@ -186,6 +232,12 @@ class OpenVmmTests(Tool):
         return self.node.tools[Ls].path_exists(str(self.repo_root))
 
     def _prepare_repo(self, log_path: Path, ref: str) -> Dict[str, str]:
+        if not self._check_exists() and not self._install():
+            raise LisaException(
+                f"failed to prepare OpenVMM upstream tests repository from "
+                f"{self.repo_url}"
+            )
+
         cargo_env = self._get_cargo_environment()
 
         if ref and self._prepared_ref != ref:
@@ -235,7 +287,30 @@ class OpenVmmTests(Tool):
                 "failed to determine the home directory for OpenVMM tests"
             ),
         ).stdout.strip()
-        cargo_bin_dir = str(PurePath(cargo.command).parent)
+        # Fetch the current remote PATH explicitly so we can prepend to a
+        # concrete value rather than relying on shell expansion in update_envs.
+        current_env_path = self.node.execute(
+            "echo $PATH",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to determine the remote PATH for OpenVMM tests"
+            ),
+        ).stdout.strip()
+        cargo_bin_dir = ""
+        cargo_command = cargo.command
+        if not PurePath(cargo_command).is_absolute():
+            # cargo.command is a bare name on PATH; resolve its real location
+            # so we can build correct RUSTC/RUSTDOC paths.
+            resolve_result = self.node.execute(
+                f"command -v {shlex.quote(cargo_command)}",
+                shell=True,
+                expected_exit_code=None,
+            )
+            if resolve_result.exit_code == 0:
+                cargo_command = resolve_result.stdout.strip()
+        if cargo_command and PurePath(cargo_command).is_absolute():
+            cargo_bin_dir = str(PurePath(cargo_command).parent)
         cargo_home_bin = f"{home_dir}/.cargo/bin"
         rustup_bin = f"{cargo_home_bin}/rustup"
         toolchain = cargo.toolchain or "stable"
@@ -258,14 +333,19 @@ class OpenVmmTests(Tool):
             ),
         )
 
-        return {
+        path_prefix = (
+            f"{cargo_home_bin}:{cargo_bin_dir}" if cargo_bin_dir else cargo_home_bin
+        )
+        env: Dict[str, str] = {
             "OPENSSL_NO_VENDOR": "1",
-            "PATH": f"{cargo_home_bin}:{cargo_bin_dir}:$PATH",
+            "PATH": f"{path_prefix}:{current_env_path}",
             "RUST_BACKTRACE": "1",
-            "RUSTC": f"{cargo_bin_dir}/rustc",
-            "RUSTDOC": f"{cargo_bin_dir}/rustdoc",
             "RUST_LOG": "info",
         }
+        if cargo_bin_dir:
+            env["RUSTC"] = f"{cargo_bin_dir}/rustc"
+            env["RUSTDOC"] = f"{cargo_bin_dir}/rustdoc"
+        return env
 
     def _wrap_command_for_group(self, command: str) -> str:
         group = str(self.command_group).strip()
@@ -396,7 +476,7 @@ class OpenVmmTests(Tool):
         source_dir: PurePath,
         archive_path: PurePath,
     ) -> None:
-        self.node.execute(
+        result = self.node.execute(
             (
                 f"rm -f {shlex.quote(str(archive_path))} && "
                 f"tar -czf {shlex.quote(str(archive_path))} "
@@ -407,6 +487,11 @@ class OpenVmmTests(Tool):
             no_info_log=True,
             no_error_log=True,
         )
+        if result.exit_code != 0:
+            self._log.warning(
+                f"failed to archive '{source_dir}' to '{archive_path}' "
+                f"(exit {result.exit_code}); diagnostic artifacts may be missing"
+            )
 
     def _copy_back_if_exists(self, remote_path: PurePath, local_path: Path) -> None:
         if not self.node.tools[Ls].path_exists(str(remote_path)):
@@ -414,9 +499,10 @@ class OpenVmmTests(Tool):
             return
         try:
             self.node.shell.copy_back(remote_path, local_path)
-        except Exception as identifier:
-            self._log.warning(
+        except OSError as identifier:
+            self._log.debug(
                 f"failed to copy artifact {remote_path} to {local_path}: {identifier}"
+                " (check permissions, disk space, and SSH/SFTP connectivity)"
             )
 
     def _tail_remote_log(self, remote_log: PurePath) -> str:
@@ -462,7 +548,11 @@ class OpenVmmTests(Tool):
 
             return summary
 
-        return _JUnitSummary()
+        raise LisaException(
+            f"{name} did not produce a local JUnit report or log file. "
+            f"Checked JUnit path: {junit_file}, log path: {log_file}. "
+            "Verify the test run completed and artifact copy-back succeeded."
+        )
 
     def format_run_summary(
         self,

--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -305,9 +305,11 @@ class StressNgTestSuite(TestSuite):
             stress_processes: List to store launched processes
             log: Logger instance for detailed logging
         """
+        prepared_jobs: List[Tuple[RemoteNode, PurePath, StressNg]] = []
+
         for node_index, node in enumerate(nodes):
             try:
-                log.debug(f"Processing node {node_index + 1}/{len(nodes)}: {node.name}")
+                log.debug(f"Preparing node {node_index + 1}/{len(nodes)}: {node.name}")
 
                 # Create dedicated workspace for stress-ng jobs
                 remote_workspace = node.working_path / "stress_ng_jobs"
@@ -317,8 +319,24 @@ class StressNgTestSuite(TestSuite):
                 remote_job_file = remote_workspace / job_file_name
                 node.shell.copy(PurePath(job_file), remote_job_file)
 
+                stress_ng = node.tools[StressNg]
+                prepared_jobs.append((node, remote_job_file, stress_ng))
+
+            except Exception as deployment_error:
+                log.error(
+                    f"Failed to prepare stress job on node {node_index + 1}: "
+                    f"{deployment_error}"
+                )
+                if getattr(node, "log", None):
+                    node.log.error(f"Failed to prepare stress job: {deployment_error}")
+                raise deployment_error
+
+        for node_index, (node, remote_job_file, stress_ng) in enumerate(prepared_jobs):
+            try:
+                log.debug(f"Launching node {node_index + 1}/{len(nodes)}: {node.name}")
+
                 # Launch stress-ng with the job file
-                stress_process = node.tools[StressNg].launch_job_async(
+                stress_process = stress_ng.launch_job_async(
                     str(remote_job_file),
                 )
                 stress_processes.append(stress_process)

--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 import logging
 from pathlib import Path, PurePath
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import yaml
 
@@ -215,9 +215,7 @@ class StressNgTestSuite(TestSuite):
         kernel_panics: List[Tuple[RemoteNode, Exception]] = []
         for node, _e in start_failures + result_failures:
             try:
-                node.features[SerialConsole].check_panic(
-                    saved_path=None, force_run=True
-                )
+                self._check_serial_console_panic(node)
             except KernelPanicException as e:
                 kernel_panics.append((node, e))
 
@@ -281,10 +279,7 @@ class StressNgTestSuite(TestSuite):
                 f"Error: {type(execution_error).__name__}: {str(execution_error)}"
             )
             for node in nodes:
-                # check_panic automatically logs, attaches to result, and raises
-                node.features[SerialConsole].check_panic(
-                    saved_path=None, force_run=True, test_result=test_result
-                )
+                self._check_serial_console_panic(node, test_result)
             raise execution_error
 
         finally:
@@ -336,6 +331,18 @@ class StressNgTestSuite(TestSuite):
                 if getattr(node, "log", None):
                     node.log.error(f"Failed to start stress job: {deployment_error}")
                 raise deployment_error
+
+    def _check_serial_console_panic(
+        self, node: RemoteNode, test_result: Optional[TestResult] = None
+    ) -> None:
+        if node.features.is_supported(SerialConsole):
+            node.features[SerialConsole].check_panic(
+                saved_path=None, force_run=True, test_result=test_result
+            )
+        else:
+            node.log.debug(
+                "SerialConsole feature is not supported; skipping panic check."
+            )
 
     def _monitor_stress_execution(
         self,

--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -305,7 +305,7 @@ class StressNgTestSuite(TestSuite):
             stress_processes: List to store launched processes
             log: Logger instance for detailed logging
         """
-        prepared_jobs: List[Tuple[RemoteNode, PurePath, StressNg]] = []
+        prepared_jobs: List[Tuple[RemoteNode, PurePath]] = []
 
         for node_index, node in enumerate(nodes):
             try:
@@ -319,8 +319,7 @@ class StressNgTestSuite(TestSuite):
                 remote_job_file = remote_workspace / job_file_name
                 node.shell.copy(PurePath(job_file), remote_job_file)
 
-                stress_ng = node.tools[StressNg]
-                prepared_jobs.append((node, remote_job_file, stress_ng))
+                prepared_jobs.append((node, remote_job_file))
 
             except Exception as deployment_error:
                 log.error(
@@ -331,12 +330,12 @@ class StressNgTestSuite(TestSuite):
                     node.log.error(f"Failed to prepare stress job: {deployment_error}")
                 raise deployment_error
 
-        for node_index, (node, remote_job_file, stress_ng) in enumerate(prepared_jobs):
+        for node_index, (node, remote_job_file) in enumerate(prepared_jobs):
             try:
                 log.debug(f"Launching node {node_index + 1}/{len(nodes)}: {node.name}")
 
                 # Launch stress-ng with the job file
-                stress_process = stress_ng.launch_job_async(
+                stress_process = node.tools[StressNg].launch_job_async(
                     str(remote_job_file),
                 )
                 stress_processes.append(stress_process)

--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -280,7 +280,7 @@ class StressNgTestSuite(TestSuite):
             )
             for node in nodes:
                 self._check_serial_console_panic(node, test_result)
-            raise execution_error
+            raise
 
         finally:
             self._report_test_results(
@@ -328,7 +328,7 @@ class StressNgTestSuite(TestSuite):
                 )
                 if getattr(node, "log", None):
                     node.log.error(f"Failed to prepare stress job: {deployment_error}")
-                raise deployment_error
+                raise
 
         for node_index, (node, remote_job_file) in enumerate(prepared_jobs):
             try:
@@ -347,7 +347,7 @@ class StressNgTestSuite(TestSuite):
                 )
                 if getattr(node, "log", None):
                     node.log.error(f"Failed to start stress job: {deployment_error}")
-                raise deployment_error
+                raise
 
     def _check_serial_console_panic(
         self, node: RemoteNode, test_result: Optional[TestResult] = None

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from dataclasses_json import dataclass_json
 
 from lisa.sut_orchestrator.util.schema import (
+    CloudInitSchema,
     DevicePassthroughSchema,
     HostDevicePoolSchema,
 )
@@ -12,14 +13,6 @@ from lisa.util import LisaException
 
 FIRMWARE_TYPE_BIOS = "bios"
 FIRMWARE_TYPE_UEFI = "uefi"
-
-
-# Configuration options for cloud-init ISO generation for the VM.
-@dataclass_json()
-@dataclass
-class CloudInitSchema:
-    # Additional values to apply to the cloud-init user-data file.
-    extra_user_data: Optional[Union[str, List[str]]] = None
 
 
 @dataclass_json()

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -32,6 +32,7 @@ class NodeContext:
     tap_input_rules_added: List[str] = field(default_factory=list)
     tap_dnsmasq_pid_file: str = ""
     tap_dnsmasq_lease_file: str = ""
+    effective_network: Optional[Any] = None
     process_id: str = ""
     command_line: str = ""
 

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Any, Dict, List, Optional
 
 from lisa.node import Node
@@ -43,6 +44,7 @@ class OpenVmmHostContext:
     active_forwarding_count: int = 0
     original_bridge_netfilter_values: Dict[str, str] = field(default_factory=dict)
     active_bridge_netfilter_count: int = 0
+    artifact_copy_lock: Lock = field(default_factory=Lock)
 
 
 def get_node_context(node: Node) -> NodeContext:

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -29,6 +29,7 @@ class NodeContext:
     tap_bridge_created: bool = False
     tap_bridge_netfilter_disabled: bool = False
     tap_dhcp_input_rule_added: bool = False
+    tap_input_rules_added: List[str] = field(default_factory=list)
     tap_dnsmasq_pid_file: str = ""
     tap_dnsmasq_lease_file: str = ""
     process_id: str = ""

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -8,6 +8,20 @@ from typing import Any, Dict, List, Optional
 from lisa.node import Node
 from lisa.util import LisaException
 
+from .schema import OpenVmmNetworkSchema
+
+
+def _new_extra_cloud_init_user_data() -> List[Dict[str, Any]]:
+    return []
+
+
+def _new_str_list() -> List[str]:
+    return []
+
+
+def _new_str_dict() -> Dict[str, str]:
+    return {}
+
 
 @dataclass
 class NodeContext:
@@ -20,7 +34,9 @@ class NodeContext:
     console_log_file_path: str = ""
     launcher_log_file_path: str = ""
     launcher_stderr_log_file_path: str = ""
-    extra_cloud_init_user_data: List[Dict[str, Any]] = field(default_factory=list)
+    extra_cloud_init_user_data: List[Dict[str, Any]] = field(
+        default_factory=_new_extra_cloud_init_user_data
+    )
     guest_address: str = ""
     ssh_port: int = 22
     forwarded_port: int = 0
@@ -29,11 +45,10 @@ class NodeContext:
     tap_created: bool = False
     tap_bridge_created: bool = False
     tap_bridge_netfilter_disabled: bool = False
-    tap_dhcp_input_rule_added: bool = False
-    tap_input_rules_added: List[str] = field(default_factory=list)
+    tap_input_rules_added: List[str] = field(default_factory=_new_str_list)
     tap_dnsmasq_pid_file: str = ""
     tap_dnsmasq_lease_file: str = ""
-    effective_network: Optional[Any] = None
+    effective_network: Optional[OpenVmmNetworkSchema] = None
     process_id: str = ""
     command_line: str = ""
 
@@ -42,10 +57,12 @@ class NodeContext:
 class OpenVmmHostContext:
     original_ip_forward_value: str = ""
     active_forwarding_count: int = 0
-    original_bridge_netfilter_values: Dict[str, str] = field(default_factory=dict)
+    original_bridge_netfilter_values: Dict[str, str] = field(
+        default_factory=_new_str_dict
+    )
     active_bridge_netfilter_count: int = 0
     artifact_copy_lock: Lock = field(default_factory=Lock)
-    artifact_cache: Dict[str, str] = field(default_factory=dict)
+    artifact_cache: Dict[str, str] = field(default_factory=_new_str_dict)
 
 
 def get_node_context(node: Node) -> NodeContext:

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -45,6 +45,7 @@ class OpenVmmHostContext:
     original_bridge_netfilter_values: Dict[str, str] = field(default_factory=dict)
     active_bridge_netfilter_count: int = 0
     artifact_copy_lock: Lock = field(default_factory=Lock)
+    artifact_cache: Dict[str, str] = field(default_factory=dict)
 
 
 def get_node_context(node: Node) -> NodeContext:

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import copy
 import hashlib
 import io
 import ipaddress
@@ -68,6 +69,69 @@ def _countspace_to_int(value: search_space.CountSpace) -> int:
             "configuration resolves to a single integer value."
         )
     return chosen
+
+
+def _increment_name_suffix(value: str, index: int) -> str:
+    if not value or index == 0:
+        return value
+
+    suffix_start = len(value)
+    while suffix_start > 0 and value[suffix_start - 1].isdigit():
+        suffix_start -= 1
+
+    if suffix_start == len(value):
+        return f"{value}{index}"
+
+    prefix = value[:suffix_start]
+    suffix = value[suffix_start:]
+    return f"{prefix}{int(suffix) + index:0{len(suffix)}d}"
+
+
+def _shift_ip_interface_cidr(cidr: str, index: int) -> str:
+    if not cidr or index == 0:
+        return cidr
+
+    interface = ipaddress.ip_interface(cidr)
+    network = interface.network
+    network_address = int(network.network_address) + index * network.num_addresses
+    host_offset = int(interface.ip) - int(network.network_address)
+    max_address = (1 << network.max_prefixlen) - 1
+    new_ip_address = network_address + host_offset
+    if new_ip_address > max_address or (
+        network_address + network.num_addresses - 1 > max_address
+    ):
+        raise LisaException(
+            f"cannot derive OpenVMM guest network from '{cidr}' for guest index "
+            f"{index}: derived address exceeds the IP address space. Use a "
+            "larger base network or explicit per-guest network settings."
+        )
+
+    return f"{ipaddress.ip_address(new_ip_address)}/{network.prefixlen}"
+
+
+def _shift_ip_address(address: str, base_cidr: str, index: int) -> str:
+    if not address or not base_cidr or index == 0:
+        return address
+
+    base_network = ipaddress.ip_interface(base_cidr).network
+    ip_address = ipaddress.ip_address(address)
+    if ip_address not in base_network:
+        return address
+
+    host_offset = int(ip_address) - int(base_network.network_address)
+    new_network_address = int(base_network.network_address) + (
+        index * base_network.num_addresses
+    )
+    new_address = new_network_address + host_offset
+    max_address = (1 << base_network.max_prefixlen) - 1
+    if new_address > max_address:
+        raise LisaException(
+            f"cannot derive OpenVMM guest address from '{address}' for guest "
+            f"index {index}: derived address exceeds the IP address space. "
+            "Use a larger base network or explicit per-guest network settings."
+        )
+
+    return str(ipaddress.ip_address(new_address))
 
 
 class GuestIpResolver(ABC):
@@ -151,10 +215,53 @@ class OpenVmmController:
             openvmm.set_binary_path("openvmm")
         return openvmm
 
+    def create_effective_network(
+        self, network: OpenVmmNetworkSchema, guest_index: int
+    ) -> OpenVmmNetworkSchema:
+        effective_network = copy.deepcopy(network)
+        if effective_network.mode != OPENVMM_NETWORK_MODE_TAP:
+            return effective_network
+
+        base_tap_host_cidr = effective_network.tap_host_cidr
+        effective_network.tap_name = _increment_name_suffix(
+            effective_network.tap_name, guest_index
+        )
+        effective_network.bridge_name = _increment_name_suffix(
+            effective_network.bridge_name, guest_index
+        )
+        effective_network.tap_host_cidr = _shift_ip_interface_cidr(
+            effective_network.tap_host_cidr, guest_index
+        )
+        effective_network.guest_address = _shift_ip_address(
+            effective_network.guest_address, base_tap_host_cidr, guest_index
+        )
+        effective_network.consomme_cidr = _shift_ip_interface_cidr(
+            effective_network.consomme_cidr, guest_index
+        )
+        if effective_network.forward_ssh_port:
+            effective_network.forwarded_port += guest_index
+            if effective_network.forwarded_port > 65535:
+                raise LisaException(
+                    "cannot derive OpenVMM forwarded SSH port from "
+                    f"'{network.forwarded_port}' for guest index {guest_index}: "
+                    "derived port exceeds 65535. Use a lower base forwarded_port."
+                )
+
+        return effective_network
+
+    def _get_node_network(
+        self, node: "OpenVmmGuestNode", node_context: NodeContext
+    ) -> OpenVmmNetworkSchema:
+        if node_context.effective_network:
+            return cast(OpenVmmNetworkSchema, node_context.effective_network)
+
+        return cast(OpenVmmGuestNodeSchema, node.runbook).network
+
     def launch(self, node: "OpenVmmGuestNode", log: Logger) -> None:
         runbook = cast(OpenVmmGuestNodeSchema, node.runbook)
         node_context = get_node_context(node)
-        self._prepare_tap_network(runbook.network, node_context)
+        network = self._get_node_network(node, node_context)
+        self._prepare_tap_network(network, node_context)
         launch_config = OpenVmmLaunchConfig(
             uefi_firmware_path=node_context.uefi_firmware_path,
             disk_img_path=node_context.disk_img_path,
@@ -165,9 +272,9 @@ class OpenVmmController:
             ),
             processors=_countspace_to_int(node.capability.core_count),
             memory_mb=_countspace_to_int(node.capability.memory_mb),
-            network_mode=runbook.network.mode,
-            tap_name=getattr(runbook.network, "tap_name", ""),
-            network_cidr=runbook.network.consomme_cidr,
+            network_mode=network.mode,
+            tap_name=getattr(network, "tap_name", ""),
+            network_cidr=network.consomme_cidr,
             serial_mode=runbook.serial.mode,
             serial_path=node_context.console_log_file_path,
             extra_args=runbook.extra_args,
@@ -180,9 +287,9 @@ class OpenVmmController:
         node_context.process_id = openvmm.launch_vm(
             launch_config,
             cwd=launch_cwd,
-            sudo=runbook.network.mode == OPENVMM_NETWORK_MODE_TAP,
+            sudo=network.mode == OPENVMM_NETWORK_MODE_TAP,
         )
-        self._ensure_process_running(node_context, runbook.network)
+        self._ensure_process_running(node_context, network)
         log.debug(
             f"Launched OpenVMM VM '{node_context.vm_name}' with pid "
             f"{node_context.process_id}"
@@ -571,8 +678,8 @@ class OpenVmmController:
 
     def configure_connection(self, node: RemoteNode, log: Logger) -> None:
         runbook = cast(OpenVmmGuestNodeSchema, node.runbook)
-        network = runbook.network
         node_context = get_node_context(node)
+        network = self._get_node_network(cast(OpenVmmGuestNode, node), node_context)
 
         guest_address = self._resolve_guest_address(node_context, network, log)
         node_context.guest_address = guest_address
@@ -613,7 +720,7 @@ class OpenVmmController:
                 "configuration is correct, the SSH service is listening on the "
                 "expected port, and review the OpenVMM guest and host logs for "
                 "startup or networking errors. "
-                f"{self._get_openvmm_failure_context(node_context, runbook.network)}"
+                f"{self._get_openvmm_failure_context(node_context, network)}"
             ) from identifier
         if not is_ready:
             raise LisaException(
@@ -623,7 +730,7 @@ class OpenVmmController:
                 "port forwarding or network configuration is correct, the SSH "
                 "service is listening on the expected port, and review the "
                 "OpenVMM guest and host logs for startup or networking errors. "
-                f"{self._get_openvmm_failure_context(node_context, runbook.network)}"
+                f"{self._get_openvmm_failure_context(node_context, network)}"
             )
 
     def _resolve_guest_address(
@@ -953,7 +1060,7 @@ class OpenVmmController:
         self._disable_ssh_forwarding(node)
         self._teardown_tap_network(
             node_context,
-            cast(OpenVmmGuestNodeSchema, node.runbook).network,
+            self._get_node_network(cast(OpenVmmGuestNode, node), node_context),
         )
 
         if wait_failure:
@@ -1143,7 +1250,7 @@ class OpenVmmController:
         node_context = get_node_context(node)
         self._disable_ssh_forwarding_context(
             node_context,
-            cast(OpenVmmGuestNodeSchema, node.runbook).network,
+            self._get_node_network(cast(OpenVmmGuestNode, node), node_context),
         )
 
     def _disable_ssh_forwarding_context(
@@ -1436,6 +1543,11 @@ class OpenVmmGuestNode(RemoteNode):
         node_context = get_node_context(self)
         node_context.vm_name = vm_name
         node_context.host = host_node
+        node_context.effective_network = (
+            self._openvmm_controller.create_effective_network(
+                runbook.network, self.index
+            )
+        )
 
         base_working_path = host_node.get_pure_path(runbook.lisa_working_dir)
         working_path = base_working_path / vm_name

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -195,7 +195,9 @@ class OpenVmmController:
         self._log.info(
             f"Copying OpenVMM artifact '{source.name}' to host path '{destination}'."
         )
-        self.host_node.shell.copy(source, destination)
+        host_context = get_host_context(self.host_node)
+        with host_context.artifact_copy_lock:
+            self.host_node.shell.copy(source, destination)
         self._log.info(
             f"Copied OpenVMM artifact '{source.name}' to host path "
             f"'{destination}' in {copy_timer.elapsed_text()}."
@@ -350,10 +352,12 @@ class OpenVmmController:
                     ("/meta-data", meta_data_string),
                 ],
             )
-            self.host_node.shell.copy(
-                Path(iso_path),
-                self.host_node.get_pure_path(node_context.cloud_init_file_path),
-            )
+            host_context = get_host_context(self.host_node)
+            with host_context.artifact_copy_lock:
+                self.host_node.shell.copy(
+                    Path(iso_path),
+                    self.host_node.get_pure_path(node_context.cloud_init_file_path),
+                )
         finally:
             tmp_dir.cleanup()
 

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -97,13 +97,9 @@ class StaticAddressResolver(GuestIpResolver):
 
 
 class OpenVmmController:
-    def __init__(self, node: "OpenVmmGuestNode") -> None:
-        self._node = node
-        host_node = node.parent
-        if host_node is None:
-            raise LisaException("OpenVMM guest node must have a parent host node")
+    def __init__(self, host_node: Node, log: Logger) -> None:
         self.host_node = host_node
-        self._log = node.log
+        self._log = log
 
     @classmethod
     def type_name(cls) -> str:
@@ -1357,7 +1353,10 @@ class OpenVmmGuestNode(RemoteNode):
             encoding=encoding,
             **kwargs,
         )
-        self._openvmm_controller = OpenVmmController(self)
+        host_node = self.parent
+        if host_node is None:
+            raise LisaException("OpenVMM guest node must have a parent host node")
+        self._openvmm_controller = OpenVmmController(host_node, self.log)
         self._initialize_capability()
         self.features = Features(self, cast(Any, self._openvmm_controller))
 

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -47,6 +47,7 @@ OPENVMM_IP_DISCOVERY_TIMEOUT = 300
 # Capture enough recent log lines to include the relevant launch or boot failure.
 OPENVMM_LOG_TAIL_LINES = 40
 OPENVMM_DHCP_SERVER_PORT = 67
+OPENVMM_DNS_SERVER_PORT = 53
 OPENVMM_BRIDGE_NETFILTER_KEYS = [
     "net.bridge.bridge-nf-call-iptables",
     "net.bridge.bridge-nf-call-arptables",
@@ -126,7 +127,15 @@ class OpenVmmController:
             :8
         ]
         destination = working_path / f"{source.stem}-{source_id}{source.suffix}"
+        copy_timer = create_timer()
+        self._log.info(
+            f"Copying OpenVMM artifact '{source.name}' to host path '{destination}'."
+        )
         self.host_node.shell.copy(source, destination)
+        self._log.info(
+            f"Copied OpenVMM artifact '{source.name}' to host path "
+            f"'{destination}' in {copy_timer.elapsed_text()}."
+        )
         return str(destination)
 
     def get_openvmm_tool(self, binary_path: str) -> OpenVmm:
@@ -374,7 +383,9 @@ class OpenVmmController:
         ip_tool.up(tap_name)
 
         if network.address_mode != OPENVMM_ADDRESS_MODE_STATIC:
-            self._ensure_tap_dhcp_input_allowed(host_interface_name, node_context)
+            self._ensure_tap_host_services_input_allowed(
+                host_interface_name, node_context
+            )
             pid_file = f"/var/run/qemu-dnsmasq-{host_interface_name}.pid"
             lease_file = f"/var/run/qemu-dnsmasq-{host_interface_name}.leases"
             host.execute(
@@ -400,6 +411,10 @@ class OpenVmmController:
                 kill_existing=False,
                 pid_file=pid_file,
                 lease_file=lease_file,
+                dhcp_options=[
+                    f"option:router,{tap_gateway}",
+                    f"option:dns-server,{tap_gateway}",
+                ],
             )
             node_context.tap_dnsmasq_pid_file = pid_file
             node_context.tap_dnsmasq_lease_file = lease_file
@@ -481,7 +496,7 @@ class OpenVmmController:
                 expected_exit_code_failure_message=failure_message,
             )
 
-    def _ensure_tap_dhcp_input_allowed(
+    def _ensure_tap_host_services_input_allowed(
         self, host_interface_name: str, node_context: NodeContext
     ) -> None:
         iptables_exists = self.host_node.execute(
@@ -495,31 +510,47 @@ class OpenVmmController:
         if iptables_exists.exit_code != 0:
             return
 
-        rule = (
-            f"INPUT -i {shlex.quote(host_interface_name)} -p udp -m udp "
-            f"--dport {OPENVMM_DHCP_SERVER_PORT} -j ACCEPT"
-        )
-        check_result = self.host_node.execute(
-            f"iptables -C {rule}",
-            shell=True,
-            sudo=True,
-            no_info_log=True,
-            no_error_log=True,
-            expected_exit_code=None,
-        )
-        if check_result.exit_code == 0:
-            return
+        for rule in self._get_tap_host_service_input_rules(host_interface_name):
+            check_result = self.host_node.execute(
+                f"iptables -C {rule}",
+                shell=True,
+                sudo=True,
+                no_info_log=True,
+                no_error_log=True,
+                expected_exit_code=None,
+            )
+            if check_result.exit_code == 0:
+                continue
 
-        self.host_node.execute(
-            f"iptables -I {rule}",
-            shell=True,
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=(
-                "failed to allow DHCP traffic to the OpenVMM host interface"
+            self.host_node.execute(
+                f"iptables -I {rule}",
+                shell=True,
+                sudo=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    "failed to allow OpenVMM DHCP/DNS traffic to the host "
+                    f"interface {host_interface_name}"
+                ),
+            )
+            node_context.tap_input_rules_added.append(rule)
+            node_context.tap_dhcp_input_rule_added = True
+
+    def _get_tap_host_service_input_rules(self, host_interface_name: str) -> List[str]:
+        quoted_interface = shlex.quote(host_interface_name)
+        return [
+            (
+                f"INPUT -i {quoted_interface} -p udp -m udp "
+                f"--dport {OPENVMM_DHCP_SERVER_PORT} -j ACCEPT"
             ),
-        )
-        node_context.tap_dhcp_input_rule_added = True
+            (
+                f"INPUT -i {quoted_interface} -p udp -m udp "
+                f"--dport {OPENVMM_DNS_SERVER_PORT} -j ACCEPT"
+            ),
+            (
+                f"INPUT -i {quoted_interface} -p tcp -m tcp "
+                f"--dport {OPENVMM_DNS_SERVER_PORT} -j ACCEPT"
+            ),
+        ]
 
     def _get_tap_network_config(self, network: OpenVmmNetworkSchema) -> tuple[str, str]:
         host_interface = ipaddress.ip_interface(network.tap_host_cidr)
@@ -1264,18 +1295,19 @@ class OpenVmmController:
         if network.mode != OPENVMM_NETWORK_MODE_TAP:
             return
 
-        if node_context.tap_dhcp_input_rule_added:
+        if node_context.tap_dhcp_input_rule_added or node_context.tap_input_rules_added:
             host_interface_name = _get_tap_host_interface_name(network)
-            self.host_node.execute(
-                (
-                    "iptables -D INPUT -i "
-                    f"{shlex.quote(host_interface_name)} -p udp -m udp "
-                    f"--dport {OPENVMM_DHCP_SERVER_PORT} -j ACCEPT || true"
-                ),
-                shell=True,
-                sudo=True,
-                expected_exit_code=0,
+            rules_to_remove = node_context.tap_input_rules_added or (
+                self._get_tap_host_service_input_rules(host_interface_name)
             )
+            for rule in rules_to_remove:
+                self.host_node.execute(
+                    f"iptables -D {rule} || true",
+                    shell=True,
+                    sudo=True,
+                    expected_exit_code=0,
+                )
+            node_context.tap_input_rules_added.clear()
             node_context.tap_dhcp_input_rule_added = False
 
         if node_context.tap_dnsmasq_pid_file:

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -191,13 +191,50 @@ class OpenVmmController:
             :8
         ]
         destination = working_path / f"{source.stem}-{source_id}{source.suffix}"
+        cache_directory = working_path.parent / ".openvmm-artifacts"
+        cache_path = cache_directory / f"{source.stem}-{source_id}{source.suffix}"
+        cache_key = str(source.resolve())
         copy_timer = create_timer()
-        self._log.info(
-            f"Copying OpenVMM artifact '{source.name}' to host path '{destination}'."
-        )
         host_context = get_host_context(self.host_node)
         with host_context.artifact_copy_lock:
-            self.host_node.shell.copy(source, destination)
+            cached_path = host_context.artifact_cache.get(cache_key)
+            if not cached_path:
+                self.host_node.execute(
+                    f"mkdir -p {shlex.quote(str(cache_directory))}",
+                    shell=True,
+                    expected_exit_code=0,
+                    expected_exit_code_failure_message=(
+                        "failed to create OpenVMM artifact cache directory "
+                        f"'{cache_directory}'"
+                    ),
+                )
+                self._log.info(
+                    f"Copying OpenVMM artifact '{source.name}' to host cache "
+                    f"'{cache_path}'."
+                )
+                self.host_node.shell.copy(source, cache_path)
+                host_context.artifact_cache[cache_key] = str(cache_path)
+                self._log.info(
+                    f"Copied OpenVMM artifact '{source.name}' to host cache "
+                    f"'{cache_path}' in {copy_timer.elapsed_text()}."
+                )
+            else:
+                self._log.debug(
+                    f"Using cached OpenVMM artifact '{source.name}' from "
+                    f"'{cached_path}'."
+                )
+
+            self.host_node.execute(
+                "cp -f --reflink=auto "
+                f"{shlex.quote(host_context.artifact_cache[cache_key])} "
+                f"{shlex.quote(str(destination))}",
+                shell=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    f"failed to clone OpenVMM artifact '{source.name}' from host "
+                    f"cache to '{destination}'"
+                ),
+            )
         self._log.info(
             f"Copied OpenVMM artifact '{source.name}' to host path "
             f"'{destination}' in {copy_timer.elapsed_text()}."

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from __future__ import annotations
+
 import copy
 import hashlib
 import io
@@ -187,17 +189,41 @@ class OpenVmmController:
         if not source.exists():
             raise LisaException(f"file does not exist: {source_path}")
 
-        source_id = hashlib.sha256(str(source.resolve()).encode("utf-8")).hexdigest()[
-            :8
-        ]
+        # Include mtime+size in the cache key so the entry is invalidated when
+        # the local file changes between calls (same path, new content).
+        source_stat = source.stat()
+        source_id = hashlib.sha256(
+            f"{source.resolve()}|{source_stat.st_mtime}|{source_stat.st_size}".encode(
+                "utf-8"
+            )
+        ).hexdigest()[:8]
         destination = working_path / f"{source.stem}-{source_id}{source.suffix}"
         cache_directory = working_path.parent / ".openvmm-artifacts"
         cache_path = cache_directory / f"{source.stem}-{source_id}{source.suffix}"
-        cache_key = str(source.resolve())
+        cache_key = f"{source.resolve()}|{source_stat.st_mtime}|{source_stat.st_size}"
         copy_timer = create_timer()
         host_context = get_host_context(self.host_node)
+
+        # Narrow the lock to the cache-miss path so that once the shared cache
+        # entry is populated, other guests can do their per-guest cp in parallel.
         with host_context.artifact_copy_lock:
             cached_path = host_context.artifact_cache.get(cache_key)
+
+            # Verify the cached remote path still exists; repopulate if removed.
+            if cached_path:
+                check = self.host_node.execute(
+                    f"test -f {shlex.quote(cached_path)}",
+                    shell=True,
+                    expected_exit_code=None,
+                )
+                if check.exit_code != 0:
+                    self._log.debug(
+                        f"Cached OpenVMM artifact '{cached_path}' no longer "
+                        "exists on the remote host; re-uploading."
+                    )
+                    cached_path = None
+                    del host_context.artifact_cache[cache_key]
+
             if not cached_path:
                 self.host_node.execute(
                     f"mkdir -p {shlex.quote(str(cache_directory))}",
@@ -214,6 +240,7 @@ class OpenVmmController:
                 )
                 self.host_node.shell.copy(source, cache_path)
                 host_context.artifact_cache[cache_key] = str(cache_path)
+                cached_path = str(cache_path)
                 self._log.info(
                     f"Copied OpenVMM artifact '{source.name}' to host cache "
                     f"'{cache_path}' in {copy_timer.elapsed_text()}."
@@ -224,9 +251,25 @@ class OpenVmmController:
                     f"'{cached_path}'."
                 )
 
+        # Per-guest copy is done outside the lock so multiple guests on the same
+        # host can proceed in parallel once the shared cache is warm.
+        # Try copy-on-write (reflink) first; fall back to a plain copy when the
+        # filesystem does not support it (e.g. ext4 without reflink patches).
+        result = self.host_node.execute(
+            f"cp --reflink=auto "
+            f"{shlex.quote(cached_path)} "
+            f"{shlex.quote(str(destination))}",
+            shell=True,
+            expected_exit_code=None,
+        )
+        if result.exit_code != 0:
+            self._log.debug(
+                f"cp --reflink=auto failed (exit {result.exit_code}), "
+                f"attempting plain copy fallback: {result.stderr or result.stdout}"
+            )
             self.host_node.execute(
-                "cp -f --reflink=auto "
-                f"{shlex.quote(host_context.artifact_cache[cache_key])} "
+                f"cp -f "
+                f"{shlex.quote(cached_path)} "
                 f"{shlex.quote(str(destination))}",
                 shell=True,
                 expected_exit_code=0,
@@ -292,7 +335,7 @@ class OpenVmmController:
         self, node: "OpenVmmGuestNode", node_context: NodeContext
     ) -> OpenVmmNetworkSchema:
         if node_context.effective_network:
-            return cast(OpenVmmNetworkSchema, node_context.effective_network)
+            return node_context.effective_network
 
         return cast(OpenVmmGuestNodeSchema, node.runbook).network
 
@@ -681,7 +724,6 @@ class OpenVmmController:
                 ),
             )
             node_context.tap_input_rules_added.append(rule)
-            node_context.tap_dhcp_input_rule_added = True
 
     def _get_tap_host_service_input_rules(self, host_interface_name: str) -> List[str]:
         quoted_interface = shlex.quote(host_interface_name)
@@ -1443,11 +1485,8 @@ class OpenVmmController:
         if network.mode != OPENVMM_NETWORK_MODE_TAP:
             return
 
-        if node_context.tap_dhcp_input_rule_added or node_context.tap_input_rules_added:
-            host_interface_name = _get_tap_host_interface_name(network)
-            rules_to_remove = node_context.tap_input_rules_added or (
-                self._get_tap_host_service_input_rules(host_interface_name)
-            )
+        if node_context.tap_input_rules_added:
+            rules_to_remove = node_context.tap_input_rules_added
             for rule in rules_to_remove:
                 self.host_node.execute(
                     f"iptables -D {rule} || true",
@@ -1456,7 +1495,6 @@ class OpenVmmController:
                     expected_exit_code=0,
                 )
             node_context.tap_input_rules_added.clear()
-            node_context.tap_dhcp_input_rule_added = False
 
         if node_context.tap_dnsmasq_pid_file:
             self.host_node.execute(

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -3,12 +3,13 @@
 
 import ipaddress
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from dataclasses_json import config, dataclass_json
 
 from lisa import schema
 from lisa.secret import PATTERN_HEADTAIL, add_secret
+from lisa.sut_orchestrator.util.schema import CloudInitSchema
 from lisa.util import LisaException
 
 from .. import OPENVMM
@@ -20,12 +21,6 @@ OPENVMM_NETWORK_MODE_USER = "user"
 OPENVMM_NETWORK_MODE_TAP = "tap"
 OPENVMM_SERIAL_MODE_STDERR = "stderr"
 OPENVMM_SERIAL_MODE_FILE = "file"
-
-
-@dataclass_json()
-@dataclass
-class CloudInitSchema:
-    extra_user_data: Optional[Union[str, List[str]]] = None
 
 
 @dataclass_json()

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -1,8 +1,15 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Union, cast
+from typing import List, Optional, Union, cast
 
 from dataclasses_json import dataclass_json
+
+
+@dataclass_json()
+@dataclass
+class CloudInitSchema:
+    # Additional values to apply to the cloud-init user-data file.
+    extra_user_data: Optional[Union[str, List[str]]] = None
 
 
 class HostDevicePoolType(Enum):

--- a/lisa/tools/dnsmasq.py
+++ b/lisa/tools/dnsmasq.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import shlex
+from typing import List, Optional
 
 from lisa.executable import Tool
 from lisa.operating_system import Posix
@@ -32,6 +33,7 @@ class Dnsmasq(Tool):
         kill_existing: bool = True,
         pid_file: str = "",
         lease_file: str = "",
+        dhcp_options: Optional[List[str]] = None,
     ) -> None:
         if stop_firewall:
             # stop firewall
@@ -49,20 +51,23 @@ class Dnsmasq(Tool):
 
         # setup dnsmasq on interface `nic_name` and listen on `nic_address`
         # assign dhcp address in `dhcp_range`
-        cmd = shlex.join(
-            [
-                "--strict-order",
-                "--except-interface=lo",
-                f"--interface={nic_name}",
-                f"--listen-address={gateway}",
-                "--bind-interfaces",
-                f"--dhcp-range={dhcp_range}",
-                "--conf-file=",
-                f"--pid-file={pid_file}",
-                f"--dhcp-leasefile={lease_file}",
-                "--dhcp-no-override",
-            ]
-        )
+        command_parts = [
+            "--strict-order",
+            "--except-interface=lo",
+            f"--interface={nic_name}",
+            f"--listen-address={gateway}",
+            "--bind-interfaces",
+            f"--dhcp-range={dhcp_range}",
+            "--conf-file=",
+            f"--pid-file={pid_file}",
+            f"--dhcp-leasefile={lease_file}",
+            "--dhcp-no-override",
+        ]
+        if dhcp_options:
+            command_parts.extend(
+                f"--dhcp-option={dhcp_option}" for dhcp_option in dhcp_options
+            )
+        cmd = shlex.join(command_parts)
 
         # start dnsmasq
         self.run(

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -58,6 +58,7 @@ class RunnerTestCase(TestCase):
 
     def setUp(self) -> None:
         lisa.environment._global_environment_id = 0
+        test_testsuite.cleanup_cases_metadata()  # Clear any globally-registered cases
 
     def tearDown(self) -> None:
         test_testsuite.cleanup_cases_metadata()  # Necessary side effects!

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 from lisa.sut_orchestrator.openvmm.context import NodeContext
 from lisa.sut_orchestrator.openvmm.node import OpenVmmController, OpenVmmGuestNode
 from lisa.sut_orchestrator.openvmm.schema import (
+    OPENVMM_NETWORK_MODE_TAP,
     OpenVmmGuestNodeSchema,
     OpenVmmNetworkSchema,
     OpenVmmUefiSchema,
@@ -124,6 +125,36 @@ class OpenVmmNodeTestCase(TestCase):
             cwd=PurePosixPath("/var/tmp/openvmm-host-g0"),
             sudo=False,
         )
+
+    def test_create_effective_network_derives_unique_tap_settings(self) -> None:
+        controller, _, _, _ = self._create_controller()
+        network = OpenVmmNetworkSchema(
+            mode=OPENVMM_NETWORK_MODE_TAP,
+            tap_name="tap0",
+            bridge_name="ovmbr0",
+            tap_host_cidr="10.0.0.1/24",
+            guest_address="10.0.0.2",
+            consomme_cidr="10.0.0.0/24",
+            forward_ssh_port=True,
+            forwarded_port=60022,
+        )
+
+        first_guest_network = controller.create_effective_network(network, 0)
+        third_guest_network = controller.create_effective_network(network, 2)
+
+        self.assertEqual("tap0", first_guest_network.tap_name)
+        self.assertEqual("ovmbr0", first_guest_network.bridge_name)
+        self.assertEqual("10.0.0.1/24", first_guest_network.tap_host_cidr)
+        self.assertEqual("10.0.0.2", first_guest_network.guest_address)
+        self.assertEqual(60022, first_guest_network.forwarded_port)
+        self.assertEqual("tap2", third_guest_network.tap_name)
+        self.assertEqual("ovmbr2", third_guest_network.bridge_name)
+        self.assertEqual("10.0.2.1/24", third_guest_network.tap_host_cidr)
+        self.assertEqual("10.0.2.2", third_guest_network.guest_address)
+        self.assertEqual("10.0.2.0/24", third_guest_network.consomme_cidr)
+        self.assertEqual(60024, third_guest_network.forwarded_port)
+        self.assertEqual("tap0", network.tap_name)
+        self.assertEqual("10.0.0.1/24", network.tap_host_cidr)
 
     def test_provision_uses_host_pure_path_for_working_directory(self) -> None:
         host_node = SimpleNamespace(

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -32,8 +32,7 @@ class OpenVmmNodeTestCase(TestCase):
             shell=SimpleNamespace(copy=shell_copy),
             tools={Kill: SimpleNamespace(by_pid=kill_by_pid)},
         )
-        guest_node = SimpleNamespace(parent=host_node, log=guest_log)
-        controller = OpenVmmController(cast(Any, guest_node))
+        controller = OpenVmmController(cast(Any, host_node), cast(Any, guest_log))
         return controller, shell_copy, kill_by_pid, guest_log
 
     def test_resolve_guest_artifact_path_uses_unique_names(self) -> None:

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -29,6 +29,7 @@ class OpenVmmNodeTestCase(TestCase):
         guest_log = MagicMock()
         host_node = SimpleNamespace(
             is_remote=True,
+            execute=MagicMock(),
             get_pure_path=PurePosixPath,
             shell=SimpleNamespace(copy=shell_copy),
             tools={Kill: SimpleNamespace(by_pid=kill_by_pid)},
@@ -62,6 +63,26 @@ class OpenVmmNodeTestCase(TestCase):
 
         self.assertNotEqual(first_destination, second_destination)
         self.assertEqual(2, shell_copy.call_count)
+
+    def test_resolve_guest_artifact_path_reuses_host_cache(self) -> None:
+        controller, shell_copy, _, _ = self._create_controller()
+        with TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "guest.raw"
+            source.write_text("disk")
+
+            first_destination = controller.resolve_guest_artifact_path(
+                str(source),
+                is_remote_path=False,
+                working_path=PurePath("/var/tmp/openvmm/g0"),
+            )
+            second_destination = controller.resolve_guest_artifact_path(
+                str(source),
+                is_remote_path=False,
+                working_path=PurePath("/var/tmp/openvmm/g1"),
+            )
+
+        self.assertNotEqual(first_destination, second_destination)
+        self.assertEqual(1, shell_copy.call_count)
 
     def test_stop_node_kills_process_after_wait_timeout(self) -> None:
         controller, _, kill_by_pid, guest_log = self._create_controller()

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -27,9 +27,12 @@ class OpenVmmNodeTestCase(TestCase):
         shell_copy = MagicMock()
         kill_by_pid = MagicMock()
         guest_log = MagicMock()
+        # execute() returns a result with exit_code=0 so that cache freshness
+        # checks (test -f ...) appear to succeed and the cache is reused.
+        execute_result = SimpleNamespace(exit_code=0, stderr="", stdout="")
         host_node = SimpleNamespace(
             is_remote=True,
-            execute=MagicMock(),
+            execute=MagicMock(return_value=execute_result),
             get_pure_path=PurePosixPath,
             shell=SimpleNamespace(copy=shell_copy),
             tools={Kill: SimpleNamespace(by_pid=kill_by_pid)},

--- a/selftests/test_openvmm_tests_suite.py
+++ b/selftests/test_openvmm_tests_suite.py
@@ -12,6 +12,7 @@ from lisa.microsoft.testsuites.openvmm.openvmm_tests import (
     _get_openvmm_tests_type,
 )
 from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import _JUnitSummary
+from lisa.operating_system import Ubuntu
 from lisa.tools import Ls, Uname
 from lisa.tools.usermod import Usermod
 from lisa.util import SkippedException
@@ -137,6 +138,27 @@ class OpenVmmTestsSuiteTestCase(TestCase):
         )
 
         self.assertEqual(result, "(test(linux_direct) | test(ubuntu) | test(alpine))")
+
+    def test_before_case_initializes_host_before_os_check(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        host = MagicMock()
+        tool = MagicMock()
+        openvmm_tests_type = _get_openvmm_tests_type()
+        host.tools = {openvmm_tests_type: tool}
+
+        def initialize_host() -> None:
+            host.os = object.__new__(Ubuntu)
+
+        host.initialize.side_effect = initialize_host
+
+        suite.before_case(
+            MagicMock(),
+            node=host,
+            variables={"openvmm_tests_repo": "https://example.com/openvmm.git"},
+        )
+
+        host.initialize.assert_called_once()
+        self.assertEqual("https://example.com/openvmm.git", tool.repo_url)
 
     def test_verify_openvmm_upstream_vmm_tests_sets_multiline_summary(self) -> None:
         suite = self._suite_type.__new__(self._suite_type)

--- a/selftests/test_openvmm_tests_suite.py
+++ b/selftests/test_openvmm_tests_suite.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from lisa.microsoft.testsuites.openvmm.openvmm_tests import (
+    OpenVmmUpstreamTestSuite,
+    _get_openvmm_tests_type,
+)
+from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import _JUnitSummary
+from lisa.tools import Ls, Uname
+from lisa.tools.usermod import Usermod
+from lisa.util import SkippedException
+
+
+class OpenVmmTestsSuiteTestCase(TestCase):
+    _suite_type = cast(Any, OpenVmmUpstreamTestSuite).__wrapped__
+
+    def _create_host(self, kernel_version_raw: str = "6.8.0-generic") -> MagicMock:
+        uname = MagicMock()
+        uname.get_linux_information.return_value = SimpleNamespace(
+            hardware_platform="x86_64",
+            kernel_version_raw=kernel_version_raw,
+        )
+        host = MagicMock()
+        host.tools = {Uname: uname}
+        return host
+
+    def test_ensure_vmm_tests_supported_raises_when_mshv_is_not_accessible(
+        self,
+    ) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        uname = MagicMock()
+        uname.get_linux_information.return_value = SimpleNamespace(
+            hardware_platform="x86_64"
+        )
+        ls = MagicMock()
+        ls.path_exists.side_effect = lambda path, sudo: path in (
+            "/dev/kvm",
+            "/dev/mshv",
+        )
+        usermod = MagicMock()
+        host = MagicMock()
+        host.tools = {Uname: uname, Ls: ls, Usermod: usermod}
+        host.execute.side_effect = [
+            SimpleNamespace(exit_code=0),
+            SimpleNamespace(exit_code=1),
+            SimpleNamespace(exit_code=1),
+        ]
+
+        with self.assertRaises(SkippedException) as context:
+            suite._ensure_vmm_tests_supported(host)
+
+        self.assertIn("detect /dev/mshv before /dev/kvm", str(context.exception))
+        self.assertEqual(usermod.add_user_to_group.call_count, 2)
+
+    def test_ensure_vmm_tests_supported_accepts_accessible_mshv(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        uname = MagicMock()
+        uname.get_linux_information.return_value = SimpleNamespace(
+            hardware_platform="x86_64"
+        )
+        ls = MagicMock()
+        ls.path_exists.side_effect = lambda path, sudo: path == "/dev/mshv"
+        usermod = MagicMock()
+        host = MagicMock()
+        host.tools = {Uname: uname, Ls: ls, Usermod: usermod}
+        host.execute.return_value = SimpleNamespace(exit_code=0)
+
+        suite._ensure_vmm_tests_supported(host)
+
+        usermod.add_user_to_group.assert_called_once_with("mshv", sudo=True)
+
+    def test_ensure_vmm_tests_supported_uses_mshv_group_wrapper(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        uname = MagicMock()
+        uname.get_linux_information.return_value = SimpleNamespace(
+            hardware_platform="x86_64"
+        )
+        ls = MagicMock()
+        ls.path_exists.side_effect = lambda path, sudo: path == "/dev/mshv"
+        usermod = MagicMock()
+        host = MagicMock()
+        host.tools = {Uname: uname, Ls: ls, Usermod: usermod}
+        host.execute.side_effect = [
+            SimpleNamespace(exit_code=1),
+            SimpleNamespace(exit_code=0),
+        ]
+
+        result = suite._ensure_vmm_tests_supported(host)
+
+        self.assertEqual(result, "mshv")
+
+    def test_ensure_vmm_tests_supported_raises_when_no_backend_is_accessible(
+        self,
+    ) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        uname = MagicMock()
+        uname.get_linux_information.return_value = SimpleNamespace(
+            hardware_platform="x86_64"
+        )
+        ls = MagicMock()
+        ls.path_exists.side_effect = lambda path, sudo: path == "/dev/kvm"
+        usermod = MagicMock()
+        host = MagicMock()
+        host.tools = {Uname: uname, Ls: ls, Usermod: usermod}
+        host.execute.return_value = SimpleNamespace(exit_code=1)
+
+        with self.assertRaises(SkippedException) as context:
+            suite._ensure_vmm_tests_supported(host)
+
+        self.assertIn("cannot open either device", str(context.exception))
+
+    def test_compose_vmm_tests_filter_excludes_pcat_on_native_linux(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+
+        result = suite._compose_vmm_tests_filter(
+            {"openvmm_vmm_tests_guest_os": "linux"},
+            self._create_host(),
+        )
+
+        self.assertEqual(
+            result,
+            "((test(linux_direct) | test(ubuntu) | test(alpine))) & (!test(pcat))",
+        )
+
+    def test_compose_vmm_tests_filter_keeps_pcat_on_wsl(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+
+        result = suite._compose_vmm_tests_filter(
+            {"openvmm_vmm_tests_guest_os": "linux"},
+            self._create_host("6.6.87.2-microsoft-standard-WSL2"),
+        )
+
+        self.assertEqual(result, "(test(linux_direct) | test(ubuntu) | test(alpine))")
+
+    def test_verify_openvmm_upstream_vmm_tests_sets_multiline_summary(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        host = MagicMock()
+        node = MagicMock()
+        node.parent = host
+        tool = MagicMock()
+        tool.run_vmm_tests.return_value = _JUnitSummary(
+            tests=3,
+            passed=3,
+            skipped=45,
+            passed_tests=[
+                "multiarch::openvmm_uefi_x64_ubuntu_2404_server_x64_boot",
+                "multiarch::ic::openvmm_uefi_x64_ubuntu_2504_server_x64_timesync_ic",
+                "multiarch::vmgs::openvmm_uefi_x64_ubuntu_2504_server_x64_default_boot",
+            ],
+        )
+        tool.format_run_summary.return_value = (
+            "3 tests run: 3 passed, 0 failed, 45 skipped\n"
+            "Passed tests:\n"
+            "  - multiarch::openvmm_uefi_x64_ubuntu_2404_server_x64_boot"
+        )
+        host.tools = {_get_openvmm_tests_type(): tool}
+
+        result = SimpleNamespace(message="")
+
+        suite._get_host_node = MagicMock(return_value=host)
+        suite._ensure_vmm_tests_supported = MagicMock(return_value="")
+        suite._is_truthy = MagicMock(return_value=True)
+        suite._compose_vmm_tests_filter = MagicMock(return_value="")
+
+        suite.verify_openvmm_upstream_vmm_tests(
+            node=node,
+            log_path=Path("."),
+            result=result,
+            variables={},
+        )
+
+        self.assertIn("upstream vmm_tests:", result.message)
+        self.assertIn("3 tests run: 3 passed, 0 failed, 45 skipped", result.message)

--- a/selftests/test_openvmm_tests_suite.py
+++ b/selftests/test_openvmm_tests_suite.py
@@ -158,7 +158,9 @@ class OpenVmmTestsSuiteTestCase(TestCase):
         )
 
         host.initialize.assert_called_once()
-        self.assertEqual("https://example.com/openvmm.git", tool.repo_url)
+        tool.configure_repository.assert_called_once_with(
+            "https://example.com/openvmm.git", ""
+        )
 
     def test_verify_openvmm_upstream_vmm_tests_sets_multiline_summary(self) -> None:
         suite = self._suite_type.__new__(self._suite_type)

--- a/selftests/test_openvmm_tests_tool.py
+++ b/selftests/test_openvmm_tests_tool.py
@@ -1,0 +1,159 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import OpenVmmTests
+from lisa.util import LisaException
+
+
+class OpenVmmTestsToolTestCase(TestCase):
+    def test_check_vmm_tests_results_raises_on_junit_failures(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            log_file = temp_path / "openvmm_vmm_tests.log"
+            junit_file = temp_path / "openvmm_vmm_tests.junit.xml"
+            log_file.write_text("", encoding="utf-8")
+            junit_file.write_text(
+                """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="x64-linux-vmm-tests" tests="17" failures="7" errors="0" skipped="41">
+    <testcase
+      classname="vmm_tests::tests"
+      name="multiarch::ic::openvmm_uefi_x64_ubuntu_2504_server_x64_timesync_ic">
+      <failure message="failed">stack</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(LisaException) as context:
+                tool._check_vmm_tests_results(
+                    name="openvmm_vmm_tests",
+                    log_file=log_file,
+                    junit_file=junit_file,
+                )
+
+            self.assertIn(
+                "17 tests run: 0 passed, 7 failed, 41 skipped",
+                str(context.exception),
+            )
+            self.assertIn("Failed tests:", str(context.exception))
+        self.assertIn(
+            "multiarch::ic::openvmm_uefi_x64_ubuntu_2504_server_x64_timesync_ic",
+            str(context.exception),
+        )
+
+    def test_check_vmm_tests_results_raises_on_log_summary_without_junit(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            log_file = temp_path / "openvmm_vmm_tests.log"
+            log_file.write_text(
+                """
+Summary [   0.071s] 7/17 tests run: 0 passed, 7 failed, 41 skipped
+    FAIL [   0.069s] vmm_tests::tests
+          multiarch::ic::openvmm_uefi_x64_ubuntu_2504_server_x64_timesync_ic
+warning: 10/17 tests were not run due to test failure
+error: test run failed
+encountered at least one test failure!
+encountered test failures.
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(LisaException) as context:
+                tool._check_vmm_tests_results(
+                    name="openvmm_vmm_tests",
+                    log_file=log_file,
+                    junit_file=temp_path / "missing.junit.xml",
+                )
+
+            self.assertIn(
+                "7/17 tests run: 0 passed, 7 failed, 41 skipped",
+                str(context.exception),
+            )
+        self.assertIn("7 failed", str(context.exception))
+
+    def test_check_vmm_tests_results_deduplicates_failed_tests_and_reports_passes(
+        self,
+    ) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            log_file = temp_path / "openvmm_vmm_tests.log"
+            log_file.write_text(
+                """
+Summary [ 600.338s] 3 tests run: 2 passed, 1 failed, 45 skipped
+    PASS [ 120.000s] vmm_tests::tests
+          multiarch::openvmm_uefi_x64_ubuntu_2404_server_x64_boot
+    PASS [ 130.000s] vmm_tests::tests
+          multiarch::ic::openvmm_uefi_x64_ubuntu_2504_server_x64_timesync_ic
+    FAIL [ 600.335s] vmm_tests::tests
+          multiarch::openvmm_uefi_x64_alpine_3_23_x64_boot_small
+    FAIL [ 600.335s] vmm_tests::tests
+          multiarch::openvmm_uefi_x64_alpine_3_23_x64_boot_small
+encountered at least one test failure!
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(LisaException) as context:
+                tool._check_vmm_tests_results(
+                    name="openvmm_vmm_tests",
+                    log_file=log_file,
+                    junit_file=temp_path / "missing.junit.xml",
+                )
+
+        message = str(context.exception)
+        self.assertIn("3 tests run: 2 passed, 1 failed, 45 skipped", message)
+        self.assertIn("Passed tests:", message)
+        self.assertIn("Failed tests:", message)
+        failed_test_name = "multiarch::openvmm_uefi_x64_alpine_3_23_x64_boot_small"
+        self.assertEqual(
+            1,
+            message.count(failed_test_name),
+        )
+
+    def test_check_vmm_tests_results_accepts_passing_junit(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            log_file = temp_path / "openvmm_vmm_tests.log"
+            junit_file = temp_path / "openvmm_vmm_tests.junit.xml"
+            log_file.write_text("", encoding="utf-8")
+            junit_file.write_text(
+                """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="x64-linux-vmm-tests" tests="2" failures="0" errors="0" skipped="1">
+    <testcase classname="vmm_tests::tests" name="multiarch::openvmm_boot" />
+    <testcase classname="vmm_tests::tests" name="multiarch::openvmm_skip">
+      <skipped message="filtered" />
+    </testcase>
+  </testsuite>
+</testsuites>
+""",
+                encoding="utf-8",
+            )
+
+            summary = tool._check_vmm_tests_results(
+                name="openvmm_vmm_tests",
+                log_file=log_file,
+                junit_file=junit_file,
+            )
+
+        self.assertEqual(2, summary.tests)
+        self.assertEqual(1, summary.skipped)
+        self.assertEqual(
+            ["vmm_tests::tests multiarch::openvmm_boot"],
+            summary.passed_tests,
+        )

--- a/selftests/test_openvmm_tests_tool.py
+++ b/selftests/test_openvmm_tests_tool.py
@@ -1,15 +1,62 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import OpenVmmTests
+from lisa.tools import Curl
 from lisa.util import LisaException
 
 
 class OpenVmmTestsToolTestCase(TestCase):
+    def test_run_logged_command_redirects_entire_command_to_log(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+        tool.repo_root = PurePosixPath("/repo/openvmm")
+        tool._artifact_root = PurePosixPath("/repo/openvmm/target/lisa-openvmm-tests")
+        tool.node = MagicMock()
+        tool.node.execute.return_value = SimpleNamespace(exit_code=0)
+        with TemporaryDirectory() as temp_dir, patch.object(
+            tool, "_copy_back_if_exists"
+        ):
+            tool._run_logged_command(
+                name="openvmm_sample",
+                command="echo before && false",
+                log_path=Path(temp_dir),
+                timeout=60,
+                update_envs={},
+            )
+
+        logged_command = tool.node.execute.call_args.args[0]
+        self.assertIn(
+            "{ echo before && false; } > "
+            "/repo/openvmm/target/lisa-openvmm-tests/openvmm_sample.log 2>&1",
+            logged_command,
+        )
+
+    def test_ensure_cargo_nextest_uses_release_checksum_asset(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+        tool._artifact_root = PurePosixPath("/repo/openvmm/target/lisa-openvmm-tests")
+        tool.node = MagicMock()
+        tool.node.tools = {Curl: SimpleNamespace(command="curl")}
+        tool._log = MagicMock()
+        with TemporaryDirectory() as temp_dir, patch.object(
+            tool, "_has_cargo_nextest", side_effect=[False, True]
+        ), patch.object(tool, "_run_logged_command") as run_logged_command:
+            tool._ensure_cargo_nextest(Path(temp_dir), {})
+
+        install_command = run_logged_command.call_args.kwargs["command"]
+        release_url = (
+            "https://github.com/nextest-rs/nextest/releases/download/"
+            "cargo-nextest-0.9.101"
+        )
+        asset_name = "cargo-nextest-0.9.101-x86_64-unknown-linux-gnu"
+        self.assertIn(f"{release_url}/{asset_name}.tar.gz", install_command)
+        self.assertIn(f"{release_url}/{asset_name}.sha256", install_command)
+
     def test_check_vmm_tests_results_raises_on_junit_failures(self) -> None:
         tool = OpenVmmTests.__new__(OpenVmmTests)
 

--- a/selftests/test_openvmm_tests_tool.py
+++ b/selftests/test_openvmm_tests_tool.py
@@ -13,6 +13,21 @@ from lisa.util import LisaException
 
 
 class OpenVmmTestsToolTestCase(TestCase):
+    def test_set_repo_paths_uses_repo_url_hash(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+
+        with patch.object(tool, "get_tool_path", return_value=PurePosixPath("/tools")):
+            tool.repo_url = "https://example.com/first/openvmm.git"
+            tool._set_repo_paths()
+            first_repo_root = tool.repo_root
+
+            tool.repo_url = "https://example.com/second/openvmm.git"
+            tool._set_repo_paths()
+
+        self.assertNotEqual(first_repo_root, tool.repo_root)
+        self.assertTrue(str(first_repo_root).startswith("/tools/openvmm-"))
+        self.assertTrue(str(tool.repo_root).startswith("/tools/openvmm-"))
+
     def test_run_logged_command_redirects_entire_command_to_log(self) -> None:
         tool = OpenVmmTests.__new__(OpenVmmTests)
         tool.repo_root = PurePosixPath("/repo/openvmm")
@@ -204,3 +219,36 @@ encountered at least one test failure!
             ["vmm_tests::tests multiarch::openvmm_boot"],
             summary.passed_tests,
         )
+
+    def test_archive_remote_directory_logs_warning_on_failure(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+        tool.node = MagicMock()
+        tool._log = MagicMock()
+        tool.node.execute.return_value = SimpleNamespace(
+            exit_code=1, stdout="", stderr="No such file or directory"
+        )
+
+        tool._archive_remote_directory(
+            source_dir=PurePosixPath("/remote/artifacts"),
+            archive_path=PurePosixPath("/remote/artifacts.tar.gz"),
+        )
+
+        tool._log.warning.assert_called_once()
+        warning_message = tool._log.warning.call_args.args[0]
+        self.assertIn("/remote/artifacts", warning_message)
+        self.assertIn("/remote/artifacts.tar.gz", warning_message)
+
+    def test_archive_remote_directory_does_not_warn_on_success(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+        tool.node = MagicMock()
+        tool._log = MagicMock()
+        tool.node.execute.return_value = SimpleNamespace(
+            exit_code=0, stdout="", stderr=""
+        )
+
+        tool._archive_remote_directory(
+            source_dir=PurePosixPath("/remote/artifacts"),
+            archive_path=PurePosixPath("/remote/artifacts.tar.gz"),
+        )
+
+        tool._log.warning.assert_not_called()


### PR DESCRIPTION
## Description

Adds an OpenVMM “upstream vmm_tests” test suite and supporting Tool implementation, along with unit tests and a small schema refactor to share cloud-init configuration.

Changes:

Introduces OpenVmmUpstreamTestSuite.verify_openvmm_upstream_vmm_tests to run upstream OpenVMM vmm_tests on a Linux x64 host with configurable guest/filter options.
Adds OpenVmmTests Tool to clone/prepare the OpenVMM repo, run the upstream flowey pipeline, and parse results from JUnit/log output.
Refactors CloudInitSchema into a shared sut_orchestrator/util/schema.py location and updates OpenVMM/Libvirt schemas accordingly.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
