### PR TITLE
fix: Add _initialize_package_installation for Fedora

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1802,6 +1802,23 @@ class Fedora(RPMDistro):
 
         return kernel_information
 
+    @retry(tries=5, delay=5)  # type: ignore
+    def _initialize_package_installation(self) -> None:
+        self._log.debug("Refreshing DNF cache before package installation")
+        self._node.execute(
+            f"{self._dnf_tool()} clean metadata",
+            sudo=True,
+            timeout=300,
+        )
+        result = self._node.execute(
+            f"{self._dnf_tool()} makecache",
+            sudo=True,
+            timeout=300,
+        )
+        if result.exit_code != 0:
+            raise LisaException(f"Failed to refresh DNF cache: {result.stdout}")
+        self._log.debug("Fedora: DNF cache refreshed successfully.")
+
     def install_epel(self) -> None:
         # Extra Packages for Enterprise Linux (EPEL) is a special interest group
         # (SIG) from the Fedora Project that provides a set of additional packages

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1805,19 +1805,28 @@ class Fedora(RPMDistro):
     @retry(tries=5, delay=5)  # type: ignore
     def _initialize_package_installation(self) -> None:
         self._log.debug("Refreshing DNF cache before package installation")
-        self._node.execute(
+        result = self._node.execute(
             f"{self._dnf_tool()} clean metadata",
             sudo=True,
             timeout=300,
         )
+        if result.exit_code != 0:
+            raise LisaException(
+                f"Failed to clean DNF metadata: {result.stdout} "
+                f"exit_code: {result.exit_code}, stderr: {result.stderr}"
+            )
+
         result = self._node.execute(
             f"{self._dnf_tool()} makecache",
             sudo=True,
             timeout=300,
         )
         if result.exit_code != 0:
-            raise LisaException(f"Failed to refresh DNF cache: {result.stdout}")
-        self._log.debug("Fedora: DNF cache refreshed successfully.")
+            raise LisaException(
+                f"Failed to refresh DNF cache: {result.stdout} "
+                f"exit_code: {result.exit_code}, stderr: {result.stderr}"
+            )
+        self._log.debug("DNF cache refreshed successfully.")
 
     def install_epel(self) -> None:
         # Extra Packages for Enterprise Linux (EPEL) is a special interest group


### PR DESCRIPTION
## Description
Add `_initialize_package_installation()` override in the Fedora class to refresh DNF metadata cache before the first package installation. On freshly provisioned Fedora VMs, package installations can fail due to stale DNF metadata. Seen intermittent failures during daily runs for Fedora Rawhide.

This mirrors the existing pattern in the Debian class which runs `apt-get update` before first package install.

**Changes**
- Run `dnf clean metadata` to remove stale cache
- Run `dnf makecache` to download fresh repository metadata
- Retry up to 5 times with 5s delay for transient network failures

## Related Issue

<!-- Leave blank if none -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_network_interface_reload_via_ip_link

**Impacted LISA Features:**
NetworkInterface

**Tested Azure Marketplace Images:**
- Fedora-Cloud-Rawhide-Arm64 (community gallery)

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| Fedora-Cloud-Rawhide-Arm64 | Standard_D2ps_v5 | PASSED |