### PR TITLE
[AI Generated] BugFix: find sshd_config on SUSE/SLES 16 without scanning entire root fs

### DIFF
--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -71,6 +71,7 @@ class Ssh(Tool):
             result = find.find_files(
                 self.node.get_pure_path(search_root),
                 file_name,
+                file_type="f",
                 sudo=True,
                 ignore_not_exist=True,
             )

--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -50,15 +50,31 @@ class Ssh(Tool):
 
     def get_default_sshd_config_path(self) -> str:
         file_name = "sshd_config"
-        default_path = f"/etc/ssh/{file_name}"
-        if self.node.shell.exists(self.node.get_pure_path(default_path)):
-            return default_path
+        # Check well-known locations first. SUSE/SLES 16 and other modern
+        # distros ship the vendor sshd_config under /usr/etc/ssh while
+        # /etc/ssh/sshd_config may not exist by default.
+        candidate_paths = [
+            f"/etc/ssh/{file_name}",
+            f"/usr/etc/ssh/{file_name}",
+            f"/usr/local/etc/ssh/{file_name}",
+        ]
+        for path in candidate_paths:
+            if self.node.shell.exists(self.node.get_pure_path(path)):
+                return path
+        # Fall back to a scoped find. Restrict to /etc and /usr/etc to avoid
+        # traversing /proc, /sys, /run/user/* etc. on minimal images where
+        # `find /` exits non-zero due to permission-denied warnings.
         find = self.node.tools[Find]
-        result = find.find_files(self.node.get_pure_path("/"), file_name, sudo=True)
-        if result and result[0]:
-            return result[0]
-        else:
-            raise LisaException("not find sshd_config")
+        for search_root in ("/etc", "/usr/etc", "/usr/local/etc"):
+            result = find.find_files(
+                self.node.get_pure_path(search_root),
+                file_name,
+                sudo=True,
+                ignore_not_exist=True,
+            )
+            if result and result[0]:
+                return result[0]
+        raise LisaException("not find sshd_config")
 
     def set_max_session(self, count: int = 200) -> None:
         config_path = self.get_default_sshd_config_path()

--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -66,7 +66,8 @@ class Ssh(Tool):
         # on minimal images where `find /` exits non-zero due to
         # permission-denied warnings.
         find = self.node.tools[Find]
-        for search_root in ("/etc", "/usr/etc", "/usr/local/etc"):
+        search_roots = ("/etc", "/usr/etc", "/usr/local/etc")
+        for search_root in search_roots:
             result = find.find_files(
                 self.node.get_pure_path(search_root),
                 file_name,
@@ -75,7 +76,14 @@ class Ssh(Tool):
             )
             if result and result[0]:
                 return result[0]
-        raise LisaException("not find sshd_config")
+        raise LisaException(
+            f"Could not locate '{file_name}'. Checked candidate paths "
+            f"{candidate_paths} and searched under {list(search_roots)}. "
+            "Verify that the OpenSSH server (sshd) package is installed "
+            "on the target node and that its configuration file exists; "
+            "if it lives under a non-standard prefix, update "
+            "get_default_sshd_config_path() to include that location."
+        )
 
     def set_max_session(self, count: int = 200) -> None:
         config_path = self.get_default_sshd_config_path()

--- a/lisa/tools/ssh.py
+++ b/lisa/tools/ssh.py
@@ -61,9 +61,10 @@ class Ssh(Tool):
         for path in candidate_paths:
             if self.node.shell.exists(self.node.get_pure_path(path)):
                 return path
-        # Fall back to a scoped find. Restrict to /etc and /usr/etc to avoid
-        # traversing /proc, /sys, /run/user/* etc. on minimal images where
-        # `find /` exits non-zero due to permission-denied warnings.
+        # Fall back to a scoped find. Restrict to /etc, /usr/etc, and
+        # /usr/local/etc to avoid traversing /proc, /sys, /run/user/* etc.
+        # on minimal images where `find /` exits non-zero due to
+        # permission-denied warnings.
         find = self.node.tools[Find]
         for search_root in ("/etc", "/usr/etc", "/usr/local/etc"):
             result = find.find_files(


### PR DESCRIPTION
## Problem

On SUSE SLES 16 (and other modern SUSE images) the vendor `sshd_config` ships under `/usr/etc/ssh/sshd_config` rather than `/etc/ssh/sshd_config`. `Ssh.get_default_sshd_config_path()` falls back to `find / -name sshd_config -print0` when the default path is missing. On minimal arm64 images this `find` exits with code `1` (permission-denied warnings on `/proc`, `/sys`, `/run/user/*`, transient PIDs, etc.), so `Find.find_files()`'s `assert_exit_code()` raises and aborts the test.

## Failing test

- Image: `suse sles-16-0-arm64 gen2 2026.02.05`
- Test: `NetworkPerformace.perf_udp_iperf_sriov`
- Error:
  ```
  AssertionError: [Get unexpected exit code on cmd 3377 ['sudo', 'sh', '-c', `find / \( -name 'sshd_config' \) -print0`]]
    Expected <[0]> to contain item <1>, but did not.
  ```

Call path: `performance/common.py:697 ssh.set_max_session()` -> `ssh.py get_default_sshd_config_path()` -> `find /`.

## Fix

1. Check well-known candidate paths first (`/etc/ssh`, `/usr/etc/ssh`, `/usr/local/etc/ssh`) before falling back to `find`.
2. Restrict the `find` fallback to `/etc`, `/usr/etc`, `/usr/local/etc` (instead of `/`) and pass `ignore_not_exist=True` so missing roots don't fail.

This avoids both the SUSE path mismatch and the brittle full-filesystem traversal.

## Validation

`perf_udp_iperf_sriov` run on `suse sles-16-0-arm64 gen2 2026.02.05` / `Standard_D8ps_v5`  Passed

