### PR TITLE
[AI Generated] BugFix: check RustVMM virtualization support

### DIFF
--- a/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
+++ b/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
@@ -10,7 +10,7 @@ from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.messages import TestStatus, send_sub_test_result_message
 from lisa.operating_system import BSD, Linux, Windows
 from lisa.testsuite import TestResult, simple_requirement
-from lisa.tools import Cargo, Dmesg, Git, Ls, RemoteCopy
+from lisa.tools import Cargo, Dmesg, Git, Ls, Lscpu, RemoteCopy
 from lisa.util import SkippedException
 from lisa.util.process import ExecutableResult
 
@@ -30,6 +30,10 @@ class RustVmmTestSuite(TestSuite):
         # may misclassify the node and bypass the supported_os gate.
         if isinstance(node.os, BSD) or isinstance(node.os, Windows):
             raise SkippedException(f"{node.os} is not supported.")
+
+        virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
+        if not virtualization_enabled:
+            raise SkippedException("Virtualization is not enabled in hardware")
 
         mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)
         if not mshv_exists:


### PR DESCRIPTION
## Summary
Checks RustVMM host hardware virtualization support before deciding whether the `/dev/mshv` backend is available, so hosts without virtualization enabled report the correct skip reason.

## Validation Results
| Validation | Result |
|------------|--------|
| Focused guard-ordering harness | PASSED |
| Black, Flake8, Pylint, MyPy | PASSED |