### PR TITLE
Fix MSHV install guest path handling

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_install.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_install.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Dict
 
 from microsoft.testsuites.mshv.cloud_hypervisor_tool import CloudHypervisor
@@ -21,19 +21,19 @@ from lisa.util import SkippedException
 class MshvHostInstallSuite(TestSuite):
     CONFIG_BINPATH = "mshv_binpath"
 
-    _test_path_init_hvix = Path("/home/cloud") / "hvix64.exe"
+    _test_path_init_hvix = PurePosixPath("/home/cloud") / "hvix64.exe"
 
-    _init_path_init_kdstub = Path("/home/cloud") / "kdstub.dll"
+    _init_path_init_kdstub = PurePosixPath("/home/cloud") / "kdstub.dll"
 
-    _init_path_init_lxhvloader = Path("/home/cloud") / "lxhvloader.dll"
+    _init_path_init_lxhvloader = PurePosixPath("/home/cloud") / "lxhvloader.dll"
 
-    _test_path_dst_hvix = Path("/boot/efi/Windows/System32") / "hvix64.exe"
+    _test_path_dst_hvix = PurePosixPath("/boot/efi/Windows/System32") / "hvix64.exe"
 
-    _test_path_dst_kdstub = Path("/boot/efi/Windows/System32") / "kdstub.dll"
+    _test_path_dst_kdstub = PurePosixPath("/boot/efi/Windows/System32") / "kdstub.dll"
 
-    _test_path_dst_lxhvloader = Path("/boot/efi") / "lxhvloader.dll"
+    _test_path_dst_lxhvloader = PurePosixPath("/boot/efi") / "lxhvloader.dll"
 
-    def _get_file_md5(self, node: Node, file_path: Path) -> str:
+    def _get_file_md5(self, node: Node, file_path: PurePath) -> str:
         """Get MD5 checksum of a file on the remote node."""
         result = node.execute(f"md5sum {file_path}", sudo=True, shell=True)
         if result.exit_code != 0:


### PR DESCRIPTION
## Description

Installing the Microsoft hypervisor on a guest doesn't work when the host is Windows. The reason is that the path concatenation APIs use Windows path semantics and misinterpret the POSIX paths.

The fix is to use `PurePosixPath`. 

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

With this fix, I can run the LISA tests that are part of our automated nightly testing.

**Key Test Cases:**
 verify_mshv_install_succeeds

**Impacted LISA Features:**
 MshvHostInstallSuite

**Tested Azure Marketplace Images:**
 N/A - local Azure Linux Dom0 VHD booted via Hyper-V

## Test Results

 | Image | VM Size | Result |
 |-------|---------|--------|
 | Azure Linux Dom0 VHD, 3.0.20260517, kernel 6.6.121.mshv3-1000.gaf140a66.lv3 | Local Hyper-V VM, 2 vCPU / 1 GB | PASSED |

