### PR TITLE
Bump Pillow to >=12.2.0 to fix GHSA-pwv6-vv43-88gr (gated for Python …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ azure = [
     "azure-keyvault-certificates ~= 4.7.0",
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
-    "Pillow >= 12.2.0, < 13.0.0",
+    "Pillow >= 12.2.0; python_version >= '3.10'",
+    "Pillow; python_version < '3.10'",
     "PyGObject <= 3.50.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,7 @@ azure = [
     "azure-keyvault-certificates ~= 4.7.0",
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
-    "Pillow >= 12.2.0; python_version >= '3.10'",
-    "Pillow; python_version < '3.10'",
+    "Pillow >= 12.2.0, < 13.0.0",
     "PyGObject <= 3.50.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ azure = [
     "azure-keyvault-certificates ~= 4.7.0",
     "msrestazure ~= 0.6.4",
     "cachetools ~= 5.2.0",
-    "Pillow <= 12.1.1",
+    "Pillow >= 12.2.0; python_version >= '3.10'",
+    "Pillow; python_version < '3.10'",
     "PyGObject <= 3.50.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]


### PR DESCRIPTION
…>=3.10)

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
