### PR TITLE
[AI Generated] BugFix: exclude kexec tests on confidential VMs

### DIFF
--- a/lisa/microsoft/testsuites/kexec/kexec_suite.py
+++ b/lisa/microsoft/testsuites/kexec/kexec_suite.py
@@ -18,7 +18,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.base_tools import Cat, Uname
-from lisa.features.security_profile import CvmDisabled
+from lisa.features.security_profile import CvmEnabled
 from lisa.operating_system import Posix
 from lisa.tools import Ls
 from lisa.util import LisaException, SkippedException, create_timer
@@ -32,7 +32,7 @@ from lisa.util import LisaException, SkippedException, create_timer
     Validates kernel's ability to load and execute a new kernel
     without going through BIOS/firmware reboot.
     """,
-    requirement=simple_requirement(supported_features=[CvmDisabled()]),
+    requirement=simple_requirement(unsupported_features=[CvmEnabled()]),
 )
 class KexecSuite(TestSuite):
     RECONNECT_TIMEOUT = 600  # 10 minutes

--- a/lisa/microsoft/testsuites/kexec/kexec_suite.py
+++ b/lisa/microsoft/testsuites/kexec/kexec_suite.py
@@ -15,8 +15,10 @@ from lisa import (
     TestResult,
     TestSuite,
     TestSuiteMetadata,
+    simple_requirement,
 )
 from lisa.base_tools import Cat, Uname
+from lisa.features.security_profile import CvmDisabled
 from lisa.operating_system import Posix
 from lisa.tools import Ls
 from lisa.util import LisaException, SkippedException, create_timer
@@ -30,6 +32,7 @@ from lisa.util import LisaException, SkippedException, create_timer
     Validates kernel's ability to load and execute a new kernel
     without going through BIOS/firmware reboot.
     """,
+    requirement=simple_requirement(supported_features=[CvmDisabled()]),
 )
 class KexecSuite(TestSuite):
     RECONNECT_TIMEOUT = 600  # 10 minutes
@@ -48,7 +51,7 @@ class KexecSuite(TestSuite):
         This test verifies the core kexec functionality by performing
         a controlled kernel-to-kernel reboot and validating the transition.
         """,
-        priority=3,
+        priority=5,
     )
     def verify_kexec_reboot_systemd(
         self, node: Node, log: Logger, result: TestResult
@@ -74,7 +77,7 @@ class KexecSuite(TestSuite):
         Tests the core kexec mechanism where the new kernel is executed
         immediately without running shutdown scripts.
         """,
-        priority=3,
+        priority=5,
     )
     def verify_kexec_reboot_direct(
         self, node: Node, log: Logger, result: TestResult


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
