### PR TITLE
[AI Generated] BugFix: Handle missing cache topology in lscpu output for verify_l3_cache

### DIFF
--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -121,6 +121,16 @@ class CPU(TestSuite):
         # For all other cases, check L3 cache mapping with socket awareness
         cpu_info = lscpu.get_cpu_info()
 
+        # On some VMs (e.g. confidential VMs), cache topology is not exposed
+        # by the hypervisor, so lscpu reports "-" for all cache values.
+        # In this case, we cannot verify L3 cache mapping.
+        if any(cpu.l3_cache == -1 for cpu in cpu_info):
+            raise SkippedException(
+                "Cache topology is not exposed on this VM. "
+                "lscpu reports no cache information (likely a confidential VM "
+                "or a VM size that does not expose cache topology to the guest)."
+            )
+
         # Build a mapping of socket -> NUMA nodes and socket -> L3 caches
         socket_to_numa_nodes: dict[int, set[int]] = {}
         socket_to_l3_caches: dict[int, set[int]] = {}
@@ -299,6 +309,11 @@ class CPU(TestSuite):
 
     def _verify_node_mapping(self, node: Node, numa_node_size: int) -> None:
         cpu_info = node.tools[Lscpu].get_cpu_info()
+        if any(cpu.l3_cache == -1 for cpu in cpu_info):
+            raise SkippedException(
+                "Cache topology is not exposed on this VM. "
+                "lscpu reports no cache information."
+            )
         cpu_info.sort(key=lambda cpu: cpu.cpu)
         for i, cpu in enumerate(cpu_info):
             numa_node_id = i // numa_node_size

--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -23,6 +23,7 @@ from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import AzureNodeSchema
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.tools import Cat, InterruptInspector, Lscpu, TaskSet, Uname
+from lisa.tools.lscpu import UNKNOWN_CACHE_ID
 
 hyperv_interrupt_substr = ["hyperv", "hypervsum", "Hypervisor", "Hyper-V"]
 
@@ -124,11 +125,21 @@ class CPU(TestSuite):
         # On some VMs (e.g. confidential VMs), cache topology is not exposed
         # by the hypervisor, so lscpu reports "-" for all cache values.
         # In this case, we cannot verify L3 cache mapping.
-        if any(cpu.l3_cache == -1 for cpu in cpu_info):
+        unknown_l3_cache_count = sum(
+            1 for cpu in cpu_info if cpu.l3_cache == UNKNOWN_CACHE_ID
+        )
+        if unknown_l3_cache_count == len(cpu_info):
             raise SkippedException(
                 "Cache topology is not exposed on this VM. "
                 "lscpu reports no cache information (likely a confidential VM "
                 "or a VM size that does not expose cache topology to the guest)."
+            )
+        if unknown_l3_cache_count:
+            raise LisaException(
+                "Inconsistent L3 cache topology reported by lscpu: "
+                f"{unknown_l3_cache_count} of {len(cpu_info)} CPUs have unknown "
+                "L3 cache IDs while others have valid values. Investigate lscpu "
+                "parsing or host cache-topology exposure on this VM."
             )
 
         # Build a mapping of socket -> NUMA nodes and socket -> L3 caches
@@ -309,10 +320,20 @@ class CPU(TestSuite):
 
     def _verify_node_mapping(self, node: Node, numa_node_size: int) -> None:
         cpu_info = node.tools[Lscpu].get_cpu_info()
-        if any(cpu.l3_cache == -1 for cpu in cpu_info):
+        unknown_l3_cache_count = sum(
+            1 for cpu in cpu_info if cpu.l3_cache == UNKNOWN_CACHE_ID
+        )
+        if unknown_l3_cache_count == len(cpu_info):
             raise SkippedException(
                 "Cache topology is not exposed on this VM. "
                 "lscpu reports no cache information."
+            )
+        if unknown_l3_cache_count:
+            raise LisaException(
+                "Inconsistent L3 cache topology reported by lscpu: "
+                f"{unknown_l3_cache_count} of {len(cpu_info)} CPUs have unknown "
+                "L3 cache IDs while others have valid values. Investigate lscpu "
+                "parsing or host cache-topology exposure on this VM."
             )
         cpu_info.sort(key=lambda cpu: cpu.cpu)
         for i, cpu in enumerate(cpu_info):

--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -327,7 +327,7 @@ class CPU(TestSuite):
 
     def _check_cache_topology_exposed(
         self,
-        cpu_info: list,
+        cpu_info: list[Any],
         skip_message: str,
     ) -> None:
         # On some VMs (e.g. confidential VMs), cache topology is not exposed

--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -122,25 +122,14 @@ class CPU(TestSuite):
         # For all other cases, check L3 cache mapping with socket awareness
         cpu_info = lscpu.get_cpu_info()
 
