### PR TITLE
Fix OpenVMM perf networking and disk setup

### DIFF
--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -299,6 +299,36 @@ class OpenVmmController:
             openvmm.set_binary_path("openvmm")
         return openvmm
 
+    def ensure_minimum_raw_disk_size(
+        self, disk_img_path: str, min_raw_disk_size_gb: int
+    ) -> None:
+        if not disk_img_path or min_raw_disk_size_gb <= 0:
+            return
+        if Path(disk_img_path).suffix.lower() != ".raw":
+            self._log.debug(
+                "Skipping OpenVMM raw disk growth for non-raw disk image "
+                f"'{disk_img_path}'."
+            )
+            return
+
+        minimum_size_bytes = min_raw_disk_size_gb * 1024 * 1024 * 1024
+        quoted_disk_img_path = shlex.quote(disk_img_path)
+        self.host_node.execute(
+            (
+                f"current_size=$(stat -c %s {quoted_disk_img_path}); "
+                f'if [ "$current_size" -lt {minimum_size_bytes} ]; then '
+                f"truncate -s {min_raw_disk_size_gb}G {quoted_disk_img_path}; "
+                "fi"
+            ),
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to ensure OpenVMM raw guest disk "
+                f"'{disk_img_path}' is at least {min_raw_disk_size_gb} GiB. "
+                "Verify the host has enough free space and supports sparse files."
+            ),
+        )
+
     def create_effective_network(
         self, network: OpenVmmNetworkSchema, guest_index: int
     ) -> OpenVmmNetworkSchema:
@@ -397,6 +427,13 @@ class OpenVmmController:
         user_data: dict[str, Any] = {
             "users": ["default", user],
         }
+        if runbook.min_raw_disk_size_gb > 0:
+            user_data["growpart"] = {
+                "mode": "auto",
+                "devices": ["/"],
+                "ignore_growroot_disabled": False,
+            }
+            user_data["resize_rootfs"] = True
         if runbook.username == "root":
             user_data["disable_root"] = False
         if runbook.password:
@@ -1295,6 +1332,24 @@ class OpenVmmController:
             ),
             (
                 "iptables -C FORWARD -i "
+                f"{shlex.quote(host_interface)} "
+                "-j ACCEPT "
+                "|| "
+                "iptables -I FORWARD -i "
+                f"{shlex.quote(host_interface)} "
+                "-j ACCEPT"
+            ),
+            (
+                "iptables -C FORWARD -o "
+                f"{shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT "
+                "|| "
+                "iptables -I FORWARD -o "
+                f"{shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT"
+            ),
+            (
+                "iptables -C FORWARD -i "
                 f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
                 "-m state --state RELATED,ESTABLISHED -j ACCEPT "
                 "|| "
@@ -1392,6 +1447,16 @@ class OpenVmmController:
                 "iptables -D FORWARD -i "
                 f"{shlex.quote(host_interface)} -o {shlex.quote(forwarding_interface)} "
                 "-j ACCEPT || true"
+            ),
+            (
+                "iptables -D FORWARD -i "
+                f"{shlex.quote(host_interface)} "
+                "-j ACCEPT || true"
+            ),
+            (
+                "iptables -D FORWARD -o "
+                f"{shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT || true"
             ),
             (
                 "iptables -D FORWARD -i "
@@ -1682,6 +1747,10 @@ class OpenVmmGuestNode(RemoteNode):
                     runbook.disk_img_is_remote_path,
                     working_path,
                 )
+            )
+            self._openvmm_controller.ensure_minimum_raw_disk_size(
+                node_context.disk_img_path,
+                runbook.min_raw_disk_size_gb,
             )
 
         if runbook.cloud_init:

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -64,12 +64,8 @@ def _get_tap_host_interface_name(network: OpenVmmNetworkSchema) -> str:
     return network.bridge_name or network.tap_name
 
 
