### PR TITLE
[AI Generated] BugFix: default raw VHD image source to x64 architecture

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -600,6 +600,9 @@ class VhdSchema(AzureImageSchema):
                 ],
             )
             self.encrypt_disk = search_space.SetSpace(True, [False])
+        # Azure does not deploy raw VHD blobs to ARM64 VMs; default to x64.
+        if self.architecture is None:
+            self.architecture = schema.ArchitectureType.x64
 
 
 @dataclass_json()


### PR DESCRIPTION
## Summary

Default `VhdSchema.architecture` to `x64` when not explicitly set, so LISA's `Architecture` feature produces an x64-only requirement for raw VHD image sources. Without this default, `Architecture.create_image_requirement()` returns `None` for VHDs, allowing ARM64 SKUs (e.g. `Standard_D2pds_v6`) to be picked for x64-only VHD blobs and causing deployment failures such as:

> Cannot create a VM of size 'Standard_D2pds_v6' ... only supports a CPU Architecture of 'Arm64'

Azure does not deploy raw VHD blobs to ARM64 VMs, so x64 is the safe and correct default. Users with ARM64 VHDs can still override via `vhd.architecture: Arm64` in their runbook.

## Change

3 lines added to `VhdSchema.load_from_platform()` in `lisa/sut_orchestrator/azure/common.py`:

```python
# Azure does not deploy raw VHD blobs to ARM64 VMs; default to x64.
if self.architecture is None:
    self.architecture = schema.ArchitectureType.x64
```

## Validation

- **Offline unit checks** (3/3 pass): default --> x64; explicit Arm64 preserved; CVM path also defaults to x64.
- **Live LISA smoke test** on a real Ubuntu Noble x64 raw VHD in westus2, hyperv_generation=2:
  - Pre-fix behavior: LISA selected `Standard_D2pds_v6` (Arm64) --> deployment fails with architecture mismatch.
  - Post-fix behavior: LISA selected `Standard_D2ads_v5` (x64) --> deployed in 94s, smoke_test `PASSED` in 86s.
- `pylint`: 10/10 on changed lines.