### PR TITLE
libvirt: add PCI_NVME device pool support

### DIFF
--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, cast
 from lisa.node import Node, RemoteNode
 from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
 from lisa.sut_orchestrator.util.schema import HostDevicePoolSchema, HostDevicePoolType
-from lisa.tools import Ls, Lspci, Modprobe
+from lisa.tools import Ls, Lsblk, Lspci, Modprobe, Readlink
 from lisa.util import (
     LisaException,
     ResourceAwaitableException,
@@ -40,6 +40,7 @@ class LibvirtDevicePool(BaseDevicePool):
         self.supported_pool_type = [
             HostDevicePoolType.PCI_NIC,
             HostDevicePoolType.PCI_GPU,
+            HostDevicePoolType.PCI_NVME,
         ]
         self.host_node = host_node
         self.platform_runbook = runbook
@@ -146,33 +147,38 @@ class LibvirtDevicePool(BaseDevicePool):
                 interface_name = line.split()[1].strip()
 
         assert interface_name, "Can not find interface name"
-        result = self.host_node.execute(
-            cmd=f"readlink -f /sys/class/net/{interface_name}/device",
+        readlink = self.host_node.tools[Readlink]
+        sysfs_path = readlink.get_canonical_path(
+            f"/sys/class/net/{interface_name}/device",
             sudo=True,
-            shell=True,
+            no_error_log=True,
         )
-        stdout = result.stdout.strip()
-        pci_address = PurePosixPath(stdout).name
-        if not re.fullmatch(
-            r"[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]",
-            pci_address,
-        ):
-            self.host_node.log.debug(
-                f"Primary interface '{interface_name}' is not backed by a PCI "
-                f"device on the libvirt host; skipping primary NIC IOMMU "
-                f"exclusion. Sysfs device path: {stdout or '<empty>'}"
-            )
+        return self._resolve_iommu_group_from_sysfs_path(
+            sysfs_path, context="primary NIC"
+        )
+
+    def get_rootfs_nvme_id(self) -> List[str]:
+        # Find the NVMe device backing the root filesystem to exclude it
+        # from the passthrough pool (passing it through would crash the host).
+        lsblk = self.host_node.tools[Lsblk]
+        root_disk = lsblk.find_disk_by_mountpoint("/")
+
+        # Only NVMe devices have names like nvme0n1, nvme1n1, etc.
+        # Root could be on a SATA SSD (sda), HDD (sda), or virtio disk (vda)
+        # — none of which are NVMe PCI devices, so skip exclusion.
+        if not root_disk.name.startswith("nvme"):
             return []
 
-        device = DeviceAddressSchema()
-        domain, bus, slot, fn = self._parse_pci_address_str(addr=pci_address)
-        device.domain = domain
-        device.bus = bus
-        device.slot = slot
-        device.function = fn
-
-        iommu_grp = self._get_device_iommu_group(device)
-        return [iommu_grp]
+        # Resolve the PCI address of the NVMe device via sysfs.
+        readlink = self.host_node.tools[Readlink]
+        sysfs_path = readlink.get_canonical_path(
+            f"/sys/block/{root_disk.name}/device/device",
+            sudo=True,
+            no_error_log=True,
+        )
+        return self._resolve_iommu_group_from_sysfs_path(
+            sysfs_path, context="rootfs NVMe"
+        )
 
     def create_device_pool(
         self,
@@ -303,6 +309,31 @@ class LibvirtDevicePool(BaseDevicePool):
             f"{', '.join(sorted(available_iommu_devices)) or 'none'}"
         )
 
+    def _resolve_iommu_group_from_sysfs_path(
+        self,
+        sysfs_path: str,
+        context: str,
+    ) -> List[str]:
+        if not sysfs_path:
+            self.host_node.log.debug(
+                f"Sysfs path for {context} is empty; skipping IOMMU exclusion."
+            )
+            return []
+
+        pci_address = PurePosixPath(sysfs_path).name
+        try:
+            domain, bus, slot, fn = self._parse_pci_address_str(addr=pci_address)
+        except (IndexError, ValueError):
+            self.host_node.log.debug(
+                f"Sysfs path for {context} does not resolve to a PCI device; "
+                f"skipping IOMMU exclusion. Path: {sysfs_path or '<empty>'}"
+            )
+            return []
+
+        device = self._get_pci_address_instance(domain, bus, slot, fn)
+        iommu_grp = self._get_device_iommu_group(device)
+        return [iommu_grp]
+
     def _get_passthrough_device_candidates(
         self,
         pool_type: HostDevicePoolType,
@@ -315,12 +346,22 @@ class LibvirtDevicePool(BaseDevicePool):
             )
         elif pool_type == HostDevicePoolType.PCI_GPU:
             pool_devices = lspci.get_gpu_devices(force_run=True)
+        elif pool_type == HostDevicePoolType.PCI_NVME:
+            pool_devices = lspci.get_devices_by_type(
+                constants.DEVICE_TYPE_NVME, force_run=True
+            )
         else:
             return []
 
         primary_nic_iommu = (
             self.get_primary_nic_id() if pool_type == HostDevicePoolType.PCI_NIC else []
         )
+        rootfs_nvme_iommu = (
+            self.get_rootfs_nvme_id()
+            if pool_type == HostDevicePoolType.PCI_NVME
+            else []
+        )
+        excluded_iommu = primary_nic_iommu + rootfs_nvme_iommu
         candidates: List[str] = []
         for pool_device in pool_devices:
             domain, bus, slot, fn = self._parse_pci_address_str(pool_device.slot)
@@ -330,7 +371,7 @@ class LibvirtDevicePool(BaseDevicePool):
             except LisaException:
                 continue
 
-            if iommu_group in primary_nic_iommu:
+            if iommu_group in excluded_iommu:
                 continue
 
             candidates.append(pool_device.slot)
@@ -344,6 +385,8 @@ class LibvirtDevicePool(BaseDevicePool):
     ) -> None:
         iommu_grp_of_used_devices = []
         primary_nic_iommu = self.get_primary_nic_id()
+        rootfs_nvme_iommu = self.get_rootfs_nvme_id()
+        excluded_iommu = primary_nic_iommu + rootfs_nvme_iommu
         for bdf in bdf_list:
             domain, bus, slot, fn = self._parse_pci_address_str(bdf)
             dev = self._get_pci_address_instance(domain, bus, slot, fn)
@@ -359,7 +402,7 @@ class LibvirtDevicePool(BaseDevicePool):
                 # Remove iommu group from pool: a device in it is already in use.
                 self.available_host_devices[pool_type].pop(iommu_group, None)
                 iommu_grp_of_used_devices.append(iommu_group)
-            elif iommu_group not in primary_nic_iommu:
+            elif iommu_group not in excluded_iommu:
                 devices = self.available_host_devices[pool_type].setdefault(
                     iommu_group, []
                 )

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -118,7 +118,7 @@ class LibvirtDevicePool(BaseDevicePool):
                 pool[iommu_grp] = pool_devices
             self.available_host_devices[pool_type] = pool
 
-    def get_primary_nic_id(self) -> List[str]:
+    def get_primary_nic_iommu_group(self) -> str:
         # This is for baremetal. For azure, we have to get private IP
         host_ip = cast(RemoteNode, self.host_node).connection_info.get("address")
         assert host_ip, "Host IP is empty"
@@ -157,7 +157,7 @@ class LibvirtDevicePool(BaseDevicePool):
             sysfs_path, context="primary NIC"
         )
 
