### PR TITLE
[AI Generated] BugFix: auto-bump osdisk_size_in_gb when ARM rejects too-small OS disk

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -162,6 +162,15 @@ AZURE_INTERNAL_ERROR_PATTERN = re.compile(
     r"OSProvisioningInternalError: OS Provisioning failed "
     r"for VM.*due to an internal error."
 )
+# Matches ARM error when the requested OS disk size is smaller than the
+# image's OS disk size, e.g.
+#   "The specified disk size 30 GB is smaller than the size of the
+#    corresponding disk in the VM image: 64 GB."
+OSDISK_SIZE_TOO_SMALL_PATTERN = re.compile(
+    r"specified disk size (?P<requested>\d+)\s*GB is smaller than "
+    r"the size of the corresponding disk in the VM image:\s*(?P<required>\d+)\s*GB",
+    re.IGNORECASE,
+)
 
 VM_SIZE_FALLBACK_PATTERNS = [
     # First priority: Standard_D series with single digit
@@ -526,6 +535,12 @@ class AzurePlatform(Platform):
 
         self._private_key_lock = threading.Lock()
         self._lisa_sha_cache: Optional[str] = None
+        # Cache of OS disk size discovered at deploy time, keyed by marketplace
+        # identifier "publisher/offer/sku/version". Populated by the retry path
+        # in ``_deploy`` and consulted in ``_create_node_arm_parameters`` so
+        # subsequent environments using the same image deploy with the right
+        # size on the first try instead of failing once and retrying.
+        self._osdisk_size_cache: Dict[str, int] = {}
 
     @classmethod
     def type_name(cls) -> str:
@@ -1723,6 +1738,22 @@ class AzurePlatform(Platform):
                         plan_publisher=plan_publisher,
                     )
 
+        # Apply OS disk size discovered from a previous failed deployment of
+        # the same marketplace image. Some marketplace images don't expose
+        # their disk size via the virtual_machine_images API, so
+        # ``get_image_info`` returns None and the bump above is skipped. The
+        # first deploy then fails and ``_deploy`` retries with the size from
+        # the ARM error; this cache lets subsequent environments skip that
+        # round-trip.
+        if arm_parameters.marketplace:
+            cached_size = self._osdisk_size_cache.get(
+                self._marketplace_cache_key(arm_parameters.marketplace)
+            )
+            if cached_size:
+                arm_parameters.osdisk_size_in_gb = max(
+                    arm_parameters.osdisk_size_in_gb, cached_size
+                )
+
         # Set Hyper-V Generation
         # Note: Image capability has already been merged with the VM capability
         hyperv_generation = capability._find_feature_by_type(
@@ -1829,6 +1860,7 @@ class AzurePlatform(Platform):
         deployment_parameters: Dict[str, Any],
         log: Logger,
         environment: Environment,
+        _attempt: int = 1,
     ) -> None:
         resource_group_name = deployment_parameters[AZURE_RG_NAME_KEY]
         storage_account_name = get_storage_account_name(self.subscription_id, location)
@@ -1944,8 +1976,119 @@ class AzurePlatform(Platform):
                         error_message = (
                             f"OSProvisioningTimedOut: {type(ex).__name__}: {ex}"
                         )
+                # If the deployment failed because the requested OS disk size
+                # is smaller than the image's actual OS disk size, bump the
+                # parameter to the size reported by ARM and retry once. This
+                # avoids the user having to know the image's OS disk size up
+                # front (some marketplace images don't expose it via the
+                # virtual_machine_images API).
+                if self._maybe_retry_with_bumped_osdisk_size(
+                    error_message,
+                    location,
+                    deployment_parameters,
+                    log,
+                    environment,
+                    _attempt,
+                ):
+                    return
                 plugin_manager.hook.azure_deploy_failed(error_message=error_message)
                 raise LisaException(error_message)
