### PR TITLE
[AI Generated] azure: skip test when requested VM size is not available in region

### DIFF
--- a/lisa/sut_orchestrator/azure/hooks.py
+++ b/lisa/sut_orchestrator/azure/hooks.py
@@ -101,6 +101,19 @@ class AzureHookSpecDefaultImpl:
             SkippedException,
         ),
         (
+            # InvalidParameter: The requested VM size <sku> is not available
+            # in the current region. The sizes available in the current region
+            # are: ...
+            # The selected VM SKU is simply not offered in the picked region
+            # The case can never run on this combination, so skip rather than fail.
+            "The requested VM size is not available in the current region",
+            re.compile(
+                r"InvalidParameter: The requested VM size \S+ is not available "
+                r"in the current region"
+            ),
+            SkippedException,
+        ),
+        (
             # ResourceCollectionRequestsThrottled - Too many requests to Azure API
             "Azure API throttling detected. The deployment was throttled "
             "due to too many requests",


### PR DESCRIPTION
## Summary
When the requested VM size is not available in the target Azure region, ARM
returns `InvalidParameter: The requested VM size <sku> is not available in the
current region`. Previously LISA treated this as a **failed** test. After this
fix, the test is **skipped** since it is an environment limitation, not a
product defect.

## Behavior

### Before fix
- ARM error `InvalidParameter: The requested VM size Standard_D2pds_v7 is not
  available in the current region` is wrapped into `LisaException`.
- Test result: **FAILED**
- Counted against pass-rate; pollutes failure dashboards and triggers bug
  filing.

### After fix
- New entry added to `AzureHookSpecDefaultImpl.__error_maps` in
  `lisa/sut_orchestrator/azure/hooks.py` matching:
  `InvalidParameter: The requested VM size <sku> is not available in the current region`
  → raised as `SkippedException`.
- Test result: **SKIPPED** with reason
  `deployment skipped: The requested VM size is not available in the current region. ...`
- Does not affect pass-rate; correctly classified as environment constraint.
