### PR TITLE
[AI Generated] BugFix: install build-essential for lagscope source build on Debian

### DIFF
--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -482,6 +482,7 @@ class Lagscope(Tool, KillableMixin):
                 "libaio1",
                 "sysstat",
                 "cmake",
+                "build-essential",
             ]
         elif isinstance(self.node.os, Suse):
             package_list = [


### PR DESCRIPTION
### Problem

On minimal Debian-family cloud images (e.g., **Ubuntu 25.10 arm64** `canonical ubuntu-25_10 server-arm64 25.10.202601100`), the `Lagscope` tool fails to install with:

```n lisa.util.LisaException: install 'lagscope' failed. After installed, it cannot be detected.
```

The Debian dep list `[libaio1, sysstat, cmake]` is missing `build-essential`. The `Git` / `Make` / `Gcc` tool dependencies pull in individual packages, but on minimal cloud images a full C toolchain (linker, glibc headers, etc.) is not present, leading to silent build failures from `do-cmake.sh build`.

### Fix

Add `build-essential` to the Debian `package_list` in `Lagscope._install_dep_packages()`. Same pattern as PR #4485 (netperf).

### Validation

- Repro confirmed on `canonical ubuntu-25_10 server-arm64 25.10.202601100` running `XdpPerformance.perf_xdp_lagscope_latency` on `Standard_D8ps_v5`.
- Linked ADO bug filed separately.

---

This pull request was authored with the assistance of an AI agent (GitHub Copilot).