-    def get_rootfs_nvme_id(self) -> List[str]:
+    def get_rootfs_nvme_iommu_group(self) -> str:
         # Find the NVMe device backing the root filesystem to exclude it
         # from the passthrough pool (passing it through would crash the host).
         lsblk = self.host_node.tools[Lsblk]
@@ -167,7 +167,7 @@ class LibvirtDevicePool(BaseDevicePool):
         # Root could be on a SATA SSD (sda), HDD (sda), or virtio disk (vda)
         # — none of which are NVMe PCI devices, so skip exclusion.
         if not root_disk.name.startswith("nvme"):
-            return []
+            return ""
 
         # Resolve the PCI address of the NVMe device via sysfs.
         readlink = self.host_node.tools[Readlink]
@@ -313,12 +313,12 @@ class LibvirtDevicePool(BaseDevicePool):
         self,
         sysfs_path: str,
         context: str,
-    ) -> List[str]:
+    ) -> str:
         if not sysfs_path:
             self.host_node.log.debug(
                 f"Sysfs path for {context} is empty; skipping IOMMU exclusion."
             )
-            return []
+            return ""
 
         pci_address = PurePosixPath(sysfs_path).name
         try:
@@ -328,11 +328,23 @@ class LibvirtDevicePool(BaseDevicePool):
                 f"Sysfs path for {context} does not resolve to a PCI device; "
                 f"skipping IOMMU exclusion. Path: {sysfs_path or '<empty>'}"
             )
