### PR TITLE
[AI Generated] BugFix: don't assert in unsubscribe_log when handler is missing

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -282,7 +282,12 @@ class TestResult:
         if is_unittest():
             return
 
-        assert self._log_file_handler, "Log file handler is not set"
+        # The handler may not have been created if subscribe_log raised before
+        # create_file_handler ran (e.g. log path could not be created). In that
+        # case there is nothing to detach; skip rather than mask the real error
+        # with an AssertionError from the surrounding finally block.
+        if not self._log_file_handler:
+            return
         remove_handler(self._log_file_handler, log)
 
     def get_case_log_path(self) -> Path:


### PR DESCRIPTION
## Problem

When deploying an environment, `lisa_runner._deploy_environment_task` does:

```python
try:
    test_result.subscribe_log(environment.log)
    ...
finally:
    test_result.unsubscribe_log(environment.log)
```

`subscribe_log` lazily creates the per-case log file handler the first time it runs. If that creation fails (e.g. the case log directory can't be created, the path is too long on Windows, the disk is full, or `relative_to(RUN_LOCAL_LOG_PATH)` raises), `self._log_file_handler` stays `None`. The `finally` block still calls `unsubscribe_log`, which then trips:

```
File ".../lisa/testsuite.py", line 285, in unsubscribe_log
    assert self._log_file_handler, "Log file handler is not set"
AssertionError: Log file handler is not set
```

That `AssertionError` masks the original deployment / log-setup error, making the real failure invisible in CI.

## Change

In `lisa/testsuite.py`, replace the `assert` in `unsubscribe_log` with a defensive early return when the handler was never attached. There's nothing to detach in that case, and the original exception then propagates normally.

No other behavior changes.