### PR TITLE
MANA module unload order fix

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -140,7 +140,7 @@ class Nics(InitializableMixin):
         "mlx5_core": ModuleInformation(["mlx5_ib"], "CONFIG_MLX5_CORE"),
         "mlx4_core": ModuleInformation(["mlx4_en", "mlx4_ib"], "CONFIG_MLX4_CORE"),
         "mana": ModuleInformation(
-            ["mana", "mana_en", "mana_ib"], "CONFIG_MICROSOFT_MANA"
+            ["mana_en", "mana_ib", "mana"], "CONFIG_MICROSOFT_MANA"
         ),
     }
 


### PR DESCRIPTION
## Description

Fixed the MANA driver module unload order in `nic.py`. The previous order was `["mana", "mana_en", "mana_ib"]`, which attempted to remove the core `mana` module before its dependents `mana_en` and `mana_ib`, causing `modprobe -r` failures. Reversed the order to `["mana_en", "mana_ib", "mana"]` so dependent modules are unloaded before the core module.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_sriov_ethtool_offload_setting, verify_sriov_reload_modules

**Impacted LISA Features:**
NetworkInterface

**Tested Azure Marketplace Images:**
- RedHat RHEL 97-gen2 latest
- RedHat RHEL 101-gen2 latest

## Test Results
| Image | VM Size | Result |
|-------|---------|--------|
| RedHat RHEL 97-gen2 latest | Standard_E32-16as_v7 | PASSED |
| RedHat RHEL 101-gen2 latest | Standard_E32-16as_v7 | PASSED |
