### PR TITLE
verify_os_update - mark node dirty after OS update

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -719,13 +719,15 @@ class AzureImageStandard(TestSuite):
     )
     def verify_os_update(self, node: Node) -> None:
         if isinstance(node.os, Posix):
-            node.os.update_packages("")
             # After OS update some times kernel version may change.
             # When LISA is used to validate a VM image with specific kernel version,
             # changing the kernel will result in running tests with undesired kernel
             # which is not expected.
             # Marking the node dirty after OS update to avoid such issues.
-            node.mark_dirty()
+            try:
+                node.os.update_packages("")
+            finally:
+                node.mark_dirty()
             node.reboot()
         else:
             raise SkippedException(f"Unsupported OS or distro type : {type(node.os)}")

--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -719,7 +719,7 @@ class AzureImageStandard(TestSuite):
     )
     def verify_os_update(self, node: Node) -> None:
         if isinstance(node.os, Posix):
-            # After OS update some times kernel version may change.
+            # After OS update sometimes kernel version may change.
             # When LISA is used to validate a VM image with specific kernel version,
             # changing the kernel will result in running tests with undesired kernel
             # which is not expected.

--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -720,9 +720,15 @@ class AzureImageStandard(TestSuite):
     def verify_os_update(self, node: Node) -> None:
         if isinstance(node.os, Posix):
             node.os.update_packages("")
+            # After OS update some times kernel version may change.
+            # When LISA is used to validate a VM image with specific kernel version,
+            # changing the kernel will result in running tests with undesired kernel
+            # which is not expected.
+            # Marking the node dirty after OS update to avoid such issues.
+            node.mark_dirty()
+            node.reboot()
         else:
             raise SkippedException(f"Unsupported OS or distro type : {type(node.os)}")
-        node.reboot()
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
After OS update sometimes kernel version may change. When LISA is used to validate a VM image with specific kernel version, changing the kernel will result in running tests with undesired kernel which should be avoided. Marking the node dirty after OS update to avoid such issues.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_os_update
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical ubuntu-26_04-lts server latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-26_04-lts server latest|Standard_DC2as_v6|PASSED|
