### PR TITLE
[AI Generated] BugFix: install build-essential for netperf source build on Debian

### DIFF
--- a/lisa/tools/netperf.py
+++ b/lisa/tools/netperf.py
@@ -93,7 +93,7 @@ class Netperf(Tool):
         if isinstance(self.node.os, Redhat):
             package_list = ["sysstat", "wget", "automake"]
         elif isinstance(self.node.os, Debian):
-            package_list = ["sysstat", "automake"]
+            package_list = ["sysstat", "automake", "build-essential"]
         elif isinstance(self.node.os, Suse):
             package_list = ["sysstat", "automake"]
         elif isinstance(self.node.os, CBLMariner):


### PR DESCRIPTION
## Summary
On minimal Debian/Ubuntu cloud images (e.g. Ubuntu 25.10 server), `build-essential` is not preinstalled, causing netperf's `./configure CC=gcc CFLAGS='-std=gnu89 -fcommon'` to fail with exit code 77 (autoconf ""missing required program"").

Add `build-essential` to the Debian dependency list in `Netperf._install_dep_packages()` so the compiler toolchain (gcc, make, libc-dev) is installed before building netperf from source.

## Validation
| Image | Test | Result |
|---|---|---|
| canonical ubuntu-25_10 server-gen1 25.10.202601100 | NetworkPerformace.perf_tcp_single_pps_synthetic | PASSED |