### PR TITLE
Apply guest requirements to guest environments

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -20,6 +20,7 @@ from lisa.action import ActionStatus
 from lisa.environment import (
     Environment,
     Environments,
+    EnvironmentSpace,
     EnvironmentStatus,
     load_environments,
 )
@@ -296,6 +297,7 @@ class LisaRunner(BaseRunner):
     def _deploy_environment_task(
         self, environment: Environment, test_results: List[TestResult]
     ) -> None:
+        test_result: Optional[TestResult] = None
         try:
             test_result = test_results[0]
             test_result.subscribe_log(environment.log)
@@ -324,14 +326,18 @@ class LisaRunner(BaseRunner):
                 environment.status = EnvironmentStatus.New
             else:
                 # Final attempt failed; handle the failure
-                self._attach_failed_environment_to_result(
-                    environment=environment,
-                    result=test_result,
-                    exception=e,
-                )
+                if test_result:
+                    self._attach_failed_environment_to_result(
+                        environment=environment,
+                        result=test_result,
+                        exception=e,
+                    )
                 self._delete_environment_task(environment=environment, test_results=[])
+                if not test_result:
+                    raise
         finally:
-            test_result.unsubscribe_log(environment.log)
+            if test_result:
+                test_result.unsubscribe_log(environment.log)
 
     def _initialize_environment_task(
         self, environment: Environment, test_results: List[TestResult]
@@ -823,6 +829,7 @@ class LisaRunner(BaseRunner):
             # object cross test results.
             platform_requirement = self._create_platform_requirement()
             test_req: TestCaseRequirement = test_result.runtime_data.requirement
+            environment_requirement: Optional[EnvironmentSpace] = None
 
             check_result = test_result.check_platform(platform_type)
             if not check_result.result:
@@ -838,98 +845,23 @@ class LisaRunner(BaseRunner):
                 if ignored_features:
                     cases_ignored_features[test_result.name] = ignored_features
 
-                environment_requirement = copy.deepcopy(test_req.environment)
-                if platform_requirement:
-                    node_count = 1
+                if getattr(self, "_guest_enabled", False):
+                    environment_requirement = self._create_guest_parent_requirement(
+                        platform_requirement
+                    )
+                else:
+                    environment_requirement = copy.deepcopy(test_req.environment)
 
-                    if platform_requirement.node_count:
-                        # get minimun node count from the runbook.
-                        node_count = search_space.choose_value_countspace(
-                            platform_requirement.node_count,
-                            platform_requirement.node_count,
-                        )
-
-                        # Reset to 1 since platform_requirement will be used as
-                        # a template for intersecting with individual node
-                        # requirements, not for the entire environment
-                        platform_requirement.node_count = 1
-
-                    # Use the larger node count between test requirements and
-                    # runbook settings to support scaling scenarios where
-                    # runbook overrides test defaults
-                    node_count = max(len(environment_requirement.nodes), node_count)
-                    node_requirement_data: Dict[str, Any] = {}
-                    for index in range(node_count):
-                        if index < len(environment_requirement.nodes):
-                            node_requirement = environment_requirement.nodes[index]
-
-                            node_requirement_data = (
-                                node_requirement.to_dict()  # type: ignore
-                            )
-                        else:
-                            # Runbook has bigger node count, copy from the last
-                            # node space of the environment.
-                            node_requirement = schema.load_by_type(
-                                schema.NodeSpace, node_requirement_data
-                            )
-
-                        assert node_requirement_data, "Node requirement data is missing"
-                        original_node_requirement = schema.load_by_type(
-                            schema.NodeSpace, node_requirement_data
-                        )
-
-                        # Manage the union of the platform requirements and the node
-                        # requirements before taking the intersection of
-                        # the rest of the requirements.
-                        platform_requirement.features = search_space.SetSpace(
-                            True,
-                            (
-                                platform_requirement.features.items
-                                if platform_requirement.features
-                                else []
-                            )
-                            + (
-                                original_node_requirement.features.items
-                                if original_node_requirement.features
-                                else []
-                            ),
-                        )
-                        platform_requirement.excluded_features = search_space.SetSpace(
-                            False,
-                            (
-                                platform_requirement.excluded_features.items
-                                if platform_requirement.excluded_features
-                                else []
-                            )
-                            + (
-                                original_node_requirement.excluded_features.items
-                                if original_node_requirement.excluded_features
-                                else []
-                            ),
-                        )
-
-                        try:
-                            node_requirement = original_node_requirement.intersect(
-                                platform_requirement
-                            )
-                        except NotMeetRequirementException as e:
-                            test_result.set_status(TestStatus.SKIPPED, str(e))
-                            break
-
-                        assert isinstance(platform_requirement.extended_schemas, dict)
-                        assert isinstance(node_requirement.extended_schemas, dict)
-                        node_requirement.extended_schemas = deep_update_dict(
-                            platform_requirement.extended_schemas,
-                            node_requirement.extended_schemas,
-                        )
-                        if index < len(environment_requirement.nodes):
-                            environment_requirement.nodes[index] = node_requirement
-                        else:
-                            # add extra nodes, which is more from runbook.
-                            environment_requirement.nodes.append(node_requirement)
+                if platform_requirement and not getattr(self, "_guest_enabled", False):
+                    self._merge_platform_requirement(
+                        environment_requirement,
+                        platform_requirement,
+                        test_result,
+                    )
 
             if test_result.can_run:
                 # the requirement may be skipped by high platform requirement.
+                assert environment_requirement
                 env = existing_environments.from_requirement(environment_requirement)
                 if env:
                     # if env prepare or deploy failed and the test result is not
@@ -944,6 +876,117 @@ class LisaRunner(BaseRunner):
                 f"the feature(s) {ignored_features} have "
                 f"been ignored for case {case_name}"
             )
