### PR TITLE
Add SerialConsole support for OpenVMM guests

### DIFF
--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -41,6 +41,7 @@ from .schema import (
     OpenVmmGuestNodeSchema,
     OpenVmmNetworkSchema,
 )
+from .serial_console import SerialConsole
 from .start_stop import StartStop
 
 # Allow slower guest boot and reconnect paths on loaded L1 hosts.
@@ -174,7 +175,7 @@ class OpenVmmController:
 
     @classmethod
     def supported_features(cls) -> List[Type[Any]]:
-        return [StartStop]
+        return [StartStop, SerialConsole]
 
     def resolve_guest_artifact_path(
         self, source_path: str, is_remote_path: bool, working_path: PurePath

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -1207,6 +1207,13 @@ class OpenVmmController:
     def ensure_minimum_raw_disk_size(
         self, disk_image_path: str, minimum_size_gb: int
     ) -> None:
+        """
+        Ensure a .raw OpenVMM guest disk image is at least the requested size.
+
+        Args:
+            disk_image_path: Path to the guest disk image on the OpenVMM host.
+            minimum_size_gb: Minimum image size, in GiB.
+        """
         if not disk_image_path.lower().endswith(".raw"):
             return
 

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -1204,6 +1204,29 @@ class OpenVmmController:
         node_context.console_log_file_path = ""
         node_context.launcher_log_file_path = ""
 
+    def ensure_minimum_raw_disk_size(
+        self, disk_image_path: str, minimum_size_gb: int
+    ) -> None:
+        if not disk_image_path.lower().endswith(".raw"):
+            return
+
+        minimum_size_bytes = minimum_size_gb * 1024 * 1024 * 1024
+        self.host_node.execute(
+            (
+                f"current_size=$(stat -c %s {shlex.quote(disk_image_path)}) && "
+                f"if [ \"$current_size\" -lt {minimum_size_bytes} ]; then "
+                f"truncate -s {minimum_size_gb}G {shlex.quote(disk_image_path)}; "
+                "fi"
+            ),
+            shell=True,
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to ensure minimum OpenVMM raw disk size for "
+                f"'{disk_image_path}'"
+            ),
+        )
+
     def _get_host_public_address(self) -> str:
         if self.host_node.is_remote:
             return cast(RemoteNode, self.host_node).public_address

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -1222,7 +1222,7 @@ class OpenVmmController:
         self.host_node.execute(
             (
                 f"current_size=$(stat -c %s {shlex.quote(disk_image_path)}) && "
-                f"if [ \"$current_size\" -lt {minimum_size_bytes} ]; then "
+                f'if [ "$current_size" -lt {minimum_size_bytes} ]; then '
                 f"truncate -s {minimum_size_gb}G {shlex.quote(disk_image_path)}; "
                 "fi"
             ),

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -52,6 +52,7 @@ OPENVMM_IP_DISCOVERY_TIMEOUT = 300
 OPENVMM_LOG_TAIL_LINES = 40
 OPENVMM_DHCP_SERVER_PORT = 67
 OPENVMM_DNS_SERVER_PORT = 53
+OPENVMM_GIBIBYTE = 1 << 30
 OPENVMM_BRIDGE_NETFILTER_KEYS = [
     "net.bridge.bridge-nf-call-iptables",
     "net.bridge.bridge-nf-call-arptables",
@@ -1217,7 +1218,7 @@ class OpenVmmController:
         if not disk_image_path.lower().endswith(".raw"):
             return
 
-        minimum_size_bytes = minimum_size_gb * 1024 * 1024 * 1024
+        minimum_size_bytes = minimum_size_gb * OPENVMM_GIBIBYTE
         self.host_node.execute(
             (
                 f"current_size=$(stat -c %s {shlex.quote(disk_image_path)}) && "

--- a/lisa/sut_orchestrator/openvmm/serial_console.py
+++ b/lisa/sut_orchestrator/openvmm/serial_console.py
@@ -45,6 +45,7 @@ class SerialConsole(features.SerialConsole):
         log = host_node.tools[Cat].read(
             shlex.quote(console_log_file_path),
             force_run=True,
+            sudo=True,
             no_debug_log=True,
         )
         log = re.sub("\x1b\\[[0-9;]*[mGKF]", "", log)

--- a/lisa/sut_orchestrator/openvmm/serial_console.py
+++ b/lisa/sut_orchestrator/openvmm/serial_console.py
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+import shlex
+from pathlib import Path
+from typing import Any, Optional
+
+from lisa import features
+from lisa.tools import Cat
+from lisa.util import LisaException
+
+from .context import get_node_context
+from .schema import OPENVMM_SERIAL_MODE_FILE, OPENVMM_SERIAL_MODE_STDERR
+
+
+class SerialConsole(features.SerialConsole):
+    def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        super()._initialize(*args, **kwargs)
+
+    def _get_console_log(self, saved_path: Optional[Path]) -> bytes:
+        node_context = get_node_context(self._node)
+        host_node = node_context.host
+        if not host_node:
+            raise LisaException(
+                f"OpenVMM guest '{self._node.name}' does not have a host node "
+                "recorded for serial console collection. Verify the guest was "
+                "provisioned by the OpenVMM orchestrator."
+            )
+
+        runbook = getattr(self._node, "runbook", None)
+        serial_mode = getattr(
+            getattr(runbook, "serial", None), "mode", OPENVMM_SERIAL_MODE_FILE
+        )
+        console_log_file_path = node_context.console_log_file_path
+        if serial_mode == OPENVMM_SERIAL_MODE_STDERR:
+            console_log_file_path = node_context.launcher_stderr_log_file_path
+
+        if not console_log_file_path:
+            raise LisaException(
+                f"OpenVMM guest '{self._node.name}' does not have a serial console "
+                "log path. Verify OpenVMM launch completed before checking panic."
+            )
+
+        log = host_node.tools[Cat].read(
+            shlex.quote(console_log_file_path),
+            force_run=True,
+            no_debug_log=True,
+        )
+        log = re.sub("\x1b\\[[0-9;]*[mGKF]", "", log)
+        return log.encode("utf-8")

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -8,15 +8,21 @@ from typing import Any, Tuple, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from lisa import schema
+from lisa.features import SerialConsole as SerialConsoleFeature
 from lisa.sut_orchestrator.openvmm.context import NodeContext
 from lisa.sut_orchestrator.openvmm.node import OpenVmmController, OpenVmmGuestNode
 from lisa.sut_orchestrator.openvmm.schema import (
     OPENVMM_NETWORK_MODE_TAP,
     OpenVmmGuestNodeSchema,
     OpenVmmNetworkSchema,
+    OpenVmmSerialSchema,
     OpenVmmUefiSchema,
 )
-from lisa.tools import Kill, Mkdir
+from lisa.sut_orchestrator.openvmm.serial_console import (
+    SerialConsole as OpenVmmSerialConsole,
+)
+from lisa.tools import Cat, Ip, Kill, Mkdir
 from lisa.util import LisaException
 
 
@@ -179,6 +185,137 @@ class OpenVmmNodeTestCase(TestCase):
         self.assertEqual(60024, third_guest_network.forwarded_port)
         self.assertEqual("tap0", network.tap_name)
         self.assertEqual("10.0.0.1/24", network.tap_host_cidr)
+
+    def test_supported_features_include_serial_console(self) -> None:
+        supported_feature_names = [
+            feature.name() for feature in OpenVmmController.supported_features()
+        ]
+
+        self.assertIn(SerialConsoleFeature.name(), supported_feature_names)
+
+    def test_serial_console_reads_openvmm_host_console_log(self) -> None:
+        cat = SimpleNamespace(
+            read=MagicMock(return_value="\x1b[31mKernel panic\x1b[0m")
+        )
+        host_node = SimpleNamespace(tools={Cat: cat})
+        with TemporaryDirectory() as temp_dir:
+            node_context = NodeContext(
+                host=cast(Any, host_node),
+                console_log_file_path="/var/tmp/openvmm-host-g0/openvmm-console.log",
+            )
+            node = SimpleNamespace(
+                name="g0",
+                get_context=MagicMock(return_value=node_context),
+                local_log_path=Path(temp_dir),
+                log=MagicMock(),
+            )
+            serial_console = OpenVmmSerialConsole(
+                schema.FeatureSettings.create(SerialConsoleFeature.name()),
+                cast(Any, node),
+                MagicMock(),
+            )
+            serial_console.initialize()
+
+            console_log = serial_console.get_console_log()
+
+        self.assertEqual("Kernel panic", console_log)
+        cat.read.assert_called_once_with(
+            "/var/tmp/openvmm-host-g0/openvmm-console.log",
+            force_run=True,
+            no_debug_log=True,
+        )
+
+    def test_serial_console_reads_openvmm_stderr_console_log(self) -> None:
+        cat = SimpleNamespace(read=MagicMock(return_value="Kernel panic"))
+        host_node = SimpleNamespace(tools={Cat: cat})
+        with TemporaryDirectory() as temp_dir:
+            node_context = NodeContext(
+                host=cast(Any, host_node),
+                console_log_file_path="/var/tmp/openvmm-host-g0/openvmm-console.log",
+                launcher_stderr_log_file_path=(
+                    "/var/tmp/openvmm-host-g0/openvmm-launcher.stderr.log"
+                ),
+            )
+            node = SimpleNamespace(
+                name="g0",
+                get_context=MagicMock(return_value=node_context),
+                local_log_path=Path(temp_dir),
+                log=MagicMock(),
+                runbook=SimpleNamespace(serial=OpenVmmSerialSchema(mode="stderr")),
+            )
+            serial_console = OpenVmmSerialConsole(
+                schema.FeatureSettings.create(SerialConsoleFeature.name()),
+                cast(Any, node),
+                MagicMock(),
+            )
+            serial_console.initialize()
+
+            console_log = serial_console.get_console_log()
+
+        self.assertEqual("Kernel panic", console_log)
+        cat.read.assert_called_once_with(
+            "/var/tmp/openvmm-host-g0/openvmm-launcher.stderr.log",
+            force_run=True,
+            no_debug_log=True,
+        )
+
+    def test_enable_ssh_forwarding_allows_openvmm_guest_subnet_routing(
+        self,
+    ) -> None:
+        bridge_name = "ovmbr1"
+        guest_address = "10.0.1.2"
+        tap_host_cidr = "10.0.1.1/24"
+        execute_result = SimpleNamespace(exit_code=0, stderr="", stdout="0")
+        host_node = SimpleNamespace(
+            is_remote=True,
+            execute=MagicMock(return_value=execute_result),
+            tools={Ip: SimpleNamespace(get_default_route_info=lambda: ("eth0", ""))},
+        )
+        controller = OpenVmmController(cast(Any, host_node), MagicMock())
+        node_context = NodeContext(guest_address=guest_address, ssh_port=22)
+        network = OpenVmmNetworkSchema(
+            mode=OPENVMM_NETWORK_MODE_TAP,
+            tap_name="tap1",
+            bridge_name=bridge_name,
+            tap_host_cidr=tap_host_cidr,
+            guest_address=guest_address,
+            forward_ssh_port=True,
+            forwarded_port=60023,
+        )
+
+        controller._enable_ssh_forwarding(node_context, guest_address, network)
+        controller._disable_ssh_forwarding_context(node_context, network)
+
+        commands = [call.args[0] for call in host_node.execute.call_args_list]
+        self.assertTrue(
+            any(
+                f"iptables -C FORWARD -i {bridge_name} -j ACCEPT" in command
+                for command in commands
+            )
+        )
+        self.assertTrue(
+            any(
+                f"iptables -D FORWARD -i {bridge_name} -j ACCEPT" in command
+                for command in commands
+            )
+        )
+
+    def test_ensure_minimum_raw_disk_size_grows_raw_image(self) -> None:
+        controller, _, _, _ = self._create_controller()
+
+        controller.ensure_minimum_raw_disk_size("/var/tmp/guest.raw", 16)
+
+        execute = cast(MagicMock, controller.host_node.execute)
+        command = execute.call_args.args[0]
+        self.assertIn("stat -c %s /var/tmp/guest.raw", command)
+        self.assertIn("truncate -s 16G /var/tmp/guest.raw", command)
+
+    def test_ensure_minimum_raw_disk_size_skips_non_raw_image(self) -> None:
+        controller, _, _, _ = self._create_controller()
+
+        controller.ensure_minimum_raw_disk_size("/var/tmp/guest.vhd", 16)
+
+        cast(MagicMock, controller.host_node.execute).assert_not_called()
 
     def test_provision_uses_host_pure_path_for_working_directory(self) -> None:
         host_node = SimpleNamespace(

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -222,6 +222,7 @@ class OpenVmmNodeTestCase(TestCase):
         cat.read.assert_called_once_with(
             "/var/tmp/openvmm-host-g0/openvmm-console.log",
             force_run=True,
+            sudo=True,
             no_debug_log=True,
         )
 
@@ -256,6 +257,7 @@ class OpenVmmNodeTestCase(TestCase):
         cat.read.assert_called_once_with(
             "/var/tmp/openvmm-host-g0/openvmm-launcher.stderr.log",
             force_run=True,
+            sudo=True,
             no_debug_log=True,
         )
 
@@ -289,13 +291,13 @@ class OpenVmmNodeTestCase(TestCase):
         commands = [call.args[0] for call in host_node.execute.call_args_list]
         self.assertTrue(
             any(
-                f"iptables -C FORWARD -i {bridge_name} -j ACCEPT" in command
+                f"iptables -C FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
                 for command in commands
             )
         )
         self.assertTrue(
             any(
-                f"iptables -D FORWARD -i {bridge_name} -j ACCEPT" in command
+                f"iptables -D FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
                 for command in commands
             )
         )


### PR DESCRIPTION
Kdump and reboot diagnostics call node.features[SerialConsole].check_panic() to inspect the guest serial log. OpenVMM guests already launch with COM1 wired to an OpenVMM-managed log path, but the OpenVMM controller only advertised StartStop, so tests that require SerialConsole failed during feature lookup with 'feature [SerialConsole] isn't supported on platform [openvmm]'.

Add an OpenVMM SerialConsole feature that reads the guest console from the parent host, because the COM1 file is host-side state rather than a file inside the guest. The implementation reads the configured file serial log by default, falls back to the launcher stderr log when the runbook uses serial.mode=stderr, and strips ANSI control sequences before the common panic scanner processes the content.

Register SerialConsole in OpenVMM supported_features and add selftests for feature registration, file-backed console collection, stderr-backed console collection, and ANSI cleanup.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

2026-05-11 18:56:39.624[140297817466688][INFO] lisa.RootRunner ________________________________________
2026-05-11 18:56:39.624[140297817466688][INFO] lisa.RootRunner     OpenVmmPlatformSuite.verify_openvmm_guest_boot: PASSED   
2026-05-11 18:56:39.624[140297817466688][INFO] lisa.RootRunner OpenVmmPlatformSuite.verify_openvmm_restart_via_platform: PASSED   
2026-05-11 18:56:39.625[140297817466688][INFO] lisa.RootRunner                               CPU.verify_cpu_count: PASSED   
2026-05-11 18:56:39.625[140297817466688][INFO] lisa.RootRunner         KdumpCrash.verify_kdumpcrash_on_random_cpu: PASSED  
