### PR TITLE
Enable full OpenVMM test backtraces

### DIFF
--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -345,7 +345,7 @@ class OpenVmmTests(Tool):
         env: Dict[str, str] = {
             "OPENSSL_NO_VENDOR": "1",
             "PATH": f"{path_prefix}:{current_env_path}",
-            "RUST_BACKTRACE": "1",
+            "RUST_BACKTRACE": "full",
             "RUST_LOG": "info",
         }
         if cargo_bin_dir:


### PR DESCRIPTION
Set RUST_BACKTRACE=full for upstream OpenVMM VMM test runs so panic logs include the verbose Rust backtrace requested by the OpenVMM failure message. This keeps the change scoped to the test tool environment used by cargo xflowey vmm-tests-run.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
