### PR TITLE
Fail smoke test on reboot errors

### DIFF
--- a/lisa/microsoft/testsuites/core/provisioning.py
+++ b/lisa/microsoft/testsuites/core/provisioning.py
@@ -584,7 +584,7 @@ class Provisioning(TestSuite):
             else:
                 node.reboot()
             log.info(f"node '{node.name}' rebooted in {timer}")
-        except Exception as e:
+        except Exception as error:
             if node.features.is_supported(SerialConsole):
                 serial_console = node.features[SerialConsole]
                 # if there is any panic, fail before partial pass
@@ -592,11 +592,23 @@ class Provisioning(TestSuite):
                     saved_path=log_path, stage="reboot", force_run=True
                 )
 
-            # if node cannot be connected after reboot, it should be failed.
-            if isinstance(e, TcpConnectionException):
-                raise BadEnvironmentStateException(f"after reboot, {e}")
-            raise PassedException(e)
+            if isinstance(error, TcpConnectionException) or self._is_reboot_timeout(
+                error
+            ):
+                raise BadEnvironmentStateException(
+                    f"reboot failed on node '{node.name}': {error}. "
+                    f"Check serial console logs under '{log_path}' and verify the "
+                    "node is reachable."
+                ) from error
+
+            raise PassedException(error) from error
         return timer.elapsed()
+
+    @staticmethod
+    def _is_reboot_timeout(error: Exception) -> bool:
+        return isinstance(error, LisaException) and "timeout to wait reboot" in str(
+            error
+        )
 
     def is_mana_device_discovered(self, node: RemoteNode) -> bool:
         lspci = node.tools[Lspci]


### PR DESCRIPTION
## Description
The smoke test currently only marks reboot failures as bad environment when the caught exception is TcpConnectionException. Other reboot failures from node.reboot(), such as a reboot timeout while waiting for the boot marker to advance, fall through to PassedException and make the test pass with a warning.

That creates a false positive for cases where the guest never completes reboot. The daily Cloud Hypervisor v51 smoke run hit this path with 'timeout to wait reboot, the node may stuck on reboot command' but still exited successfully.

Treat any exception from the reboot step as BadEnvironmentStateException after checking serial console panic, matching the existing comment that reboot connectivity failures should fail the test.



<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
Smoke test 
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
Smoke test

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

2026-05-19 03:21:10.574[139919805806400][INFO] lisa.RootRunner ________________________________________
2026-05-19 03:21:10.574[139919805806400][INFO] lisa.RootRunner                            Provisioning.smoke_test: PASSED   
2026-05-19 03:21:10.574[139919805806400][INFO] lisa.RootRunner                               CPU.verify_cpu_count: PASSED 

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
