### PR TITLE
Fix LTP skip test cases bug in WSL Env

### DIFF
--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -174,6 +174,24 @@ class Ltp(Tool):
                 self.node.shell.copy(PurePath(local_tmp_path), PurePosixPath(skip_file))
             finally:
                 os.unlink(local_tmp_path)
+            # Verify the skip file was actually created on the remote node.
+            # For some node types (e.g. WSL), shell.copy() may silently fail
+            # to transfer the file into the node's filesystem, causing runltp
+            # to see an empty -S argument and skip nothing.
+            if not ls.path_exists(skip_file):
+                self._log.warning(
+                    f"shell.copy() did not create {skip_file}, "
+                    "falling back to writing skip tests directly on the remote node"
+                )
+                # LTP test names are plain alphanumeric identifiers; single-quoting
+                # them is safe and avoids any shell-expansion issues.
+                quoted = " ".join(f"'{t}'" for t in skip_tests)
+                self.node.execute(
+                    f"printf '%s\\n' {quoted} | tee {skip_file} > /dev/null",
+                    sudo=True,
+                    shell=True,
+                    expected_exit_code=0,
+                )
             parameters += f"-S {skip_file} "
 
         # Minimum 4M swap space is needed by some mmp test

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -97,6 +97,58 @@ class Ltp(Tool):
             # default binary_file install path is /tmp/ltp
             self._command_path = "/tmp/ltp" if self._binary_file else "/opt/ltp"
 
+    def _write_skip_tests_to_remote(
+        self, skip_file: str, skip_tests: List[str]
+    ) -> None:
+        """Write skip test names directly on the remote node.
+
+        Uses ``printf | tee`` instead of ``shell.copy()`` because the latter
+        is unreliable for some node types (e.g. WSL): it may create the
+        destination file but leave it empty (0 bytes), causing runltp to
+        silently discard the ``-S`` argument.
+        """
+        quoted = " ".join(f"'{t}'" for t in skip_tests)
+        self.node.execute(
+            f"printf '%s\\n' {quoted} | sudo tee {skip_file} > /dev/null",
+            sudo=True,
+            shell=True,
+            expected_exit_code=0,
+        )
+        self._assert_skip_file_non_empty(skip_file, skip_tests)
+
+    def _verify_or_rewrite_skip_file(self, skip_file: str, local_path: str) -> None:
+        """Verify a copied skip file is non-empty; rewrite it if not."""
+        verify = self.node.execute(f"test -s {skip_file}", sudo=True, shell=True)
+        if verify.exit_code != 0:
+            self._log.warning(
+                f"shell.copy() left {skip_file} empty; " "rewriting via remote command"
+            )
+            with open(local_path, "r") as f:
+                lines = [line.strip() for line in f if line.strip()]
+            if not lines:
+                raise LisaException(
+                    f"Local skip file {local_path} is empty; "
+                    "cannot generate a valid skip file."
+                )
+            self._write_skip_tests_to_remote(skip_file, lines)
+
+    def _assert_skip_file_non_empty(
+        self, skip_file: str, skip_tests: List[str]
+    ) -> None:
+        """Assert the remote skip file is non-empty.
+
+        runltp checks both ``-r`` (readable) and ``-s`` (non-empty) before
+        passing ``-S`` to ltp-pan; an empty file causes the skip list to be
+        silently discarded.
+        """
+        verify = self.node.execute(f"test -s {skip_file}", sudo=True, shell=True)
+        if verify.exit_code != 0:
+            raise LisaException(
+                f"Skip file {skip_file} is empty after write; "
+                "skip tests will not be applied. "
+                f"Attempted to write: {skip_tests}"
+            )
+
     def run_test(
         self,
         test_result: TestResult,
@@ -159,36 +211,13 @@ class Ltp(Tool):
                 PurePath(user_input_skip_file),
                 PurePosixPath(skip_file),
             )
+            # shell.copy() is unreliable for some node types (e.g. WSL): it
+            # may create the file but leave it empty.  Fall back to writing
+            # the content via a remote command when that happens.
+            self._verify_or_rewrite_skip_file(skip_file, user_input_skip_file)
             parameters += f"-S {skip_file} "
         elif len(skip_tests) > 0:
