### PR TITLE
Fix SSH connection hang in test_connection and add prepare timing

### DIFF
--- a/lisa/node.py
+++ b/lisa/node.py
@@ -570,7 +570,7 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         self.log.debug("mark node to dirty")
         self._is_dirty = True
 
-    def test_connection(self) -> bool:
+    def test_connection(self, timeout: int = 30) -> bool:
         if not self._shell:
             self.log.debug(
                 f"connection test failed for node '{self.name}' because its "
@@ -580,11 +580,23 @@ class Node(subclasses.BaseClassWithRunbookMixin, ContextMixin, InitializableMixi
         if not self._shell.is_remote:
             return True
         self.log.debug("testing connection...")
+        # Use a shorter connection timeout for the health check so that an
+        # unreachable VM does not block for the full default (300 s).
+        is_ssh = isinstance(self._shell, SshShell)
+        saved_timeout: int = 0
+        if is_ssh:
+            assert isinstance(self._shell, SshShell)
+            saved_timeout = self._shell.connection_timeout
+            self._shell.connection_timeout = timeout
         try:
-            self.execute("echo connected", timeout=10)
+            self.execute("echo connected", timeout=min(timeout, 10))
             return True
         except Exception as e:
             self.log.debug(f"cannot access VM {self.name}, error is {e}")
+        finally:
+            if is_ssh:
+                assert isinstance(self._shell, SshShell)
+                self._shell.connection_timeout = saved_timeout
         return False
 
     def check_kernel_panic(self) -> None:

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -594,6 +594,8 @@ class AzurePlatform(Platform):
         if not environment.runbook.nodes_requirement:
             return True
 
+        prepare_timer = create_timer()
+
         # reload requirement to match
         environment.runbook.reload_requirements()
         nodes_requirement = environment.runbook.nodes_requirement
@@ -661,6 +663,9 @@ class AzurePlatform(Platform):
             self._resolve_marketplace_image_version(
                 environment.runbook.nodes_requirement
             )
+
+        elapsed = prepare_timer.elapsed()
+        log.info(f"environment '{environment.name}' prepared in {elapsed:.1f}s")
 
         return is_success
 

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -274,13 +274,25 @@ class SshShell(InitializableMixin):
         self.bash_prompt: str = ""
         self.spawn_initialization_error_string = ""
         self.spawn_timeout: int = 20
+        # Total time budget (in seconds) for TCP port readiness and SSH
+        # handshake during _initialize(). Callers such as
+        # Node.test_connection() may lower this temporarily to avoid
+        # long hangs when a VM is unreachable.
+        self.connection_timeout: int = 300
 
         paramiko_logger = logging.getLogger("paramiko")
         paramiko_logger.setLevel(logging.WARN)
 
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
+        deadline_timer = create_timer()
+
+        def _remaining() -> int:
+            return max(1, self.connection_timeout - int(deadline_timer.elapsed(False)))
+
         is_ready, tcp_error_code = wait_tcp_port_ready(
-            self.connection_info.address, self.connection_info.port
+            self.connection_info.address,
+            self.connection_info.port,
+            timeout=_remaining(),
         )
         if not is_ready:
             raise TcpConnectionException(
@@ -295,7 +307,9 @@ class SshShell(InitializableMixin):
         )
 
         try:
-            stdout = try_connect(self.connection_info, sock=sock)
+            stdout = try_connect(
+                self.connection_info, ssh_timeout=_remaining(), sock=sock
+            )
         except Exception as e:
             raise LisaException(
                 "failed to connect SSH port of the VM. It might be due to one of the "


### PR DESCRIPTION
After each test case, test_connection() closes the SSH shell and then attempts to reconnect to check if the VM is still reachable. The SSH re-initialization could hang for up to 600 seconds (300s TCP wait + 300s SSH handshake) if the VM becomes unreachable, because the 10s timeout on execute() only applied to command execution, not to the underlying SSH connection setup.

Changes:
- Add configurable connection_timeout to SshShell (default 300s)
- Use a single total deadline for TCP + SSH initialization in SshShell._initialize() instead of independent 300s timeouts
- In Node.test_connection(), temporarily lower connection_timeout to 30s so unreachable VMs are detected quickly instead of blocking
- Add INFO-level timing log for environment preparation to help diagnose slow prepare phases

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
