### PR TITLE
Add extra check to only set the IP Service tags if not already set

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1355,8 +1355,8 @@ class AzurePlatform(Platform):
             arm_parameters.availability_options,
             availability_copied_fields,
         )
-        if self._is_byoip_feature_registered():
-            arm_parameters.ip_service_tags["FirstPartyUsage"] = "/SyntheticLoad"
+        #if self._is_byoip_feature_registered():
+        #    arm_parameters.ip_service_tags["FirstPartyUsage"] = "/SyntheticLoad"
 
         arm_parameters.virtual_network_resource_group = (
             self._azure_runbook.virtual_network_resource_group

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1355,6 +1355,9 @@ class AzurePlatform(Platform):
             arm_parameters.availability_options,
             availability_copied_fields,
         )
+        if not arm_parameters.ip_service_tags:
+            if self._is_byoip_feature_registered():
+                arm_parameters.ip_service_tags = {"FirstPartyUsage": "/SyntheticLoad"}
 
         arm_parameters.virtual_network_resource_group = (
             self._azure_runbook.virtual_network_resource_group

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1355,8 +1355,6 @@ class AzurePlatform(Platform):
             arm_parameters.availability_options,
             availability_copied_fields,
         )
-        #if self._is_byoip_feature_registered():
-        #    arm_parameters.ip_service_tags["FirstPartyUsage"] = "/SyntheticLoad"
 
         arm_parameters.virtual_network_resource_group = (
             self._azure_runbook.virtual_network_resource_group


### PR DESCRIPTION
## Description

Removes setting the IP Service tags if BYOIP is enabled.  The code was overwriting any IP service tags set with ip_service_tags in a runbook.

## Related Issue



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

Set a custom IP service tag using ip_service_tags in a runbook.  Ran a LISA smoke test, and I can see the custom IP service tag in Azure with the fix.

**Key Test Cases:**
smoke_test

**Impacted LISA Features:**

**Tested Azure Marketplace Images:**
canonical ubuntu-24_04-lts server-arm64 latest


## Test Results



| Image | VM Size | Result |
|-------|---------|--------|
| canonical ubuntu-24_04-lts server-arm64 latest | Standard_D32pds_v6 | PASSED |