-            return []
+            return ""
 
         device = self._get_pci_address_instance(domain, bus, slot, fn)
         iommu_grp = self._get_device_iommu_group(device)
-        return [iommu_grp]
+        return iommu_grp
+
+    def _get_iommu_groups_to_exclude(self) -> List[str]:
+        # Always exclude both the primary NIC and rootfs NVMe IOMMU groups
+        # regardless of pool type
+        excluded: List[str] = []
+        nic_iommu = self.get_primary_nic_iommu_group()
+        if nic_iommu:
+            excluded.append(nic_iommu)
+        nvme_iommu = self.get_rootfs_nvme_iommu_group()
+        if nvme_iommu:
+            excluded.append(nvme_iommu)
+        return excluded
 
     def _get_passthrough_device_candidates(
         self,
@@ -353,15 +365,7 @@ class LibvirtDevicePool(BaseDevicePool):
         else:
             return []
 
-        primary_nic_iommu = (
-            self.get_primary_nic_id() if pool_type == HostDevicePoolType.PCI_NIC else []
-        )
-        rootfs_nvme_iommu = (
-            self.get_rootfs_nvme_id()
-            if pool_type == HostDevicePoolType.PCI_NVME
-            else []
-        )
-        excluded_iommu = primary_nic_iommu + rootfs_nvme_iommu
+        excluded_iommu = self._get_iommu_groups_to_exclude()
         candidates: List[str] = []
         for pool_device in pool_devices:
             domain, bus, slot, fn = self._parse_pci_address_str(pool_device.slot)
@@ -384,9 +388,7 @@ class LibvirtDevicePool(BaseDevicePool):
         bdf_list: List[str],
     ) -> None:
         iommu_grp_of_used_devices = []
-        primary_nic_iommu = self.get_primary_nic_id()
-        rootfs_nvme_iommu = self.get_rootfs_nvme_id()
-        excluded_iommu = primary_nic_iommu + rootfs_nvme_iommu
+        excluded_iommu = self._get_iommu_groups_to_exclude()
         for bdf in bdf_list:
             domain, bus, slot, fn = self._parse_pci_address_str(bdf)
             dev = self._get_pci_address_instance(domain, bus, slot, fn)

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -47,9 +47,6 @@ class BaseDevicePool:
             f"{type(self).__name__} for pool type '{pool_type}'."
         )
 
-    def get_primary_nic_id(self) -> List[str]:
-        raise NotImplementedError()
-
     def request_devices(
         self,
         pool_type: HostDevicePoolType,

--- a/lisa/sut_orchestrator/util/schema.py
+++ b/lisa/sut_orchestrator/util/schema.py
@@ -8,6 +8,7 @@ from dataclasses_json import dataclass_json
 class HostDevicePoolType(Enum):
     PCI_NIC = "pci_net"
     PCI_GPU = "pci_gpu"
+    PCI_NVME = "pci_nvme"
 
 
 @dataclass_json()


### PR DESCRIPTION
## Description

libvirt: add PCI_NVME device pool support
similar to nic, exclude the nvme if it is mounted as rootfs.

remove the unwanted get_primary_nic_id() from BaseDevicePool class
more readable names for primary nic and rootfs nvme iommu group fetching methods
extract some common code to helper function

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
