### PR TITLE
transformers: add host kernel boot parameters transformer

### DIFF
--- a/docs/run_test/transformers.rst
+++ b/docs/run_test/transformers.rst
@@ -565,3 +565,56 @@ reboot
 type: bool | Default: false
 
 Reboot the node after script execution.
+
+
+Use Host Kernel Boot Parameters Transformer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This transformer sets kernel boot parameters on a host node, reboots the node,
+and validates that the requested parameters are present in ``/proc/cmdline``
+after reboot. It uses the OS-specific ``GrubConfig`` tool to update the boot
+loader configuration.
+
+Usage
+``````
+.. code:: yaml
+
+  transformer:
+    - type: host_kernel_boot_parameters
+      phase: expanded
+      connection:
+        address: $(host_address)
+        private_key_file: $(admin_private_key_file)
+      parameters: "intel_iommu=on iommu=pt"
+      reboot_timeout: 900
+
+Outputs
+````````
+This transformer does not generate output variables.
+
+Reference
+`````````
+
+connection
+^^^^^^^^^^
+type: RemoteNode | Default: None
+
+SSH connection information for the host node. This is required when the
+transformer is not running with an already connected deployment node.
+
+parameters
+^^^^^^^^^^
+type: string | Default: ""
+
+Whitespace-separated kernel boot parameters in ``name=value`` format. Parameter
+names may contain letters, numbers, underscores, dots, and hyphens. Parameter
+values may contain letters, numbers, underscores, dots, commas, colons, slashes,
+plus signs, percent signs, at signs, equals signs, and hyphens. If no parameters
+are provided, the transformer exits without changing the node.
+
+reboot_timeout
+^^^^^^^^^^^^^^
+type: int | Default: 900
+
+Maximum time, in seconds, to wait for the node to reboot after updating the boot
+loader configuration.

--- a/lisa/mixin_modules.py
+++ b/lisa/mixin_modules.py
@@ -82,6 +82,7 @@ import lisa.sut_orchestrator.openvmm.transformers  # noqa: F401
 import lisa.transformers.dom0_kernel_installer  # noqa: F401
 import lisa.transformers.dump_variables  # noqa: F401
 import lisa.transformers.file_uploader  # noqa: F401
+import lisa.transformers.host_kernel_boot_parameters  # noqa: F401
 import lisa.transformers.kernel_source_installer  # noqa: F401
 import lisa.transformers.kernel_source_packager  # noqa: F401
 import lisa.transformers.package_installer  # noqa: F401

--- a/lisa/transformers/host_kernel_boot_parameters.py
+++ b/lisa/transformers/host_kernel_boot_parameters.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Tuple, Type
 from dataclasses_json import dataclass_json
 
 from lisa import schema
-from lisa.tools import GrubConfig
+from lisa.tools import Cat, GrubConfig
 from lisa.transformers.deployment_transformer import (
     DeploymentTransformer,
     DeploymentTransformerSchema,
@@ -66,7 +66,38 @@ class HostKernelBootParameters(DeploymentTransformer):
             f"(timeout: {runbook.reboot_timeout}s)"
         )
         self._node.reboot(time_out=runbook.reboot_timeout)
+        self._validate_parameters_applied(kernel_parameters)
         return {}
+
+    def _validate_parameters_applied(
+        self, kernel_parameters: List[Tuple[str, str]]
+    ) -> None:
+        cmdline = (
+            self._node.tools[Cat]
+            .read("/proc/cmdline", sudo=True, force_run=True)
+            .strip()
+        )
+        cmdline_tokens = set(cmdline.split())
+        expected_parameters = [
+            f"{parameter_name}={parameter_value}"
+            for parameter_name, parameter_value in kernel_parameters
+        ]
+        missing_parameters = [
+            parameter
+            for parameter in expected_parameters
+            if parameter not in cmdline_tokens
+        ]
+        if missing_parameters:
+            raise LisaException(
+                "Host kernel boot parameters were not applied after reboot. "
+                f"Missing parameters: {', '.join(missing_parameters)}. "
+                f"Actual /proc/cmdline: {cmdline}"
+            )
+
+        self._log.info(
+            "Validated host kernel boot parameters in /proc/cmdline: "
+            f"{', '.join(expected_parameters)}"
+        )
 
     def _parse_parameters(self, raw_parameters: str) -> List[Tuple[str, str]]:
         raw_parameters = raw_parameters.strip()

--- a/lisa/transformers/host_kernel_boot_parameters.py
+++ b/lisa/transformers/host_kernel_boot_parameters.py
@@ -1,0 +1,114 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple, Type
+
+from dataclasses_json import dataclass_json
+
+from lisa import schema
+from lisa.tools import GrubConfig
+from lisa.transformers.deployment_transformer import (
+    DeploymentTransformer,
+    DeploymentTransformerSchema,
+)
+from lisa.util import LisaException, field_metadata
+
+_KERNEL_ARG_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+_KERNEL_ARG_VALUE_PATTERN = re.compile(r"^[A-Za-z0-9_.,:/+%@=-]*$")
+
+
+@dataclass_json
+@dataclass
+class HostKernelBootParametersTransformerSchema(DeploymentTransformerSchema):
+    parameters: str = field(default="", metadata=field_metadata(required=False))
+    reboot_timeout: int = field(default=900, metadata=field_metadata(required=False))
+
+
+class HostKernelBootParameters(DeploymentTransformer):
+    @classmethod
+    def type_name(cls) -> str:
+        return "host_kernel_boot_parameters"
+
+    @classmethod
+    def type_schema(cls) -> Type[schema.TypedSchema]:
+        return HostKernelBootParametersTransformerSchema
+
+    @property
+    def _output_names(self) -> List[str]:
+        return []
+
+    def _internal_run(self) -> Dict[str, Any]:
+        runbook: HostKernelBootParametersTransformerSchema = self.runbook
+        kernel_parameters = self._parse_parameters(runbook.parameters)
+
+        if not kernel_parameters:
+            self._log.info("No host kernel boot parameters were provided")
+            return {}
+
+        self._log.info(
+            "Applying host kernel boot parameters: "
+            f"{self._format_parameters(kernel_parameters)}"
+        )
+
+        grub_config = self._node.tools[GrubConfig]
+        for parameter_name, parameter_value in kernel_parameters:
+            self._log.info(
+                f"Setting host kernel boot parameter "
+                f"'{parameter_name}={parameter_value}'"
+            )
+            grub_config.set_kernel_cmdline_arg(parameter_name, parameter_value)
+
+        self._log.info(
+            f"Rebooting after setting host kernel boot parameters "
+            f"(timeout: {runbook.reboot_timeout}s)"
+        )
+        self._node.reboot(time_out=runbook.reboot_timeout)
+        return {}
+
+    def _parse_parameters(self, raw_parameters: str) -> List[Tuple[str, str]]:
+        raw_parameters = raw_parameters.strip()
+        if not raw_parameters:
+            return []
+
+        try:
+            parameter_tokens = shlex.split(raw_parameters)
+        except ValueError as identifier:
+            raise LisaException(
+                f"Failed to parse host kernel boot parameters: {identifier}"
+            ) from identifier
+
+        kernel_parameters: List[Tuple[str, str]] = []
+        for parameter_token in parameter_tokens:
+            if "=" not in parameter_token:
+                raise LisaException(
+                    "Host kernel boot parameters must be whitespace-separated "
+                    f"name=value pairs. Invalid parameter: '{parameter_token}'"
+                )
+
+            parameter_name, parameter_value = parameter_token.split("=", 1)
+            if not _KERNEL_ARG_NAME_PATTERN.fullmatch(parameter_name):
+                raise LisaException(
+                    "Host kernel boot parameter names may contain only letters, "
+                    "numbers, underscores, dots, and hyphens. Invalid name: "
+                    f"'{parameter_name}'"
+                )
+            if not _KERNEL_ARG_VALUE_PATTERN.fullmatch(parameter_value):
+                raise LisaException(
+                    "Host kernel boot parameter values may contain only letters, "
+                    "numbers, underscores, dots, commas, colons, slashes, plus "
+                    "signs, percent signs, at signs, equals signs, and hyphens. "
+                    f"Invalid value for '{parameter_name}': '{parameter_value}'"
+                )
+
+            kernel_parameters.append((parameter_name, parameter_value))
+
+        return kernel_parameters
+
+    def _format_parameters(self, kernel_parameters: List[Tuple[str, str]]) -> str:
+        return " ".join(
+            f"{parameter_name}={parameter_value}"
+            for parameter_name, parameter_value in kernel_parameters
+        )


### PR DESCRIPTION
Add a new transformer that applies custom kernel boot parameters to the host (Dom0) kernel cmdline and reboots to activate them.

Register the transformer in mixin_modules so LISA's reflection-based factory can discover it at runtime.

The transformer validates each name=value token before calling GrubConfig.set_kernel_cmdline_arg, then reboots the node with the configured timeout.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
