### PR TITLE
Increase Cloud Hypervisor rustup timeout

### DIFF
--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -25,6 +25,9 @@ from lisa.util.logger import Logger
 from lisa.util.process import ExecutableResult
 
 CLOUD_HYPERVISOR_RELEASE_REF_PATTERN = re.compile(r"^v\d+(?:\.\d+)*(?:[-+].*)?$")
+# Rustup downloads the full Rust toolchain. Bare-metal lab network throughput can
+# be slow enough to exceed the generic 600-second command timeout.
+RUSTUP_INSTALL_TIMEOUT_SECONDS = 1800
 
 
 @dataclass_json()
@@ -514,8 +517,13 @@ class CloudHypervisorSourceInstaller(CloudHypervisorInstaller):
             "curl https://sh.rustup.rs -sSf | sh -s -- -y",
             shell=True,
             sudo=False,
+            timeout=RUSTUP_INSTALL_TIMEOUT_SECONDS,
             expected_exit_code=0,
-            expected_exit_code_failure_message="Failed to install Rust & Cargo",
+            expected_exit_code_failure_message=(
+                "Failed to install Rust & Cargo. Verify rustup network "
+                "connectivity and retry if the toolchain download timed out "
+                "or was interrupted."
+            ),
         )
         self._node.execute("source ~/.cargo/env", shell=True, sudo=False)
         if isinstance(self._node.os, Ubuntu):


### PR DESCRIPTION
The BareMetal L1VH run failed while installing Rust for the Cloud Hypervisor source installer. rustup was still downloading rustc at low throughput when the generic 600-second command timeout killed the process, which surfaced as exit code 1 from the curl | sh install command.

Use a named 1800-second rustup install timeout for this dependency step and expand the failure message so future failures point reviewers toward rustup network connectivity or interrupted toolchain downloads.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