+
+    def _create_guest_parent_requirement(
+        self, platform_requirement: Optional[schema.NodeSpace]
+    ) -> EnvironmentSpace:
+        if platform_requirement:
+            return EnvironmentSpace(nodes=[platform_requirement])
+
+        return EnvironmentSpace(nodes=[schema.NodeSpace()])
+
+    def _merge_platform_requirement(
+        self,
+        environment_requirement: EnvironmentSpace,
+        platform_requirement: schema.NodeSpace,
+        test_result: TestResult,
+    ) -> None:
+        node_count = 1
+
+        if platform_requirement.node_count:
+            # get minimum node count from the runbook.
+            node_count = search_space.choose_value_countspace(
+                platform_requirement.node_count,
+                platform_requirement.node_count,
+            )
+
+            # Reset to 1 since platform_requirement will be used as
+            # a template for intersecting with individual node
+            # requirements, not for the entire environment
+            platform_requirement.node_count = 1
+
+        # Use the larger node count between test requirements and
+        # runbook settings to support scaling scenarios where
+        # runbook overrides test defaults
+        node_count = max(len(environment_requirement.nodes), node_count)
+        node_requirement_data: Dict[str, Any] = {}
+        for index in range(node_count):
+            if index < len(environment_requirement.nodes):
+                node_requirement = environment_requirement.nodes[index]
+
+                node_requirement_data = node_requirement.to_dict()  # type: ignore
+            else:
+                # Runbook has bigger node count, copy from the last
+                # node space of the environment.
+                node_requirement = schema.load_by_type(
+                    schema.NodeSpace, node_requirement_data
+                )
+
+            assert node_requirement_data, "Node requirement data is missing"
+            original_node_requirement = schema.load_by_type(
+                schema.NodeSpace, node_requirement_data
+            )
+            node_platform_requirement = copy.deepcopy(platform_requirement)
+
+            # Manage the union of the platform requirements and the node
+            # requirements before taking the intersection of
+            # the rest of the requirements.
+            node_platform_requirement.features = search_space.SetSpace(
+                True,
+                (
+                    node_platform_requirement.features.items
+                    if node_platform_requirement.features
+                    else []
+                )
+                + (
+                    original_node_requirement.features.items
+                    if original_node_requirement.features
+                    else []
+                ),
+            )
+            node_platform_requirement.excluded_features = search_space.SetSpace(
+                False,
+                (
+                    node_platform_requirement.excluded_features.items
+                    if node_platform_requirement.excluded_features
+                    else []
+                )
+                + (
+                    original_node_requirement.excluded_features.items
+                    if original_node_requirement.excluded_features
+                    else []
+                ),
+            )
+
+            try:
+                node_requirement = original_node_requirement.intersect(
+                    node_platform_requirement
+                )
+            except NotMeetRequirementException as e:
+                test_result.set_status(TestStatus.SKIPPED, str(e))
+                break
+
+            platform_extended_schemas_object = getattr(
+                node_platform_requirement, "extended_schemas", None
+            )
+            node_extended_schemas_object = getattr(
+                node_requirement, "extended_schemas", None
+            )
+            assert isinstance(platform_extended_schemas_object, dict)
+            assert isinstance(node_extended_schemas_object, dict)
+            platform_extended_schemas = cast(
+                Dict[str, Any], platform_extended_schemas_object
+            )
+            node_extended_schemas = cast(Dict[str, Any], node_extended_schemas_object)
+            node_requirement.extended_schemas = deep_update_dict(
+                platform_extended_schemas,
+                node_extended_schemas,
+            )
+            if index < len(environment_requirement.nodes):
+                environment_requirement.nodes[index] = node_requirement
+            else:
+                # add extra nodes, which is more from runbook.
+                environment_requirement.nodes.append(node_requirement)
 
     def _create_platform_requirement(self) -> Optional[schema.NodeSpace]:
         if not hasattr(self, "platform"):

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1464,6 +1464,20 @@ class GuestNode(Node):
     use_parent_capability: bool = True
 
 
