### PR TITLE
[AI Generated] BugFix: support nfs-server.service unit name on SLES 16

### DIFF
--- a/lisa/tools/nfs_server.py
+++ b/lisa/tools/nfs_server.py
@@ -19,6 +19,19 @@ class NFSServer(Tool):
     def can_install(self) -> bool:
         return True
 
+    def _get_suse_service_name(self) -> str:
+        # SLES 15 and older expose the NFS server as ``nfsserver.service``.
+        # SLES 16 has switched to the upstream ``nfs-server.service`` unit
+        # name and the legacy alias is no longer shipped. Probe which one
+        # actually exists so the tool keeps working on both.
+        service = self.node.tools[Service]
+        for name in ("nfs-server", "nfsserver"):
+            if service.check_service_exists(name):
+                return name
+        # Fall back to the upstream name; restart will surface a clear
+        # ``Unit nfs-server.service not found`` error if NFS is missing.
+        return "nfs-server"
+
     def create_shared_dir(self, client_ips: List[str], dir_name: str) -> None:
         # create directory to share
         self.node.execute(f"chmod -R a+rwX {dir_name}", sudo=True)
@@ -51,7 +64,7 @@ class NFSServer(Tool):
             )
         elif isinstance(self.node.os, Suse):
             self.node.tools[Service].restart_service(
-                "nfsserver",
+                self._get_suse_service_name(),
             )
         else:
             raise UnsupportedDistroException(self.node.os)
@@ -63,7 +76,7 @@ class NFSServer(Tool):
         elif isinstance(self.node.os, Debian):
             return service.check_service_exists("nfs-kernel-server")
         elif isinstance(self.node.os, Suse):
-            return service.check_service_exists("nfsserver")
+            return service.check_service_exists(self._get_suse_service_name())
         else:
             raise UnsupportedDistroException(self.node.os)
 
@@ -74,7 +87,7 @@ class NFSServer(Tool):
         elif isinstance(self.node.os, Debian):
             service.stop_service("nfs-kernel-server")
         elif isinstance(self.node.os, Suse):
-            service.stop_service("nfsserver")
+            service.stop_service(self._get_suse_service_name())
         else:
             raise UnsupportedDistroException(self.node.os)
 
@@ -96,6 +109,8 @@ class NFSServer(Tool):
         elif isinstance(self.node.os, Debian):
             return self.node.tools[Service].check_service_exists("nfs-kernel-server")
         elif isinstance(self.node.os, Suse):
-            return self.node.tools[Service].check_service_exists("nfs-server")
+            return self.node.tools[Service].check_service_exists(
+                self._get_suse_service_name()
+            )
         else:
             raise UnsupportedDistroException(self.node.os)


### PR DESCRIPTION
## Problem

On SLES 16, `perf_storage_over_nfs_sriov_tcp_4k` (and any other test using `NFSServer`) fails at the configure step with:

```
Failed to restart nfsserver.service: Unit nfsserver.service not found.
AssertionError: [Get unexpected exit code on cmd ['sudo', 'sh', '-c', 'systemctl restart nfsserver']] Expected <[0, 0]> to contain item <5>, but did not.
```

Root cause: SLES 16 ships the upstream `nfs-utils` systemd unit (`nfs-server.service`) and no longer provides the legacy SUSE `nfsserver.service` alias. `lisa/tools/nfs_server.py` hard-codes `nfsserver` on the `Suse` branch, so `systemctl restart nfsserver` returns exit code 5 (`Unit not found`).

Note: `_check_exists()` already used `nfs-server` for Suse, but `create_shared_dir`, `is_running` and `stop` still used `nfsserver` — inconsistent.

## Fix

Add `_get_suse_service_name()` which probes `nfs-server` first, then falls back to legacy `nfsserver` via `Service.check_service_exists()`. All four Suse branches now use the helper, so:

- SLES 12 / 15 → resolves to `nfsserver`
- SLES 16+ → resolves to `nfs-server`

## Validation

 `suse sles-16-0-x86-64 gen1 2026.02.05` / `Standard_DS3_v2` — case `perf_storage_over_nfs_sriov_tcp_4k`. passed

## Related

- Pattern matches sibling fix microsoft/lisa#4487 (sshd_config on SLES 16)