### PR TITLE
Add Fix for DNF Tool, Missing Systemd-Logind configs, Modetest, GrubConfig for 4.0

### DIFF
--- a/lisa/microsoft/testsuites/display/modetest.py
+++ b/lisa/microsoft/testsuites/display/modetest.py
@@ -3,7 +3,15 @@
 from typing import List, Type, Union
 
 from lisa.executable import Tool
-from lisa.operating_system import SLES, CpuArchitecture, Oracle, Redhat, Suse, Ubuntu
+from lisa.operating_system import (
+    SLES,
+    CBLMariner,
+    CpuArchitecture,
+    Oracle,
+    Redhat,
+    Suse,
+    Ubuntu,
+)
 from lisa.tools.gcc import Gcc
 from lisa.tools.git import Git
 from lisa.util import UnsupportedDistroException
@@ -33,6 +41,11 @@ class Modetest(Tool):
     def _install(self) -> bool:
         if isinstance(self.node.os, Ubuntu):
             self.node.os.install_packages("libdrm-tests")
+        if (
+            isinstance(self.node.os, CBLMariner)
+            and self.node.os.information.version.major >= 4
+        ):
+            self.node.os.install_packages("drm-utils")
         if isinstance(self.node.os, Redhat) or isinstance(self.node.os, Suse):
             self._install_from_src()
         return self._check_exists()

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2321,13 +2321,35 @@ class CBLMariner(RPMDistro):
     # Disable KillUserProcesses to avoid test processes being terminated when
     # the SSH session is reset
     def set_kill_user_processes(self) -> None:
+        service = self._node.tools[Service]
+        if not service.check_service_exists("systemd-logind"):
+            self._log.debug(
+                "Skipping restart because systemd-logind service is absent."
+            )
+            return
+
+        if self.information.version.major >= 4:
+            from lisa.tools import Mkdir, Tee
+
+            drop_in_dir = self._node.get_pure_path("/etc/systemd/logind.conf.d")
+            drop_in_file = drop_in_dir / "90-lisa.conf"
+
+            self._node.tools[Mkdir].create_directory(str(drop_in_dir), sudo=True)
+            self._node.tools[Tee].write_to_file(
+                value="[Login]\nKillUserProcesses=no",
+                file=drop_in_file,
+                sudo=True,
+            )
+            service.restart_service("systemd-logind")
+            return
+
         sed = self._node.tools[Sed]
         sed.append(
             text="KillUserProcesses=no",
             file="/etc/systemd/logind.conf",
             sudo=True,
         )
-        self._node.tools[Service].restart_service("systemd-logind")
+        service.restart_service("systemd-logind")
 
     def _replace_default_entry(self, entry: str) -> None:
         self._log.debug(f"set boot entry to: {entry}")

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2252,7 +2252,7 @@ class CBLMariner(RPMDistro):
 
     def __init__(self, node: Any) -> None:
         super().__init__(node)
-        self._dnf_tool_name: str
+        self._dnf_tool_name: Optional[str] = None
 
     def _initialize_package_installation(self) -> None:
         self.set_kill_user_processes()
@@ -2265,6 +2265,8 @@ class CBLMariner(RPMDistro):
         self._dnf_tool_name = "tdnf -q"
 
     def _dnf_tool(self) -> str:
+        if not self._dnf_tool_name:
+            self._initialize_package_installation()
         return self._dnf_tool_name
 
     def _package_exists(self, package: str) -> bool:

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2267,10 +2267,12 @@ class CBLMariner(RPMDistro):
     def _dnf_tool(self) -> str:
         if not self._dnf_tool_name:
             self._initialize_package_installation()
+        assert self._dnf_tool_name is not None
         return self._dnf_tool_name
 
     def _package_exists(self, package: str) -> bool:
-        self._initialize_package_installation()
+        if not self._dnf_tool_name:
+            self._initialize_package_installation()
         return super()._package_exists(package)
 
     def add_azure_core_repo(

--- a/lisa/tools/grub_config.py
+++ b/lisa/tools/grub_config.py
@@ -24,6 +24,8 @@ class GrubConfig(Tool):
                 return GrubConfigAzl2(node, args, kwargs)
             if node.os.information.release == "3.0":
                 return GrubConfigAzl3(node, args, kwargs)
+            if node.os.information.version.major >= 4:
+                return GrubConfigAzl4(node, args, kwargs)
         elif isinstance(node.os, Debian):
             return GrubConfigDebian(node, args, kwargs)
         elif isinstance(node.os, Redhat):
@@ -31,7 +33,7 @@ class GrubConfig(Tool):
 
         raise UnsupportedDistroException(
             os=node.os,
-            message="Grub tool only supported on CBLMariner 2.0/3.0, "
+            message="Grub tool only supported on CBLMariner 2.0/3.0/4.0, "
             "Debian-based distributions, and RHEL-based distributions.",
         )
 
@@ -167,6 +169,13 @@ class GrubConfigDebian(GrubConfig):
 class GrubConfigRedhat(GrubConfig):
     _GRUB_CMDLINE_LINE_REGEX = r"^GRUB_CMDLINE_LINUX="
     _GRUB_DEFAULT_FILE = "/etc/default/grub"
+    _UEFI_GRUB_PATHS = [
+        "/boot/efi/EFI/redhat/grub.cfg",
+        "/boot/efi/EFI/centos/grub.cfg",
+        "/boot/efi/EFI/almalinux/grub.cfg",
+        "/boot/efi/EFI/rocky/grub.cfg",
+        "/boot/efi/EFI/BOOT/grub.cfg",
+    ]
 
     def __init__(self, node: "Node", *args: Any, **kwargs: Any) -> None:
         super().__init__("grub2-mkconfig", "grub2-tools", node, *args, **kwargs)
@@ -251,15 +260,7 @@ class GrubConfigRedhat(GrubConfig):
             self._log.debug("Detected UEFI system, checking for UEFI GRUB paths")
 
             # UEFI system - check common UEFI paths
-            uefi_paths = [
-                "/boot/efi/EFI/redhat/grub.cfg",
-                "/boot/efi/EFI/centos/grub.cfg",
-                "/boot/efi/EFI/almalinux/grub.cfg",
-                "/boot/efi/EFI/rocky/grub.cfg",
-                "/boot/efi/EFI/BOOT/grub.cfg",
-            ]
-
-            for path in uefi_paths:
+            for path in self._UEFI_GRUB_PATHS:
                 ls_result = ls_tool.run(path, sudo=True, force_run=True)
                 if ls_result.exit_code == 0:
                     self._log.debug(f"Found UEFI GRUB config at: {path}")
@@ -278,3 +279,11 @@ class GrubConfigRedhat(GrubConfig):
         # Default to BIOS path
         self._log.debug("Using default BIOS GRUB config path")
         return "/boot/grub2/grub.cfg"
+
+
+class GrubConfigAzl4(GrubConfigRedhat):
+    # On Azure Linux 4 the grub config is under the azurelinux EFI directory.
+    _UEFI_GRUB_PATHS = [
+        "/boot/efi/EFI/azurelinux/grub.cfg",
+        "/boot/efi/EFI/BOOT/grub.cfg",
+    ]


### PR DESCRIPTION
## Description

Establish Azure Linux 4.0 Support in Lisa

- Add Lazy-Init DNF tool for CBL Mariner 4.0 to avoid `dnf_tool_unavailable` errors
- Use drop-ins to handle missing systemd-logind config in Azl 4.0
- Install `drm-utils` for modetest in 4.0
- Add BLS Aware Grub Config for Azl 4.0 (inherited from Redhat) with updated Path for the files

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