+def _guest_node_runbook_to_dict(raw_runbook: Any) -> Dict[str, Any]:
+    if isinstance(raw_runbook, dict):
+        return cast(Dict[str, Any], raw_runbook)
+
+    to_dict = getattr(raw_runbook, "to_dict", None)
+    if not callable(to_dict):
+        raise LisaException(
+            f"guest node runbook must be a dict or support to_dict(), got "
+            f"'{type(raw_runbook).__name__}'"
+        )
+
+    return cast(Dict[str, Any], to_dict())
+
+
 def load_typed_guest_node(raw_runbook: Any) -> GuestNode:
     """
     Load a guest-node runbook into the concrete GuestNode schema for its type.
@@ -1482,8 +1496,7 @@ def load_typed_guest_node(raw_runbook: Any) -> GuestNode:
     if isinstance(raw_runbook, GuestNode) and type(raw_runbook) is not GuestNode:
         return raw_runbook
 
-    if not isinstance(raw_runbook, dict):
-        raw_runbook = raw_runbook.to_dict()
+    raw_runbook = _guest_node_runbook_to_dict(raw_runbook)
 
     from lisa import node as node_module
     from lisa.util import subclasses
@@ -1522,6 +1535,41 @@ def load_typed_guest_node(raw_runbook: Any) -> GuestNode:
         )
 
     return guest_runbook
+
+
+def _get_guest_node_count(raw_runbook: Dict[str, Any]) -> int:
+    raw_capability = raw_runbook.get("capability")
+    if not isinstance(raw_capability, dict):
+        return 1
+
+    raw_node_count = raw_capability.get("node_count")
+    if raw_node_count is None:
+        return 1
+
+    node_count_space = search_space.decode_count_space(raw_node_count)
+    node_count = search_space.choose_value_countspace(
+        node_count_space, node_count_space
+    )
+    if node_count < 1:
+        raise LisaException("guest capability.node_count must be at least 1")
+
+    return node_count
+
+
+def _load_guest_node_templates(raw_runbooks: List[Any]) -> List[GuestNode]:
+    loaded_runbooks: List[GuestNode] = []
+    for raw_runbook in raw_runbooks:
+        raw_runbook = _guest_node_runbook_to_dict(raw_runbook)
+        raw_runbook = copy.deepcopy(raw_runbook)
+        node_count = _get_guest_node_count(raw_runbook)
+        for _ in range(node_count):
+            guest_runbook = copy.deepcopy(raw_runbook)
+            raw_capability = guest_runbook.get("capability")
+            if isinstance(raw_capability, dict):
+                raw_capability["node_count"] = 1
+            loaded_runbooks.append(load_typed_guest_node(guest_runbook))
+
+    return loaded_runbooks
 
 
 @dataclass_json()
@@ -1646,7 +1694,7 @@ class Platform(TypedSchema, ExtendableSchemaMixin):
         add_secret(self.admin_password)
 
         if self.guests:
-            self.guests = [load_typed_guest_node(guest) for guest in self.guests]
+            self.guests = _load_guest_node_templates(self.guests)
 
         if isinstance(self.keep_environment, bool):
             if self.keep_environment:

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -140,6 +140,9 @@ class OpenVmmNetworkSchema:
                 f"{OPENVMM_ADDRESS_MODE_STATIC}"
             )
 
+        if self.forwarded_port:
+            self.forward_ssh_port = True
+
         if self.forward_ssh_port:
             if self.mode != OPENVMM_NETWORK_MODE_TAP:
                 raise LisaException(

--- a/selftests/runners/test_lisa_runner.py
+++ b/selftests/runners/test_lisa_runner.py
@@ -2,12 +2,13 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
-from typing import List, Optional, Union, cast
+from typing import Any, List, Optional, Union, cast
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import lisa
-from lisa import LisaException, constants, schema
-from lisa.environment import EnvironmentStatus, load_environments
+from lisa import LisaException, constants, schema, search_space
+from lisa.environment import EnvironmentSpace, EnvironmentStatus, load_environments
 from lisa.messages import TestResultMessage, TestStatus
 from lisa.notifier import _notifiers, flush_notifications, register_notifier
 from lisa.parameter_parser.runbook import RunbookBuilder
@@ -88,6 +89,83 @@ class RunnerTestCase(TestCase):
             expected_status=[TestStatus.QUEUED, TestStatus.QUEUED, TestStatus.QUEUED],
             expected_message=["", "", ""],
             test_results=test_results,
+        )
+
+    def test_merge_req_guest_enabled_uses_platform_requirement(self) -> None:
+        envs = load_environments(None)
+        runner = generate_runner(None)
+        platform = test_platform.generate_platform()
+        platform.runbook.guest_enabled = True
+        platform.runbook.requirement = {"node_count": 1, "core_count": 4}
+        runner.platform = platform
+        runner._guest_enabled = True
+
+        test_results = test_testsuite.generate_cases_result()
+        runner._merge_test_requirements(
+            test_results=test_results,
+            existing_environments=envs,
+            platform_type=constants.PLATFORM_MOCK,
+        )
+
+        first_env = next(iter(envs.values()))
+        assert first_env.runbook.nodes_requirement
+        self.assertEqual(1, len(first_env.runbook.nodes_requirement))
+        self.assertEqual(4, first_env.runbook.nodes_requirement[0].core_count)
+
+        test_environment = test_results[0].runtime_data.requirement.environment
+        assert test_environment
+        self.assertEqual(2, len(test_environment.nodes))
+
+    def test_merge_req_platform_features_do_not_bleed_between_nodes(self) -> None:
+        runner = generate_runner(None)
+        test_result = test_testsuite.generate_cases_result()[0]
+        platform_requirement = schema.NodeSpace()
+        platform_requirement.features = search_space.SetSpace[schema.FeatureSettings](
+            True, [schema.FeatureSettings.create("PlatformFeature")]
+        )
+        environment_requirement = EnvironmentSpace(
+            nodes=[
+                schema.NodeSpace(),
+                schema.NodeSpace(),
+            ]
+        )
+        environment_requirement.nodes[0].features = search_space.SetSpace[
+            schema.FeatureSettings
+        ](True, [schema.FeatureSettings.create("NodeOneFeature")])
+        environment_requirement.nodes[1].features = search_space.SetSpace[
+            schema.FeatureSettings
+        ](True, [schema.FeatureSettings.create("NodeTwoFeature")])
+
+        runner._merge_platform_requirement(
+            environment_requirement,
+            platform_requirement,
+            test_result,
+        )
+
+        node_features = [
+            {feature.type for feature in node.features or []}
+            for node in environment_requirement.nodes
+        ]
+        self.assertEqual(
+            [
+                {"PlatformFeature", "NodeOneFeature"},
+                {"PlatformFeature", "NodeTwoFeature"},
+            ],
+            node_features,
+        )
+
+    def test_deploy_environment_empty_results_still_cleans_up(self) -> None:
+        runner = generate_runner(None)
+        environment = cast(Any, MagicMock())
+
+        with patch.object(runner, "_need_retry", return_value=False), patch.object(
+            runner, "_delete_environment_task"
+        ) as delete_environment_task:
+            with self.assertRaises(IndexError):
+                runner._deploy_environment_task(environment, [])
+
+        delete_environment_task.assert_called_once_with(
+            environment=environment, test_results=[]
         )
 
     def test_merge_req(self) -> None:

--- a/selftests/test_guest_node_schema.py
+++ b/selftests/test_guest_node_schema.py
@@ -59,3 +59,21 @@ class GuestNodeSchemaTestCase(TestCase):
         loaded = schema.load_typed_guest_node(cast(Any, runbook))
 
         self.assertIs(runbook, loaded)
+
+    def test_platform_expands_object_guest_node_count(self) -> None:
+        runbook = OpenVmmGuestNodeSchema(
+            uefi=OpenVmmUefiSchema(firmware_path="/tmp/MSVM.fd"),
+            disk_img="/tmp/guest.img",
+            network=OpenVmmNetworkSchema(connection_address="127.0.0.1"),
+        )
+        runbook.capability.node_count = 2
+
+        platform = schema.Platform(guests=[runbook])
+
+        self.assertEqual(2, len(platform.guests))
+        self.assertTrue(
+            all(isinstance(guest, OpenVmmGuestNodeSchema) for guest in platform.guests)
+        )
+        self.assertEqual(
+            [1, 1], [guest.capability.node_count for guest in platform.guests]
+        )


### PR DESCRIPTION


## Description

When guest_enabled is set, build the parent environment requirement from the platform/runbook requirement instead of copying the testcase environment requirement. This keeps testcase min_count, OS, and feature constraints on the guest environment path while Azure/OpenVMM parent hosts are sized by the orchestrator configuration.

The existing platform/test requirement merge remains unchanged for non-guest runs and is factored into a helper. The deploy task also initializes its test result before cleanup so static analysis can prove it is always bound.

Add a runner regression test that verifies guest-enabled runs create a one-node parent environment from the platform requirement while preserving the two-node testcase requirement for guests.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
