### PR TITLE
Fix 62681087: set verify_python_version priority to 5

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -1596,7 +1596,7 @@ class AzureImageStandard(TestSuite):
         3. Fail the test if the version is lower than the minimum supported version,
            otherwise pass.
         """,
-        priority=1,
+        priority=5,
         requirement=simple_requirement(supported_platform_type=[AZURE, QEMU]),
     )
     def verify_python_version(self, node: Node) -> None:


### PR DESCRIPTION
Change AzureImageStandard.verify_python_version test case priority from 1 to 5

Setting priority to 5 ensures it only runs when a project explicitly selects it.