### PR TITLE
verify_dns_name_resolution_after_upgrade - mark node dirty after OS u…

### DIFF
--- a/lisa/microsoft/testsuites/core/dns.py
+++ b/lisa/microsoft/testsuites/core/dns.py
@@ -67,6 +67,7 @@ class Dns(TestSuite):
             raise PassedException(e) from e
 
         finally:
+            node.mark_dirty()
             self._check_dns_name_resolution(node)
             node.reboot()
             self._check_dns_name_resolution(node)

--- a/lisa/microsoft/testsuites/core/dns.py
+++ b/lisa/microsoft/testsuites/core/dns.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from lisa import (
+    Logger,
     Node,
     TestCaseMetadata,
     TestSuite,
@@ -39,6 +41,11 @@ class Dns(TestSuite):
         r"ModuleNotFoundError: No module named \'apt_inst\'", re.M
     )
 
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        log.debug("after_case: mark node as dirty to avoid affecting other test cases")
+        node = kwargs["node"]
+        node.mark_dirty()
+
     @TestCaseMetadata(
         description="""
         This test case check DNS name resolution by ping bing.com.
@@ -67,7 +74,6 @@ class Dns(TestSuite):
             raise PassedException(e) from e
 
         finally:
-            node.mark_dirty()
             self._check_dns_name_resolution(node)
             node.reboot()
             self._check_dns_name_resolution(node)


### PR DESCRIPTION
…pdate

After OS upgrade sometimes kernel version may change. When LISA is used to validate a VM image with specific kernel version, changing the kernel will result in running tests with undesired kernel which should be avoided. Marking the node dirty after OS update to avoid such issues.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_dns_name_resolution_after_upgrade

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical ubuntu-26_04-lts server latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-26_04-lts server latest|Standard_D2ads_v5| PASSED|
