### PR TITLE
Add PyPI publishing workflow (Trusted Publishing / OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+name: Publish to PyPI
+
+# Publishes mslisa to PyPI when a version tag (vX.Y.Z) is pushed.
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens stored.
+#
+# Bootstrap (one-time, see RELEASE.md):
+#   1. Add a pending publisher on PyPI:
+#      project=mslisa, owner=microsoft, repo=lisa,
+#      workflow=publish.yml, environment=pypi
+#   2. Add a pending publisher on TestPyPI with environment=testpypi
+#   3. Create GitHub Environments "testpypi" and "pypi";
+#      put required reviewers on "pypi".
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:   # manual run for build-only smoke tests
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # setuptools_scm needs full tag history
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+      - name: Build distributions
+        run: python -m build
+      - name: Validate metadata
+        run: python -m twine check dist/*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for OIDC
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/mslisa/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi   # add required reviewers here for human approval gate
+      url: https://pypi.org/project/mslisa/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish to PyPI
 
-# Publishes mslisa to PyPI when a version tag (vX.Y.Z) is pushed.
+# Publishes mslisa to PyPI when a CalVer tag (YYYYMMDD.N) is pushed.
 # Uses PyPI Trusted Publishing (OIDC) — no API tokens stored.
 #
 # Bootstrap (one-time, see RELEASE.md):
@@ -14,7 +14,8 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - "v*.*.*"
+      # CalVer: e.g. 20260420.1, 20260420.2
+      - "2[0-9][0-9][0-9][0-9][0-9][0-9][0-9].*"
   workflow_dispatch:   # manual run for build-only smoke tests
 
 permissions:
@@ -46,7 +47,7 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for OIDC

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,9 @@
 prune .github
 exclude .git*
 
+# AI training data is large and not needed at runtime; exclude from sdist/wheel.
+# Without pruning, the deeply-nested log paths exceed the Windows 260-char limit
+# during `python -m build` and break sdist creation.
+prune lisa/ai/data
+
 # Everything else tracked by git is include automatically by setuptools-scm

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,126 @@
+# Releasing `mslisa` to PyPI
+
+LISA is published to PyPI as the [`mslisa`](https://pypi.org/project/mslisa/)
+package. Releases are driven by the
+[`publish.yml`](.github/workflows/publish.yml) workflow and use **PyPI Trusted
+Publishing (OIDC)** — no API tokens are stored anywhere.
+
+End user install:
+
+```bash
+pip install mslisa            # core only
+pip install "mslisa[azure]"   # most common: with Azure SDK extras
+pip install "mslisa[azure,libvirt]"
+lisa --help
+```
+
+---
+
+## One-time bootstrap (do once per project / per environment)
+
+These steps are needed before the first successful release. After bootstrap they
+do not need to be repeated.
+
+### 1. PyPI pending publishers
+
+Any maintainer signs in to PyPI **and** TestPyPI with their personal account
+(2FA required), then adds a **pending publisher**:
+
+- PyPI → <https://pypi.org/manage/account/publishing/> → *Add a new pending publisher*
+  - PyPI Project Name: `mslisa`
+  - Owner: `microsoft`
+  - Repository name: `lisa`
+  - Workflow name: `publish.yml`
+  - Environment name: `pypi`
+- TestPyPI → <https://test.pypi.org/manage/account/publishing/> → same form, but
+  - Environment name: `testpypi`
+
+The first successful workflow run claims the project name automatically. After
+that the personal account can be removed from the project; the trust is bound
+to `microsoft/lisa` + `publish.yml`, not to the person.
+
+### 2. GitHub Environments
+
+In `microsoft/lisa` → **Settings → Environments**, create two environments:
+
+| Environment | Required reviewers | Purpose |
+|---|---|---|
+| `testpypi`  | (none, optional)   | Auto-publishes pre-release artifacts |
+| `pypi`      | 1–2 LSG maintainers | Human approval gate before PyPI |
+
+Reviewers approve via the Actions run UI when the workflow pauses on the `pypi`
+environment.
+
+### 3. Tag protection (recommended)
+
+**Settings → Tags → Add rule** → pattern `v*.*.*`, restrict push to release
+managers. Prevents accidental tag-based releases.
+
+---
+
+## Cutting a release
+
+1. Make sure `main` is green.
+2. Decide the version using semver (`vMAJOR.MINOR.PATCH`).
+3. Update `CHANGELOG.md` (or release notes draft) and merge.
+4. Tag and push:
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git tag -a v3.13.0 -m "v3.13.0"
+   git push origin v3.13.0
+   ```
+5. Watch **Actions → Publish to PyPI**.
+6. After the `publish-testpypi` job succeeds, smoke test in a clean venv:
+   ```powershell
+   py -3.12 -m venv C:\tmp\mslisa-rc
+   & C:\tmp\mslisa-rc\Scripts\python.exe -m pip install `
+       --index-url https://test.pypi.org/simple/ `
+       --extra-index-url https://pypi.org/simple/ `
+       "mslisa[azure]==3.13.0"
+   & C:\tmp\mslisa-rc\Scripts\lisa.exe --help
+   ```
+7. Approve the `pypi` environment in the workflow run.
+8. Verify the live release:
+   ```bash
+   pip install --upgrade "mslisa==3.13.0"
+   lisa --version
+   ```
+
+> A version that has been uploaded to PyPI **cannot** be replaced. To fix a bad
+> release, yank it on PyPI and publish a new patch version.
+
+---
+
+## Local dry run (no upload)
+
+Use this any time you change packaging metadata, `MANIFEST.in`, or
+`pyproject.toml`:
+
+```powershell
+cd lisa
+.\.venv\Scripts\python.exe -m pip install --upgrade build twine
+.\.venv\Scripts\python.exe -m build --wheel    # wheel only on Windows;
+                                               # CI builds sdist on Linux
+.\.venv\Scripts\python.exe -m twine check dist\*
+
+# Try installing into a fresh venv
+py -3.12 -m venv C:\tmp\mslisa-local
+$wheel = (Get-Item dist\mslisa-*.whl).FullName
+& C:\tmp\mslisa-local\Scripts\python.exe -m pip install "$wheel[azure]"
+& C:\tmp\mslisa-local\Scripts\lisa.exe --help
+```
+
+---
+
+## Known limitations
+
+- **sdist build fails on Windows** because `setuptools_scm` includes every git-
+  tracked file (including deeply nested logs under `lisa/ai/data/...`) and the
+  resulting paths exceed Windows' 260-character limit. CI builds on Linux are
+  unaffected. The wheel is what users actually install.
+- **`MANIFEST.in` `prune` rules don't apply** to files already tracked by git
+  when `setuptools_scm` is the file finder. To shrink the sdist, move
+  `lisa/ai/data/` out of git (git-lfs or a sibling repo).
+- **Optional extras** (`baremetal`, `aws`, `ai`, etc.) are *not* installed by
+  `pip install mslisa`. Users opt in with `pip install "mslisa[azure,ai,…]"`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,37 +53,43 @@ environment.
 
 ### 3. Tag protection (recommended)
 
-**Settings → Tags → Add rule** → pattern `v*.*.*`, restrict push to release
-managers. Prevents accidental tag-based releases.
+**Settings → Tags → Add rule** → pattern `2[0-9][0-9][0-9][0-9][0-9][0-9][0-9].*`,
+restrict push to release managers. Prevents accidental tag-based releases.
 
 ---
 
 ## Cutting a release
 
+LISA uses **CalVer** tags in the form `YYYYMMDD.N` (e.g. `20260420.1`,
+`20260420.2`). `setuptools_scm` derives the package version directly from the
+tag, so the PyPI version equals the tag (no `v` prefix).
+
 1. Make sure `main` is green.
-2. Decide the version using semver (`vMAJOR.MINOR.PATCH`).
+2. Pick today's date and the next sequence number for that day.
 3. Update `CHANGELOG.md` (or release notes draft) and merge.
 4. Tag and push:
    ```bash
    git checkout main
    git pull --ff-only
-   git tag -a v3.13.0 -m "v3.13.0"
-   git push origin v3.13.0
+   TAG=$(date +%Y%m%d).1          # bump .1 -> .2 if a tag for today exists
+   git tag -a "$TAG" -m "$TAG"
+   git push origin "$TAG"
    ```
 5. Watch **Actions → Publish to PyPI**.
 6. After the `publish-testpypi` job succeeds, smoke test in a clean venv:
    ```powershell
+   $TAG = "20260513.1"   # use the tag you just pushed
    py -3.12 -m venv C:\tmp\mslisa-rc
    & C:\tmp\mslisa-rc\Scripts\python.exe -m pip install `
        --index-url https://test.pypi.org/simple/ `
        --extra-index-url https://pypi.org/simple/ `
-       "mslisa[azure]==3.13.0"
+       "mslisa[azure]==$TAG"
    & C:\tmp\mslisa-rc\Scripts\lisa.exe --help
    ```
 7. Approve the `pypi` environment in the workflow run.
 8. Verify the live release:
    ```bash
-   pip install --upgrade "mslisa==3.13.0"
+   pip install --upgrade "mslisa==20260513.1"
    lisa --version
    ```
 


### PR DESCRIPTION
# `mslisa` PyPI Publishing — Design and Pre-release Testing Guide

> Branch: `feature/pip-install-lisa_130526_105955` on `microsoft/lisa`
> PR: [#4480 Add PyPI publishing workflow (Trusted Publishing / OIDC)](https://github.com/microsoft/lisa/pull/4480)
> Package name: **`mslisa`** (test package name on TestPyPI: `mslisa-lildeng-test`)

---

## 1. Why `pip install`?

### 1.1 Current state (before this change)

The only documented way to install LISA has been:

```bash
git clone https://github.com/microsoft/lisa.git
cd lisa
python3 -m pip install --editable .[azure,libvirt] --config-settings editable_mode=compat
```

This approach has several long-standing problems:

| Problem | Impact |
|---|---|
| Forces a `git clone` | Every user / CI agent must pull the full git history — large download, slow on constrained networks |
| Requires `--editable` mode | Great for contributors (edits are live), but a burden for deployers (the source tree must stay around) |
| No version concept | No `pip install lisa==X.Y.Z`, no pinning, no rollback |
| Hard to use in restricted environments | Offline / locked-down images can pull a single wheel much more easily than a git clone + dependency resolution |
| Dependency isolation is awkward | Users must know the magic extras names (`[azure,libvirt]`) |

### 1.2 Goal

Make this work for any Python user:

```bash
pip install mslisa            # core only
pip install "mslisa[azure]"   # most common: with Azure SDK
pip install "mslisa[azure,libvirt]"
lisa --help
```

Properties:
- No source clone required
- Real version numbers (CalVer: `YYYYMMDD.N`)
- **Coexists** with the existing `--editable` development workflow — contributors are not affected

---

## 2. Design principles

### 2.1 Package name `mslisa`

`lisa` is already taken on PyPI, so the project ships as **`mslisa`** (Microsoft LISA).

- Install command: `pip install mslisa`
- The console script name is **unchanged**: [lisa/pyproject.toml](../lisa/pyproject.toml) declares `[project.scripts] lisa = "lisa.main:cli"`, so users still type `lisa`.
- The Python import path is **unchanged**: `import lisa`.

### 2.2 Versioning: CalVer + `setuptools_scm`

- Version format: **`YYYYMMDD.N`** (e.g. `20260420.1`, `20260420.2`)
- No hand-maintained `__version__`; `setuptools_scm` derives the version from the git tag.
- Multiple releases per day are fine — bump `.1` → `.2` → `.3`.
- Once published, a version **cannot be replaced** (PyPI policy). To fix a bad release, yank it and publish a new one.

### 2.3 Trusted Publishing (OIDC, no secrets)

No long-lived API tokens anywhere. GitHub Actions proves its identity to PyPI / TestPyPI over OIDC.

- The trust relationship is bound to: `microsoft/lisa` repo + `publish.yml` workflow + GitHub Environment name (`pypi` or `testpypi`).
- Maintainers can come and go without rotating credentials.

### 2.4 Two-stage publish: TestPyPI → PyPI (with manual gate)

Every pushed tag automatically:

1. Builds sdist + wheel
2. Uploads to **TestPyPI** (no approval) — for human smoke testing
3. Waits for **manual review** on the GitHub Environment `pypi`
4. After approval, uploads to the real **PyPI**

This gives a "back out" window so a broken artifact never reaches the production index unattended.

### 2.5 Optional extras for opt-in features

`pip install mslisa` installs only core dependencies (paramiko, PyYAML, etc.).
Platform-specific and developer dependencies are opt-in via extras ([lisa/pyproject.toml](../lisa/pyproject.toml#L37)):

| Extra | Purpose |
|---|---|
| `azure` | Azure SDK packages required for Azure tests |
| `libvirt` | libvirt platform |
| `aws` | AWS platform |
| `baremetal` | Bare-metal / Redfish |
| `ai` | AI-agent tests |
| `docs`, `mypy`, `pylint`, `black`, `flake8`, `isort`, `typing`, `test` | Dev tooling |

---

## 3. How the package is built

### 3.1 Key files

| File | Role |
|---|---|
| [lisa/pyproject.toml](../lisa/pyproject.toml) | Metadata, dependencies, extras, console script, build system |
| [lisa/MANIFEST.in](../lisa/MANIFEST.in) | sdist include/exclude rules (note: `prune` doesn't apply to files already tracked by git when `setuptools_scm` is the file finder) |
| [lisa/.github/workflows/publish.yml](../lisa/.github/workflows/publish.yml) | Publish workflow |
| [lisa/RELEASE.md](../lisa/RELEASE.md) | Release runbook |

### 3.2 Build backend

```toml
[build-system]
requires = ["setuptools >= 70", "setuptools_scm[toml] >= 6.2"]
build-backend = "setuptools.build_meta"
```

- Backend: `setuptools` + `setuptools_scm`
- Artifacts:
  - `mslisa-<version>-py3-none-any.whl` (pure-Python wheel, cross-platform)
  - `mslisa-<version>.tar.gz` (sdist)

### 3.3 Known limitations

- **sdist build fails on Windows.** `setuptools_scm` includes every git-tracked file (including deeply nested paths under `lisa/ai/data/...`), and the resulting paths exceed Windows' 260-character limit. The CI build on Linux is unaffected. End users install the wheel.
- **`MANIFEST.in` `prune` rules don't apply** to files already tracked by git, because the file finder is `setuptools_scm`. To shrink the sdist, move `lisa/ai/data/` out of git (git-lfs or a sibling repo).

---

## 4. How the publish workflow runs

### 4.1 Trigger

[lisa/.github/workflows/publish.yml](../lisa/.github/workflows/publish.yml):

```yaml
on:
  push:
    tags:
      - "2[0-9][0-9][0-9][0-9][0-9][0-9][0-9].*"   # CalVer
  workflow_dispatch:   # manual run for build-only smoke tests
```

### 4.2 The three jobs

```
┌─────────────┐     ┌──────────────────┐     ┌──────────────────┐
│   build     │ ──▶ │ publish-testpypi │ ──▶ │  publish-pypi    │
│ sdist+wheel │     │  (auto, OIDC)    │     │ (manual approval)│
└─────────────┘     └──────────────────┘     └──────────────────┘
```

1. **`build`**
   - `actions/checkout@v4` with `fetch-depth: 0` (`setuptools_scm` needs the full tag history)
   - `python -m build` produces wheel + sdist
   - `python -m twine check dist/*` validates metadata
   - Uploads `dist/` as an artifact

2. **`publish-testpypi`**
   - Only runs on tag push
   - GitHub Environment: `testpypi` (no reviewers required)
   - Uses `pypa/gh-action-pypi-publish@release/v1` with OIDC
   - Target: `https://test.pypi.org/legacy/`

3. **`publish-pypi`**
   - Depends on `publish-testpypi` succeeding
   - GitHub Environment: `pypi` (**required reviewers configured**)
   - A maintainer must click "Review deployments" in the Actions UI to continue
   - Target: production PyPI

### 4.3 One-time bootstrap (already done)

See [lisa/RELEASE.md](../lisa/RELEASE.md). Summary:

1. Add a **pending publisher** on PyPI and TestPyPI (binding `microsoft/lisa` + `publish.yml` + environment name).
2. In GitHub Settings → Environments, create `testpypi` and `pypi`, and add 1–2 LSG maintainers as required reviewers on `pypi`.
3. (Recommended) Add a tag protection rule `2[0-9][0-9][0-9][0-9][0-9][0-9][0-9].*` so only release managers can push release tags.

### 4.4 Cutting a release

```bash
git checkout main
git pull --ff-only
TAG=$(date +%Y%m%d).1          # bump to .2 if today already has .1
git tag -a "$TAG" -m "$TAG"
git push origin "$TAG"
# Then watch the Actions run. Smoke test from TestPyPI, then approve to promote to PyPI.
```

---

## 5. Pre-release testing (before approving the final PyPI push)

Before the `pypi` environment is approved, the artifact already exists on **TestPyPI**. Anyone can install it from there and run end-to-end validation.

### 5.1 On WSL / Ubuntu 24.04 (recommended — isolated environment)

> Ubuntu 24.04's system Python is locked down by PEP 668, so you cannot `pip install` into the system interpreter. Use a venv.

```bash
# 1. Install Python venv tooling
sudo apt update
sudo apt install -y python3 python3-venv python3-full

# 2. Confirm Python version (Ubuntu 24.04 ships 3.12)
python3 --version

# 3. Create a clean venv just for verification
python3 -m venv /tmp/lisa-pypi-verify

# 4. Activate
source /tmp/lisa-pypi-verify/bin/activate

# 5. Upgrade pip
pip install --upgrade pip

# 6. Install the pre-release from TestPyPI
#    --index-url       : pull the package itself from TestPyPI
#    --extra-index-url : resolve normal dependencies from PyPI
#    [azure]           : install Azure extras
#    ==<TAG>           : pin the version (required for rc/pre-release builds —
#                        pip skips pre-releases unless you spell out the version)
TAG="20260513.1rc1"   # replace with the tag you want to verify
pip install \
    --index-url https://test.pypi.org/simple/ \
    --extra-index-url https://pypi.org/simple/ \
    "mslisa-lildeng-test[azure]==${TAG}"
# After the real release on PyPI, the package name becomes mslisa:
# pip install \
#     --index-url https://test.pypi.org/simple/ \
#     --extra-index-url https://pypi.org/simple/ \
#     "mslisa[azure]==${TAG}"

# 7. Verify
lisa --help
python -c "import lisa; print(lisa.__file__)"

# 8. Exit when done
deactivate
```

> **Want a fully isolated WSL instance?** In Windows PowerShell:
> ```powershell
> Invoke-WebRequest -Uri "https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz" -OutFile "$env:TEMP\noble-rootfs.tar.gz"
> New-Item -ItemType Directory -Force -Path C:\WSL\lisa-pypi-test | Out-Null
> wsl --import lisa-pypi-test C:\WSL\lisa-pypi-test "$env:TEMP\noble-rootfs.tar.gz" --version 2
> wsl -d lisa-pypi-test
> ```
> Remove when done: `wsl --unregister lisa-pypi-test; Remove-Item -Recurse -Force C:\WSL\lisa-pypi-test`

### 5.2 On Windows

```powershell
$py = "C:\Users\<you>\AppData\Local\Programs\Python\Python313\python.exe"
& $py --version    # expect: Python 3.13.x
& $py -m venv C:\tmp\lisa-pypi-verify

$TAG = "20260513.1rc1"
& C:\tmp\lisa-pypi-verify\Scripts\python.exe -m pip install `
    --index-url https://test.pypi.org/simple/ `
    --extra-index-url https://pypi.org/simple/ `
    "mslisa-lildeng-test[azure]==$TAG"

& C:\tmp\lisa-pypi-verify\Scripts\lisa.exe --help
```

### 5.3 Local dry run (no upload anywhere)

Whenever you change `pyproject.toml` or `MANIFEST.in`, build locally first:

```bash
cd lisa
python -m pip install --upgrade build twine
python -m build --wheel      # sdist fails on Windows — wheel only there
python -m twine check dist/*

# Try installing into a fresh venv
python -m venv /tmp/mslisa-local
/tmp/mslisa-local/bin/pip install ./dist/mslisa-*.whl[azure]
/tmp/mslisa-local/bin/lisa --help
```

### 5.4 Verification checklist (run for every rc)

- [ ] `pip install` completes with no dependency conflicts
- [ ] `lisa --help` prints normally
- [ ] `lisa --version` matches the tag
- [ ] `python -c "import lisa"` succeeds
- [ ] A simple runbook (e.g. `examples/runbook/hello_world.yml`) runs to completion
- [ ] An Azure-platform runbook can authenticate and deploy a VM
- [ ] Wheel size is reasonable (a sudden jump means something unwanted was packaged)

---

## 6. Contributor workflow is unchanged

Publishing to PyPI **does not affect** contributors. They keep using:

```bash
git clone https://github.com/microsoft/lisa.git
cd lisa
python3 -m pip install --editable .[azure,libvirt] --config-settings editable_mode=compat
```

Source edits are live, selftests work as before, PRs work as before.

One-line summary: **`pip install mslisa` is for users; `pip install -e .` is for contributors.**

---

## 7. References

- PR: [microsoft/lisa#4480](https://github.com/microsoft/lisa/pull/4480)
- Release runbook: [lisa/RELEASE.md](../lisa/RELEASE.md)
- Workflow: [lisa/.github/workflows/publish.yml](../lisa/.github/workflows/publish.yml)
- Package metadata: [lisa/pyproject.toml](../lisa/pyproject.toml)
- PyPI project page (after release): <https://pypi.org/project/mslisa/>
- TestPyPI test package (current): <https://test.pypi.org/project/mslisa-lildeng-test/>
- PEP 668 (externally managed environments): <https://peps.python.org/pep-0668/>
- PyPI Trusted Publishing docs: <https://docs.pypi.org/trusted-publishers/>