### PR TITLE
[AI Generated] BugFix: sriov - install irqbalance before verifying balance

### DIFF
--- a/lisa/microsoft/testsuites/network/sriov.py
+++ b/lisa/microsoft/testsuites/network/sriov.py
@@ -723,7 +723,11 @@ class Sriov(TestSuite):
             ).exit_code
             != 0
         ):
-            raise SkippedException("irqbalance is not installed")
+            if not isinstance(
+                server_node.os, Posix
+            ) or not server_node.os.is_package_in_repo("irqbalance"):
+                raise SkippedException("irqbalance is not available")
+            server_node.os.install_packages("irqbalance")
 
         # Get the irqbalance version if we can
         if isinstance(server_node.os, Posix):


### PR DESCRIPTION
## Summary
`Sriov.verify_irqbalance` was skipping unconditionally on images where `irqbalance` is not preinstalled (e.g. recent Ubuntu 24.04 marketplace images). Try to install the package via the node's Posix package manager when available; only fall back to `SkippedException` when the package genuinely cannot be installed.

## Change
`lisa/microsoft/testsuites/network/sriov.py` — when `command -v irqbalance` fails, attempt `server_node.os.install_packages("irqbalance")` if the node is `Posix` and the package is in the repo; otherwise raise `SkippedException("irqbalance is not available")`.

## Validation Results
| Image | VM Size | Region | Result |
|-------|---------|--------|--------|
| canonical ubuntu-24_04-lts server 24.04.202605310 | Standard_D4lds_v5 | westus2 | PASSED (335s, full 240s iperf3 + IRQ balance verified) |

Same image previously skipped in ~138s with "irqbalance is not installed". After the change, the package is installed on-demand and the test completes the full traffic/IRQ-distribution verification.