-def _should_grow_raw_disk(disk_img_path: str, min_raw_disk_size_gb: int) -> bool:
-    return (
-        bool(disk_img_path)
-        and min_raw_disk_size_gb > 0
-        and Path(disk_img_path).suffix.lower() == ".raw"
-    )
+def _is_raw_disk_image(disk_img_path: str) -> bool:
+    return Path(disk_img_path).suffix.lower() == ".raw"
 
 
 def _countspace_to_int(value: search_space.CountSpace) -> int:
@@ -308,31 +304,39 @@ class OpenVmmController:
         return openvmm
 
     def ensure_minimum_raw_disk_size(
-        self, disk_img_path: str, min_raw_disk_size_gb: int
+        self, disk_image_path: str, minimum_size_gb: int
     ) -> None:
-        if not disk_img_path or min_raw_disk_size_gb <= 0:
+        """
+        Ensure a .raw OpenVMM guest disk image is at least the requested size.
+
+        Args:
+            disk_image_path: Path to the guest disk image on the OpenVMM host.
+            minimum_size_gb: Minimum image size, in GiB.
+        """
+        if not disk_image_path or minimum_size_gb <= 0:
             return
-        if not _should_grow_raw_disk(disk_img_path, min_raw_disk_size_gb):
+        if not _is_raw_disk_image(disk_image_path):
             self._log.debug(
                 "Skipping OpenVMM raw disk growth for non-raw disk image "
-                f"'{disk_img_path}'."
+                f"'{disk_image_path}'."
             )
             return
 
-        minimum_size_bytes = min_raw_disk_size_gb * 1024 * 1024 * 1024
-        quoted_disk_img_path = shlex.quote(disk_img_path)
+        minimum_size_bytes = minimum_size_gb * OPENVMM_GIBIBYTE
+        quoted_disk_img_path = shlex.quote(disk_image_path)
         self.host_node.execute(
             (
-                f"current_size=$(stat -c %s {quoted_disk_img_path}); "
+                f"current_size=$(stat -c %s -- {quoted_disk_img_path}) && "
                 f'if [ "$current_size" -lt {minimum_size_bytes} ]; then '
-                f"truncate -s {min_raw_disk_size_gb}G {quoted_disk_img_path}; "
+                f"truncate -s {minimum_size_gb}G -- {quoted_disk_img_path}; "
                 "fi"
             ),
             shell=True,
+            sudo=True,
             expected_exit_code=0,
             expected_exit_code_failure_message=(
                 "failed to ensure OpenVMM raw guest disk "
-                f"'{disk_img_path}' is at least {min_raw_disk_size_gb} GiB. "
+                f"'{disk_image_path}' is at least {minimum_size_gb} GiB. "
                 "Verify the host has enough free space and supports sparse files."
             ),
         )
@@ -351,6 +355,13 @@ class OpenVmmController:
         effective_network.bridge_name = _increment_name_suffix(
             effective_network.bridge_name, guest_index
         )
+        try:
+            effective_network.validate_tap_interface_names()
+        except LisaException as identifier:
+            raise LisaException(
+                "cannot derive OpenVMM tap network interface names for guest "
+                f"index {guest_index}: {identifier}"
+            ) from identifier
         effective_network.tap_host_cidr = _shift_ip_interface_cidr(
             effective_network.tap_host_cidr, guest_index
         )
@@ -435,8 +446,8 @@ class OpenVmmController:
         user_data: dict[str, Any] = {
             "users": ["default", user],
         }
