### PR TITLE
Fix flash-kernel hook failures during source kernel install on Ubuntu ARM64

### DIFF
--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -276,7 +276,7 @@ class SourceInstaller(BaseInstaller):
             lscpu = node.tools[Lscpu]
             if (
                 isinstance(node.os, Ubuntu)
-                and arch == CpuArchitecture.ARM64
+                and lscpu.get_architecture() == CpuArchitecture.ARM64
                 and node.shell.exists(
                     node.get_pure_path("/etc/initramfs/post-update.d/flash-kernel")
                 )

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -270,28 +270,30 @@ class SourceInstaller(BaseInstaller):
             result = node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
             result.assert_exit_code()
         else:
-            # On Ubuntu ARM64, flash-kernel postinst hook fails because
-            # there is no supported board on Azure VMs. Neutralize it
-            # before running make install.
+            # On Ubuntu ARM64, the flash-kernel package hooks into both
+            # initramfs post-update and kernel postinst. It always fails
+            # on Azure VMs because there is no recognized ARM board/DTB.
+            # Disable all flash-kernel hooks before running make install.
             lscpu = node.tools[Lscpu]
             if (
                 isinstance(node.os, Ubuntu)
                 and lscpu.get_architecture() == CpuArchitecture.ARM64
-                and node.shell.exists(
-                    node.get_pure_path("/etc/initramfs/post-update.d/flash-kernel")
-                )
             ):
                 self._log.info(
-                    "Disabling flash-kernel hook on Ubuntu ARM64 "
+                    "Disabling flash-kernel hooks on Ubuntu ARM64 "
                     "(unsupported on Azure VMs)"
                 )
-                result = node.execute(
-                    "echo '#!/bin/sh\nexit 0' > "
+                for hook_path in [
                     "/etc/initramfs/post-update.d/flash-kernel",
-                    sudo=True,
-                    shell=True,
-                )
-                result.assert_exit_code()
+                    "/etc/kernel/postinst.d/zz-flash-kernel",
+                ]:
+                    node.execute(
+                        f"test -f {hook_path} && "
+                        f"mv {hook_path} {hook_path}.disabled "
+                        f"|| true",
+                        sudo=True,
+                        shell=True,
+                    )
             make.make(arguments="install", cwd=code_path, sudo=True)
 
         # The build for Redhat needs extra steps than RPM package. So put it

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -270,6 +270,28 @@ class SourceInstaller(BaseInstaller):
             result = node.execute("grub2-mkconfig -o /boot/grub2/grub.cfg", sudo=True)
             result.assert_exit_code()
         else:
+            # On Ubuntu ARM64, flash-kernel postinst hook fails because
+            # there is no supported board on Azure VMs. Neutralize it
+            # before running make install.
+            lscpu = node.tools[Lscpu]
+            if (
+                isinstance(node.os, Ubuntu)
+                and arch == CpuArchitecture.ARM64
+                and node.shell.exists(
+                    node.get_pure_path("/etc/initramfs/post-update.d/flash-kernel")
+                )
+            ):
+                self._log.info(
+                    "Disabling flash-kernel hook on Ubuntu ARM64 "
+                    "(unsupported on Azure VMs)"
+                )
+                result = node.execute(
+                    "echo '#!/bin/sh\nexit 0' > "
+                    "/etc/initramfs/post-update.d/flash-kernel",
+                    sudo=True,
+                    shell=True,
+                )
+                result.assert_exit_code()
             make.make(arguments="install", cwd=code_path, sudo=True)
 
         # The build for Redhat needs extra steps than RPM package. So put it

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -339,6 +339,7 @@ class SourceInstaller(BaseInstaller):
                             overwrite=True,
                             sudo=True,
                         )
+                        self._log.info(f"Disabled flash-kernel hook: {hook_path}")
             make.make(arguments="install", cwd=code_path, sudo=True)
 
         # The build for Redhat needs extra steps than RPM package. So put it

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -292,16 +292,33 @@ class SourceInstaller(BaseInstaller):
                         "Disabling flash-kernel hooks (machine not supported "
                         "by flash-kernel)"
                     )
+                    mv = node.tools[Mv]
                     for hook_path in [
                         "/etc/initramfs/post-update.d/flash-kernel",
                         "/etc/kernel/postinst.d/zz-flash-kernel",
                     ]:
-                        node.execute(
-                            f"test -f {hook_path} && "
-                            f"mv {hook_path} {hook_path}.disabled "
-                            f"|| true",
+                        # Check existence and rename in two distinct steps so
+                        # that a missing hook is silently skipped (expected on
+                        # images without flash-kernel installed) but any other
+                        # mv failure (permissions, read-only fs, etc.) is
+                        # surfaced rather than swallowed by `|| true`.
+                        exists_check = node.execute(
+                            f"test -f {hook_path}",
                             sudo=True,
                             shell=True,
+                            no_error_log=True,
+                        )
+                        if exists_check.exit_code != 0:
+                            self._log.debug(
+                                f"flash-kernel hook not present, skipping: "
+                                f"{hook_path}"
+                            )
+                            continue
+                        mv.move(
+                            hook_path,
+                            f"{hook_path}.disabled",
+                            overwrite=True,
+                            sudo=True,
                         )
             make.make(arguments="install", cwd=code_path, sudo=True)
 

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -293,10 +293,8 @@ class SourceInstaller(BaseInstaller):
                     no_error_log=True,
                 )
                 if fk_present.exit_code != 0:
