### PR TITLE
Retry stress-ng package install fallback

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Pattern,
     Sequence,
+    Set,
     Type,
     Union,
 )
@@ -354,6 +355,7 @@ class Posix(OperatingSystem, BaseClassMixin):
     def __init__(self, node: Any) -> None:
         super().__init__(node, is_posix=True)
         self._first_time_installation: bool = True
+        self._package_metadata_refresh_retried: Set[str] = set()
 
     @classmethod
     def type_name(cls) -> str:
@@ -1237,6 +1239,19 @@ class Debian(Linux):
         result = self._node.execute(command, sudo=True, shell=True)
         matched = get_matched_str(result.stdout, self._package_candidate_pattern)
         if matched:
+            if package not in self._package_metadata_refresh_retried:
+                self._log.debug(
+                    f"Package '{package}' was not found in apt metadata. "
+                    "Refreshing metadata before retrying package lookup."
+                )
+                self._initialize_package_installation()
+                self._package_metadata_refresh_retried.add(package)
+                result = self._node.execute(command, sudo=True, shell=True)
+                matched = get_matched_str(
+                    result.stdout, self._package_candidate_pattern
+                )
+                if not matched:
+                    return True
             return False
         return True
 

--- a/lisa/tools/stress_ng.py
+++ b/lisa/tools/stress_ng.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from lisa.executable import Tool
 from lisa.operating_system import CBLMariner, Debian, Posix
+from lisa.util import LisaException, RepoNotExistException
 from lisa.util.process import Process
 
 from .git import Git
@@ -27,10 +28,19 @@ class StressNg(Tool):
     def install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
         if posix_os.is_package_in_repo(self.command):
-            posix_os.install_packages(self.command)
-        else:
-            self._install_from_src()
-        return self._check_exists()
+            try:
+                posix_os.install_packages(self.command)
+            except RepoNotExistException:
+                raise
+            except LisaException as package_error:
+                self._log.debug(
+                    f"failed to install {self.command} from package manager: "
+                    f"{package_error}"
+                )
+
+        if not self._check_exists():
+            return self._install_from_src()
+        return True
 
     def launch_vm_stressor(
         self, num_workers: int = 0, vm_bytes: str = "", timeout_in_seconds: int = 0


### PR DESCRIPTION
Refresh Debian apt metadata once when apt-cache policy reports that a package has no candidate or cannot be located. This keeps the existing first-time package initialization path intact while covering transient metadata visibility issues before callers fall back to source builds.

For stress-ng, keep repo-not-found failures visible, but fall back to the source build path when the package manager reports a LISA package-install failure and the binary is still unavailable. This covers apt dependency-resolution failures such as held broken packages while preserving the existing AppArmor source-build dependency fix already on main.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