-        if _should_grow_raw_disk(
-            node_context.disk_img_path, runbook.min_raw_disk_size_gb
+        if runbook.min_raw_disk_size_gb > 0 and _is_raw_disk_image(
+            node_context.disk_img_path
         ):
             user_data["growpart"] = {
                 "mode": "auto",
@@ -1252,36 +1263,6 @@ class OpenVmmController:
         node_context.console_log_file_path = ""
         node_context.launcher_log_file_path = ""
 
-    def ensure_minimum_raw_disk_size(
-        self, disk_image_path: str, minimum_size_gb: int
-    ) -> None:
-        """
-        Ensure a .raw OpenVMM guest disk image is at least the requested size.
-
-        Args:
-            disk_image_path: Path to the guest disk image on the OpenVMM host.
-            minimum_size_gb: Minimum image size, in GiB.
-        """
-        if not disk_image_path.lower().endswith(".raw"):
-            return
-
-        minimum_size_bytes = minimum_size_gb * OPENVMM_GIBIBYTE
-        self.host_node.execute(
-            (
-                f"current_size=$(stat -c %s {shlex.quote(disk_image_path)}) && "
-                f'if [ "$current_size" -lt {minimum_size_bytes} ]; then '
-                f"truncate -s {minimum_size_gb}G {shlex.quote(disk_image_path)}; "
-                "fi"
-            ),
-            shell=True,
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=(
-                "failed to ensure minimum OpenVMM raw disk size for "
-                f"'{disk_image_path}'"
-            ),
-        )
-
     def _get_host_public_address(self) -> str:
         if self.host_node.is_remote:
             return cast(RemoteNode, self.host_node).public_address
@@ -1342,10 +1323,30 @@ class OpenVmmController:
             ),
             (
                 "iptables -C FORWARD -i "
+                f"{shlex.quote(host_interface)} ! -o "
+                f"{shlex.quote(forwarding_interface)} "
+                "-j ACCEPT "
+                "|| "
+                "iptables -I FORWARD -i "
+                f"{shlex.quote(host_interface)} ! -o "
+                f"{shlex.quote(forwarding_interface)} "
+                "-j ACCEPT"
+            ),
+            (
+                "iptables -C FORWARD -i "
                 f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
                 "-m state --state RELATED,ESTABLISHED -j ACCEPT "
                 "|| "
                 "iptables -I FORWARD -i "
+                f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT"
+            ),
+            (
+                "iptables -C FORWARD ! -i "
+                f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT "
+                "|| "
+                "iptables -I FORWARD ! -i "
                 f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
                 "-m state --state RELATED,ESTABLISHED -j ACCEPT"
             ),
@@ -1442,6 +1443,17 @@ class OpenVmmController:
             ),
             (
                 "iptables -D FORWARD -i "
+                f"{shlex.quote(host_interface)} ! -o "
+                f"{shlex.quote(forwarding_interface)} "
+                "-j ACCEPT || true"
+            ),
+            (
+                "iptables -D FORWARD -i "
+                f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT || true"
+            ),
+            (
+                "iptables -D FORWARD ! -i "
                 f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
                 "-m state --state RELATED,ESTABLISHED -j ACCEPT || true"
             ),
@@ -1730,8 +1742,8 @@ class OpenVmmGuestNode(RemoteNode):
                     working_path,
                 )
             )
