### PR TITLE
Move synthetic NIC stress tests into a dedicated `synthetic` test area

### DIFF
--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -147,6 +147,110 @@ class Stress(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Reboot VM from guest.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            ),
+        ),
+    )
+    def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                node.reboot()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    @TestCaseMetadata(
+        description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Reboot VM from API.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            ),
+        ),
+    )
+    def stress_sriov_with_max_nics_reboot_from_platform(
+        self, environment: Environment
+    ) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                start_stop = node.features[StartStop]
+                start_stop.restart()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    @TestCaseMetadata(
+        description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Stop and Start VM from API.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            )
+        ),
+    )
+    def stress_sriov_with_max_nics_stop_start_from_platform(
+        self, environment: Environment
+    ) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                start_stop = node.features[StartStop]
+                start_stop.stop()
+                start_stop.start()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        environment: Environment = kwargs.pop("environment")
+        cleanup_iperf3(environment)
+
+
+@TestSuiteMetadata(
+    area="synthetic",
+    category="stress",
+    description="""
+    This test suite uses to verify synthetic network functionality under stress.
+    """,
+)
+class StressSynthetic(TestSuite):
+    @TestCaseMetadata(
+        description="""
         This case verify VM works well when provison with max synthetic nics.
 
         Steps,
@@ -243,98 +347,3 @@ class Stress(TestSuite):
                 start_stop.stop()
                 start_stop.start()
             initialize_nic_info(environment, is_sriov=False)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Reboot VM from guest.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            ),
-        ),
-    )
-    def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                node.reboot()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Reboot VM from API.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            ),
-        ),
-    )
-    def stress_sriov_with_max_nics_reboot_from_platform(
-        self, environment: Environment
-    ) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                start_stop = node.features[StartStop]
-                start_stop.restart()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Stop and Start VM from API.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            )
-        ),
-    )
-    def stress_sriov_with_max_nics_stop_start_from_platform(
-        self, environment: Environment
-    ) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                start_stop = node.features[StartStop]
-                start_stop.stop()
-                start_stop.start()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    def after_case(self, log: Logger, **kwargs: Any) -> None:
-        environment: Environment = kwargs.pop("environment")
-        cleanup_iperf3(environment)

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -279,7 +279,7 @@ class StressSynthetic(TestSuite):
             skip_if_no_synthetic_nics(node)
 
         initialize_nic_info(environment, is_sriov=False)
-        for _ in range(10):
+        for _ in range(10):  # repeat reboot cycles to stress NIC stability
             for node in environment.nodes.list():
                 node.reboot()
             initialize_nic_info(environment, is_sriov=False)

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -167,7 +167,7 @@ class Stress(TestSuite):
     def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
         initialize_nic_info(environment)
         sriov_basic_test(environment)
-        for _ in range(10):
+        for _ in range(10):  # repeat reboot cycles to stress NIC stability
             for node in environment.nodes.list():
                 node.reboot()
             initialize_nic_info(environment)

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -314,7 +314,7 @@ class StressSynthetic(TestSuite):
             skip_if_no_synthetic_nics(node)
 
         initialize_nic_info(environment, is_sriov=False)
-        for _ in range(10):
+        for _ in range(10):  # repeat platform restart cycles to stress NIC stability
             for node in environment.nodes.list():
                 start_stop = node.features[StartStop]
                 start_stop.restart()

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -286,7 +286,7 @@ class StressSynthetic(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This case verify VM works well when provison with max synthetic nics.
+        This case verify VM works well when provisioning with max synthetic nics.
 
         Steps,
         1. Provision VM with max network interfaces with synthetic network.

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -36,7 +36,7 @@ from lisa.tools import Cat, Iperf3
     area="sriov",
     category="stress",
     description="""
-    This test suite uses to verify accelerated network functionality under stress.
+    This test suite is used to verify accelerated network functionality under stress.
     """,
 )
 class Stress(TestSuite):
@@ -245,7 +245,7 @@ class Stress(TestSuite):
     area="synthetic",
     category="stress",
     description="""
-    This test suite uses to verify synthetic network functionality under stress.
+    This test suite is used to verify synthetic network functionality under stress.
     """,
 )
 class StressSynthetic(TestSuite):

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -147,6 +147,110 @@ class Stress(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Reboot VM from guest.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            ),
+        ),
+    )
+    def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                node.reboot()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    @TestCaseMetadata(
+        description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Reboot VM from API.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            ),
+        ),
+    )
+    def stress_sriov_with_max_nics_reboot_from_platform(
+        self, environment: Environment
+    ) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                start_stop = node.features[StartStop]
+                start_stop.restart()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    @TestCaseMetadata(
+        description="""
+        This case verify VM works well when provisioning with max sriov nics.
+
+        Steps,
+        1. Provision VM with max network interfaces with enabling accelerated network.
+        2. Do the basic sriov testing.
+        3. Stop and Start VM from API.
+        4. Do the basic sriov testing.
+        5. Repeat step 3 and 4 for 10 times.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            network_interface=schema.NetworkInterfaceOptionSettings(
+                nic_count=IntRange(min=2, choose_max_value=True),
+                data_path=schema.NetworkDataPath.Sriov,
+            )
+        ),
+    )
+    def stress_sriov_with_max_nics_stop_start_from_platform(
+        self, environment: Environment
+    ) -> None:
+        initialize_nic_info(environment)
+        sriov_basic_test(environment)
+        for _ in range(10):
+            for node in environment.nodes.list():
+                start_stop = node.features[StartStop]
+                start_stop.stop()
+                start_stop.start()
+            initialize_nic_info(environment)
+            sriov_basic_test(environment)
+
+    def after_case(self, log: Logger, **kwargs: Any) -> None:
+        environment: Environment = kwargs.pop("environment")
+        cleanup_iperf3(environment)
+
+
+@TestSuiteMetadata(
+    area="synthetic",
+    category="stress",
+    description="""
+    This test suite uses to verify synthetic network functionality under stress.
+    """,
+)
+class StressSynthetic(TestSuite):
+    @TestCaseMetadata(
+        description="""
         This case verify VM works well when provison with max synthetic nics.
 
         Steps,
@@ -252,98 +356,3 @@ class Stress(TestSuite):
                 start_stop.stop()
                 start_stop.start()
             initialize_nic_info(environment, is_sriov=False)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Reboot VM from guest.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            ),
-        ),
-    )
-    def stress_sriov_with_max_nics_reboot(self, environment: Environment) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                node.reboot()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Reboot VM from API.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            ),
-        ),
-    )
-    def stress_sriov_with_max_nics_reboot_from_platform(
-        self, environment: Environment
-    ) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                start_stop = node.features[StartStop]
-                start_stop.restart()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    @TestCaseMetadata(
-        description="""
-        This case verify VM works well when provisioning with max sriov nics.
-
-        Steps,
-        1. Provision VM with max network interfaces with enabling accelerated network.
-        2. Do the basic sriov testing.
-        3. Stop and Start VM from API.
-        4. Do the basic sriov testing.
-        5. Repeat step 3 and 4 for 10 times.
-        """,
-        priority=2,
-        requirement=simple_requirement(
-            network_interface=schema.NetworkInterfaceOptionSettings(
-                nic_count=IntRange(min=2, choose_max_value=True),
-                data_path=schema.NetworkDataPath.Sriov,
-            )
-        ),
-    )
-    def stress_sriov_with_max_nics_stop_start_from_platform(
-        self, environment: Environment
-    ) -> None:
-        initialize_nic_info(environment)
-        sriov_basic_test(environment)
-        for _ in range(10):
-            for node in environment.nodes.list():
-                start_stop = node.features[StartStop]
-                start_stop.stop()
-                start_stop.start()
-            initialize_nic_info(environment)
-            sriov_basic_test(environment)
-
-    def after_case(self, log: Logger, **kwargs: Any) -> None:
-        environment: Environment = kwargs.pop("environment")
-        cleanup_iperf3(environment)

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -251,7 +251,7 @@ class Stress(TestSuite):
 class StressSynthetic(TestSuite):
     @TestCaseMetadata(
         description="""
-        This case verify VM works well when provison with max synthetic nics.
+        This case verify VM works well when provisioning with max synthetic nics.
 
         Steps,
         1. Provision VM with max network interfaces with synthetic network.

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -228,7 +228,7 @@ class Stress(TestSuite):
     ) -> None:
         initialize_nic_info(environment)
         sriov_basic_test(environment)
