### PR TITLE
kernel_installer transformer: Use main repo component as default

### DIFF
--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -261,9 +261,13 @@ class RepoInstaller(BaseInstaller):
                 repo_entry = f"deb {self.repo_url} {version_name} {repo_component}"
             elif "proposed2" in self.repo_url:
                 repo_entry = "ppa:canonical-kernel-team/proposed2"
-            else:
+            elif "proposed" in self.repo_url:
                 version_name = f"{release}-proposed"
                 repo_entry = "ppa:canonical-kernel-team/proposed"
+            else:
+                # use 'main' repo component for all other repositories
+                repo_component = "main"
+                repo_entry = f"deb {self.repo_url} {version_name} {repo_component}"
         else:
             repo_entry = f"deb {self.repo_url} {version_name} {repo_component}"
 
@@ -321,7 +325,12 @@ class RepoInstaller(BaseInstaller):
             r"(?P<kernel_version>[^.]+\.[^.]+\.[^.-]+[.-][^.]+)\..*installed.*[\r\n]+",
             re.M,
         )
-        result = node.execute(f"apt search {source}", shell=True)
+        # Pipe through `cat` so apt's stdout is not a TTY. Otherwise `apt search`
+        # sends its output to an interactive pager (less) that waits for input,
+        # causing the command to hang until it times out.
+        result = node.execute(
+            f"apt search {source} 2>&1 | cat", sudo=True, shell=True
+        )
         result_output = filter_ansi_escape(result.stdout)
         kernel_version = get_matched_str(result_output, kernel_version_package_pattern)
         assert kernel_version, (

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -328,7 +328,11 @@ class RepoInstaller(BaseInstaller):
         # Pipe through `cat` so apt's stdout is not a TTY. Otherwise `apt search`
         # sends its output to an interactive pager (less) that waits for input,
         # causing the command to hang until it times out.
-        result = node.execute(f"apt search {source} 2>&1 | cat", sudo=True, shell=True)
+        result = node.execute(
+            f'bash -o pipefail -c "apt search {source} 2>&1 | cat"',
+            sudo=True,
+            shell=True,
+        )
         result_output = filter_ansi_escape(result.stdout)
         kernel_version = get_matched_str(result_output, kernel_version_package_pattern)
         assert kernel_version, (

--- a/lisa/transformers/kernel_installer.py
+++ b/lisa/transformers/kernel_installer.py
@@ -328,9 +328,7 @@ class RepoInstaller(BaseInstaller):
         # Pipe through `cat` so apt's stdout is not a TTY. Otherwise `apt search`
         # sends its output to an interactive pager (less) that waits for input,
         # causing the command to hang until it times out.
-        result = node.execute(
-            f"apt search {source} 2>&1 | cat", sudo=True, shell=True
-        )
+        result = node.execute(f"apt search {source} 2>&1 | cat", sudo=True, shell=True)
         result_output = filter_ansi_escape(result.stdout)
         kernel_version = get_matched_str(result_output, kernel_version_package_pattern)
         assert kernel_version, (


### PR DESCRIPTION
- Use main repo component as default enabling custom ppa kernel installation.
- Pipe through `cat` so apt's stdout is not a TTY.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D2ds_v5|PASSED|
