### PR TITLE
Decouple CH subtest discovery timeout

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -50,10 +50,13 @@ class CloudHypervisorTestResult:
 
 class CloudHypervisorTests(Tool):
     CMD_TIME_OUT = 3600
+    # dev_cli.sh test discovery may download guest images and build test binaries
+    # before cargo can list the test cases on cold lab nodes.
+    SUBTEST_DISCOVERY_TIME_OUT = 5400
     # Slightly higher case timeout to give the case a window to
     # - list subtests before running the tests.
     # - extract sub test results from stdout and report them.
-    CASE_TIME_OUT = CMD_TIME_OUT + 1200
+    CASE_TIME_OUT = CMD_TIME_OUT + SUBTEST_DISCOVERY_TIME_OUT + 1200
     # 6 Hrs of timeout for perf tests and 2400 seconds for other operations
     PERF_CASE_TIME_OUT = 21600 + 2400
     PERF_CMD_TIME_OUT = 1200
@@ -1392,7 +1395,7 @@ exit $ec
         )
         result = self.run(
             cmd_args,
-            timeout=self.CMD_TIME_OUT,
+            timeout=self.SUBTEST_DISCOVERY_TIME_OUT,
             force_run=True,
             cwd=self.repo_root,
             no_info_log=False,


### PR DESCRIPTION
Cloud Hypervisor live-migration discovery invokes dev_cli.sh with --list, but that path may still download guest images and build test binaries on cold lab nodes before cargo can enumerate tests.

The L1VH bare-metal failure spent more than 44 minutes downloading the Jammy qcow2 during discovery, leaving too little of the original 3600-second command timeout for build and cargo test --list. Add a separate discovery timeout budget and expand the test case timeout to cover discovery, the actual test run, and result processing while keeping the real test command timeout unchanged.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
