### PR TITLE
Purchase plan support to sig transformer

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -443,6 +443,22 @@ def _get_image_tags(image: Any) -> Dict[str, Any]:
     ):
         for feat in image.features:
             image_tags[feat.name] = feat.value
+
+    # Marketplace images expose plan on `plan`, while gallery/community images
+    # expose it on `purchase_plan`.
+    for plan_attr in ("plan", "purchase_plan"):
+        if hasattr(image, plan_attr):
+            image_plan = getattr(image, plan_attr)
+            if image_plan:
+                purchase_plan: Dict[str, str] = {}
+                for key in PURCHASE_PLAN_KEYS:
+                    value = getattr(image_plan, key, None)
+                    if isinstance(value, str) and value:
+                        purchase_plan[key] = value
+                if len(purchase_plan) == len(PURCHASE_PLAN_KEYS):
+                    image_tags["purchase_plan"] = purchase_plan
+                    break
+
     return image_tags
 
 
@@ -2886,6 +2902,7 @@ def check_or_create_gallery_image(
     gallery_image_hyperv_generation: int,
     gallery_image_architecture: str,
     gallery_image_features: Dict[str, Any],
+    gallery_image_purchase_plan: Optional[Dict[str, str]] = None,
 ) -> None:
     try:
         compute_client = get_compute_client(platform)
@@ -2925,6 +2942,10 @@ def check_or_create_gallery_image(
                     }
                     for (key, value) in gallery_image_features.items()
                 ]
+
+            if gallery_image_purchase_plan:
+                image_post_body["purchase_plan"] = gallery_image_purchase_plan
+
             operation = compute_client.gallery_images.begin_create_or_update(
                 gallery_resource_group_name,
                 gallery_name,

--- a/lisa/sut_orchestrator/azure/transformers.py
+++ b/lisa/sut_orchestrator/azure/transformers.py
@@ -625,6 +625,7 @@ class SharedGalleryImageTransformer(Transformer):
 
         # Get features from marketplace image if specified
         features = self._get_image_features(platform, runbook.marketplace_source)
+        purchase_plan = self._get_image_purchase_plan(features)
         if features:
             runbook.gallery_image_hyperv_generation = features.pop(
                 "hyper_v_generation", runbook.gallery_image_hyperv_generation
@@ -678,6 +679,7 @@ class SharedGalleryImageTransformer(Transformer):
             runbook.gallery_image_hyperv_generation,
             runbook.gallery_image_architecture,
             features,
+            purchase_plan,
         )
 
         check_or_create_gallery_image_version(
@@ -727,6 +729,22 @@ class SharedGalleryImageTransformer(Transformer):
             features.pop("hyper_v_generation", None)
 
         return features
+
+    def _get_image_purchase_plan(
+        self, image_features: Dict[str, Any]
+    ) -> Optional[Dict[str, str]]:
+        raw_purchase_plan = image_features.pop("purchase_plan", None)
+        if not isinstance(raw_purchase_plan, dict):
+            return None
+
+        purchase_plan: Dict[str, str] = {}
+        for key in ("name", "product", "publisher"):
+            value = raw_purchase_plan.get(key)
+            if not isinstance(value, str) or not value:
+                return None
+            purchase_plan[key] = value
+
+        return purchase_plan
 
 
 @dataclass_json


### PR DESCRIPTION
## Description
Each Azure Pro image comes with a purchase plan. This purchase plan required to be passed during VM creation when .vhd / SIG created these pro images.  Purchase plan support for .vhd files was already added. This change is for SIG images.

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
smoke_test

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-Canonical ubuntu-24_04-lts server latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-24_04-lts server latest|Standard_D2ads_v5| PASSED / FAILED / SKIPPED |
