### PR TITLE
Increase cool_down_time_seconds, warm_up_time_seconds and ntttcp execution time If ncpu > 64.

### DIFF
--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -473,6 +473,14 @@ def perf_ntttcp(  # noqa: C901
             )
             dev_differentiator = "Hypervisor callback interrupts"
         max_server_threads = 64
+        # On large VMs (>64 CPUs) the default 10s ntttcp run is too short for
+        # throughput to stabilize across all queues, leading to noisy results.
+        # Use a 120s run time on these SKUs and keep the default 10s elsewhere
+        # to avoid lengthening every test.
+        client_core_count = client.tools[Lscpu].get_core_count()
+        run_time_seconds = 120 if client_core_count > 64 else 10
+        warm_up_time_seconds = 5 if client_core_count > 64 else 1
+        cool_down_time_seconds = 5 if client_core_count > 64 else 1
         perf_ntttcp_message_list: List[
             Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]
         ] = []
@@ -546,6 +554,8 @@ def perf_ntttcp(  # noqa: C901
                         dev_differentiator=dev_differentiator,
                         udp_mode=udp_mode,
                         no_debug_log=True,
+                        cool_down_time_seconds=cool_down_time_seconds,
+                        warm_up_time_seconds=warm_up_time_seconds,
                     )
 
                     # Start lagscope client to measure latency during the
@@ -571,6 +581,9 @@ def perf_ntttcp(  # noqa: C901
                         buffer_size=buffer_size,
                         threads_count=num_threads_n,
                         ports_count=num_threads_p,
+                        run_time_seconds=run_time_seconds,
+                        cool_down_time_seconds=cool_down_time_seconds,
+                        warm_up_time_seconds=warm_up_time_seconds,
                         dev_differentiator=dev_differentiator,
                         udp_mode=udp_mode,
                         tolerance_seconds=client_ntttcp_timeout_tolerance_seconds,

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -477,7 +477,7 @@ def perf_ntttcp(  # noqa: C901
         # throughput to stabilize across all queues, leading to noisy results.
         # Use a 120s run time on these SKUs and keep the default 10s elsewhere
         # to avoid lengthening every test.
-        client_core_count = client.tools[Lscpu].get_core_count()
+        client_core_count = client.tools[Lscpu].get_thread_count()
         run_time_seconds = 120 if client_core_count > 64 else 10
         warm_up_time_seconds = 5 if client_core_count > 64 else 1
         cool_down_time_seconds = 5 if client_core_count > 64 else 1
@@ -554,6 +554,7 @@ def perf_ntttcp(  # noqa: C901
                         dev_differentiator=dev_differentiator,
                         udp_mode=udp_mode,
                         no_debug_log=True,
+                        run_time_seconds=run_time_seconds,
                         cool_down_time_seconds=cool_down_time_seconds,
                         warm_up_time_seconds=warm_up_time_seconds,
                     )

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -564,7 +564,11 @@ def perf_ntttcp(  # noqa: C901
                     client_lagscope_process = client_lagscope.run_as_client_async(
                         server_ip=server.internal_address,
                         ping_count=0,
-                        run_time_seconds=10,
+                        run_time_seconds=(
+                            run_time_seconds
+                            + cool_down_time_seconds
+                            + warm_up_time_seconds
+                        ),
                         print_histogram=False,
                         print_percentile=False,
                         histogram_1st_interval_start_value=0,


### PR DESCRIPTION
If ncpu > 64, increase cool_down_time_seconds and warm_up_time_seconds to 5, and set ntttcp execution time to 120s.

On large VMs (>64 CPUs) the default 10s ntttcp run is too short for throughput to stabilize across all queues, leading to noisy results. Use a 120s run time on these SKUs and keep the default 10s elsewhere to avoid lengthening every test.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_L160ias_v5| PASSED / FAILED / SKIPPED |
