### PR TITLE
Fix perf PPS stale process cleanup

### DIFF
--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -277,23 +277,31 @@ def perf_tcp_pps(
         # set server and client from environment, if not set explicitly
         server = cast(RemoteNode, environment.nodes[1])
         client = cast(RemoteNode, environment.nodes[0])
+    server_node: RemoteNode = server
+    client_node: RemoteNode = client
 
     client_netperf, server_netperf = run_in_parallel(
-        [lambda: client.tools[Netperf], lambda: server.tools[Netperf]]  # type: ignore
+        [lambda: client_node.tools[Netperf], lambda: server_node.tools[Netperf]]
+    )
+    run_in_parallel(
+        [
+            lambda: client_node.tools[Kill].by_name("netperf", ignore_not_exist=True),
+            lambda: server_node.tools[Kill].by_name("netserver", ignore_not_exist=True),
+        ]
     )
 
     server_interface_ip: str = ""
     client_interface_ip: str = ""
     if use_internal_address:
-        assert server.internal_address, "Server Node: internal address is not set"
-        assert client.internal_address, "Client Node: internal address is not set"
-        server_interface_ip = server.internal_address
-        client_interface_ip = client.internal_address
+        assert server_node.internal_address, "Server Node: internal address is not set"
+        assert client_node.internal_address, "Client Node: internal address is not set"
+        server_interface_ip = server_node.internal_address
+        client_interface_ip = client_node.internal_address
 
-    cpu = client.tools[Lscpu]
+    cpu = client_node.tools[Lscpu]
     thread_count = cpu.get_thread_count()
     if "maxpps" == test_type:
-        ssh = client.tools[Ssh]
+        ssh = client_node.tools[Ssh]
         ssh.set_max_session()
         ports = range(30000, 30032)
     else:
@@ -304,13 +312,13 @@ def perf_tcp_pps(
         # Use server.internal_address as target since netperf client needs
         # the server's IP (which may differ from the interface it binds to)
         client_netperf.run_as_client_async(
-            server_ip=server.internal_address,
+            server_ip=server_node.internal_address,
             core_count=thread_count,
             port=port,
             interface_ip=client_interface_ip,
         )
-    client_sar = client.tools[Sar]
-    server_sar = server.tools[Sar]
+    client_sar = client_node.tools[Sar]
+    server_sar = server_node.tools[Sar]
     server_sar.get_statistics_async()
     result = client_sar.get_statistics()
     pps_message = client_sar.create_pps_performance_messages(

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -277,6 +277,8 @@ def perf_tcp_pps(
         # set server and client from environment, if not set explicitly
         server = cast(RemoteNode, environment.nodes[1])
         client = cast(RemoteNode, environment.nodes[0])
+    assert server is not None, "server must not be None before perf_tcp_pps run"
+    assert client is not None, "client must not be None before perf_tcp_pps run"
     server_node: RemoteNode = server
     client_node: RemoteNode = client
 
@@ -293,8 +295,12 @@ def perf_tcp_pps(
     server_interface_ip: str = ""
     client_interface_ip: str = ""
     if use_internal_address:
-        assert server_node.internal_address, "Server Node: internal address is not set"
-        assert client_node.internal_address, "Client Node: internal address is not set"
+        assert_that(server_node.internal_address).described_as(
+            "Server Node: internal address is not set"
+        ).is_not_empty()
+        assert_that(client_node.internal_address).described_as(
+            "Client Node: internal address is not set"
+        ).is_not_empty()
         server_interface_ip = server_node.internal_address
         client_interface_ip = client_node.internal_address
 


### PR DESCRIPTION
Kill stale netperf clients and netserver instances before starting a new PPS run so leftover processes from earlier cleanup failures cannot make the next run fail with address-in-use errors.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