+
+    def _maybe_retry_with_bumped_osdisk_size(
+        self,
+        error_message: str,
+        location: str,
+        deployment_parameters: Dict[str, Any],
+        log: Logger,
+        environment: Environment,
+        attempt: int,
+    ) -> bool:
+        """Retry deployment once after bumping osdisk_size_in_gb.
+
+        Returns True if a retry was performed (caller should not raise).
+        """
+        if attempt != 1:
+            return False
+        disk_match = OSDISK_SIZE_TOO_SMALL_PATTERN.search(error_message)
+        if not disk_match:
+            return False
+        requested = int(disk_match.group("requested"))
+        image_size = int(disk_match.group("required"))
+        if not self._bump_osdisk_size_in_parameters(
+            deployment_parameters, image_size, log
+        ):
+            return False
+        log.info(
+            f"image OS disk size is {image_size} GB, "
+            f"requested {requested} GB. Bumping "
+            f"osdisk_size_in_gb to {image_size} GB "
+            f"and retrying deployment."
+        )
+        self._deploy(
+            location,
+            deployment_parameters,
+            log,
+            environment,
+            _attempt=attempt + 1,
+        )
+        return True
+
+    def _bump_osdisk_size_in_parameters(
+        self,
+        deployment_parameters: Dict[str, Any],
+        new_size_gb: int,
+        log: Logger,
+    ) -> bool:
+        """Bump every node's ``osdisk_size_in_gb`` to at least ``new_size_gb``.
+
+        Also caches the discovered size against each node's marketplace
+        identifier so future deployments of the same image skip the retry.
+
+        Returns True if any node parameter was actually changed.
+        """
+        deployment = deployment_parameters["parameters"]
+        try:
+            nodes_param = deployment.properties.parameters["nodes"]["value"]
+        except (AttributeError, KeyError, TypeError):
+            log.debug(
+                "could not locate 'nodes' parameter in deployment_parameters; "
+                "skip osdisk size bump"
+            )
+            return False
+        changed = False
+        for node in nodes_param:
+            current = int(node.get("osdisk_size_in_gb", 0) or 0)
+            if current < new_size_gb:
+                node["osdisk_size_in_gb"] = new_size_gb
+                changed = True
+            marketplace = node.get("marketplace")
+            if isinstance(marketplace, dict):
+                key = self._marketplace_cache_key(marketplace)
+                if key:
+                    prev = self._osdisk_size_cache.get(key, 0)
+                    if new_size_gb > prev:
+                        self._osdisk_size_cache[key] = new_size_gb
+        return changed
+
+    def _marketplace_cache_key(self, marketplace: Any) -> str:
+        """Build a stable cache key from a marketplace value.
+
+        Accepts either an ``AzureVmMarketplaceSchema`` instance or the
+        equivalent dict form found in ARM deployment parameters.
+        """
+        if isinstance(marketplace, dict):
+            publisher = marketplace.get("publisher", "")
+            offer = marketplace.get("offer", "")
+            sku = marketplace.get("sku", "")
+            version = marketplace.get("version", "")
+        else:
+            publisher = getattr(marketplace, "publisher", "") or ""
+            offer = getattr(marketplace, "offer", "") or ""
+            sku = getattr(marketplace, "sku", "") or ""
+            version = getattr(marketplace, "version", "") or ""
+        if not (publisher and offer and sku):
+            return ""
+        return f"{publisher}/{offer}/{sku}/{version}".lower()
 
     def _parse_detail_errors(self, error: Any) -> List[str]:
         # original message may be a summary, get lowest level details.


### PR DESCRIPTION
When an Azure marketplace image's OS disk is larger than the requested osdisk_size_in_gb, ARM fails the deployment with OperationNotAllowed. Some images don't expose their disk size via the virtual_machine_images API, so the pre-deploy bump in _create_node_arm_parameters is skipped.

This change parses the ARM error, bumps osdisk_size_in_gb to the size reported by ARM, and retries the deployment once. The discovered size is cached against the marketplace identifier so subsequent environments using the same image deploy correctly on the first try.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
