### PR TITLE
[AI Generated] xfstests: don't replace /bin/gcc when devtoolset-7 install fails

### DIFF
--- a/lisa/microsoft/testsuites/xfstests/xfstests.py
+++ b/lisa/microsoft/testsuites/xfstests/xfstests.py
@@ -984,12 +984,22 @@ class Xfstests(Tool):
             posix_os.install_packages(
                 packages="devtoolset-7-gcc*", extra_args=["--skip-broken"]
             )
-            self.node.execute("rm -f /bin/gcc", sudo=True, shell=True)
-            self.node.execute(
-                "ln -s /usr/bin/x86_64-redhat-linux-gcc /bin/gcc",
-                sudo=True,
-                shell=True,
-            )
+            # Only redirect /bin/gcc to the SCL toolchain if devtoolset-7 actually
+            # installed and the arch-specific binary is present. CentOS 7 SCL
+            # mirrors are EOL (mirrorlist.centos.org no longer resolves) so
+            # devtoolset-7 install can silently fail with --skip-broken; in that
+            # case we must keep the base gcc rather than replace it with a
+            # dangling symlink. Also pick the right arch (aarch64 vs x86_64).
+            if posix_os.package_exists("devtoolset-7-gcc"):
+                arch = self.node.os.get_kernel_information().hardware_platform
+                scl_gcc = f"/usr/bin/{arch}-redhat-linux-gcc"
+                if self.node.shell.exists(PurePosixPath(scl_gcc)):
+                    self.node.execute("rm -f /bin/gcc", sudo=True, shell=True)
+                    self.node.execute(
+                        f"ln -s {scl_gcc} /bin/gcc",
+                        sudo=True,
+                        shell=True,
+                    )
         # fix compile issue on SLES12SP5
         if (
             isinstance(self.node.os, Suse)


### PR DESCRIPTION
On CentOS 7 / RHEL 7, after attempting to install devtoolset-7-gcc with --skip-broken, the install code unconditionally removed /bin/gcc and replaced it with a symlink to /usr/bin/x86_64-redhat-linux-gcc. Two problems:

1. CentOS 7 SCL mirrors are EOL: mirrorlist.centos.org no longer resolves, so 'yum install --skip-broken devtoolset-7-gcc*' silently does nothing. The base gcc just installed by the previous yum step then gets deleted, leaving the system with no working compiler. configure fails with 'no acceptable C compiler found in PATH'.

2. The symlink target was hardcoded to x86_64; on aarch64 (e.g. CentOS 7.9 arm64) the binary is named aarch64-redhat-linux-gcc, so even when devtoolset-7 does install the symlink is dangling.

Now only redirect /bin/gcc when devtoolset-7-gcc is actually installed AND the arch-specific binary exists. Otherwise leave the base gcc in place.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
