### PR TITLE
perf_nvme : Remove requirement to have 8 NVMe

### DIFF
--- a/lisa/microsoft/testsuites/performance/nvmeperf.py
+++ b/lisa/microsoft/testsuites/performance/nvmeperf.py
@@ -10,7 +10,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.features import Nvme, NvmeSettings
+from lisa.features import Nvme
 from lisa.testsuite import TestResult
 from lisa.tools.fio import IoEngine
 from lisa.tools.kernel_config import KernelConfig
@@ -34,7 +34,7 @@ class NvmePerformace(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            supported_features=[NvmeSettings(disk_count=8)],
+            supported_features=[Nvme],
         ),
     )
     def perf_nvme(self, node: Node, result: TestResult) -> None:


### PR DESCRIPTION
NvmeSettings(disk_count=8) requirement is restricting the perf_nvme test from running VMs with lesser NVMe disks. For example, ARM64 VM (like plds_v6) have max of 6 NVMes.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [X] No credentials, secrets, or internal details are included
- [X] Peer review requested (if not, add required peer reviewers after raising PR)
- [X] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
perf_nvme

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical:ubuntu-24_04-lts:server-arm64:latest|Standard_D16plds_v6| PASSED |
