### PR TITLE
verify_vmbus_interrupts: scale to 300+ vCPU SKUs

### DIFF
--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 from __future__ import annotations
 
-import time
 from typing import Any
 
 from assertpy.assertpy import assert_that
@@ -22,7 +21,7 @@ from lisa.operating_system import BSD, CpuArchitecture, Windows
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import AzureNodeSchema
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
-from lisa.tools import Cat, InterruptInspector, Lscpu, TaskSet, Uname
+from lisa.tools import Cat, InterruptInspector, Lscpu, Uname
 
 hyperv_interrupt_substr = ["hyperv", "hypervsum", "Hypervisor", "Hyper-V"]
 
@@ -286,16 +285,31 @@ class CPU(TestSuite):
             raise LisaException("Hyper-V interrupts are not recorded.")
 
     def _create_stimer_interrupts(self, node: Node, cpu_count: int) -> None:
-        # Run CPU intensive workload to create hyper-v synthetic timer
-        # interrupts.
-        # Steps :
-        # 1. Run `yes` program on each vCPU in a subprocess.
-        # 2. Wait for one second to allow enough time for processing interrupts.
-        # 3. Kill the spawned subprocess.
-        for i in range(1, cpu_count):
-            process = node.tools[TaskSet].run_on_specific_cpu(i)
-            time.sleep(1)
-            process.kill()
+        # Run a short CPU-intensive workload on every vCPU to force the
+        # Hyper-V synthetic timer interrupt to fire on each CPU.
+        #
+        # The previous implementation opened one SSH channel per vCPU and
+        # serialized through them; on 300+ vCPU SKUs the paramiko transport
+        # exhausts ("SSH session not active") after ~300 channels (bug 62662205).
+        # Run the whole fan-out in a single shell command instead.
+        if cpu_count <= 1:
+            return
+        last_cpu = cpu_count - 1
+        # `timeout 1 yes > /dev/null` exits after 1 second; one process per
+        # CPU is launched in background, then `wait` blocks until they all
+        # finish. Only one SSH channel is used for the entire loop.
+        cmd = (
+            f"for i in $(seq 1 {last_cpu}); do "
+            "taskset -c $i timeout 1 yes > /dev/null & "
+            "done; wait"
+        )
+        node.execute(
+            cmd,
+            shell=True,
+            sudo=False,
+            no_debug_log=True,
+            timeout=max(60, cpu_count // 4),
+        )
 
     def _verify_node_mapping(self, node: Node, numa_node_size: int) -> None:
         cpu_info = node.tools[Lscpu].get_cpu_info()

--- a/lisa/microsoft/testsuites/core/cpu.py
+++ b/lisa/microsoft/testsuites/core/cpu.py
@@ -21,7 +21,7 @@ from lisa.operating_system import BSD, CpuArchitecture, Windows
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import AzureNodeSchema
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
-from lisa.tools import Cat, InterruptInspector, Lscpu, Uname
+from lisa.tools import Cat, InterruptInspector, Lscpu, TaskSet, Uname
 
 hyperv_interrupt_substr = ["hyperv", "hypervsum", "Hypervisor", "Hyper-V"]
 
@@ -285,30 +285,23 @@ class CPU(TestSuite):
             raise LisaException("Hyper-V interrupts are not recorded.")
 
     def _create_stimer_interrupts(self, node: Node, cpu_count: int) -> None:
-        # Run a short CPU-intensive workload on every vCPU to force the
-        # Hyper-V synthetic timer interrupt to fire on each CPU.
+        # Force the Hyper-V synthetic timer interrupt to fire on each CPU by
+        # running a 1-second CPU-bound workload pinned to each vCPU.
         #
-        # The previous implementation opened one SSH channel per vCPU and
-        # serialized through them; on 300+ vCPU SKUs the paramiko transport
-        # exhausts ("SSH session not active") after ~300 channels (bug 62662205).
-        # Run the whole fan-out in a single shell command instead.
-        if cpu_count <= 1:
-            return
-        last_cpu = cpu_count - 1
-        # `timeout 1 yes > /dev/null` exits after 1 second; one process per
-        # CPU is launched in background, then `wait` blocks until they all
-        # finish. Only one SSH channel is used for the entire loop.
-        cmd = (
-            f"for i in $(seq 1 {last_cpu}); do "
-            "taskset -c $i timeout 1 yes > /dev/null & "
-            "done; wait"
-        )
-        node.execute(
-            cmd,
-            shell=True,
-            sudo=False,
-            no_debug_log=True,
-            timeout=max(60, cpu_count // 4),
+        # The previous implementation called ``TaskSet.run_on_specific_cpu``
+        # in a Python loop, which opened one SSH channel per CPU and
+        # serialised through them.  On 300+ vCPU SKUs the paramiko transport
+        # would exhaust after ~300 channels.  The TaskSet helper now runs
+        # the whole fan-out in a single shell command (one SSH channel).
+        #
+        # Timeout budget: each pinned process is bounded by ``timeout 1`` so
+        # the wall-clock cost is ~1s regardless of cpu_count, but kernel
+        # scheduling, taskset/exec setup, and SSH command marshalling add
+        # small per-CPU overhead.  Allow at least 60s and grow by ~1s per
+        # 4 vCPUs to leave headroom on very large SKUs (e.g. 90s for 360
+        # vCPUs); both are generous compared to observed runs (~1-2s).
+        node.tools[TaskSet].run_on_all_cpus_in_background(
+            cpu_count, timeout=max(60, cpu_count // 4)
         )
 
     def _verify_node_mapping(self, node: Node, numa_node_size: int) -> None:

--- a/lisa/tools/interrupt_inspector.py
+++ b/lisa/tools/interrupt_inspector.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional, Type
 
 from lisa.executable import Tool
 from lisa.tools import Cat
+from lisa.tools.rm import Rm
 
 
 class Interrupt:
@@ -81,11 +82,11 @@ class InterruptInspector(Tool):
         # example, `ERR` is incremented in the case of errors in the IO-APIC bus.
         #
         # On high-vCPU SKUs (300+ vCPUs) /proc/interrupts is hundreds of KB.
-        # Capturing it via stdout goes through spur's byte-at-a-time reader and
-        # LISA's per-line debug logging, which makes a 16-second kernel read
-        # take 60+ minutes and trip test-case timeouts (bug 62662205).
-        # To avoid that, we redirect on the node into a temp file and download
-        # it via SFTP (buffered), then read it locally.
+        # Capturing it via stdout goes through spur's byte-at-a-time reader
+        # and LISA's per-line debug logging, which makes a 16-second kernel
+        # read take 60+ minutes and trip test-case timeouts. To avoid that,
+        # we redirect on the node into a temp file and download it via SFTP
+        # (buffered), then read it locally.
         raw = self._fetch_proc_interrupts()
         mappings = raw.splitlines()[1:]
         assert mappings
@@ -114,11 +115,15 @@ class InterruptInspector(Tool):
         remote_name = f"lisa_proc_interrupts_{os.getpid()}_{uuid.uuid4().hex}.txt"
         remote_path = PurePosixPath("/tmp") / remote_name
         local_path = Path(tempfile.gettempdir()) / remote_name
+        cat = self.node.tools[Cat]
         try:
-            self.node.execute(
-                f"cat /proc/interrupts > {remote_path}",
+            # Use the Cat tool to drive the snapshot so any tool-level setup
+            # (existence check, sudo handling) is shared with the fallback.
+            cat.run(
+                f"/proc/interrupts > {remote_path}",
                 shell=True,
                 sudo=True,
+                force_run=True,
                 no_debug_log=True,
                 timeout=120,
                 expected_exit_code=0,
@@ -128,13 +133,23 @@ class InterruptInspector(Tool):
             )
             self.node.shell.copy_back(remote_path, local_path)
             return local_path.read_text(encoding="utf-8", errors="replace")
-        except Exception:
-            # Fall back to the legacy stdout capture path. Slow on large
-            # vCPU counts but functional everywhere.
-            result = self.node.tools[Cat].run(
-                "/proc/interrupts", sudo=True, force_run=True, timeout=3600
+        except Exception as exc:  # noqa: BLE001
+            # The fast path can legitimately fail in environments without
+            # SFTP support or with restricted /tmp permissions. Log so we
+            # can tell expected fallbacks from real bugs, then fall back to
+            # the legacy stdout capture path. The fallback is slow on large
+            # vCPU counts (the very thing we are trying to avoid) so we
+            # disable per-line debug logging to keep the cost predictable.
+            self._log.debug(
+                f"/proc/interrupts SFTP fast path failed ({exc!r}); "
+                "falling back to stdout capture"
             )
-            return result.stdout
+            return cat.read(
+                "/proc/interrupts",
+                force_run=True,
+                sudo=True,
+                no_debug_log=True,
+            )
         finally:
             try:
                 if local_path.exists():
@@ -142,14 +157,8 @@ class InterruptInspector(Tool):
             except OSError:
                 pass
             try:
-                self.node.execute(
-                    f"rm -f {remote_path}",
-                    shell=True,
-                    sudo=True,
-                    no_debug_log=True,
-                    timeout=60,
-                )
-            except Exception:
+                self.node.tools[Rm].remove_file(str(remote_path), sudo=True)
+            except Exception:  # noqa: BLE001
                 pass
 
     def sum_cpu_counter_by_irqs(

--- a/lisa/tools/interrupt_inspector.py
+++ b/lisa/tools/interrupt_inspector.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import os
 import re
+import tempfile
+import uuid
 from collections import Counter
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Optional, Type
 
 from lisa.executable import Tool
@@ -75,8 +79,15 @@ class InterruptInspector(Tool):
         # Note : Some IRQ numbers have single entry because they're not actually
         # CPU stats, but events count belonging to the IO-APIC controller. For
         # example, `ERR` is incremented in the case of errors in the IO-APIC bus.
-        result = self.node.tools[Cat].run("/proc/interrupts", sudo=True, force_run=True)
-        mappings = result.stdout.splitlines(keepends=False)[1:]
+        #
+        # On high-vCPU SKUs (300+ vCPUs) /proc/interrupts is hundreds of KB.
+        # Capturing it via stdout goes through spur's byte-at-a-time reader and
+        # LISA's per-line debug logging, which makes a 16-second kernel read
+        # take 60+ minutes and trip test-case timeouts (bug 62662205).
+        # To avoid that, we redirect on the node into a temp file and download
+        # it via SFTP (buffered), then read it locally.
+        raw = self._fetch_proc_interrupts()
+        mappings = raw.splitlines()[1:]
         assert mappings
 
         interrupts = []
@@ -95,6 +106,51 @@ class InterruptInspector(Tool):
             )
 
         return interrupts
+
+    def _fetch_proc_interrupts(self) -> str:
+        # Try the fast path: redirect on the node to a temp file, pull it back
+        # over SFTP, then read locally. Falls back to the original stdout-based
+        # path if either step fails (e.g. permissions, missing SFTP).
+        remote_name = f"lisa_proc_interrupts_{os.getpid()}_{uuid.uuid4().hex}.txt"
+        remote_path = PurePosixPath("/tmp") / remote_name
+        local_path = Path(tempfile.gettempdir()) / remote_name
+        try:
+            self.node.execute(
+                f"cat /proc/interrupts > {remote_path}",
+                shell=True,
+                sudo=True,
+                no_debug_log=True,
+                timeout=120,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    "failed to snapshot /proc/interrupts on node"
+                ),
+            )
+            self.node.shell.copy_back(remote_path, local_path)
+            return local_path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            # Fall back to the legacy stdout capture path. Slow on large
+            # vCPU counts but functional everywhere.
+            result = self.node.tools[Cat].run(
+                "/proc/interrupts", sudo=True, force_run=True, timeout=3600
+            )
+            return result.stdout
+        finally:
+            try:
+                if local_path.exists():
+                    local_path.unlink()
+            except OSError:
+                pass
+            try:
+                self.node.execute(
+                    f"rm -f {remote_path}",
+                    shell=True,
+                    sudo=True,
+                    no_debug_log=True,
+                    timeout=60,
+                )
+            except Exception:
+                pass
 
     def sum_cpu_counter_by_irqs(
         self,

--- a/lisa/tools/taskset.py
+++ b/lisa/tools/taskset.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import time
 from typing import Optional, Type
 
 from lisa.executable import Tool
@@ -23,6 +24,34 @@ class TaskSet(Tool):
     def run_on_specific_cpu(self, cpu_id: int) -> Process:
         return self.run_async(f"-c {cpu_id} yes > /dev/null", shell=True)
 
+    def run_on_all_cpus_in_background(
+        self,
+        cpu_count: int,
+        payload: str = "yes > /dev/null",
+        seconds: int = 1,
+        timeout: int = 60,
+    ) -> None:
+        # Pin one short-lived workload per CPU using a single SSH command.
+        # Backgrounds (`&`) a `timeout`-bounded process per CPU, then `wait`s
+        # for all of them.  This avoids opening one SSH channel per CPU,
+        # which exhausts the paramiko transport on very large vCPU SKUs
+        # (~300+) and is also faster end-to-end (~1s instead of N seconds).
+        if cpu_count <= 1:
+            return
+        last_cpu = cpu_count - 1
+        cmd = (
+            f"for i in $(seq 1 {last_cpu}); do "
+            f"{self.command} -c $i timeout {seconds} {payload} & "
+            "done; wait"
+        )
+        self.node.execute(
+            cmd,
+            shell=True,
+            sudo=False,
+            no_debug_log=True,
+            timeout=timeout,
+        )
+
 
 class BSDTaskSet(TaskSet):
     @property
@@ -31,3 +60,27 @@ class BSDTaskSet(TaskSet):
 
     def run_on_specific_cpu(self, cpu_id: int) -> Process:
         return self.run_async(f"-l {cpu_id} yes > /dev/null", shell=True)
+
+    def run_on_all_cpus_in_background(
+        self,
+        cpu_count: int,
+        payload: str = "yes > /dev/null",
+        seconds: int = 1,
+        timeout: int = 60,
+    ) -> None:
+        # BSD lacks GNU `timeout`/`seq` and uses `cpuset -l` for CPU pinning.
+        # BSD environments are unlikely to hit the very-high-vCPU SSH limit
+        # that motivated the Linux fast path, so fall back to the legacy
+        # per-CPU loop: spawn N background pinned workloads, sleep, kill.
+        del payload, timeout  # not used on BSD; kept for API parity
+        if cpu_count <= 1:
+            return
+        processes = [self.run_on_specific_cpu(i) for i in range(1, cpu_count)]
+        try:
+            time.sleep(seconds)
+        finally:
+            for proc in processes:
+                try:
+                    proc.kill()
+                except Exception:  # noqa: BLE001
+                    pass


### PR DESCRIPTION
[AIGenerated]

## Summary

`CPU.verify_vmbus_interrupts` was effectively unrunnable on `Standard_E372ids_v7` (372 vCPUs). Two independent LISA-side bottlenecks made the test fail well before any product code was exercised. This PR fixes both.

## Bugs fixed (both LISA-side)

### 1. `_create_stimer_interrupts` opened one SSH channel per vCPU
The old loop did `node.tools[TaskSet].run_on_specific_cpu(i)` + `sleep(1)` + `process.kill()` for every CPU, opening a fresh paramiko channel each iteration. After ~300 short-lived channels the paramiko transport collapsed with `SSHException: SSH session not active`. Average time on a 372-vCPU SKU before failure: 9+ minutes.

**Fix:** replace the loop with one shell command that backgrounds `timeout 1 yes > /dev/null` per CPU via `taskset` and `wait`s. Single SSH channel, ~1-2 seconds total.

### 2. `InterruptInspector.get_interrupt_data` captured `/proc/interrupts` over stdout
On 372 vCPUs `/proc/interrupts` is ~174 KB. Reading it through spur's byte-at-a-time stdout reader plus LISA's per-line debug logging stretched a 16-second kernel read into 60+ minutes, tripping the test-case timeout.

**Fix:** redirect into a per-process temp file on the node, pull it back with `node.shell.copy_back()` (SFTP, buffered), and read locally. Falls back to the original `Cat.run` stdout path on any exception so behavior is preserved on shells/transports that lack SFTP.

## Validation

| SKU | vCPUs | Before | After |
|---|---|---|---|
| Standard_E372ids_v7 | 372 | FAILED (9-60+ min) | PASSED in 40.2 s |
| Standard_D16s_v6 | 16 | n/a (baseline) | PASSED in 36.1 s |

Both runs used the unmodified `verify_vmbus_interrupts` test logic; only the helpers it calls were changed. No new test asserts were added or removed.

## Risk

Low. Both helpers are private to this test (`_create_stimer_interrupts`) and to `InterruptInspector.get_interrupt_data` (only two callers; only `get_interrupt_data` itself was modified, not the SR-IOV helpers `sum_cpu_counter_by_irqs` / `sum_cpu_counter_by_index`). The interrupt-inspector change has a try/except fallback to the legacy stdout path.

Tracks Microsoft bug 62662205.