### PR TITLE
[AI Generated] BugFix: Skip MSR Hyper-V platform-id test on arm64 (rdmsr/msr-tools is x86-only)

### DIFF
--- a/lisa/microsoft/testsuites/core/msr.py
+++ b/lisa/microsoft/testsuites/core/msr.py
@@ -48,10 +48,13 @@ IS_OPEN_SOURCE_OS_MASK = 0x8000_0000_0000_0000
 
 
 class HvOsPlatformInfo:
-    # HV_REGISTER_GUEST_OSID constant declared in linus kernel source:
+    # HV_REGISTER_GUEST_OSID constant declared in linux kernel source:
     # arch/{ARCH_NAME}/include/asm/hyperv-tlfs.h
+    # Only x86 is listed: this test reads the register with the x86-only
+    # rdmsr/msr-tools utilities. The register also exists on arm64
+    # (HV_REGISTER_GUEST_OSID = 0x00090002), but is read via the hypercall
+    # interface (HvGetVpRegisters) rather than rdmsr.
     HV_REGISTER_GUEST_OSID = {
-        CpuArchitecture.ARM64: "0x00090002",
         CpuArchitecture.X64: "0x40000000",
     }
     OS_ID_UNDEFINED = 0
@@ -134,6 +137,16 @@ class Msr(TestSuite):
 
         # get the msr offset to read, this constant is arch specific
         arch_id = node.tools[Lscpu].get_architecture()
+
+        # rdmsr/msr-tools and the x86 "msr" driver are x86-only. The register
+        # exists on arm64 but is read via the hypercall interface, not rdmsr,
+        # so skip early instead of failing later on the msr-tools install.
+        if arch_id == CpuArchitecture.ARM64:
+            raise SkippedException(
+                "MSR platform-id test uses rdmsr/msr-tools (x86-only); on arm64 "
+                "the register is read via hypercall, not rdmsr."
+            )
+
         try:
             arch_msr_offset = HvOsPlatformInfo.HV_REGISTER_GUEST_OSID[arch_id]
         except KeyError as missing_key:


### PR DESCRIPTION
## Problem

`Msr.verify_hyperv_platform_id` reads the Hyper-V guest OS id register using `rdmsr` (from `msr-tools`, backed by the x86 `msr` char-device driver). All three are **x86-only**. On arm64 there is no `rdmsr` instruction, `msr-tools` is not packaged (`E: Unable to locate package msr-tools`), and the `msr` driver does not exist.

Previously the test still attempted to install `msr-tools` on arm64, looped on retries (~100s wasted), and finally skipped with a misleading message. The arch map also contained an arm64 entry (`0x00090002`) that falsely implied `rdmsr` could read it — but that value is a Hyper-V **synthetic register identifier** read via the hypercall interface (`HvGetVpRegisters`), not an x86 MSR number.

## Fix

- Detect arm64 early (right after `Lscpu.get_architecture()`) and skip with an accurate reason, before any `msr-tools` install attempt.
- Remove the misleading arm64 entry from `HV_REGISTER_GUEST_OSID` (the rdmsr offset map).
- Preserve the arm64 register knowledge in a comment for a future hypercall-based implementation.

## Validation

Ran `Msr.verify_hyperv_platform_id` on a real arm64 VM (Standard_D2pds_v5, Ubuntu 22.04 arm64, hardware_platform `aarch64`):

- **Result:** SKIPPED with `MSR platform-id test uses rdmsr/msr-tools (x86-only); on arm64 the register is read via hypercall, not rdmsr.`
- **0** `msr-tools` retry-loop lines (was ~12 before the fix).
- Test body skips in microseconds; no wasted install retries.

No behavior change on x86 — the test runs exactly as before.