-        # On some VMs (e.g. confidential VMs), cache topology is not exposed
-        # by the hypervisor, so lscpu reports "-" for all cache values.
-        # In this case, we cannot verify L3 cache mapping.
-        unknown_l3_cache_count = sum(
-            1 for cpu in cpu_info if cpu.l3_cache == UNKNOWN_CACHE_ID
-        )
-        if unknown_l3_cache_count == len(cpu_info):
-            raise SkippedException(
+        self._check_cache_topology_exposed(
+            cpu_info,
+            skip_message=(
                 "Cache topology is not exposed on this VM. "
                 "lscpu reports no cache information (likely a confidential VM "
                 "or a VM size that does not expose cache topology to the guest)."
-            )
-        if unknown_l3_cache_count:
-            raise LisaException(
-                "Inconsistent L3 cache topology reported by lscpu: "
-                f"{unknown_l3_cache_count} of {len(cpu_info)} CPUs have unknown "
-                "L3 cache IDs while others have valid values. Investigate lscpu "
-                "parsing or host cache-topology exposure on this VM."
-            )
+            ),
+        )
 
         # Build a mapping of socket -> NUMA nodes and socket -> L3 caches
         socket_to_numa_nodes: dict[int, set[int]] = {}
@@ -320,21 +309,13 @@ class CPU(TestSuite):
 
     def _verify_node_mapping(self, node: Node, numa_node_size: int) -> None:
         cpu_info = node.tools[Lscpu].get_cpu_info()
-        unknown_l3_cache_count = sum(
-            1 for cpu in cpu_info if cpu.l3_cache == UNKNOWN_CACHE_ID
-        )
-        if unknown_l3_cache_count == len(cpu_info):
-            raise SkippedException(
+        self._check_cache_topology_exposed(
+            cpu_info,
+            skip_message=(
                 "Cache topology is not exposed on this VM. "
                 "lscpu reports no cache information."
-            )
-        if unknown_l3_cache_count:
-            raise LisaException(
-                "Inconsistent L3 cache topology reported by lscpu: "
-                f"{unknown_l3_cache_count} of {len(cpu_info)} CPUs have unknown "
-                "L3 cache IDs while others have valid values. Investigate lscpu "
-                "parsing or host cache-topology exposure on this VM."
-            )
+            ),
+        )
         cpu_info.sort(key=lambda cpu: cpu.cpu)
         for i, cpu in enumerate(cpu_info):
             numa_node_id = i // numa_node_size
@@ -343,6 +324,28 @@ class CPU(TestSuite):
                 "L3 cache of each core must be mapped to the NUMA node "
                 "associated with the core.",
             ).is_equal_to(numa_node_id)
+
+    def _check_cache_topology_exposed(
+        self,
+        cpu_info: list,
+        skip_message: str,
+    ) -> None:
+        # On some VMs (e.g. confidential VMs), cache topology is not exposed
+        # by the hypervisor, so lscpu reports "-" for all cache values.
+        # If all CPUs lack cache info, skip the test. If only some do, treat it
+        # as a real failure so a partial/mixed state isn't silently masked.
+        unknown_l3_cache_count = sum(
+            1 for cpu in cpu_info if cpu.l3_cache == UNKNOWN_CACHE_ID
+        )
+        if unknown_l3_cache_count == len(cpu_info):
+            raise SkippedException(skip_message)
+        if unknown_l3_cache_count:
+            raise LisaException(
+                "Inconsistent L3 cache topology reported by lscpu: "
+                f"{unknown_l3_cache_count} of {len(cpu_info)} CPUs have unknown "
+                "L3 cache IDs while others have valid values. Investigate lscpu "
+                "parsing or host cache-topology exposure on this VM."
+            )
 
     def _is_one_to_one_mapping(
         self,

--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -91,6 +91,12 @@ class Lscpu(Tool):
         r"(?P<l1_data_cache>\d+):(?P<l1_instruction_cache>\d+):"
         r"(?P<l2_cache>\d+):(?P<l3_cache>\d+)$"
     )
+    # On some VMs (e.g. confidential VMs), cache topology is not exposed
+    # and lscpu outputs "-" instead of cache IDs:
+    # 0 0 0 -
+    _core_numa_no_cache = re.compile(
+        r"\s*(?P<cpu>\d+)\s+(?P<numa_node>\d+)\s+(?P<socket>\d+)\s+-$"
+    )
     # Model name:          Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz
     # Model name:          AMD EPYC 7763 64-Core Processor
     #   Model name:          AMD EPYC 7763 64-Core Processor
