### PR TITLE
[AI Generated] BugFix: check MSHV root partition first

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -49,6 +49,9 @@ class MshvHostTestSuite(TestSuite):
 
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
+        if not node.tools[Ls].path_exists("/dev/mshv", sudo=True):
+            raise SkippedException("This suite is for MSHV root partition only")
+
         if not node.tools[KernelConfig].is_enabled("CONFIG_MSHV_DIAG"):
             raise SkippedException("MSHV_DIAG not enabled, skip")
 


### PR DESCRIPTION
## Summary
Checks for the MSHV root partition device in `MshvHostTestSuite.before_case` before checking MSHV diagnostic support, so non-root hosts skip on suite applicability first.

## Validation Results
| Validation | Result |
|------------|--------|
| Local guard-ordering harness | PASSED |
| Black, Flake8, Pylint, MyPy | PASSED |