### PR TITLE
Fix Dom0 source kernel GRUB rewrite

### DIFF
--- a/lisa/transformers/dom0_kernel_installer.py
+++ b/lisa/transformers/dom0_kernel_installer.py
@@ -408,14 +408,16 @@ def _update_mariner_v2_config(
 
     # Param for Dom0 3.0 kernel installation
     mariner_config = "/boot/grub2/grub.cfg"
-    vmlinuz_regexp = f"vmlinuz-{current_kernel}"
-    vmlinuz_replacement = f"vmlinuz-{new_kernel}"
+    vmlinuz_regexp = f"vmlinuz-{current_kernel}\\([[:space:]]\\)"
+    vmlinuz_replacement = f"vmlinuz-{new_kernel}\\1"
     initrd_regexp = f"initramfs-{current_kernel}.img"
     initrd_replacement = f"initramfs-{new_kernel}.img"
 
     if isinstance(node.os, CBLMariner) and mariner_version <= 2:
         # Change param for Dom0 2.0 kernel installation
         mariner_config = "/boot/mariner-mshv.cfg"
+        vmlinuz_regexp = f"vmlinuz-{current_kernel}"
+        vmlinuz_replacement = f"vmlinuz-{new_kernel}"
         initrd_regexp = f"mariner_initrd_mshv=initrd.img-{current_kernel}"
         initrd_replacement = f"mariner_initrd_mshv=initrd.img-{new_kernel}"
 


### PR DESCRIPTION
The Dom0 source kernel installer rewrites /boot/grub2/grub.cfg on Azure Linux 3 and newer after building a source kernel. The old vmlinuz substitution replaced only the kernel image name, so a line like linux ... vmlinuz-<current> root=... could become vmlinuz-<new>root=... and produce an invalid boot entry.

Match the vmlinuz name together with its following whitespace and reinsert that delimiter with a sed backreference. Leave the Mariner 2 /boot/mariner-mshv.cfg replacement unchanged because that legacy Dom0 config uses a different boot format.

Tests: python -m black --check --line-length=88 lisa/transformers/dom0_kernel_installer.py; python -m flake8 --max-line-length=88 lisa/transformers/dom0_kernel_installer.py

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
