### PR TITLE
lspci: use controller_id for NVMe discovery, exclude ASAP by device_id

### DIFF
--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -225,16 +225,11 @@ class Lspci(Tool):
         return devices_slots
 
     # Returns device slot ids for given device type based on controller ids.
-    # This method cannot distinguish between different device types which uses same
-    # controller id. For example, NVME and ASAP devices use same controller id for.
-    # In such cases, use 'get_device_names_by_device_id' method.
+    # For NVME, ASAP devices share the same controller id (0108) and are
+    # excluded by filtering on their device ids.
     def get_device_names_by_type(
         self, device_type: str, force_run: bool = False
     ) -> List[str]:
-        # NVME devices are searched based on device ids as 'ASAP' devices use same
-        # controller id.
-        if device_type.upper() in [constants.DEVICE_TYPE_NVME]:
-            return self.get_device_names_by_device_id(device_type, force_run)
         if device_type.upper() not in CONTROLLER_ID_DICT.keys():
             raise LisaException(f"pci_type '{device_type}' is not recognized.")
         devices_list = self.get_devices(force_run)
@@ -242,6 +237,12 @@ class Lspci(Tool):
 
         for device in devices_list:
             if device.controller_id in CONTROLLER_ID_DICT[device_type.upper()]:
+                # ASAP devices use the same controller id as NVME (0108).
+                # Exclude them so they are not mistaken for local NVMe disks.
+                if device.device_id in DEVICE_ID_DICT.get(
+                    constants.DEVICE_TYPE_ASAP, []
+                ):
+                    continue
                 devices_slots.append(device.slot)
         return devices_slots
 
@@ -266,10 +267,6 @@ class Lspci(Tool):
     def get_devices_by_type(
         self, device_type: str, force_run: bool = False
     ) -> List[PciDevice]:
-        # NVME devices are searched based on device ids as 'ASAP' devices use same
-        # controller id.
-        if device_type.upper() in [constants.DEVICE_TYPE_NVME]:
-            return self.get_devices_by_device_id(device_type, force_run)
         if device_type.upper() not in CONTROLLER_ID_DICT.keys():
             raise LisaException(
                 f"pci_type '{device_type}' is not supported to be searched."
@@ -278,6 +275,12 @@ class Lspci(Tool):
         device_type_list = []
         for device in devices_list:
             if device.controller_id in CONTROLLER_ID_DICT[device_type.upper()]:
+                # ASAP devices use the same controller id as NVME (0108).
+                # Exclude them so they are not mistaken for local NVMe disks.
+                if device.device_id in DEVICE_ID_DICT.get(
+                    constants.DEVICE_TYPE_ASAP, []
+                ):
+                    continue
                 device_type_list.append(device)
 
         return device_type_list


### PR DESCRIPTION

## Description
Previosuly, NVMe devices are discovered filtering on the device id maintained in DEVICE_ID_DICT. This was because both NVMe and ASAP device have same controller (0108). But this approach mandates, every kind of nvme device id to be added into the DEVICE_ID_DICT which is not scalable.

Instead, fetch the devices using the nvme controller itself and then filter out the ASAP devices based on its device id.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
