### PR TITLE
[AI Generated] BugFix: skip SRIOV tests on Confidential VMs

### DIFF
--- a/lisa/microsoft/testsuites/core/provisioning.py
+++ b/lisa/microsoft/testsuites/core/provisioning.py
@@ -269,6 +269,7 @@ class Provisioning(TestSuite):
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
             network_interface=Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_deployment_provision_sriov(

--- a/lisa/microsoft/testsuites/network/sriov.py
+++ b/lisa/microsoft/testsuites/network/sriov.py
@@ -37,6 +37,7 @@ from lisa import (
 )
 from lisa.base_tools import Systemctl
 from lisa.features import NetworkInterface, SerialConsole, StartStop
+from lisa.features.security_profile import CvmDisabled
 from lisa.nic import NicInfo
 from lisa.operating_system import BSD, Posix, Windows
 from lisa.sut_orchestrator import AZURE, HYPERV
@@ -96,6 +97,7 @@ class Sriov(TestSuite):
         priority=1,
         requirement=simple_requirement(
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_services_state(self, node: Node) -> None:
@@ -131,6 +133,7 @@ class Sriov(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_basic(self, environment: Environment) -> None:
@@ -156,6 +159,7 @@ class Sriov(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_single_vf_connection(self, environment: Environment) -> None:
@@ -184,6 +188,7 @@ class Sriov(TestSuite):
             min_count=2,
             min_core_count=64,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_single_vf_connection_max_cpu(
@@ -216,6 +221,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_max_vf_connection(self, environment: Environment) -> None:
@@ -247,6 +253,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_max_vf_connection_max_cpu(self, environment: Environment) -> None:
@@ -270,6 +277,7 @@ class Sriov(TestSuite):
         requirement=simple_requirement(
             network_interface=features.Sriov(),
             supported_platform_type=[AZURE, HYPERV],
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_disable_enable(self, environment: Environment) -> None:
@@ -291,6 +299,7 @@ class Sriov(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_disable_enable_pci(self, environment: Environment) -> None:
@@ -317,6 +326,7 @@ class Sriov(TestSuite):
         requirement=simple_requirement(
             min_count=2,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_disable_enable_on_guest(self, environment: Environment) -> None:
@@ -342,6 +352,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 max_nic_count=search_space.IntRange(min=8),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_add_max_nics(
@@ -389,6 +400,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_provision_with_max_nics(self, environment: Environment) -> None:
@@ -411,6 +423,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_provision_with_max_nics_reboot(
@@ -439,6 +452,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_provision_with_max_nics_reboot_from_platform(
@@ -468,6 +482,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_provision_with_max_nics_stop_start_from_platform(
@@ -499,6 +514,7 @@ class Sriov(TestSuite):
                 data_path=schema.NetworkDataPath.Sriov,
                 nic_count=search_space.IntRange(min=2, choose_max_value=True),
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_reload_modules(self, environment: Environment) -> None:
@@ -551,6 +567,7 @@ class Sriov(TestSuite):
             ),
             # BSD is unsupported since this is testing to patches to the linux kernel
             unsupported_os=[BSD, Windows],
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_ethtool_offload_setting(self, environment: Environment) -> None:
@@ -709,6 +726,7 @@ class Sriov(TestSuite):
             min_count=2,
             min_core_count=4,
             network_interface=features.Sriov(),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_irqbalance(self, environment: Environment, log: Logger) -> None:
@@ -803,7 +821,8 @@ class Sriov(TestSuite):
                 node_count=2,
                 core_count=search_space.IntRange(min=8, max=16),
                 network_interface=features.Sriov(),
-            )
+            ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def verify_sriov_interrupts_change(self, environment: Environment) -> None:

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -26,6 +26,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.features import StartStop
+from lisa.features.security_profile import CvmDisabled
 from lisa.nic import NicInfo
 from lisa.search_space import IntRange
 from lisa.sut_orchestrator import AZURE
@@ -56,7 +57,8 @@ class Stress(TestSuite):
             node=schema.NodeSpace(
                 node_count=2,
                 network_interface=features.Sriov(),
-            )
+            ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def stress_sriov_iperf(self, environment: Environment) -> None:
@@ -138,6 +140,7 @@ class Stress(TestSuite):
             min_core_count=4,
             network_interface=features.Sriov(),
             supported_platform_type=[AZURE],
+            supported_features=[CvmDisabled()],
         ),
     )
     def stress_sriov_disable_enable(self, environment: Environment) -> None:
@@ -261,6 +264,7 @@ class Stress(TestSuite):
                 nic_count=IntRange(min=2, choose_max_value=True),
                 data_path=schema.NetworkDataPath.Sriov,
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
@@ -289,6 +293,7 @@ class Stress(TestSuite):
                 nic_count=IntRange(min=2, choose_max_value=True),
                 data_path=schema.NetworkDataPath.Sriov,
             ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def stress_sriov_with_max_nics_reboot_from_platform(
@@ -319,7 +324,8 @@ class Stress(TestSuite):
             network_interface=schema.NetworkInterfaceOptionSettings(
                 nic_count=IntRange(min=2, choose_max_value=True),
                 data_path=schema.NetworkDataPath.Sriov,
-            )
+            ),
+            supported_features=[CvmDisabled()],
         ),
     )
     def stress_sriov_with_max_nics_stop_start_from_platform(

--- a/lisa/microsoft/testsuites/nvme/nvme.py
+++ b/lisa/microsoft/testsuites/nvme/nvme.py
@@ -13,6 +13,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.features import Nvme, NvmeSettings, Sriov
+from lisa.features.security_profile import CvmDisabled
 from lisa.search_space import IntRange
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.tools import Cat, Df, Echo, Fdisk, Lspci, Mkfs, Mount, Nvmecli
@@ -363,7 +364,7 @@ class NvmeTestSuite(TestSuite):
         priority=2,
         requirement=simple_requirement(
             network_interface=Sriov(),
-            supported_features=[Nvme],
+            supported_features=[Nvme, CvmDisabled()],
         ),
     )
     def verify_nvme_sriov_rescind(self, node: Node) -> None:


### PR DESCRIPTION
## Summary

Confidential VMs (DCasv5 / DCadsv5 / ECasv5 / ECadsv5 and other SEV-SNP / TDX SKUs) do not support Azure Accelerated Networking (SR-IOV) — the data path is forced through the synthetic netvsc path. Today, SRIOV-dependent tests run on a CVM environment fail at runtime (e.g. assertions that VF devices appear in `lspci`) instead of being filtered out by LISA's requirement-matching layer.

This change adds `supported_features=[CvmDisabled()]` to every SRIOV test requirement so those tests are SKIPPED at environment-prepare time on CVM images (with a clear reason) and continue to run normally on Standard and Trusted Launch VM images.

## Affected suites

- `microsoft/testsuites/network/sriov.py` — all 18 cases (`verify_services_state`, `verify_sriov_*`, `verify_irqbalance`).
- `microsoft/testsuites/network/stress.py` — 5 `stress_sriov_*` cases. Synthetic-only stress cases are intentionally untouched.
- `microsoft/testsuites/nvme/nvme.py` — `verify_nvme_sriov_rescind`.
- `microsoft/testsuites/core/provisioning.py` — `verify_deployment_provision_sriov`.

## Validation Results

Validated with `Sriov.verify_sriov_basic` across three security profiles: CVM (must skip), Standard (must pass), Trusted Launch / SecureBoot (must pass).

| Image | VM size | security_profile | Expected | Result |
|-------|---------|------------------|----------|--------|
| `Canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm 22.04.202512181` | `Standard_DC2as_v5` | `cvm` | SKIPPED | **SKIPPED** — `capability doesn't support requirement: security_profile: requires [not(secureboot, none)] but VM supports [cvm, stateless]` |
| `Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 22.04.202606110` | `Standard_D4s_v5` | `none` (Standard) | PASSED | **PASSED** (77.1s, kernel `6.8.0-1059-azure`) |
| `Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 22.04.202606110` | `Standard_D4s_v5` | `secureboot` (Trusted Launch) | PASSED | **PASSED** (77.2s, kernel `6.8.0-1059-azure`) |