-            if _should_grow_raw_disk(
-                node_context.disk_img_path, runbook.min_raw_disk_size_gb
+            if runbook.min_raw_disk_size_gb > 0 and _is_raw_disk_image(
+                node_context.disk_img_path
             ):
                 self._openvmm_controller.ensure_minimum_raw_disk_size(
                     node_context.disk_img_path,

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -64,6 +64,14 @@ def _get_tap_host_interface_name(network: OpenVmmNetworkSchema) -> str:
     return network.bridge_name or network.tap_name
 
 
+def _should_grow_raw_disk(disk_img_path: str, min_raw_disk_size_gb: int) -> bool:
+    return (
+        bool(disk_img_path)
+        and min_raw_disk_size_gb > 0
+        and Path(disk_img_path).suffix.lower() == ".raw"
+    )
+
+
 def _countspace_to_int(value: search_space.CountSpace) -> int:
     chosen = search_space.choose_value_countspace(value, value)
     if not isinstance(chosen, int):
@@ -304,7 +312,7 @@ class OpenVmmController:
     ) -> None:
         if not disk_img_path or min_raw_disk_size_gb <= 0:
             return
-        if Path(disk_img_path).suffix.lower() != ".raw":
+        if not _should_grow_raw_disk(disk_img_path, min_raw_disk_size_gb):
             self._log.debug(
                 "Skipping OpenVMM raw disk growth for non-raw disk image "
                 f"'{disk_img_path}'."
@@ -427,7 +435,9 @@ class OpenVmmController:
         user_data: dict[str, Any] = {
             "users": ["default", user],
         }
-        if runbook.min_raw_disk_size_gb > 0:
+        if _should_grow_raw_disk(
+            node_context.disk_img_path, runbook.min_raw_disk_size_gb
+        ):
             user_data["growpart"] = {
                 "mode": "auto",
                 "devices": ["/"],
@@ -1332,24 +1342,6 @@ class OpenVmmController:
             ),
             (
                 "iptables -C FORWARD -i "
-                f"{shlex.quote(host_interface)} "
-                "-j ACCEPT "
-                "|| "
-                "iptables -I FORWARD -i "
-                f"{shlex.quote(host_interface)} "
-                "-j ACCEPT"
-            ),
-            (
-                "iptables -C FORWARD -o "
-                f"{shlex.quote(host_interface)} "
-                "-m state --state RELATED,ESTABLISHED -j ACCEPT "
-                "|| "
-                "iptables -I FORWARD -o "
-                f"{shlex.quote(host_interface)} "
-                "-m state --state RELATED,ESTABLISHED -j ACCEPT"
-            ),
-            (
-                "iptables -C FORWARD -i "
                 f"{shlex.quote(forwarding_interface)} -o {shlex.quote(host_interface)} "
                 "-m state --state RELATED,ESTABLISHED -j ACCEPT "
                 "|| "
@@ -1447,16 +1439,6 @@ class OpenVmmController:
                 "iptables -D FORWARD -i "
                 f"{shlex.quote(host_interface)} -o {shlex.quote(forwarding_interface)} "
                 "-j ACCEPT || true"
-            ),
-            (
-                "iptables -D FORWARD -i "
-                f"{shlex.quote(host_interface)} "
-                "-j ACCEPT || true"
-            ),
-            (
-                "iptables -D FORWARD -o "
-                f"{shlex.quote(host_interface)} "
-                "-m state --state RELATED,ESTABLISHED -j ACCEPT || true"
             ),
             (
                 "iptables -D FORWARD -i "
@@ -1748,10 +1730,13 @@ class OpenVmmGuestNode(RemoteNode):
                     working_path,
                 )
             )
-            self._openvmm_controller.ensure_minimum_raw_disk_size(
-                node_context.disk_img_path,
-                runbook.min_raw_disk_size_gb,
-            )
+            if _should_grow_raw_disk(
+                node_context.disk_img_path, runbook.min_raw_disk_size_gb
+            ):
+                self._openvmm_controller.ensure_minimum_raw_disk_size(
+                    node_context.disk_img_path,
+                    runbook.min_raw_disk_size_gb,
+                )
 
         if runbook.cloud_init:
             node_context.cloud_init_file_path = str(working_path / "cloud-init.iso")

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -26,7 +26,7 @@ OPENVMM_SERIAL_MODE_FILE = "file"
 # user-supplied images unless they explicitly request it.
 OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB = 0
 OPENVMM_MAX_INTERFACE_NAME_LENGTH = 15
-OPENVMM_INTERFACE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]+$")
+OPENVMM_INTERFACE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 @dataclass_json()
@@ -119,8 +119,6 @@ class OpenVmmNetworkSchema:
             ) from identifier
 
     def _validate_interface_name(self, field_name: str, value: str) -> None:
