### PR TITLE
Fix wsl Ubuntu version to 24.04

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -493,16 +493,18 @@ data_disk_types: List[DiskType] = [
 @dataclass()
 class DiskOptionSettings(FeatureSettings):
     type: str = constants.FEATURE_DISK
-    os_disk_type: Optional[
-        Union[search_space.SetSpace[DiskType], DiskType]
-    ] = field(  # type:ignore
-        default_factory=partial(
-            search_space.SetSpace,
-            items=os_disk_types,
-        ),
-        metadata=field_metadata(
-            decoder=partial(search_space.decode_set_space_by_type, base_type=DiskType)
-        ),
+    os_disk_type: Optional[Union[search_space.SetSpace[DiskType], DiskType]] = (
+        field(  # type: ignore
+            default_factory=partial(
+                search_space.SetSpace,
+                items=os_disk_types,
+            ),
+            metadata=field_metadata(
+                decoder=partial(
+                    search_space.decode_set_space_by_type, base_type=DiskType
+                )
+            ),
+        )
     )
     os_disk_size: search_space.CountSpace = field(
         default_factory=partial(search_space.IntRange, min=0),
@@ -510,20 +512,20 @@ class DiskOptionSettings(FeatureSettings):
             allow_none=True, decoder=search_space.decode_count_space
         ),
     )
-    data_disk_type: Optional[
-        Union[search_space.SetSpace[DiskType], DiskType]
-    ] = field(  # type:ignore
-        default_factory=partial(
-            search_space.SetSpace,
-            items=data_disk_types,
-        ),
-        metadata=field_metadata(
-            decoder=partial(
-                search_space.decode_nullable_set_space,
-                base_type=DiskType,
-                default_values=data_disk_types,
-            )
-        ),
+    data_disk_type: Optional[Union[search_space.SetSpace[DiskType], DiskType]] = (
+        field(  # type: ignore
+            default_factory=partial(
+                search_space.SetSpace,
+                items=data_disk_types,
+            ),
+            metadata=field_metadata(
+                decoder=partial(
+                    search_space.decode_nullable_set_space,
+                    base_type=DiskType,
+                    default_values=data_disk_types,
+                )
+            ),
+        )
     )
     data_disk_count: search_space.CountSpace = field(
         default_factory=partial(search_space.IntRange, min=0),
@@ -567,7 +569,7 @@ class DiskOptionSettings(FeatureSettings):
     )
     disk_controller_type: Optional[
         Union[search_space.SetSpace[DiskControllerType], DiskControllerType]
-    ] = field(  # type:ignore
+    ] = field(  # type: ignore
         default_factory=partial(
             search_space.SetSpace,
             items=[DiskControllerType.SCSI, DiskControllerType.NVME],
@@ -1579,7 +1581,8 @@ class WslNode(GuestNode):
     # wsl_version can be "prerelease" or "stable"
     wsl_version: str = "prerelease"
     # force to reinstall
-    distro: str = "Ubuntu"
+    # Use Ubuntu-24.04 explicitly to avoid Ubuntu-26.04 compatibility issues with LTP
+    distro: str = "Ubuntu-24.04"
     # set to new kernel path, if it needs to specify kernel.
     kernel: str = ""
     # debug console

--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -493,18 +493,16 @@ data_disk_types: List[DiskType] = [
 @dataclass()
 class DiskOptionSettings(FeatureSettings):
     type: str = constants.FEATURE_DISK
-    os_disk_type: Optional[Union[search_space.SetSpace[DiskType], DiskType]] = (
-        field(  # type: ignore
-            default_factory=partial(
-                search_space.SetSpace,
-                items=os_disk_types,
-            ),
-            metadata=field_metadata(
-                decoder=partial(
-                    search_space.decode_set_space_by_type, base_type=DiskType
-                )
-            ),
-        )
+    os_disk_type: Optional[
+        Union[search_space.SetSpace[DiskType], DiskType]
+    ] = field(  # type: ignore
+        default_factory=partial(
+            search_space.SetSpace,
+            items=os_disk_types,
+        ),
+        metadata=field_metadata(
+            decoder=partial(search_space.decode_set_space_by_type, base_type=DiskType)
+        ),
     )
     os_disk_size: search_space.CountSpace = field(
         default_factory=partial(search_space.IntRange, min=0),
@@ -512,20 +510,20 @@ class DiskOptionSettings(FeatureSettings):
             allow_none=True, decoder=search_space.decode_count_space
         ),
     )
-    data_disk_type: Optional[Union[search_space.SetSpace[DiskType], DiskType]] = (
-        field(  # type: ignore
-            default_factory=partial(
-                search_space.SetSpace,
-                items=data_disk_types,
-            ),
-            metadata=field_metadata(
-                decoder=partial(
-                    search_space.decode_nullable_set_space,
-                    base_type=DiskType,
-                    default_values=data_disk_types,
-                )
-            ),
-        )
+    data_disk_type: Optional[
+        Union[search_space.SetSpace[DiskType], DiskType]
+    ] = field(  # type: ignore
+        default_factory=partial(
+            search_space.SetSpace,
+            items=data_disk_types,
+        ),
+        metadata=field_metadata(
+            decoder=partial(
+                search_space.decode_nullable_set_space,
+                base_type=DiskType,
+                default_values=data_disk_types,
+            )
+        ),
     )
     data_disk_count: search_space.CountSpace = field(
         default_factory=partial(search_space.IntRange, min=0),


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
Fix wsl Ubuntu version to 24.04
LTP 260130 doesn't support newest Ubuntu 26.04 WSL release

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
