### PR TITLE
Fix Cloud Hypervisor live migration nextest filtering

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -129,13 +129,12 @@ class CloudHypervisorTestSuite(TestSuite):
         # Cloud Hypervisor exposes live migration as integration subtests.
         ch_tests.run_tests(
             result,
-            "integration-live-migration",
+            "integration",
             hypervisor,
             log_path,
             ref,
             only=include_list,
             skip=exclude_list,
-            cli_test_type="integration",
             cli_test_filter="live_migration",
         )
 

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests.py
@@ -126,14 +126,17 @@ class CloudHypervisorTestSuite(TestSuite):
             "ch_live_migration_tests_excluded",
         )
         ch_tests: CloudHypervisorTests = node.tools[CloudHypervisorTests]
+        # Cloud Hypervisor exposes live migration as integration subtests.
         ch_tests.run_tests(
             result,
             "integration-live-migration",
             hypervisor,
             log_path,
             ref,
-            include_list,
-            exclude_list,
+            only=include_list,
+            skip=exclude_list,
+            cli_test_type="integration",
+            cli_test_filter="live_migration",
         )
 
     @TestCaseMetadata(

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -148,22 +148,6 @@ class CloudHypervisorTests(Tool):
     def _escape_nextest_filter_matcher(matcher: str) -> str:
         return matcher.replace("\\", "\\\\").replace(")", "\\)")
 
-    @staticmethod
-    def _quote_bash_arg(arg: str) -> str:
-        if "'" in arg:
-            fail(
-                "Unsupported character (') in argument passed to bash. "
-                "Remove single quotes from filter values before running "
-                "Cloud Hypervisor tests."
-            )
-        escaped = (
-            arg.replace("\\", "\\\\")
-            .replace('"', '\\"')
-            .replace("$", "\\$")
-            .replace("`", "\\`")
-        )
-        return f'"{escaped}"'
-
     def _build_nextest_filterset(
         self,
         base_filter: str,
@@ -192,11 +176,10 @@ class CloudHypervisorTests(Tool):
         hypervisor: str,
         only: Optional[List[str]],
         skip: Optional[List[str]],
-        cli_test_type: Optional[str] = None,
         only_test_prefixes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Prepare subtests and skip arguments."""
-        subtests = self._list_subtests(hypervisor, cli_test_type or test_type)
+        subtests = self._list_subtests(hypervisor, test_type)
         # Store the ordered list for diagnostic purposes
         self._ordered_subtests = subtests.copy()
 
@@ -470,12 +453,9 @@ class CloudHypervisorTests(Tool):
         ref: str = "",
         only: Optional[List[str]] = None,
         skip: Optional[List[str]] = None,
-        cli_test_type: Optional[str] = None,
         only_test_prefixes: Optional[List[str]] = None,
         cli_test_filter: Optional[str] = None,
     ) -> None:
-        cli_test_type = cli_test_type or test_type
-
         if ref:
             self.node.tools[Git].checkout(ref, self.repo_root)
 
@@ -487,7 +467,6 @@ class CloudHypervisorTests(Tool):
                 hypervisor,
                 only,
                 skip,
-                cli_test_type,
                 only_test_prefixes,
             )
         self._configure_environment_if_needed(hypervisor)
@@ -500,15 +479,14 @@ class CloudHypervisorTests(Tool):
                 only,
                 skip,
             )
-            test_script_args = f"--test-filter {self._quote_bash_arg(nextest_filter)}"
+            test_script_args = f"--test-filter {shlex.quote(nextest_filter)}"
             cmd_args = (
-                f"tests --hypervisor {hypervisor} --{cli_test_type} -- "
+                f"tests --hypervisor {hypervisor} --{test_type} -- "
                 f"{test_script_args}"
             )
         else:
             cmd_args = (
-                f"tests --hypervisor {hypervisor} --{cli_test_type} -- -- "
-                f"{skip_args}"
+                f"tests --hypervisor {hypervisor} --{test_type} -- -- " f"{skip_args}"
             )
         # normalize name so artifacts are predictable (no spaces/colons/slashes)
         safe_test_type = self._sanitize_name(test_type.replace("-", "_"))
@@ -1073,7 +1051,7 @@ class CloudHypervisorTests(Tool):
 
         # Create a single command that runs everything on the remote VM
         # with proper bash handling
-        full_cmd = f"""bash -lc '
+        script = f"""
 set -o pipefail
 
 # enable core dumps (best-effort)
@@ -1297,7 +1275,8 @@ else
 fi
 
 exit $ec
-'"""
+"""
+        full_cmd = f"bash -lc {shlex.quote(script)}"
 
         # Best-effort install gdb if not available
         try:
@@ -1470,8 +1449,8 @@ exit $ec
         except Exception as e:
             self._log.debug(f"Could not cache VMM version: {e}")
 
-    def _list_subtests(self, hypervisor: str, cli_test_type: str) -> List[str]:
-        cmd_args = f"tests --hypervisor {hypervisor} --{cli_test_type} -- -- --list"
+    def _list_subtests(self, hypervisor: str, test_type: str) -> List[str]:
+        cmd_args = f"tests --hypervisor {hypervisor} --{test_type} -- -- --list"
         # Use enhanced environment variables for consistency
         enhanced_env_vars = self.env_vars.copy()
         enhanced_env_vars.update(

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -144,17 +144,78 @@ class CloudHypervisorTests(Tool):
         """Sanitize names for filenames: keep alphanumeric, dot, dash, underscore."""
         return re.sub(r"[^A-Za-z0-9_.-]", "_", s)
 
+    @staticmethod
+    def _escape_nextest_filter_matcher(matcher: str) -> str:
+        return matcher.replace("\\", "\\\\").replace(")", "\\)")
+
+    @staticmethod
+    def _quote_bash_arg(arg: str) -> str:
+        if "'" in arg:
+            fail(
+                "Unsupported character (') in argument passed to bash. "
+                "Remove single quotes from filter values before running "
+                "Cloud Hypervisor tests."
+            )
+        escaped = (
+            arg.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("$", "\\$")
+            .replace("`", "\\`")
+        )
+        return f'"{escaped}"'
+
+    def _build_nextest_filterset(
+        self,
+        base_filter: str,
+        only: Optional[List[str]],
+        skip: Optional[List[str]],
+    ) -> str:
+        filterset = f"test(~{self._escape_nextest_filter_matcher(base_filter)})"
+
+        if only:
+            included_tests = "|".join(
+                f"test(={self._escape_nextest_filter_matcher(test_name)})"
+                for test_name in only
+            )
+            filterset = f"({filterset}&({included_tests}))"
+
+        if skip:
+            for skipped_test in skip:
+                skipped_filter = self._escape_nextest_filter_matcher(skipped_test)
+                filterset = f"{filterset}-test(={skipped_filter})"
+
+        return f"--filterset={filterset}"
+
     def _prepare_subtests(
         self,
         test_type: str,
         hypervisor: str,
         only: Optional[List[str]],
         skip: Optional[List[str]],
+        cli_test_type: Optional[str] = None,
+        only_test_prefixes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Prepare subtests and skip arguments."""
-        subtests = self._list_subtests(hypervisor, test_type)
+        subtests = self._list_subtests(hypervisor, cli_test_type or test_type)
         # Store the ordered list for diagnostic purposes
         self._ordered_subtests = subtests.copy()
+
+        if only_test_prefixes is not None:
+            prefixed_subtests = [
+                subtest
+                for subtest in subtests
+                if any(subtest.startswith(prefix) for prefix in only_test_prefixes)
+            ]
+            if not prefixed_subtests:
+                fail(
+                    f"No Cloud Hypervisor {test_type} subtests matched prefixes "
+                    f"{only_test_prefixes}. Verify the selected Cloud Hypervisor "
+                    "ref contains those integration tests."
+                )
+            if only is None:
+                only = prefixed_subtests
+            else:
+                only = [subtest for subtest in only if subtest in prefixed_subtests]
 
         if only is not None:
             if not skip:
@@ -409,16 +470,46 @@ class CloudHypervisorTests(Tool):
         ref: str = "",
         only: Optional[List[str]] = None,
         skip: Optional[List[str]] = None,
+        cli_test_type: Optional[str] = None,
+        only_test_prefixes: Optional[List[str]] = None,
+        cli_test_filter: Optional[str] = None,
     ) -> None:
+        cli_test_type = cli_test_type or test_type
+
         if ref:
             self.node.tools[Git].checkout(ref, self.repo_root)
 
-        subtests = self._prepare_subtests(test_type, hypervisor, only, skip)
+        if cli_test_filter:
+            subtests: Dict[str, Any] = {"subtest_set": set(), "skip_args": ""}
+        else:
+            subtests = self._prepare_subtests(
+                test_type,
+                hypervisor,
+                only,
+                skip,
+                cli_test_type,
+                only_test_prefixes,
+            )
         self._configure_environment_if_needed(hypervisor)
 
         # Use enhanced diagnostics for better debugging and monitoring
         skip_args = subtests["skip_args"]
-        cmd_args = f"tests --hypervisor {hypervisor} --{test_type} -- -- {skip_args}"
+        if cli_test_filter:
+            nextest_filter = self._build_nextest_filterset(
+                cli_test_filter,
+                only,
+                skip,
+            )
+            test_script_args = f"--test-filter {self._quote_bash_arg(nextest_filter)}"
+            cmd_args = (
+                f"tests --hypervisor {hypervisor} --{cli_test_type} -- "
+                f"{test_script_args}"
+            )
+        else:
+            cmd_args = (
+                f"tests --hypervisor {hypervisor} --{cli_test_type} -- -- "
+                f"{skip_args}"
+            )
         # normalize name so artifacts are predictable (no spaces/colons/slashes)
         safe_test_type = self._sanitize_name(test_type.replace("-", "_"))
         test_name = self._sanitize_name(f"ch_{safe_test_type}_{hypervisor}")
@@ -1379,8 +1470,8 @@ exit $ec
         except Exception as e:
             self._log.debug(f"Could not cache VMM version: {e}")
 
-    def _list_subtests(self, hypervisor: str, test_type: str) -> List[str]:
-        cmd_args = f"tests --hypervisor {hypervisor} --{test_type} -- -- --list"
+    def _list_subtests(self, hypervisor: str, cli_test_type: str) -> List[str]:
+        cmd_args = f"tests --hypervisor {hypervisor} --{cli_test_type} -- -- --list"
         # Use enhanced environment variables for consistency
         enhanced_env_vars = self.env_vars.copy()
         enhanced_env_vars.update(

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -176,29 +176,11 @@ class CloudHypervisorTests(Tool):
         hypervisor: str,
         only: Optional[List[str]],
         skip: Optional[List[str]],
-        only_test_prefixes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Prepare subtests and skip arguments."""
         subtests = self._list_subtests(hypervisor, test_type)
         # Store the ordered list for diagnostic purposes
         self._ordered_subtests = subtests.copy()
-
-        if only_test_prefixes is not None:
-            prefixed_subtests = [
-                subtest
-                for subtest in subtests
-                if any(subtest.startswith(prefix) for prefix in only_test_prefixes)
-            ]
-            if not prefixed_subtests:
-                fail(
-                    f"No Cloud Hypervisor {test_type} subtests matched prefixes "
-                    f"{only_test_prefixes}. Verify the selected Cloud Hypervisor "
-                    "ref contains those integration tests."
-                )
-            if only is None:
-                only = prefixed_subtests
-            else:
-                only = [subtest for subtest in only if subtest in prefixed_subtests]
 
         if only is not None:
             if not skip:
@@ -221,17 +203,9 @@ class CloudHypervisorTests(Tool):
         cli_test_filter: str,
         only: Optional[List[str]],
         skip: Optional[List[str]],
-        only_test_prefixes: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         subtests = self._list_subtests(hypervisor, test_type)
         self._ordered_subtests = subtests.copy()
-
-        if only_test_prefixes is not None:
-            subtests = [
-                subtest
-                for subtest in subtests
-                if any(subtest.startswith(prefix) for prefix in only_test_prefixes)
-            ]
 
         filtered_subtests = [
             subtest for subtest in subtests if cli_test_filter in subtest
@@ -494,7 +468,6 @@ class CloudHypervisorTests(Tool):
         ref: str = "",
         only: Optional[List[str]] = None,
         skip: Optional[List[str]] = None,
-        only_test_prefixes: Optional[List[str]] = None,
         cli_test_filter: Optional[str] = None,
     ) -> None:
         if ref:
@@ -507,7 +480,6 @@ class CloudHypervisorTests(Tool):
                 cli_test_filter,
                 only,
                 skip,
-                only_test_prefixes,
             )
         else:
             subtests = self._prepare_subtests(
@@ -515,7 +487,6 @@ class CloudHypervisorTests(Tool):
                 hypervisor,
                 only,
                 skip,
-                only_test_prefixes,
             )
         self._configure_environment_if_needed(hypervisor)
 

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -214,6 +214,47 @@ class CloudHypervisorTests(Tool):
 
         return {"subtest_set": set(subtests), "skip_args": skip_args}
 
+    def _prepare_filtered_subtests(
+        self,
+        test_type: str,
+        hypervisor: str,
+        cli_test_filter: str,
+        only: Optional[List[str]],
+        skip: Optional[List[str]],
+        only_test_prefixes: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        subtests = self._list_subtests(hypervisor, test_type)
+        self._ordered_subtests = subtests.copy()
+
+        if only_test_prefixes is not None:
+            subtests = [
+                subtest
+                for subtest in subtests
+                if any(subtest.startswith(prefix) for prefix in only_test_prefixes)
+            ]
+
+        filtered_subtests = [
+            subtest for subtest in subtests if cli_test_filter in subtest
+        ]
+        if only is not None:
+            filtered_subtests = [
+                subtest for subtest in filtered_subtests if subtest in only
+            ]
+        if skip is not None:
+            filtered_subtests = [
+                subtest for subtest in filtered_subtests if subtest not in skip
+            ]
+
+        if not filtered_subtests:
+            fail(
+                f"No Cloud Hypervisor {test_type} subtests matched filter "
+                f"'{cli_test_filter}'. Verify the selected Cloud Hypervisor ref "
+                "contains matching tests and review include/exclude filters."
+            )
+
+        self._log.debug(f"Final Subtests list to run: {filtered_subtests}")
+        return {"subtest_set": set(filtered_subtests), "skip_args": ""}
+
     def _configure_environment_if_needed(self, hypervisor: str) -> None:
         """Configure environment specific settings if needed."""
         if isinstance(self.node.os, CBLMariner) and hypervisor == "mshv":
@@ -460,7 +501,14 @@ class CloudHypervisorTests(Tool):
             self.node.tools[Git].checkout(ref, self.repo_root)
 
         if cli_test_filter:
-            subtests: Dict[str, Any] = {"subtest_set": set(), "skip_args": ""}
+            subtests = self._prepare_filtered_subtests(
+                test_type,
+                hypervisor,
+                cli_test_filter,
+                only,
+                skip,
+                only_test_prefixes,
+            )
         else:
             subtests = self._prepare_subtests(
                 test_type,

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -34,6 +34,7 @@ from lisa.tools import (
 )
 from lisa.util import (
     LisaException,
+    SkippedException,
     UnsupportedDistroException,
     check_test_panic,
     find_groups_in_lines,
@@ -220,10 +221,20 @@ class CloudHypervisorTests(Tool):
             ]
 
         if not filtered_subtests:
-            fail(
+            # An empty match is a legitimate "nothing to run" precondition, not a
+            # failure: some subtest families are compiled out for a given
+            # hypervisor (for example, Cloud Hypervisor gates every live
+            # migration test behind cfg(not(feature = "mshv")), so none exist in
+            # an mshv build), or the include/exclude filters removed all matches.
+            raise SkippedException(
                 f"No Cloud Hypervisor {test_type} subtests matched filter "
-                f"'{cli_test_filter}'. Verify the selected Cloud Hypervisor ref "
-                "contains matching tests and review include/exclude filters."
+                f"'{cli_test_filter}' for hypervisor '{hypervisor}' in the "
+                "selected Cloud Hypervisor ref. These tests may be gated out "
+                "for this hypervisor (for example, live migration tests are "
+                "compiled only when the 'mshv' feature is disabled), or the "
+                "include/exclude filters removed all matches. Verify the ref "
+                "builds matching tests for this hypervisor and review the "
+                "include/exclude filters."
             )
 
         self._log.debug(f"Final Subtests list to run: {filtered_subtests}")

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1478,12 +1478,15 @@ exit $ec
         # tracking keep working exactly as before.
         #
         # dev_cli.sh has no list sub-command, so nextest is run inside the same
-        # dev container via "dev_cli.sh shell". Mirror the environment the
-        # integration test scripts build with: the "mshv" feature for MSHV
-        # hosts and the devcli_testenv cfg.
+        # dev container via "dev_cli.sh shell", which executes its arguments as
+        # `bash -c "$*"`. That re-joins the arguments on spaces and drops
+        # quoting, so RUSTFLAGS must be a single space-free token: the
+        # "--cfg=<name>" form is used instead of "--cfg <name>" so the
+        # devcli_testenv cfg the integration test scripts build with is still
+        # applied. The "mshv" feature mirrors the MSHV build.
         test_features = "--features mshv" if hypervisor == "mshv" else ""
         nextest_list_cmd = (
-            "RUSTFLAGS='--cfg devcli_testenv' cargo nextest list "
+            "RUSTFLAGS=--cfg=devcli_testenv cargo nextest list "
             f"-p cloud-hypervisor {test_features} --message-format json"
         )
         cmd_args = f"shell -- {nextest_list_cmd}"
@@ -1511,22 +1514,27 @@ exit $ec
 
     @staticmethod
     def _parse_nextest_subtest_list(stdout: str) -> List[str]:
-        # "cargo nextest list --message-format json" prints a JSON document with
-        # a "rust-suites" map; each suite has a "testcases" map keyed by the test
-        # name (e.g. "live_migration::test_live_migration_local"). Build progress
-        # is written to stderr, so stdout starts at the first '{'. Return the
-        # test names to preserve the previous "<module>::<test>" list contract.
-        brace = stdout.find("{")
-        if brace == -1:
-            return []
-        try:
-            data = json.loads(stdout[brace:])
-        except json.JSONDecodeError:
-            return []
-        subtests: List[str] = []
-        for suite in data.get("rust-suites", {}).values():
-            subtests.extend(suite.get("testcases", {}).keys())
-        return subtests
+        # "cargo nextest list --message-format json" emits a JSON object with a
+        # "rust-suites" map; each suite has a "testcases" map keyed by the test
+        # name (e.g. "live_migration::test_live_migration_local"). dev_cli.sh
+        # interleaves docker pull and cargo build output on the same stream, so
+        # scan each '{' and decode the first object that has "rust-suites". The
+        # returned names preserve the previous "<module>::<test>" list contract.
+        decoder = json.JSONDecoder()
+        pos = stdout.find("{")
+        while pos != -1:
+            try:
+                decoded, _ = decoder.raw_decode(stdout[pos:])
+            except json.JSONDecodeError:
+                decoded = None
+            if isinstance(decoded, dict) and "rust-suites" in decoded:
+                data = cast(Dict[str, Any], decoded)
+                subtests: List[str] = []
+                for suite in data["rust-suites"].values():
+                    subtests.extend(suite.get("testcases", {}).keys())
+                return subtests
+            pos = stdout.find("{", pos + 1)
+        return []
 
     def _extract_test_results(
         self, output: str, log_path: Path, subtests: Set[str]

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1469,7 +1469,24 @@ exit $ec
             self._log.debug(f"Could not cache VMM version: {e}")
 
     def _list_subtests(self, hypervisor: str, test_type: str) -> List[str]:
-        cmd_args = f"tests --hypervisor {hypervisor} --{test_type} -- -- --list"
+        # Cloud Hypervisor's integration tests run under cargo-nextest, which
+        # rejects the libtest "-- -- --list" flag ("failed to parse test binary
+        # arguments `--list`: arguments are unsupported"). Enumerate the subtests
+        # with "cargo nextest list" instead. The return value is still the same
+        # List[str] of "<module>::<test>" names, so the runbook-driven
+        # include/exclude (only/skip/cli_test_filter) and per-subtest result
+        # tracking keep working exactly as before.
+        #
+        # dev_cli.sh has no list sub-command, so nextest is run inside the same
+        # dev container via "dev_cli.sh shell". Mirror the environment the
+        # integration test scripts build with: the "mshv" feature for MSHV
+        # hosts and the devcli_testenv cfg.
+        test_features = "--features mshv" if hypervisor == "mshv" else ""
+        nextest_list_cmd = (
+            "RUSTFLAGS='--cfg devcli_testenv' cargo nextest list "
+            f"-p cloud-hypervisor {test_features} --message-format json"
+        )
+        cmd_args = f"shell -- {nextest_list_cmd}"
         # Use enhanced environment variables for consistency
         enhanced_env_vars = self.env_vars.copy()
         enhanced_env_vars.update(
@@ -1488,10 +1505,28 @@ exit $ec
             shell=True,
             update_envs=enhanced_env_vars,
         )
-        # e.g. "integration::test_vfio: test"
-        matches = re.findall(r"^(.*::.*): test", result.stdout, re.M)
-        self._log.debug(f"Subtests list: {matches}")
-        return matches
+        subtests = self._parse_nextest_subtest_list(result.stdout)
+        self._log.debug(f"Subtests list: {subtests}")
+        return subtests
+
+    @staticmethod
+    def _parse_nextest_subtest_list(stdout: str) -> List[str]:
+        # "cargo nextest list --message-format json" prints a JSON document with
+        # a "rust-suites" map; each suite has a "testcases" map keyed by the test
+        # name (e.g. "live_migration::test_live_migration_local"). Build progress
+        # is written to stderr, so stdout starts at the first '{'. Return the
+        # test names to preserve the previous "<module>::<test>" list contract.
+        brace = stdout.find("{")
+        if brace == -1:
+            return []
+        try:
+            data = json.loads(stdout[brace:])
+        except json.JSONDecodeError:
+            return []
+        subtests: List[str] = []
+        for suite in data.get("rust-suites", {}).values():
+            subtests.extend(suite.get("testcases", {}).keys())
+        return subtests
 
     def _extract_test_results(
         self, output: str, log_path: Path, subtests: Set[str]


### PR DESCRIPTION
Run Cloud Hypervisor live migration tests through the CLI path and construct the nextest filter as a shell-safe expression. Preserve the base test filter while excluding the serial-only live migration test from the parallel run.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