-        for _ in range(10):
+        for _ in range(10):  # repeat platform stop/start cycles to stress NIC stability
             for node in environment.nodes.list():
                 start_stop = node.features[StartStop]
                 start_stop.stop()

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -197,7 +197,7 @@ class Stress(TestSuite):
     ) -> None:
         initialize_nic_info(environment)
         sriov_basic_test(environment)
-        for _ in range(10):
+        for _ in range(10):  # repeat platform restart cycles to stress NIC stability
             for node in environment.nodes.list():
                 start_stop = node.features[StartStop]
                 start_stop.restart()

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -350,7 +350,7 @@ class StressSynthetic(TestSuite):
             skip_if_no_synthetic_nics(node)
 
         initialize_nic_info(environment, is_sriov=False)
-        for _ in range(10):
+        for _ in range(10):  # repeat platform stop/start cycles to stress NIC stability
             for node in environment.nodes.list():
                 start_stop = node.features[StartStop]
                 start_stop.stop()

--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -322,7 +322,7 @@ class StressSynthetic(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This case verify VM works well when provison with max synthetic nics.
+        This case verify VM works well when provisioning with max synthetic nics.
 
         Steps,
         1. Provision VM with max network interfaces with synthetic network.


### PR DESCRIPTION
## Summary
Splits the network stress test suite so that the synthetic-NIC stress tests are reported under a dedicated `area="synthetic"` instead of being grouped with the SRIOV tests under `area="sriov"`.

## Changes
- Introduced a new `StressSynthetic(TestSuite)` class with `@TestSuiteMetadata(area="synthetic", category="stress")` in `lisa/microsoft/testsuites/network/stress.py`.
- Moved the three synthetic test cases out of the existing `Stress` (`area="sriov"`) suite into the new suite:
  - `stress_synthetic_provision_with_max_nics_reboot`
  - `stress_synthetic_with_max_nics_reboot_from_platform`
  - `stress_synthetic_with_max_nics_stop_start_from_platform`
- The SRIOV stress tests remain unchanged in the `Stress` suite.

## Motivation
Synthetic-NIC scenarios were previously categorized under the `sriov` area, which is misleading for reporting and test selection. Placing them in their own `synthetic` area makes the test taxonomy accurate and easier to filter.

## Behavior
- No test logic changed — only the suite class/area assignment.
- Test method names, priorities, and requirements are preserved.

---

**Key Test Cases:**
stress_synthetic_provision_with_max_nics_reboot|stress_synthetic_with_max_nics_reboot_from_platform|stress_synthetic_with_max_nics_stop_start_from_platform

**Impacted LISA Features:**
NetworkInterface, StartStop

**Tested Azure Marketplace Images:**
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
- redhat rhel 9_5 latest