@@ -267,6 +273,10 @@ class Lscpu(Tool):
         # CPU NODE SOCKET L1d:L1i:L2:L3
         # 0    0        0 0:0:0:0
         # 1    0        0 0:0:0:0
+        #
+        # On some VMs (e.g. confidential VMs), cache topology is not exposed:
+        # CPU NODE SOCKET CACHE
+        # 0    0        0 -
         result = self.run(
             "--extended=cpu,node,socket,cache", expected_exit_code=0
         ).stdout
@@ -278,21 +288,37 @@ class Lscpu(Tool):
         output: List[CPUInfo] = []
         for item in mappings:
             match_result = self._core_numa_mappings.fullmatch(item)
-            assert (
-                match_result
-            ), f"lscpu NUMA node mapping is not in expected format: {item}"
-            output.append(
-                CPUInfo(
-                    cpu=int(match_result.group("cpu")),
-                    numa_node=int(match_result.group("numa_node")),
-                    socket=int(match_result.group("socket")),
-                    l1_data_cache=int(match_result.group("l1_data_cache")),
-                    l1_instruction_cache=int(
-                        match_result.group("l1_instruction_cache")
-                    ),
-                    l2_cache=int(match_result.group("l2_cache")),
-                    l3_cache=int(match_result.group("l3_cache")),
+            if match_result:
+                output.append(
+                    CPUInfo(
+                        cpu=int(match_result.group("cpu")),
+                        numa_node=int(match_result.group("numa_node")),
+                        socket=int(match_result.group("socket")),
+                        l1_data_cache=int(match_result.group("l1_data_cache")),
+                        l1_instruction_cache=int(
+                            match_result.group("l1_instruction_cache")
+                        ),
+                        l2_cache=int(match_result.group("l2_cache")),
+                        l3_cache=int(match_result.group("l3_cache")),
+                    )
                 )
+                continue
+            no_cache_match = self._core_numa_no_cache.fullmatch(item)
+            if no_cache_match:
+                output.append(
+                    CPUInfo(
+                        cpu=int(no_cache_match.group("cpu")),
+                        numa_node=int(no_cache_match.group("numa_node")),
+                        socket=int(no_cache_match.group("socket")),
+                        l1_data_cache=-1,
+                        l1_instruction_cache=-1,
+                        l2_cache=-1,
+                        l3_cache=-1,
+                    )
+                )
+                continue
+            raise AssertionError(
+                f"lscpu NUMA node mapping is not in expected format: {item}"
             )
         return output
 

--- a/lisa/tools/lscpu.py
+++ b/lisa/tools/lscpu.py
@@ -19,6 +19,12 @@ CpuType = Enum(
 )
 
 
+# Sentinel value used in CPUInfo cache fields when lscpu does not expose
+# cache topology (e.g. confidential VMs where lscpu outputs "-" for the
+# CACHE column instead of "L1d:L1i:L2:L3").
+UNKNOWN_CACHE_ID = -1
+
+
 class CPUInfo:
     def __init__(
         self,
@@ -310,15 +316,18 @@ class Lscpu(Tool):
                         cpu=int(no_cache_match.group("cpu")),
                         numa_node=int(no_cache_match.group("numa_node")),
                         socket=int(no_cache_match.group("socket")),
-                        l1_data_cache=-1,
-                        l1_instruction_cache=-1,
-                        l2_cache=-1,
-                        l3_cache=-1,
+                        l1_data_cache=UNKNOWN_CACHE_ID,
+                        l1_instruction_cache=UNKNOWN_CACHE_ID,
+                        l2_cache=UNKNOWN_CACHE_ID,
+                        l3_cache=UNKNOWN_CACHE_ID,
                     )
                 )
                 continue
-            raise AssertionError(
-                f"lscpu NUMA node mapping is not in expected format: {item}"
+            raise LisaException(
+                "lscpu NUMA node mapping is not in the expected format: "
+                f"{item}. Verify the output of "
+                "'lscpu --extended=cpu,node,socket,cache' on the target node "
+                "and update the parser if the format has changed."
             )
         return output
 


### PR DESCRIPTION
## Summary
On confidential VMs (e.g. Standard_DC2ads_v5), `lscpu --extended=cpu,node,socket,cache` outputs `-` in the CACHE column instead of `L1d:L1i:L2:L3` format. This caused `verify_l3_cache` to fail with an assertion error. The fix adds a secondary regex to handle the `-` format and raises SkippedException when cache topology is not exposed to the guest.

## Validation Results
| Image | VM Size | Result |
|-------|---------|--------|
| Canonical ubuntu-24_04-lts server 24.04.202408210 | Standard_D2ds_v5 | PASSED |
| Canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm 22.04.202604150 | Standard_DC2ads_v5 | SKIPPED (expected) |