### PR TITLE
Fix dynamic supported_os matching

### DIFF
--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -218,7 +218,24 @@ class TestResult:
                 node_os_capability = search_space.SetSpace[Type[OperatingSystem]](
                     is_allow_set=True, items=type(node.os).__mro__
                 )
-                os_result = requirement.os_type.check(node_os_capability)
+                os_result = search_space.ResultReason()
+                if requirement.os_type.is_allow_set:
+                    supported_os = set(requirement.os_type)
+                    node_os_types = set(node_os_capability)
+                    if not supported_os.intersection(node_os_types):
+                        os_result.add_reason(
+                            f"requires [{requirement.os_type}] "
+                            f"but VM supports [{node_os_capability}]"
+                        )
+                else:
+                    excluded_os = set(requirement.os_type).intersection(
+                        node_os_capability
+                    )
+                    if excluded_os:
+                        names = sorted(os_type.__name__ for os_type in excluded_os)
+                        os_result.add_reason(
+                            f"requirements excludes {', '.join(names)}"
+                        )
                 # If one of OS mismatches, mark the test case is skipped. It
                 # assumes no more env can meet the requirements, instead of
                 # checking the rest envs one by one. The reason is this checking


### PR DESCRIPTION
The dynamic connected-environment OS check used SetSpace.check() directly against the node OS MRO. For allow sets, SetSpace.check() requires the capability set to contain every entry in the requirement, so supported_os=[CBLMariner, Ubuntu] was evaluated as CBLMariner AND Ubuntu instead of CBLMariner OR Ubuntu.

Observed error: OS type mismatch: requires [Ubuntu, CBLMariner] but VM supports [..., CBLMariner, ...].

Fix the dynamic OS check to use any-of semantics for supported_os and none-of semantics for unsupported_os during connected-environment validation. This keeps precise suite metadata and prevents valid multi-distro cases from being skipped after deployment.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
lisa.RootRunner ________________________________________
2026-06-09 20:47:35.730[140302899025728][INFO] lisa.RootRunner CloudHypervisorTestSuite.verify_cloud_hypervisor_performance_metrics_tests: PASSED