-        if not value:
-            return
         if len(value) > OPENVMM_MAX_INTERFACE_NAME_LENGTH:
             raise LisaException(
                 f"{field_name} '{value}' is invalid for OpenVMM tap networking. "
@@ -129,8 +127,17 @@ class OpenVmmNetworkSchema:
         if not OPENVMM_INTERFACE_NAME_PATTERN.fullmatch(value):
             raise LisaException(
                 f"{field_name} '{value}' is invalid for OpenVMM tap networking. "
-                "Use only letters, digits, '_', '-', '.', or ':'."
+                "Use only letters, digits, '_', '-', or '.'."
             )
+
+    def validate_tap_interface_names(self) -> None:
+        if self.mode != OPENVMM_NETWORK_MODE_TAP:
+            return
+        if not self.tap_name:
+            raise LisaException("tap_name is required when network mode is 'tap'")
+        self._validate_interface_name("tap_name", self.tap_name)
+        if self.bridge_name:
+            self._validate_interface_name("bridge_name", self.bridge_name)
 
     def __post_init__(self) -> None:
         if self.mode not in [
@@ -142,11 +149,9 @@ class OpenVmmNetworkSchema:
                 f"Supported values: {OPENVMM_NETWORK_MODE_USER}, "
                 f"{OPENVMM_NETWORK_MODE_TAP}"
             )
-        if self.mode == OPENVMM_NETWORK_MODE_TAP and not self.tap_name:
-            raise LisaException("tap_name is required when network mode is 'tap'")
-        self._validate_interface_name("tap_name", self.tap_name)
-        self._validate_interface_name("bridge_name", self.bridge_name)
-        self._validate_tap_host_cidr()
+        if self.mode == OPENVMM_NETWORK_MODE_TAP:
+            self.validate_tap_interface_names()
+            self._validate_tap_host_cidr()
         if self.address_mode not in [
             OPENVMM_ADDRESS_MODE_DISCOVER,
             OPENVMM_ADDRESS_MODE_STATIC,

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 
 import ipaddress
+import re
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -21,9 +22,9 @@ OPENVMM_NETWORK_MODE_USER = "user"
 OPENVMM_NETWORK_MODE_TAP = "tap"
 OPENVMM_SERIAL_MODE_STDERR = "stderr"
 OPENVMM_SERIAL_MODE_FILE = "file"
-# Raw guest images used for OpenVMM perf runs need room for source-built tools
-# and fio payloads; 16 GiB keeps the default sparse copy modest on the host.
-OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB = 16
+OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB = 0
+OPENVMM_MAX_INTERFACE_NAME_LENGTH = 15
+OPENVMM_INTERFACE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]+$")
 
 
 @dataclass_json()
@@ -115,6 +116,20 @@ class OpenVmmNetworkSchema:
                 "Use an interface CIDR like '10.0.0.1/24'."
             ) from identifier
 
+    def _validate_interface_name(self, field_name: str, value: str) -> None:
+        if not value:
+            return
+        if len(value) > OPENVMM_MAX_INTERFACE_NAME_LENGTH:
+            raise LisaException(
+                f"{field_name} '{value}' is invalid for OpenVMM tap networking. "
+                f"Use 1-{OPENVMM_MAX_INTERFACE_NAME_LENGTH} characters."
+            )
+        if not OPENVMM_INTERFACE_NAME_PATTERN.fullmatch(value):
+            raise LisaException(
+                f"{field_name} '{value}' is invalid for OpenVMM tap networking. "
+                "Use only letters, digits, '_', '-', '.', or ':'."
+            )
+
     def __post_init__(self) -> None:
         if self.mode not in [
             OPENVMM_NETWORK_MODE_USER,
@@ -127,6 +142,8 @@ class OpenVmmNetworkSchema:
             )
         if self.mode == OPENVMM_NETWORK_MODE_TAP and not self.tap_name:
             raise LisaException("tap_name is required when network mode is 'tap'")
