### PR TITLE
OpenSSL speed test false failure fix

### DIFF
--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -142,12 +142,14 @@ class OpenSSL(Tool):
             expected_exit_code_failure_message=("OpenSSL speed test failed."),
         )
 
-        # Check for errors in the output - OpenSSL speed can return exit code 0
-        # even when some cryptographic operations fail, so we need to check
-        # stdout for error indicators
-        if ":error:" in result.stdout:
+        # Validate that the speed test actually produced benchmark results.
+        # openssl speed prints throughput tables with "bytes per second" on
+        # success.  A non-zero exit code is already caught above; this guards
+        # against silent/empty runs.
+        if "bytes per second" not in result.stdout:
             raise LisaException(
-                f"OpenSSL speed test failed - errors found in output: {result.stdout}"
+                "OpenSSL speed test produced no benchmark results. "
+                f"Output: {result.stdout}"
             )
 
         return result

--- a/lisa/tools/openssl.py
+++ b/lisa/tools/openssl.py
@@ -149,7 +149,10 @@ class OpenSSL(Tool):
         if "bytes per second" not in result.stdout:
             raise LisaException(
                 "OpenSSL speed test produced no benchmark results. "
-                f"Output: {result.stdout}"
+                f"cmd: {result.cmd}, "
+                f"exit_code: {result.exit_code}, "
+                f"stdout: {result.stdout}, "
+                f"stderr: {result.stderr}"
             )
 
         return result


### PR DESCRIPTION
## Description

Fixed false test failures in `verify_openssl_speed_test` caused by scanning stdout for the substring `:error:`. When the system crypto policy disables legacy algorithms (e.g. DSA-SHA1), OpenSSL emits benign error lines like `Error setting up context for dsa-sha1` in stdout even though the overall speed test succeeds. The old code treated any `:error:` substring as a test failure.

Replaced the fragile error-string scanning with positive output validation - the test now checks that `"bytes per second"` appears in stdout (confirming at least one algorithm completed successfully) and continues to rely on the process exit code for actual failures.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_openssl_speed_test

**Impacted LISA Features:**
Openssl

**Tested Azure Marketplace Images:**
- RedHat RHEL 101-gen2
- oracle oracle-linux ol97-lvm-gen2
- RedHat RHEL 810-gen2

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| RedHat RHEL 101-gen2 latest | Standard_E32-16as_v7 | PASSED |
| oracle oracle-linux ol97-lvm-gen2 latest | Standard_E32-16as_v7 | PASSED |
| RedHat RHEL 810-gen2 latest | Standard_E32-16as_v7 | PASSED |