-            # Write skip tests directly on the remote node using printf + tee.
-            # shell.copy() is unreliable for some node types (e.g. WSL): it may
-            # create the destination file but leave it empty (0 bytes), causing
-            # runltp to silently discard the -S argument (runltp checks both -r
-            # and -s on the skipfile). Writing via a remote command is reliable
-            # across all node types.  LTP test names are plain alphanumeric
-            # identifiers, so single-quoting them is safe.
-            quoted = " ".join(f"'{t}'" for t in skip_tests)
-            self.node.execute(
-                f"printf '%s\\n' {quoted} | tee {skip_file} > /dev/null",
-                sudo=True,
-                shell=True,
-                expected_exit_code=0,
-            )
-            # Verify the skipfile is non-empty. runltp checks both -r (readable)
-            # and -s (non-empty) before passing -S to ltp-pan; an empty file
-            # causes the skip list to be silently discarded.
-            verify = self.node.execute(
-                f"test -s {skip_file}",
-                sudo=True,
-                shell=True,
-            )
-            if verify.exit_code != 0:
-                raise LisaException(
-                    f"Skip file {skip_file} is empty after write; "
-                    "skip tests will not be applied. "
-                    f"Attempted to write: {skip_tests}"
-                )
+            self._write_skip_tests_to_remote(skip_file, skip_tests)
             parameters += f"-S {skip_file} "
 
         # Minimum 4M swap space is needed by some mmp test

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 import os
 import re
+import shlex
 from dataclasses import dataclass
 from pathlib import PurePath, PurePosixPath
 from typing import Any, Dict, List, Optional, Type
@@ -114,17 +115,19 @@ class Ltp(Tool):
         When the skip list is large (300+ entries), the command is split into
         batches to stay within SSH/WSL command-line length limits.
         """
+        skip_file_q = shlex.quote(skip_file)
         for i in range(0, len(skip_tests), self._SKIP_BATCH_SIZE):
             batch = skip_tests[i : i + self._SKIP_BATCH_SIZE]
-            quoted = " ".join(f"'{t}'" for t in batch)
+            quoted = " ".join(shlex.quote(t) for t in batch)
             if i == 0:
-                # First batch: truncate the file
-                cmd = f"printf '%s\\n' {quoted}" f" | sudo tee {skip_file} > /dev/null"
+                # First batch: truncate the file.
+                # sudo=True on node.execute() already runs the whole shell as
+                # root; embedding a second 'sudo tee' is redundant and fails
+                # on nodes where sudo is not installed.
+                cmd = f"printf '%s\\n' {quoted} | tee {skip_file_q} > /dev/null"
             else:
                 # Subsequent batches: append
-                cmd = (
-                    f"printf '%s\\n' {quoted}" f" | sudo tee -a {skip_file} > /dev/null"
-                )
+                cmd = f"printf '%s\\n' {quoted} | tee -a {skip_file_q} > /dev/null"
             self.node.execute(
                 cmd,
                 sudo=True,
@@ -135,7 +138,9 @@ class Ltp(Tool):
 
     def _verify_or_rewrite_skip_file(self, skip_file: str, local_path: str) -> None:
         """Verify a copied skip file is non-empty; rewrite it if not."""
-        verify = self.node.execute(f"test -s {skip_file}", sudo=True, shell=True)
+        verify = self.node.execute(
+            f"test -s {shlex.quote(skip_file)}", sudo=True, shell=True
+        )
         if verify.exit_code != 0:
             self._log.warning(
                 f"shell.copy() left {skip_file} empty; " "rewriting via remote command"
@@ -158,7 +163,9 @@ class Ltp(Tool):
         passing ``-S`` to ltp-pan; an empty file causes the skip list to be
         silently discarded.
         """