+        self._validate_interface_name("tap_name", self.tap_name)
+        self._validate_interface_name("bridge_name", self.bridge_name)
         self._validate_tap_host_cidr()
         if self.address_mode not in [
             OPENVMM_ADDRESS_MODE_DISCOVER,

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -21,6 +21,9 @@ OPENVMM_NETWORK_MODE_USER = "user"
 OPENVMM_NETWORK_MODE_TAP = "tap"
 OPENVMM_SERIAL_MODE_STDERR = "stderr"
 OPENVMM_SERIAL_MODE_FILE = "file"
+# Raw guest images used for OpenVMM perf runs need room for source-built tools
+# and fio payloads; 16 GiB keeps the default sparse copy modest on the host.
+OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB = 16
 
 
 @dataclass_json()
@@ -188,6 +191,13 @@ class OpenVmmGuestNodeSchema(schema.GuestNode):
     uefi: Optional[OpenVmmUefiSchema] = None
     disk_img: str = ""
     disk_img_is_remote_path: bool = False
+    min_raw_disk_size_gb: int = field(
+        default=OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB,
+        metadata=schema.field_metadata(
+            field_function=schema.fields.Int,
+            validate=schema.validate.Range(min=0),
+        ),
+    )
     openvmm_binary: str = "/usr/local/bin/openvmm"
     serial: OpenVmmSerialSchema = field(default_factory=OpenVmmSerialSchema)
     network: OpenVmmNetworkSchema = field(default_factory=OpenVmmNetworkSchema)

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -22,6 +22,8 @@ OPENVMM_NETWORK_MODE_USER = "user"
 OPENVMM_NETWORK_MODE_TAP = "tap"
 OPENVMM_SERIAL_MODE_STDERR = "stderr"
 OPENVMM_SERIAL_MODE_FILE = "file"
+# Keep raw disk growth opt-in so existing OpenVMM runbooks don't mutate
+# user-supplied images unless they explicitly request it.
 OPENVMM_DEFAULT_MIN_RAW_DISK_SIZE_GB = 0
 OPENVMM_MAX_INTERFACE_NAME_LENGTH = 15
 OPENVMM_INTERFACE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]+$")

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -8,9 +8,10 @@ from typing import Any, Tuple, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import yaml
+
 from lisa import schema
 from lisa.features import SerialConsole as SerialConsoleFeature
-import yaml
 from lisa.sut_orchestrator.openvmm.context import NodeContext
 from lisa.sut_orchestrator.openvmm.node import OpenVmmController, OpenVmmGuestNode
 from lisa.sut_orchestrator.openvmm.schema import (
@@ -265,15 +266,16 @@ class OpenVmmNodeTestCase(TestCase):
     def test_tap_network_rejects_invalid_interface_names(self) -> None:
         valid_network = OpenVmmNetworkSchema(
             mode=OPENVMM_NETWORK_MODE_TAP,
-            tap_name="tap_0:1",
+            tap_name="tap_0-1",
             bridge_name="br-test.0",
         )
-        self.assertEqual("tap_0:1", valid_network.tap_name)
+        self.assertEqual("tap_0-1", valid_network.tap_name)
         self.assertEqual("br-test.0", valid_network.bridge_name)
 
         invalid_networks = [
-            {"tap_name": "tap 0"},
-            {"tap_name": "tap0", "bridge_name": "br!dge0"},
+            cast(Any, {"tap_name": "tap 0"}),
+            cast(Any, {"tap_name": "tap:1"}),
+            cast(Any, {"tap_name": "tap0", "bridge_name": "br!dge0"}),
         ]
 
         for invalid_network in invalid_networks:
@@ -321,7 +323,33 @@ class OpenVmmNodeTestCase(TestCase):
         )
         self.assertTrue(
             any(
+                f"iptables -C FORWARD -i {bridge_name} ! -o eth0 -j ACCEPT" in command
+                for command in commands
+            )
+        )
+        self.assertTrue(
+            any(
+                f"iptables -C FORWARD ! -i eth0 -o {bridge_name} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT" in command
+                for command in commands
+            )
+        )
+        self.assertTrue(
+            any(
                 f"iptables -D FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
+                for command in commands
+            )
+        )
+        self.assertTrue(
+            any(
+                f"iptables -D FORWARD -i {bridge_name} ! -o eth0 -j ACCEPT" in command
+                for command in commands
+            )
+        )
+        self.assertTrue(
+            any(
+                f"iptables -D FORWARD ! -i eth0 -o {bridge_name} "
+                "-m state --state RELATED,ESTABLISHED -j ACCEPT" in command
                 for command in commands
             )
         )
