### PR TITLE
Log OpenVMM repository HEAD

### DIFF
--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -231,6 +231,7 @@ class OpenVmmTests(Tool):
         return self.node.tools[Ls].path_exists(str(self.repo_root))
 
     def _prepare_repo(self, log_path: Path, ref: str) -> Dict[str, str]:
+        git = self.node.tools[Git]
         if not self._check_exists() and not self._install():
             raise LisaException(
                 f"failed to prepare OpenVMM upstream tests repository from "
@@ -240,7 +241,7 @@ class OpenVmmTests(Tool):
         cargo_env = self._get_cargo_environment()
 
         if ref and self._prepared_ref != ref:
-            self.node.tools[Git].checkout(ref, self.repo_root)
+            git.checkout(ref, self.repo_root)
             self.node.execute(
                 "git submodule update --init --recursive",
                 shell=True,
@@ -252,6 +253,12 @@ class OpenVmmTests(Tool):
                 ),
             )
             self._repo_prepared = False
+
+        openvmm_commit = git.get_current_commit_hash(self.repo_root).strip()
+        self._log.info(
+            f"OpenVMM upstream tests repository: {self.repo_url}, "
+            f"requested ref: {ref or '<default>'}, HEAD: {openvmm_commit}"
+        )
 
         if not self._repo_prepared:
             restore_command = shlex.join(

--- a/lisa/sut_orchestrator/openvmm/installer.py
+++ b/lisa/sut_orchestrator/openvmm/installer.py
@@ -149,6 +149,11 @@ class OpenVmmSourceInstaller(OpenVmmInstaller):
             auth_token=runbook.auth_token,
             fail_on_exists=False,
         )
+        openvmm_commit = git.get_current_commit_hash(code_path).strip()
+        self._log.info(
+            f"OpenVMM source repository: {runbook.repo}, "
+            f"requested ref: {runbook.ref or '<default>'}, HEAD: {openvmm_commit}"
+        )
 
         cargo_command = shlex.quote(cargo.command)
         cargo_bin_dir = self._node.get_str_path(

--- a/selftests/test_openvmm_installer.py
+++ b/selftests/test_openvmm_installer.py
@@ -37,7 +37,10 @@ class OpenVmmInstallerTestCase(TestCase):
             command="/home/test/.cargo/bin/cargo",
             toolchain="stable",
         )
-        git = SimpleNamespace(clone=MagicMock(return_value="/tmp/work/openvmm-src"))
+        git = SimpleNamespace(
+            clone=MagicMock(return_value="/tmp/work/openvmm-src"),
+            get_current_commit_hash=MagicMock(return_value="abc1234"),
+        )
         ln = SimpleNamespace(create_link=MagicMock())
         executed_commands: List[Dict[str, Any]] = []
 


### PR DESCRIPTION
OpenVMM validation runbooks use the default branch when openvmm_installer_ref is empty. Existing logs show the clone command and LISA cache directory name, but not the actual Git commit checked out, which makes regressions hard to correlate after the branch moves.

Log the requested ref and resolved HEAD commit for both the OpenVMM source installer and the upstream OpenVMM VMM test tool after clone/checkout. This makes future pipeline artifacts include a GitHub-resolvable OpenVMM revision.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
