### PR TITLE
[AI Generated] BugFix: restrict OpenVMM upstream tests to Azure Linux

### DIFF
--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
@@ -15,7 +15,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.environment import EnvironmentStatus
-from lisa.operating_system import CBLMariner, Ubuntu
+from lisa.operating_system import CBLMariner
 from lisa.secret import add_secret
 from lisa.testsuite import TestResult
 from lisa.tools import Ls, Uname
@@ -36,13 +36,14 @@ def _get_openvmm_tests_type() -> Any:
     description="""
     This suite runs the upstream OpenVMM vmm_tests from the Linux OpenVMM host.
     """,
+    requirement=simple_requirement(supported_os=[CBLMariner]),
 )
 class OpenVmmUpstreamTestSuite(TestSuite):
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         openvmm_tests_type = _get_openvmm_tests_type()
         node = cast(Node, kwargs["node"])
         host = self._get_initialized_host_node(node)
-        if not isinstance(host.os, (CBLMariner, Ubuntu)):
+        if not isinstance(host.os, CBLMariner):
             raise SkippedException(
                 f"OpenVMM upstream tests are not implemented for {host.os.name}"
             )
@@ -93,6 +94,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         timeout=43200,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
+            supported_os=[CBLMariner],
         ),
     )
     def verify_openvmm_upstream_vmm_tests(

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -10,7 +10,7 @@ from pathlib import Path, PurePath
 from typing import Any, Dict, List, Optional, Type, cast
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Posix, Ubuntu
+from lisa.operating_system import CBLMariner, Posix
 from lisa.tools import Cargo, Curl, Git, Ls
 from lisa.util import LisaException, UnsupportedDistroException
 
@@ -62,7 +62,6 @@ class OpenVmmTests(Tool):
     command_group = ""
 
     _distro_package_mapping = {
-        Ubuntu.__name__: ["libssl-dev", "perl", "pkg-config"],
         CBLMariner.__name__: [
             "gcc",
             "openssl-devel",

--- a/selftests/test_openvmm_tests_suite.py
+++ b/selftests/test_openvmm_tests_suite.py
@@ -12,7 +12,7 @@ from lisa.microsoft.testsuites.openvmm.openvmm_tests import (
     _get_openvmm_tests_type,
 )
 from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import _JUnitSummary
-from lisa.operating_system import Ubuntu
+from lisa.operating_system import CBLMariner
 from lisa.tools import Ls, Uname
 from lisa.tools.usermod import Usermod
 from lisa.util import SkippedException
@@ -147,7 +147,7 @@ class OpenVmmTestsSuiteTestCase(TestCase):
         host.tools = {openvmm_tests_type: tool}
 
         def initialize_host() -> None:
-            host.os = object.__new__(Ubuntu)
+            host.os = object.__new__(CBLMariner)
 
         host.initialize.side_effect = initialize_host
 


### PR DESCRIPTION
## Summary
Restrict OpenVMM upstream `vmm_tests` to Azure Linux hosts. Add
`supported_os=[CBLMariner]` at both the suite and case level so the planner
filters non-Azure-Linux hosts before deployment, drop the now-unreachable
Ubuntu package map, and tighten the defensive isinstance check in
`before_case` to match.

## Validation Results
| Image | Result |
|-------|--------|
| Canonical 0001-com-ubuntu-pro-microsoft pro-fips-22_04 latest | SKIPPED (expected — before_case filter fired, no apt run) |
| selftests/test_openvmm_tests_suite.py (8 tests) | PASSED |
