### PR TITLE
Use x64 as default arch for .vhd images

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -563,6 +563,13 @@ class VhdSchema(AzureImageSchema):
     data_vhd_paths: Optional[List[DataVhdPath]] = None
 
     def load_from_platform(self, platform: "AzurePlatform") -> None:
+        # VHD images are user-provided custom images. Azure does not expose
+        # architecture metadata for them, and uploaded VHDs in this codepath
+        # are x64. Restrict candidate VM sizes to x64 to avoid selecting
+        # ARM64 SKUs that would fail to boot the VHD.
+        if self.architecture is None:
+            self.architecture = schema.ArchitectureType.x64
+
         # There are no platform tags to parse, but we can assume the
         # security profile based on the presence of a VMGS path.
         if self.cvm_gueststate_path:


### PR DESCRIPTION
## Description

OS disk vhd doesn't come with any arch details. I found LISA trying to use arm64 sizes for x86 vhds and fail when test VM size is specified. This PR will use x86 as default arch for any vhd when no arch is provided.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
- verify_nvme_basic
- verify_nvme_function
- verify_nvme_function_unpartitioned
- verify_nvme_fstrim
- verify_nvme_blkdiscard
- verify_nvme_manage_ns
- verify_nvme_rescind

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-pro-microsoft pro-fips-20_04 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-pro-microsoft pro-fips-20_04 latest|Standard_L8as_v3| PASSED |