@@ -340,7 +368,9 @@ class OpenVmmNodeTestCase(TestCase):
             runbook=OpenVmmGuestNodeSchema(
                 uefi=OpenVmmUefiSchema(firmware_path="/tmp/MSVM.fd"),
                 disk_img="/tmp/guest.vhd",
-                cloud_init=SimpleNamespace(extra_user_data=[{"runcmd": ["true"]}]),
+                cloud_init=cast(
+                    Any, SimpleNamespace(extra_user_data=[{"runcmd": ["true"]}])
+                ),
                 network=OpenVmmNetworkSchema(connection_address="127.0.0.1"),
             ),
         )
@@ -371,8 +401,8 @@ class OpenVmmNodeTestCase(TestCase):
 
         execute = cast(MagicMock, controller.host_node.execute)
         command = execute.call_args.args[0]
-        self.assertIn("stat -c %s /var/tmp/guest.raw", command)
-        self.assertIn("truncate -s 16G /var/tmp/guest.raw", command)
+        self.assertIn("stat -c %s -- /var/tmp/guest.raw", command)
+        self.assertIn("truncate -s 16G -- /var/tmp/guest.raw", command)
 
     def test_ensure_minimum_raw_disk_size_skips_non_raw_image(self) -> None:
         controller, _, _, _ = self._create_controller()

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from lisa import schema
 from lisa.features import SerialConsole as SerialConsoleFeature
+import yaml
 from lisa.sut_orchestrator.openvmm.context import NodeContext
 from lisa.sut_orchestrator.openvmm.node import OpenVmmController, OpenVmmGuestNode
 from lisa.sut_orchestrator.openvmm.schema import (
@@ -261,6 +262,21 @@ class OpenVmmNodeTestCase(TestCase):
             no_debug_log=True,
         )
 
+    def test_tap_network_rejects_invalid_interface_names(self) -> None:
+        invalid_networks = [
+            {"tap_name": "tap 0"},
+            {"tap_name": "tap0", "bridge_name": "br!dge0"},
+        ]
+
+        for invalid_network in invalid_networks:
+            with self.subTest(invalid_network=invalid_network), self.assertRaises(
+                LisaException
+            ):
+                OpenVmmNetworkSchema(
+                    mode=OPENVMM_NETWORK_MODE_TAP,
+                    **invalid_network,
+                )
+
     def test_enable_ssh_forwarding_allows_openvmm_guest_subnet_routing(
         self,
     ) -> None:
@@ -291,16 +307,53 @@ class OpenVmmNodeTestCase(TestCase):
         commands = [call.args[0] for call in host_node.execute.call_args_list]
         self.assertTrue(
             any(
-                f"iptables -C FORWARD -i {bridge_name} -j ACCEPT" in command
+                f"iptables -C FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
                 for command in commands
             )
         )
         self.assertTrue(
             any(
-                f"iptables -D FORWARD -i {bridge_name} -j ACCEPT" in command
+                f"iptables -D FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
                 for command in commands
             )
         )
