### PR TITLE
Fix passthrough TCP NTTTCP setup after reboot

### DIFF
--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -4,7 +4,7 @@ import inspect
 import pathlib
 import time
 from functools import partial
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from assertpy import assert_that
 from retry import retry
@@ -58,6 +58,9 @@ from lisa.tools.ntttcp import (
 )
 from lisa.util import LisaException
 from lisa.util.process import ExecutableResult, Process
+
+# NTTTCP may need extra time after the requested run duration to emit totals.
+DEFAULT_NTTTCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS = 60
 
 
 def perf_nvme(
@@ -353,6 +356,12 @@ def perf_ntttcp(  # noqa: C901
     client_nic_name: Optional[str] = None,
     variables: Optional[Dict[str, Any]] = None,
     skip_server_task_max: bool = False,
+    post_ntttcp_setup: Optional[
+        Callable[[], Tuple[Optional[str], Optional[str]]]
+    ] = None,
+    client_ntttcp_timeout_tolerance_seconds: int = (
+        DEFAULT_NTTTCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS
+    ),
 ) -> List[Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]]:
     # Either server and client are set explicitly or we use the first two nodes
     # from the environment. We never combine the two options. We need to specify
@@ -414,6 +423,11 @@ def perf_ntttcp(  # noqa: C901
         client_ntttcp.setup_system(udp_mode, set_task_max)
         # skip_server_task_max: don't reboot the baremetal host (NIC DHCP state lost).
         server_ntttcp.setup_system(udp_mode, set_task_max and not skip_server_task_max)
+        if post_ntttcp_setup:
+            # Platform setup may reboot guests and drop test NIC DHCP state.
+            refreshed_client_nic_name, refreshed_server_nic_name = post_ntttcp_setup()
+            client_nic_name = refreshed_client_nic_name or client_nic_name
+            server_nic_name = refreshed_server_nic_name or server_nic_name
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
         client_nic = client.nics.default_nic
@@ -556,6 +570,7 @@ def perf_ntttcp(  # noqa: C901
                         ports_count=num_threads_p,
                         dev_differentiator=dev_differentiator,
                         udp_mode=udp_mode,
+                        tolerance_seconds=client_ntttcp_timeout_tolerance_seconds,
                     )
 
                     # Stop the server and collect results from both client

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -62,6 +62,7 @@ class NetworkPerformance(TestSuite):
     # PPS_TIMEOUT: 3000s (50 min) - shorter for PPS tests which are less intensive
     TIMEOUT = 12000
     PPS_TIMEOUT = 3000
+    NTTTCP_TCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS = 180  # High-fanout TCP drain.
 
     # Track baremetal host nodes for cleanup
     _baremetal_hosts: list[RemoteNode] = []
@@ -251,6 +252,12 @@ class NetworkPerformance(TestSuite):
             node, log_path, host_node=server
         )
 
+        def refresh_passthrough_nics() -> Tuple[Optional[str], Optional[str]]:
+            _, refreshed_client_nic_name = self._configure_passthrough_nic_for_node(
+                node, log_path, host_node=server
+            )
+            return refreshed_client_nic_name, None
+
         perf_ntttcp(
             test_result=result,
             client=client,
@@ -258,6 +265,10 @@ class NetworkPerformance(TestSuite):
             server_nic_name=self._get_host_nic_name(server),
             client_nic_name=client_nic_name,
             skip_server_task_max=True,  # host: TasksMax reboot clears NIC DHCP state
+            post_ntttcp_setup=refresh_passthrough_nics,
+            client_ntttcp_timeout_tolerance_seconds=(
+                self.NTTTCP_TCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS
+            ),
         )
 
     @TestCaseMetadata(
@@ -491,12 +502,25 @@ class NetworkPerformance(TestSuite):
             server_node, log_path
         )
 
+        def refresh_passthrough_nics() -> Tuple[Optional[str], Optional[str]]:
+            _, refreshed_client_nic_name = self._configure_passthrough_nic_for_node(
+                client_node, log_path
+            )
+            _, refreshed_server_nic_name = self._configure_passthrough_nic_for_node(
+                server_node, log_path
+            )
+            return refreshed_client_nic_name, refreshed_server_nic_name
+
         perf_ntttcp(
             test_result=result,
             client=client,
             server=server,
             server_nic_name=server_nic_name,
             client_nic_name=client_nic_name,
+            post_ntttcp_setup=refresh_passthrough_nics,
+            client_ntttcp_timeout_tolerance_seconds=(
+                self.NTTTCP_TCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS
+            ),
         )
 
     @TestCaseMetadata(


### PR DESCRIPTION
NTTTCP setup can reboot guests when it raises TasksMax for the 20480 TCP connection case. In passthrough scenarios that reboot drops the test NIC DHCP state, but the performance helper continued using the pre-reboot NIC names and internal addresses.

Add an optional post_ntttcp_setup hook to perf_ntttcp so callers can refresh platform-specific NIC state after setup_system completes. Use it in the passthrough host/guest and two-guest TCP NTTTCP tests to rerun passthrough NIC configuration before lagscope and NTTTCP start.

Also allow passthrough TCP NTTTCP to use a larger client timeout tolerance so the high-fanout client can finish emitting final output instead of being killed during cooldown/drain.



## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
