### PR TITLE
Retry iDRAC power state reads

### DIFF
--- a/lisa/sut_orchestrator/baremetal/cluster/idrac.py
+++ b/lisa/sut_orchestrator/baremetal/cluster/idrac.py
@@ -307,11 +307,24 @@ class Idrac(Cluster):
             )
         self._log.debug(f"{operation} initiated successfully.")
 
+    @retry(tries=3, delay=5)  # type: ignore
     def get_power_state(self) -> str:
         response = self.redfish_instance.get(
             "/redfish/v1/Systems/System.Embedded.1/",
         )
-        return str(response.dict["PowerState"])
+        response_dict = response.dict
+        power_state = response_dict.get("PowerState")
+        if power_state is not None:
+            return str(power_state)
+
+        status = getattr(response, "status", "unknown")
+        response_keys = list(response_dict.keys())
+        raise LisaException(
+            "Failed to get iDRAC power state because the System endpoint response "
+            f"did not include a non-null PowerState. "
+            f"status={status}, keys={response_keys}. "
+            "Verify the iDRAC System endpoint and Lifecycle Controller health."
+        )
 
     def login(self) -> None:
         self.redfish_instance = redfish.redfish_client(


### PR DESCRIPTION
During bare-metal deployment, iDRAC can return a decoded ComputerSystem response without a usable PowerState value. The previous direct dictionary lookup turned that response shape into a raw KeyError before reset handling could continue.

Retry the System endpoint read briefly using the existing retry decorator pattern. If PowerState is still missing or null, raise a LisaException that includes the HTTP status and response keys so future pipeline logs show what iDRAC actually returned.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