+        self.assertFalse(
+            any(
+                f"iptables -C FORWARD -i {bridge_name} -j ACCEPT" in command
+                for command in commands
+            )
+        )
+
+    def test_create_node_cloud_init_iso_skips_root_resize_for_non_raw_disk(
+        self,
+    ) -> None:
+        controller, shell_copy, _, _ = self._create_controller()
+        node = SimpleNamespace(
+            runbook=OpenVmmGuestNodeSchema(
+                uefi=OpenVmmUefiSchema(firmware_path="/tmp/MSVM.fd"),
+                disk_img="/tmp/guest.vhd",
+                cloud_init=SimpleNamespace(extra_user_data=[{"runcmd": ["true"]}]),
+                network=OpenVmmNetworkSchema(connection_address="127.0.0.1"),
+            ),
+        )
+        node_context = NodeContext(
+            vm_name="g0",
+            disk_img_path="/var/tmp/guest.vhd",
+            cloud_init_file_path="/var/tmp/cloud-init.iso",
+        )
+
+        with patch(
+            "lisa.sut_orchestrator.openvmm.node.get_node_context",
+            return_value=node_context,
+        ), patch.object(controller, "_create_iso") as create_iso:
+            controller.create_node_cloud_init_iso(cast(Any, node))
+
+        user_data = yaml.safe_load(
+            create_iso.call_args.args[1][0][1].split("\n", 1)[1]
+        )
+        self.assertNotIn("growpart", user_data)
+        self.assertNotIn("resize_rootfs", user_data)
+        shell_copy.assert_called_once()
 
     def test_ensure_minimum_raw_disk_size_grows_raw_image(self) -> None:
         controller, _, _, _ = self._create_controller()
@@ -356,3 +409,4 @@ class OpenVmmNodeTestCase(TestCase):
         host_node.tools[Mkdir].create_directory.assert_called_once_with(
             "/var/tmp/host-g0"
         )
+        controller.ensure_minimum_raw_disk_size.assert_not_called()

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -263,6 +263,14 @@ class OpenVmmNodeTestCase(TestCase):
         )
 
     def test_tap_network_rejects_invalid_interface_names(self) -> None:
+        valid_network = OpenVmmNetworkSchema(
+            mode=OPENVMM_NETWORK_MODE_TAP,
+            tap_name="tap_0:1",
+            bridge_name="br-test.0",
+        )
+        self.assertEqual("tap_0:1", valid_network.tap_name)
+        self.assertEqual("br-test.0", valid_network.bridge_name)
+
         invalid_networks = [
             {"tap_name": "tap 0"},
             {"tap_name": "tap0", "bridge_name": "br!dge0"},
@@ -348,9 +356,10 @@ class OpenVmmNodeTestCase(TestCase):
         ), patch.object(controller, "_create_iso") as create_iso:
             controller.create_node_cloud_init_iso(cast(Any, node))
 
-        user_data = yaml.safe_load(
-            create_iso.call_args.args[1][0][1].split("\n", 1)[1]
-        )
+        iso_files = create_iso.call_args.args[1]
+        user_data_file_contents = iso_files[0][1]
+        cloud_config = user_data_file_contents.split("\n", 1)[1]
+        user_data = yaml.safe_load(cloud_config)
         self.assertNotIn("growpart", user_data)
         self.assertNotIn("resize_rootfs", user_data)
         shell_copy.assert_called_once()

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -291,13 +291,13 @@ class OpenVmmNodeTestCase(TestCase):
         commands = [call.args[0] for call in host_node.execute.call_args_list]
         self.assertTrue(
             any(
-                f"iptables -C FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
+                f"iptables -C FORWARD -i {bridge_name} -j ACCEPT" in command
                 for command in commands
             )
         )
         self.assertTrue(
             any(
-                f"iptables -D FORWARD -i {bridge_name} -o eth0 -j ACCEPT" in command
+                f"iptables -D FORWARD -i {bridge_name} -j ACCEPT" in command
                 for command in commands
             )
         )


### PR DESCRIPTION
Add per-guest TAP bridge and subnet derivation, host FORWARD rule setup and cleanup, configurable raw disk growth, and cloud-init root disk resize settings for OpenVMM guests.

Update OpenVMM selftests for unique TAP settings, forwarding rules, raw disk growth, and host working path behavior.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
