### PR TITLE
Harden stress-ng package fallback

### DIFF
--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import cast
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Posix
+from lisa.operating_system import CBLMariner, Debian, Posix
 from lisa.util.process import Process
 
 from .git import Git
@@ -26,8 +26,8 @@ class StressNg(Tool):
 
     def install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
-        if posix_os.is_package_in_repo("stress-ng"):
-            posix_os.install_packages("stress-ng")
+        if posix_os.is_package_in_repo(self.command):
+            posix_os.install_packages(self.command)
         else:
             self._install_from_src()
         return self._check_exists()
@@ -102,8 +102,17 @@ class StressNg(Tool):
     def _install_required_packages(self) -> None:
         if isinstance(self.node.os, CBLMariner):
             self.node.os.install_packages(
-                ["gcc", "glibc-devel", "kernel-headers", "binutils", "make"]
+                [
+                    "gcc",
+                    "glibc-devel",
+                    "kernel-headers",
+                    "binutils",
+                    "make",
+                    "libapparmor-devel",
+                ]
             )
+        elif isinstance(self.node.os, Debian):
+            self.node.os.install_packages("libapparmor-dev")
 
     def _install_from_src(self) -> bool:
         tool_path = self.get_tool_path()


### PR DESCRIPTION
Refresh package metadata before falling back to a stress-ng source build on Debian-family systems. In the failing Ubuntu pipeline log, apt-cache policy reported 'Unable to locate package stress-ng' on one guest even though neighboring guests installed the package from focal-updates/universe, so the fallback should re-run apt metadata initialization and re-check package availability first.

Keep the source-build path robust when it is still needed. stress-ng V0.14.01 can add -lapparmor when AppArmor tooling is present, and the failed run linked with -lapparmor before failing because the development library was missing. Install libapparmor-dev on Debian-family systems and libapparmor-devel on CBLMariner before building from source.

Add Posix.refresh_package_metadata() as a small reusable hook for tools that need an explicit package metadata refresh after the initial package lookup has already happened.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