-                    self._log.debug(
-                        "flash-kernel not installed; skipping hook disable"
-                    )
-                    fk_check_exit_code = 0  # nothing to disable
+                    self._log.debug("flash-kernel not installed; skipping hook disable")
+                    fk_check_exit_code: Optional[int] = 0  # nothing to disable
                 else:
                     fk_check = node.execute(
                         "flash-kernel --supported",
@@ -305,7 +303,9 @@ class SourceInstaller(BaseInstaller):
                         no_error_log=True,
                     )
                     fk_check_exit_code = fk_check.exit_code
-                if fk_check_exit_code != 0:
+                # Treat a missing exit code (None) the same as "supported": do
+                # nothing. We only disable hooks on an explicit non-zero exit.
+                if fk_check_exit_code not in (None, 0):
                     self._log.info(
                         "Disabling flash-kernel hooks (machine not supported "
                         "by flash-kernel)"

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -288,7 +288,8 @@ class SourceInstaller(BaseInstaller):
                 # emitting a misleading "machine not supported" line for
                 # what is really a "tool not installed" situation.
                 fk_present = node.execute(
-                    "command -v flash-kernel",
+                    "command -v flash-kernel || test -x /usr/sbin/flash-kernel",
+                    sudo=True,
                     shell=True,
                     no_error_log=True,
                 )

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -271,29 +271,38 @@ class SourceInstaller(BaseInstaller):
             result.assert_exit_code()
         else:
             # On Ubuntu ARM64, the flash-kernel package hooks into both
-            # initramfs post-update and kernel postinst. It always fails
-            # on Azure VMs because there is no recognized ARM board/DTB.
-            # Disable all flash-kernel hooks before running make install.
+            # initramfs post-update and kernel postinst. On environments
+            # without a recognized ARM board/DTB (e.g., Azure VMs), these
+            # hooks fail and block make install. Only disable them when
+            # flash-kernel reports the machine is unsupported, so that
+            # bare-metal boards that rely on flash-kernel remain bootable.
             lscpu = node.tools[Lscpu]
             if (
                 isinstance(node.os, Ubuntu)
                 and lscpu.get_architecture() == CpuArchitecture.ARM64
             ):
-                self._log.info(
-                    "Disabling flash-kernel hooks on Ubuntu ARM64 "
-                    "(unsupported on Azure VMs)"
+                fk_check = node.execute(
+                    "flash-kernel --supported",
+                    sudo=True,
+                    shell=True,
+                    no_error_log=True,
                 )
-                for hook_path in [
-                    "/etc/initramfs/post-update.d/flash-kernel",
-                    "/etc/kernel/postinst.d/zz-flash-kernel",
-                ]:
-                    node.execute(
-                        f"test -f {hook_path} && "
-                        f"mv {hook_path} {hook_path}.disabled "
-                        f"|| true",
-                        sudo=True,
-                        shell=True,
+                if fk_check.exit_code != 0:
+                    self._log.info(
+                        "Disabling flash-kernel hooks (machine not supported "
+                        "by flash-kernel)"
                     )
+                    for hook_path in [
+                        "/etc/initramfs/post-update.d/flash-kernel",
+                        "/etc/kernel/postinst.d/zz-flash-kernel",
+                    ]:
+                        node.execute(
+                            f"test -f {hook_path} && "
+                            f"mv {hook_path} {hook_path}.disabled "
+                            f"|| true",
+                            sudo=True,
+                            shell=True,
+                        )
             make.make(arguments="install", cwd=code_path, sudo=True)
 
         # The build for Redhat needs extra steps than RPM package. So put it

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -281,13 +281,31 @@ class SourceInstaller(BaseInstaller):
                 isinstance(node.os, Ubuntu)
                 and lscpu.get_architecture() == CpuArchitecture.ARM64
             ):
-                fk_check = node.execute(
-                    "flash-kernel --supported",
-                    sudo=True,
+                # Pre-check: only run the --supported probe when the
+                # flash-kernel binary is actually present. This keeps the
+                # log message honest on images that never installed
+                # flash-kernel (where hooks don't exist anyway), and avoids
+                # emitting a misleading "machine not supported" line for
+                # what is really a "tool not installed" situation.
+                fk_present = node.execute(
+                    "command -v flash-kernel",
                     shell=True,
                     no_error_log=True,
                 )
-                if fk_check.exit_code != 0:
+                if fk_present.exit_code != 0:
+                    self._log.debug(
+                        "flash-kernel not installed; skipping hook disable"
+                    )
+                    fk_check_exit_code = 0  # nothing to disable
+                else:
+                    fk_check = node.execute(
+                        "flash-kernel --supported",
+                        sudo=True,
+                        shell=True,
+                        no_error_log=True,
+                    )
+                    fk_check_exit_code = fk_check.exit_code
+                if fk_check_exit_code != 0:
                     self._log.info(
                         "Disabling flash-kernel hooks (machine not supported "
                         "by flash-kernel)"


### PR DESCRIPTION
## Problem

On Ubuntu ARM64 VMs, the `flash-kernel` package hooks fail during `make install` because there is no recognized ARM board/DTB. This aborts the entire kernel install step.

## Fix

Before `make install`, detect Ubuntu + ARM64 and rename both hook scripts to `.disabled`. Only executes for Ubuntu ARM64 — no impact on x86, Redhat, or Mariner paths. Missing hooks are handled gracefully.