### PR TITLE
libvirt: device pool enhancements

### DIFF
--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -41,7 +41,7 @@ class HyperVDevicePool(BaseDevicePool):
         self._hyperv_runbook = runbook
         self.log = log
 
-    def create_device_pool(
+    def create_device_pool_from_vendor_device_id(
         self,
         pool_type: HostDevicePoolType,
         vendor_id: str,

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -452,11 +452,42 @@ class LibvirtDevicePool(BaseDevicePool):
                 self.available_host_devices[pool_type].pop(iommu_group, None)
                 iommu_grp_of_used_devices.append(iommu_group)
             elif iommu_group not in excluded_iommu:
+                if (
+                    pool_type == HostDevicePoolType.PCI_NIC
+                    and not self._is_nic_cable_connected(bdf)
+                ):
+                    # Skip NICs without a cable: passing them through would
+                    # give the guest an unusable link.
+                    self.host_node.log.debug(f"Skipping NIC {bdf}: no cable connected.")
+                    continue
                 devices = self.available_host_devices[pool_type].setdefault(
                     iommu_group, []
                 )
                 if dev not in devices:
                     devices.append(dev)
+
+    def _is_nic_cable_connected(self, bdf: str) -> bool:
+        # True if any iface bound to this NIC reports carrier=1.
+        ls = self.host_node.tools[Ls]
+        net_dir = f"/sys/bus/pci/devices/{bdf}/net"
+        if not ls.path_exists(net_dir, sudo=True):
+            return False
+        ifaces = [
+            PurePosixPath(p.strip()).name
+            for p in ls.list(net_dir, sudo=True)
+            if p.strip()
+        ]
+        for iface in ifaces:
+            result = self.host_node.execute(
+                f"cat /sys/class/net/{iface}/carrier",
+                shell=True,
+                sudo=True,
+                no_info_log=True,
+                no_error_log=True,
+            )
+            if result.exit_code == 0 and result.stdout.strip() == "1":
+                return True
+        return False
 
     def _get_pci_address_instance(
         self,

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -207,7 +207,23 @@ class LibvirtDevicePool(BaseDevicePool):
             vendor_id=vendor_id,
             device_id=device_id,
         )
-        bdf_list = [i.slot for i in device_list]
+        if not device_list:
+            raise LisaException(
+                f"Vendor:device '{vendor_id}:{device_id}' matched no PCI "
+                f"device on the host."
+            )
+
+        # Reject devices whose PCI class does not match the declared pool
+        # type, so a misconfigured runbook fails here instead of at VM boot.
+        device_bdfs = self._get_pci_bdfs_for_pool_type(pool_type)
+        mismatched = [d.slot for d in device_list if d.slot not in device_bdfs]
+        if mismatched:
+            raise LisaException(
+                f"Vendor:device '{vendor_id}:{device_id}' matched {mismatched} "
+                f"but their PCI class is not '{pool_type.value}'."
+            )
+
+        bdf_list = [d.slot for d in device_list]
         self._create_pool(pool_type, bdf_list)
 
     def create_device_pool_from_pci_addresses(
@@ -288,7 +304,14 @@ class LibvirtDevicePool(BaseDevicePool):
         ]
 
         if requested_bdf in available_iommu_devices:
-            return requested_bdf
+            # Ensure the requested BDF's PCI class matches the pool type.
+            device_bdfs = self._get_pci_bdfs_for_pool_type(pool_type)
+            if requested_bdf in device_bdfs:
+                return requested_bdf
+            raise LisaException(
+                f"PCI '{requested_bdf}' exists but is not of class "
+                f"'{pool_type.value}'"
+            )
 
         if passthrough_candidates is None:
             passthrough_candidates = self._get_passthrough_device_candidates(
@@ -361,29 +384,38 @@ class LibvirtDevicePool(BaseDevicePool):
             excluded.append(nvme_iommu)
         return excluded
 
+    def _get_pci_bdfs_for_pool_type(
+        self,
+        pool_type: HostDevicePoolType,
+    ) -> List[str]:
+        lspci = self.host_node.tools[Lspci]
+        if pool_type == HostDevicePoolType.PCI_NIC:
+            devices = lspci.get_devices_by_type(
+                constants.DEVICE_TYPE_SRIOV, force_run=True
+            )
+        elif pool_type == HostDevicePoolType.PCI_GPU:
+            devices = lspci.get_gpu_devices(force_run=True)
+        elif pool_type == HostDevicePoolType.PCI_NVME:
+            devices = lspci.get_devices_by_type(
+                constants.DEVICE_TYPE_NVME, force_run=True
+            )
+        else:
+            return []
+        return [d.slot for d in devices]
+
     def _get_passthrough_device_candidates(
         self,
         pool_type: HostDevicePoolType,
         iommu_device_paths: Optional[List[str]] = None,
     ) -> List[str]:
-        lspci = self.host_node.tools[Lspci]
-        if pool_type == HostDevicePoolType.PCI_NIC:
-            pool_devices = lspci.get_devices_by_type(
-                constants.DEVICE_TYPE_SRIOV, force_run=True
-            )
-        elif pool_type == HostDevicePoolType.PCI_GPU:
-            pool_devices = lspci.get_gpu_devices(force_run=True)
-        elif pool_type == HostDevicePoolType.PCI_NVME:
-            pool_devices = lspci.get_devices_by_type(
-                constants.DEVICE_TYPE_NVME, force_run=True
-            )
-        else:
+        device_bdfs = self._get_pci_bdfs_for_pool_type(pool_type)
+        if not device_bdfs:
             return []
 
         excluded_iommu = self._get_iommu_groups_to_exclude()
         candidates: List[str] = []
-        for pool_device in pool_devices:
-            domain, bus, slot, fn = self._parse_pci_address_str(pool_device.slot)
+        for bdf in device_bdfs:
+            domain, bus, slot, fn = self._parse_pci_address_str(bdf)
             device = self._get_pci_address_instance(domain, bus, slot, fn)
             try:
                 iommu_group = self._get_device_iommu_group(device, iommu_device_paths)
@@ -393,7 +425,7 @@ class LibvirtDevicePool(BaseDevicePool):
             if iommu_group in excluded_iommu:
                 continue
 
-            candidates.append(pool_device.slot)
+            candidates.append(bdf)
 
         return candidates
 

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -67,6 +67,16 @@ class LibvirtDevicePool(BaseDevicePool):
         if not allow_unsafe_interrupt:
             raise LisaException("Allowing unsafe interrupt failed")
 
+        # Dump the initialized pool to ease debugging of passthrough issues.
+        pool_summary = {
+            pool_type.value: {
+                iommu_grp: [self._get_pci_address_str(d) for d in devices]
+                for iommu_grp, devices in groups.items()
+            }
+            for pool_type, groups in self.available_host_devices.items()
+        }
+        self.host_node.log.debug(f"Initialized device passthrough pool: {pool_summary}")
+
     def request_devices(
         self,
         pool_type: HostDevicePoolType,

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -195,7 +195,7 @@ class LibvirtDevicePool(BaseDevicePool):
         )
         self._create_pool(pool_type, candidates)
 
-    def create_device_pool(
+    def create_device_pool_from_vendor_device_id(
         self,
         pool_type: HostDevicePoolType,
         vendor_id: str,

--- a/lisa/sut_orchestrator/util/device_pool.py
+++ b/lisa/sut_orchestrator/util/device_pool.py
@@ -15,7 +15,7 @@ class BaseDevicePool:
     def __init__(self) -> None:
         self.supported_pool_type: List[Any] = []
 
-    def create_device_pool(
+    def create_device_pool_from_vendor_device_id(
         self,
         pool_type: HostDevicePoolType,
         vendor_id: str,
@@ -137,7 +137,7 @@ class BaseDevicePool:
         if not device_id:
             raise LisaException("Device pool configuration has empty 'device_id'")
 
-        self.create_device_pool(
+        self.create_device_pool_from_vendor_device_id(
             pool_type=config.type,
             vendor_id=vendor_id,
             device_id=device_id,


### PR DESCRIPTION
## Description

device_pool: rename create_device_pool for better readability
create_device_pool_from_vendor_device_id name aligns with its
functionality.

libvirt: validate pci identifiers against pool type
The vendor:device and pci_bdf paths accepted any matching identifier
without checking its PCI class against the declared pool_type, so a
misconfigured runbook built the wrong pool results in test failures.

libvirt: exclude NICs with no cable from the passthrough pool
A NIC without a cable is useless to run network tests inside the guest.
So, exclude it from the available_host_devices list.

libvirt: log final passthrough pool
this will help in debugging

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
