### PR TITLE
libvirt: add auto-discovery support for device passthrough pools

### DIFF
--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -174,6 +174,21 @@ class LibvirtDevicePool(BaseDevicePool):
         iommu_grp = self._get_device_iommu_group(device)
         return [iommu_grp]
 
+    def auto_discover_pool(self, pool_type: HostDevicePoolType) -> None:
+        self.available_host_devices[pool_type] = {}
+        candidates = self._get_passthrough_device_candidates(pool_type)
+        if not candidates:
+            raise LisaException(
+                f"Auto-discovery found no eligible devices for pool type "
+                f"'{pool_type.value}' on the host. Verify that devices of "
+                f"this type exist and are not excluded (primary NIC, etc)."
+            )
+        self.host_node.log.debug(
+            f"Auto-discovered {len(candidates)} device(s) for pool "
+            f"'{pool_type.value}': {candidates}"
+        )
+        self._create_pool(pool_type, candidates)
+
     def create_device_pool(
         self,
         pool_type: HostDevicePoolType,

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -85,6 +85,10 @@ class BaseDevicePool:
                 )
 
     def _configure_passthrough_pool(self, config: HostDevicePoolSchema) -> None:
+        if config.auto_discover:
+            self.auto_discover_pool(config.type)
+            return
+
         devices = config.devices
         if self._is_vendor_device_id_list(devices):
             vendor_device_list = cast(List[VendorDeviceIdIdentifier], devices)
@@ -101,6 +105,9 @@ class BaseDevicePool:
         raise LisaException(
             f"Unknown device identifier of type: {type(devices)}" f", value: {devices}"
         )
+
+    def auto_discover_pool(self, pool_type: HostDevicePoolType) -> None:
+        raise NotImplementedError()
 
     def _is_vendor_device_id_list(self, devices: Any) -> bool:
         if not isinstance(devices, list):

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -43,6 +43,7 @@ class DeviceLocationPathIdentifier:
 @dataclass
 class HostDevicePoolSchema:
     type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
+    auto_discover: bool = False
     devices: Union[
         List[VendorDeviceIdIdentifier],
         PciAddressIdentifier,


### PR DESCRIPTION

## Description

Add a new flag in HostDevicePoolSchema to let lisa auto discover the device pool.

## Related Issue

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation
N/A

## Test Results
N/A