### PR TITLE
[Ntp tool] Install 'ntpsec' if 'ntp' is not available

### DIFF
--- a/lisa/tools/ntp.py
+++ b/lisa/tools/ntp.py
@@ -30,7 +30,7 @@ class Ntp(Tool):
         if self._check_exists():
             return True
 
-        # Camonical replaced 'ntp' with 'ntpsec' starting from Ubuntu version 2510 .
+        # Canonical replaced 'ntp' with 'ntpsec' starting from Ubuntu version 2510 .
         # 'ntpsec' is a modernized, security-hardened fork of 'ntp' Classic (ntpd),
         # which is the original reference implementation of the Network Time Protocol.
         # While they share the same core time-tracking algorithm, NTPsec has been

--- a/lisa/tools/ntp.py
+++ b/lisa/tools/ntp.py
@@ -26,7 +26,27 @@ class Ntp(Tool):
 
     def install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
-        posix_os.install_packages("ntp")
+
+        if self._check_exists():
+            return True
+
+        # Camonical replaced 'ntp' with 'ntpsec' starting from Ubuntu version 2510 .
+        # 'ntpsec' is a modernized, security-hardened fork of 'ntp' Classic (ntpd),
+        # which is the original reference implementation of the Network Time Protocol.
+        # While they share the same core time-tracking algorithm, NTPsec has been
+        # heavily redesigned to eliminate legacy security flaws, optimize the codebase,
+        # and implement newer internet security standards.
+        ntp_package = ""
+        for candidate in ["ntp", "ntpsec"]:
+            if posix_os.is_package_in_repo(candidate):
+                ntp_package = candidate
+                break
+
+        if not ntp_package:
+            raise LisaException("Neither ntp nor ntpsec package is found in repo.")
+
+        posix_os.install_packages(ntp_package)
+
         return self._check_exists()
 
     @retry(tries=300, delay=1)  # type: ignore

--- a/lisa/tools/ntp.py
+++ b/lisa/tools/ntp.py
@@ -30,7 +30,7 @@ class Ntp(Tool):
         if self._check_exists():
             return True
 
-        # Canonical replaced 'ntp' with 'ntpsec' starting from Ubuntu version 2510 .
+        # Canonical replaced 'ntp' with 'ntpsec' starting from Ubuntu 2510.
         # 'ntpsec' is a modernized, security-hardened fork of 'ntp' Classic (ntpd),
         # which is the original reference implementation of the Network Time Protocol.
         # While they share the same core time-tracking algorithm, NTPsec has been
@@ -43,7 +43,7 @@ class Ntp(Tool):
                 break
 
         if not ntp_package:
-            raise LisaException("Neither ntp nor ntpsec package is found in repo.")
+            raise LisaException("Neither ntp nor ntpsec package was found in repo.")
 
         posix_os.install_packages(ntp_package)
 


### PR DESCRIPTION
Camonical replaced 'ntp' with 'ntpsec' starting from Ubuntu version 2510 . 'ntpsec' is a modernized, security-hardened fork of 'ntp' Classic (ntpd), which is the original reference implementation of the Network Time Protocol. While they share the same core time-tracking algorithm, NTPsec has been heavily redesigned to eliminate legacy security flaws, optimize the codebase, and implement newer internet security standards.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_timesync_ntp
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
- Canonical ubuntu-24_04-lts server latest
- Canonical ubuntu-25_10 server-arm64 latest
- Canonical ubuntu-26_04-lts server latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical 0001-com-ubuntu-server-focal 20_04-lts-gen2 latest|Standard_D2ads_v5| PASSED|
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D2ads_v5| PASSED|
|Canonical ubuntu-24_04-lts server latest|Standard_D2ads_v5| PASSED|
|Canonical ubuntu-25_10 server-arm64 latest|Standard_D2ads_v5| PASSED|
|Canonical ubuntu-26_04-lts server latest|Standard_D2ads_v5| PASSED|
