### PR TITLE
azure: don't let console-log capture mask deployment errors

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -2432,8 +2432,12 @@ def save_console_log(
                     resource_group_name=resource_group_name, vm_name=vm_name
                 )
             )
-        except ResourceExistsError as e:
-            log.debug(f"fail to get serial console log. {e}")
+        except Exception as ex:
+            # Broad except: boot diagnostics can fail transiently with
+            # HttpResponseError (e.g. ARM 503), ResourceNotFoundError, etc.
+            # Any such failure must not mask the caller's original deployment
+            # exception when this is invoked from a failure-handling path.
+            log.debug(f"fail to get serial console log. {ex}")
             return b""
     if saved_path:
         screenshot_raw_name = saved_path / f"{screenshot_file_name}.bmp"


### PR DESCRIPTION
_save_console_log_and_check_panic is a best-effort diagnostic helper. When the boot diagnostics API returns a transient failure (e.g. 'Service Unavailable'), the HttpResponseError used to escape and either replace the original deployment timeout error or trigger an AssertionError in the outer 'except HttpResponseError' handler (where 'e.error' is None for body-less responses). Wrap the helper so any failure is logged and swallowed.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