-        verify = self.node.execute(f"test -s {skip_file}", sudo=True, shell=True)
+        verify = self.node.execute(
+            f"test -s {shlex.quote(skip_file)}", sudo=True, shell=True
+        )
         if verify.exit_code != 0:
             raise LisaException(
                 f"Skip file {skip_file} is empty after write; "

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -97,6 +97,10 @@ class Ltp(Tool):
             # default binary_file install path is /tmp/ltp
             self._command_path = "/tmp/ltp" if self._binary_file else "/opt/ltp"
 
+    # Maximum number of test names per printf command to avoid exceeding
+    # SSH/WSL command-line length limits on remote nodes.
+    _SKIP_BATCH_SIZE = 50
+
     def _write_skip_tests_to_remote(
         self, skip_file: str, skip_tests: List[str]
     ) -> None:
@@ -106,14 +110,27 @@ class Ltp(Tool):
         is unreliable for some node types (e.g. WSL): it may create the
         destination file but leave it empty (0 bytes), causing runltp to
         silently discard the ``-S`` argument.
+
+        When the skip list is large (300+ entries), the command is split into
+        batches to stay within SSH/WSL command-line length limits.
         """
-        quoted = " ".join(f"'{t}'" for t in skip_tests)
-        self.node.execute(
-            f"printf '%s\\n' {quoted} | sudo tee {skip_file} > /dev/null",
-            sudo=True,
-            shell=True,
-            expected_exit_code=0,
-        )
+        for i in range(0, len(skip_tests), self._SKIP_BATCH_SIZE):
+            batch = skip_tests[i : i + self._SKIP_BATCH_SIZE]
+            quoted = " ".join(f"'{t}'" for t in batch)
+            if i == 0:
+                # First batch: truncate the file
+                cmd = f"printf '%s\\n' {quoted}" f" | sudo tee {skip_file} > /dev/null"
+            else:
+                # Subsequent batches: append
+                cmd = (
+                    f"printf '%s\\n' {quoted}" f" | sudo tee -a {skip_file} > /dev/null"
+                )
+            self.node.execute(
+                cmd,
+                sudo=True,
+                shell=True,
+                expected_exit_code=0,
+            )
         self._assert_skip_file_non_empty(skip_file, skip_tests)
 
     def _verify_or_rewrite_skip_file(self, skip_file: str, local_path: str) -> None:

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 import os
 import re
-import tempfile
 from dataclasses import dataclass
 from pathlib import PurePath, PurePosixPath
 from typing import Any, Dict, List, Optional, Type
@@ -162,36 +161,20 @@ class Ltp(Tool):
             )
             parameters += f"-S {skip_file} "
         elif len(skip_tests) > 0:
-            # Write skip tests to a local temp file and copy to remote,
-            # avoiding shell quoting issues entirely.
-            skip_file_value = "\n".join(skip_tests)
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".skipfile", delete=False
-            ) as tmp:
-                tmp.write(skip_file_value)
-                local_tmp_path = tmp.name
-            try:
-                self.node.shell.copy(PurePath(local_tmp_path), PurePosixPath(skip_file))
-            finally:
-                os.unlink(local_tmp_path)
-            # Verify the skip file was actually created on the remote node.
-            # For some node types (e.g. WSL), shell.copy() may silently fail
-            # to transfer the file into the node's filesystem, causing runltp
-            # to see an empty -S argument and skip nothing.
-            if not ls.path_exists(skip_file):
-                self._log.warning(
-                    f"shell.copy() did not create {skip_file}, "
-                    "falling back to writing skip tests directly on the remote node"
-                )
-                # LTP test names are plain alphanumeric identifiers; single-quoting
-                # them is safe and avoids any shell-expansion issues.
-                quoted = " ".join(f"'{t}'" for t in skip_tests)
-                self.node.execute(
-                    f"printf '%s\\n' {quoted} | tee {skip_file} > /dev/null",
-                    sudo=True,
-                    shell=True,
-                    expected_exit_code=0,
-                )
+            # Write skip tests directly on the remote node using printf + tee.
+            # shell.copy() is unreliable for some node types (e.g. WSL): it may
+            # create the destination file but leave it empty (0 bytes), causing
+            # runltp to silently discard the -S argument (runltp checks both -r
+            # and -s on the skipfile). Writing via a remote command is reliable
+            # across all node types.  LTP test names are plain alphanumeric
+            # identifiers, so single-quoting them is safe.
+            quoted = " ".join(f"'{t}'" for t in skip_tests)
+            self.node.execute(
+                f"printf '%s\\n' {quoted} | tee {skip_file} > /dev/null",
+                sudo=True,
+                shell=True,
+                expected_exit_code=0,
+            )
             parameters += f"-S {skip_file} "
 
         # Minimum 4M swap space is needed by some mmp test

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -175,6 +175,20 @@ class Ltp(Tool):
                 shell=True,
                 expected_exit_code=0,
             )
+            # Verify the skipfile is non-empty. runltp checks both -r (readable)
+            # and -s (non-empty) before passing -S to ltp-pan; an empty file
+            # causes the skip list to be silently discarded.
+            verify = self.node.execute(
+                f"test -s {skip_file}",
+                sudo=True,
+                shell=True,
+            )
+            if verify.exit_code != 0:
+                raise LisaException(
+                    f"Skip file {skip_file} is empty after write; "
+                    "skip tests will not be applied. "
+                    f"Attempted to write: {skip_tests}"
+                )
             parameters += f"-S {skip_file} "
 
         # Minimum 4M swap space is needed by some mmp test


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
LTP has bug when parse in skipped cases in WSL env.
1. Quote issue in WSL parse in
2. Skip Cases too long will crash the SSH input buffer

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
