### PR TITLE
Add Zscaler distro map

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -1611,6 +1611,12 @@ class FreeBSD(BSD):
         )
 
 
+class Zscaler(FreeBSD):
+    @classmethod
+    def name_pattern(cls) -> Pattern[str]:
+        return re.compile("^ZscalerOS|zscaleros$")
+
+
 class OpenBSD(BSD):
     ...
 


### PR DESCRIPTION
## Description

This PR is to add a new distro map in operating_system.py. Zscaler is a FreeBSD system.

We have verified using a VHD image.


