### PR TITLE
libvirt: add configurable guest kernel boot parameters for CH platform

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -73,6 +73,9 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             )
         else:
             node_context.kernel_path = node_runbook.kernel.path
+        node_context.guest_kernel_boot_parameters = (
+            node_runbook.kernel_boot_parameters.strip()
+        )
         libvirt_version = self._get_libvirt_version()
         assert libvirt_version, "Can not get libvirt version"
 
@@ -153,8 +156,13 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         # - console=ttyS0,115200  : log to the ISA UART
         # - ignore_loglevel       : show all kernel messages
         # - printk.time=1         : add timestamps to kernel messages
+        # Additional guest kernel boot parameters can be supplied through runbook.
         os_cmdline = ET.SubElement(os, "cmdline")
         os_cmdline.text = "console=ttyS0,115200 ignore_loglevel printk.time=1"
+        if node_context.guest_kernel_boot_parameters:
+            os_cmdline.text = (
+                f"{os_cmdline.text} {node_context.guest_kernel_boot_parameters}"
+            )
         if node_context.guest_vm_type is GuestVmType.ConfidentialVM:
             attrb_type = "sev"
             attrb_host_data = "host_data"

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -55,6 +55,7 @@ class NodeContext:
     vm_name: str = ""
     kernel_source_path: str = ""
     kernel_path: str = ""
+    guest_kernel_boot_parameters: str = ""
     host_data: str = ""
     is_host_data_base64: bool = False
     guest_vm_type: GuestVmType = field(default_factory=lambda: GuestVmType.Standard)

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -148,3 +148,5 @@ class KernelSchema:
 class CloudHypervisorNodeSchema(BaseLibvirtNodeSchema):
     # Local or remote path to the cloud-hypervisor kernel.
     kernel: Optional[KernelSchema] = None
+    # Optional extra kernel boot parameters for the guest.
+    kernel_boot_parameters: str = ""


### PR DESCRIPTION
Add support for passing custom guest kernel cmdline parameters through the cloud-hypervisor platform, enabling independent tuning of guest VMs from the host kernel.

CHANGES
-------
schema.py (CloudHypervisorNodeSchema):
  - Add optional `kernel_boot_parameters` string field (default: "") to carry custom guest cmdline params from the runbook to the platform layer.

context.py (NodeContext):
  - Add `guest_kernel_boot_parameters: str = ""` to persist the resolved value through the node lifecycle.

ch_platform.py (CloudHypervisorPlatform):
  - In node setup: read `node_runbook.kernel_boot_parameters` and store (stripped) on `node_context.guest_kernel_boot_parameters`.
  - In domain XML generation: append the stored value to the default cmdline (`console=ttyS0,115200 ignore_loglevel printk.time=1`) when non-empty; falls back to existing defaults when not set, preserving full backward compatibility.

FLOW
----
  Pipeline: guest_kernel_boot_parameters
    -> Runbook: kernel_boot_parameters on node (ch_platform_test.yml) -> Schema: CloudHypervisorNodeSchema.kernel_boot_parameters -> Context: NodeContext.guest_kernel_boot_parameters -> Domain XML: os/cmdline element in guest domain config


## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
