### PR TITLE
azure: support running VM extension tests on Windows nodes

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/generic_vm_extension.py
@@ -37,7 +37,12 @@ class GenericVmExtension(TestSuite):
           - extension_version    (e.g. "1.0")
         """,
         priority=3,
-        requirement=simple_requirement(supported_features=[AzureExtension]),
+        requirement=simple_requirement(
+            supported_features=[AzureExtension],
+            # Empty unsupported_os overrides the default `[Windows]`, allowing
+            # both Linux/Posix and Windows nodes to run this test.
+            unsupported_os=[],
+        ),
     )
     def verify_vm_extension_install_uninstall(
         self,

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3600,7 +3600,9 @@ class AzureExtension(AzureFeatureMixin, Feature):
             AzureNodeSchema, AZURE
         )
         self._location = node_runbook.location
-        if hasattr(self._node, "os"):
+        # Waagent is a Linux-only tool; skip on Windows nodes since the Windows
+        # guest agent enables extensions by default and exposes no equivalent CLI.
+        if hasattr(self._node, "os") and self._node.os.is_posix:
             self._node.tools[Waagent].enable_configuration("Extensions.Enabled")
 
 


### PR DESCRIPTION
- AzureExtension._initialize: guard waagent.enable_configuration with is_posix (Waagent is Linux-only; Windows guest agent enables extensions by default)

- generic_vm_extension: clear default unsupported_os=[Windows] so the test runs on both Linux/Posix and Windows nodes

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_vm_extension_install_uninstall
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|   MicrosoftWindowsServer WindowsServer 2025-datacenter latest    |         | PASSED |
