### PR TITLE
Validate passthrough network line rate

### DIFF
--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -3,6 +3,7 @@
 import inspect
 import pathlib
 import time
+from decimal import Decimal
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
@@ -61,6 +62,29 @@ from lisa.util.process import ExecutableResult, Process
 
 # NTTTCP may need extra time after the requested run duration to emit totals.
 DEFAULT_NTTTCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS = 60
+
+
+def _get_iperf_udp_bitrate(
+    udp_total_bitrate_gbps: Optional[Decimal], connections: int
+) -> str:
+    if udp_total_bitrate_gbps is None:
+        return ""
+    per_stream_bitrate_mbps = (
+        udp_total_bitrate_gbps * Decimal(1000) / Decimal(connections)
+    )
+    bitrate = format(per_stream_bitrate_mbps.normalize(), "f")
+    if "." in bitrate:
+        bitrate = bitrate.rstrip("0").rstrip(".")
+    return f"{bitrate}M"
+
+
+def _set_iperf_udp_max_sessions(nodes: List[Node]) -> None:
+    for node in nodes:
+        if not node.is_remote:
+            continue
+        ssh = node.tools[Ssh]
+        ssh.set_max_session()
+        node.close()
 
 
 def perf_nvme(
@@ -192,12 +216,9 @@ def perf_disk(
 
 def get_nic_datapath(node: Node) -> str:
     data_path: str = ""
-    assert (
-        node.capability.network_interface
-        and node.capability.network_interface.data_path
-    ), "nic datapath not available"
-    if isinstance(node.capability.network_interface.data_path, NetworkDataPath):
-        data_path = node.capability.network_interface.data_path.value
+    network_interface = node.capability.network_interface
+    if network_interface and isinstance(network_interface.data_path, NetworkDataPath):
+        data_path = network_interface.data_path.value
     return data_path
 
 
@@ -376,6 +397,8 @@ def perf_ntttcp(  # noqa: C901
         # set server and client from environment, if not set explicitly
         server = cast(RemoteNode, environment.nodes[1])
         client = cast(RemoteNode, environment.nodes[0])
+    client_node = client
+    server_node = server
 
     if not test_case_name:
         # if it's not filled, assume it's called by case directly.
@@ -399,12 +422,12 @@ def perf_ntttcp(  # noqa: C901
 
     try:
         client_ntttcp, server_ntttcp = run_in_parallel(
-            [lambda: client.tools[Ntttcp], lambda: server.tools[Ntttcp]]  # type: ignore
+            [lambda: client_node.tools[Ntttcp], lambda: server_node.tools[Ntttcp]]
         )
         client_lagscope, server_lagscope = run_in_parallel(
             [
-                lambda: client.tools[Lagscope],  # type: ignore
-                lambda: server.tools[Lagscope],  # type: ignore
+                lambda: client_node.tools[Lagscope],
+                lambda: server_node.tools[Lagscope],
             ]
         )
         # no need to set task max and reboot VM when connection less than 20480
@@ -417,6 +440,8 @@ def perf_ntttcp(  # noqa: C901
             need_reboot = True
         else:
             need_reboot = False
+        client_sriov_count = 0
+        server_sriov_count = 0
         if need_reboot:
             client_sriov_count = len(client.nics.get_pci_nics(exclude_ib=True))
             server_sriov_count = len(server.nics.get_pci_nics(exclude_ib=True))
@@ -430,8 +455,8 @@ def perf_ntttcp(  # noqa: C901
             server_nic_name = refreshed_server_nic_name or server_nic_name
         for lagscope in [client_lagscope, server_lagscope]:
             lagscope.set_busy_poll()
-        client_nic = client.nics.default_nic
-        server_nic = server.nics.default_nic
+        client_nic = client_nic_name or client.nics.default_nic
+        server_nic = server_nic_name or server.nics.default_nic
         client_ip = client.tools[Ip]
         server_ip = server.tools[Ip]
         mtu = variables.get("perf_ntttcp_mtu", 0) if variables is not None else 0
@@ -762,10 +787,12 @@ def perf_iperf(
     connections: List[int],
     buffer_length_list: List[int],
     udp_mode: bool = False,
+    udp_total_bitrate_gbps: Optional[Decimal] = None,
     server: Optional[RemoteNode] = None,
     client: Optional[RemoteNode] = None,
     run_with_internal_address: bool = False,
-) -> None:
+    test_case_name: str = "",
+) -> List[Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]]:
     if server is not None or client is not None:
         assert server is not None, "server need to be specified, if client is set"
         assert client is not None, "client need to be specified, if server is set"
@@ -775,12 +802,17 @@ def perf_iperf(
         # set server and client from environment, if not set explicitly
         client = cast(RemoteNode, environment.nodes[0])
         server = cast(RemoteNode, environment.nodes[1])
+    client_node = client
+    server_node = server
 
     client_iperf3, server_iperf3 = run_in_parallel(
-        [lambda: client.tools[Iperf3], lambda: server.tools[Iperf3]]  # type: ignore
+        [lambda: client_node.tools[Iperf3], lambda: server_node.tools[Iperf3]]
     )
-    test_case_name = inspect.stack()[1][3]
-    iperf3_messages_list: List[Any] = []
+    if not test_case_name:
+        test_case_name = inspect.stack()[1][3]
+    iperf3_messages_list: List[
+        Union[NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage]
+    ] = []
     server_interface_ip = ""
     client_interface_ip = ""
     if run_with_internal_address:
@@ -790,10 +822,7 @@ def perf_iperf(
         assert client_interface_ip, "Client Node: internal address is not set"
 
     if udp_mode:
-        for node in [client, server]:
-            ssh = node.tools[Ssh]
-            ssh.set_max_session()
-            node.close()
+        _set_iperf_udp_max_sessions([client, server])
     for buffer_length in buffer_length_list:
         for connection in connections:
             server_iperf3_process_list: List[Process] = []
@@ -837,6 +866,11 @@ def perf_iperf(
                         report_unit="g",
                         port=current_client_port,
                         buffer_length=buffer_length,
+                        bitrate=(
+                            _get_iperf_udp_bitrate(udp_total_bitrate_gbps, connection)
+                            if udp_mode
+                            else ""
+                        ),
                         run_time_seconds=10,
                         parallel_number=num_threads_p,
                         ip_version="4",
@@ -874,6 +908,7 @@ def perf_iperf(
                 )
     for iperf3_message in iperf3_messages_list:
         notifier.notify(iperf3_message)
+    return iperf3_messages_list
 
 
 def perf_sockperf(

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -648,6 +648,10 @@ def perf_ntttcp(  # noqa: C901
                     # An error occurred during the test (timeout, process hang,
                     # network issue, etc.)
 
+                    for node in [client, server]:
+                        if "SSH session not active" in str(e) or not node.is_connected:
+                            node.close()
+
                     time.sleep(30)
                     client.log.error(
                         f"Error during ntttcp test for {test_thread} connections "

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -82,6 +82,9 @@ PASSTHROUGH_GUEST_START_TIMEOUT_SECONDS = 300
 # perf_ntttcp changes TasksMax and may reboot its client at 20,480 connections.
 # The immediate Linux virtualization host must remain running during calibration.
 PASSTHROUGH_NTTTCP_MAX_CONNECTIONS_WITHOUT_HOST_REBOOT = 10240
+# The 1,024-connection UDP profile can hang after lower profiles saturate the
+# dedicated peer; 512 connections retains line-rate calibration without the hang.
+PASSTHROUGH_NTTTCP_UDP_MAX_CONNECTIONS = 512
 NetworkThroughputMessage = Union[
     NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage
 ]
@@ -876,7 +879,15 @@ class NetworkPerformance(TestSuite):
             server_nic_name: str,
             profile: Optional[ThroughputProfile],
         ) -> List[NetworkThroughputMessage]:
-            connections = [profile[2]] if profile else NTTTCP_UDP_CONCURRENCY
+            connections = (
+                [profile[2]]
+                if profile
+                else [
+                    connection
+                    for connection in NTTTCP_UDP_CONCURRENCY
+                    if connection <= PASSTHROUGH_NTTTCP_UDP_MAX_CONNECTIONS
+                ]
+            )
             messages: List[NetworkThroughputMessage] = perf_ntttcp(
                 test_result=result,
                 client=cast(RemoteNode, client),

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -4,8 +4,10 @@ import re
 from decimal import Decimal
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from statistics import median
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
 
+from assertpy import assert_that
 from microsoft.testsuites.performance.common import (
     perf_iperf,
     perf_ntttcp,
@@ -25,10 +27,17 @@ from lisa import (
     simple_requirement,
 )
 from lisa.environment import Environment, Node
+from lisa.features import StartStop
+from lisa.messages import (
+    MetricRelativity,
+    NetworkTCPPerformanceMessage,
+    NetworkUDPPerformanceMessage,
+    send_unified_perf_message,
+)
 from lisa.operating_system import Windows
 from lisa.sut_orchestrator import CLOUD_HYPERVISOR, HYPERV, OPENVMM
 from lisa.testsuite import TestResult
-from lisa.tools import Dhclient, Kill, PowerShell, Sysctl
+from lisa.tools import Dhclient, Ethtool, Kill, PowerShell, Sysctl
 from lisa.tools.ip import Ip
 from lisa.tools.iperf3 import (
     IPERF_TCP_BUFFER_LENGTHS,
@@ -40,17 +49,151 @@ from lisa.tools.ntttcp import NTTTCP_TCP_CONCURRENCY, NTTTCP_UDP_CONCURRENCY, Nt
 from lisa.util import (
     LisaException,
     SkippedException,
+    check_till_timeout,
     constants,
     find_group_in_lines,
-    find_groups_in_lines,
 )
 from lisa.util.logger import get_logger
 from lisa.util.parallel import run_in_parallel
+from lisa.util.shell import wait_tcp_port_ready
 
 SUPPORTED_PASSTHROUGH_PLATFORMS = [CLOUD_HYPERVISOR, HYPERV, OPENVMM]
 WINDOWS_NTTTCP_MAX_SERVER_THREADS = 64
 WINDOWS_NTTTCP_MAX_MIXED_TCP_CONNECTIONS = 512
 WINDOWS_NTTTCP_RECEIVER_WAIT_TIMEOUT = 90
+# Three matched sweeps dampen transient throughput variation without hiding a
+# consistently slow passthrough path.
+PASSTHROUGH_MEASUREMENT_RUN_COUNT = 3
+PASSTHROUGH_BASELINE_THRESHOLD = Decimal("0.95")
+PASSTHROUGH_BASELINE_THRESHOLD_PERCENT = PASSTHROUGH_BASELINE_THRESHOLD * Decimal(100)
+# Target above line rate so UDP iperf saturates the NIC instead of using its
+# default 1 Mbit/s UDP bitrate.
+PASSTHROUGH_IPERF_UDP_BITRATE_MULTIPLIER = Decimal("1.10")
+PASSTHROUGH_HOST_BASELINE_METRIC_NAME = "passthrough_host_baseline_gbps"
+PASSTHROUGH_GUEST_MEDIAN_METRIC_NAME = "passthrough_guest_median_gbps"
+PASSTHROUGH_BASELINE_PERCENT_METRIC_NAME = "passthrough_baseline_percent"
+PASSTHROUGH_GUEST_TO_PEER = "guest-to-peer"
+PASSTHROUGH_PEER_TO_GUEST = "peer-to-guest"
+# Native-driver reattachment and guest SSH normally complete well inside these
+# bounds; exceeding them indicates a device or boot failure worth surfacing.
+PASSTHROUGH_HOST_NIC_REBIND_TIMEOUT_SECONDS = 60
+PASSTHROUGH_GUEST_START_TIMEOUT_SECONDS = 300
+# perf_ntttcp changes TasksMax and may reboot its client at 20,480 connections.
+# The immediate Linux virtualization host must remain running during calibration.
+PASSTHROUGH_NTTTCP_MAX_CONNECTIONS_WITHOUT_HOST_REBOOT = 10240
+NetworkThroughputMessage = Union[
+    NetworkTCPPerformanceMessage, NetworkUDPPerformanceMessage
+]
+ThroughputProfile = Tuple[str, str, int, Decimal]
+ThroughputProfileMedian = Tuple[Decimal, NetworkThroughputMessage]
+PassthroughBenchmark = Callable[
+    [Node, str, Node, str, Optional[ThroughputProfile]],
+    List[NetworkThroughputMessage],
+]
+
+
+def _to_decimal(value: Union[Decimal, float, int]) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _get_median_throughput_by_profile(
+    runs: List[List[NetworkThroughputMessage]],
+) -> Dict[ThroughputProfile, ThroughputProfileMedian]:
+    samples: Dict[
+        ThroughputProfile, List[Tuple[Decimal, NetworkThroughputMessage]]
+    ] = {}
+    for run_index, messages in enumerate(runs, start=1):
+        profiles_in_run: Set[ThroughputProfile] = set()
+        for message in messages:
+            throughput_gbps = _get_delivered_throughput(message)
+            if throughput_gbps <= 0:
+                continue
+            profile = _get_throughput_profile(message)
+            if profile in profiles_in_run:
+                raise LisaException(
+                    f"Throughput run [{run_index}] reported duplicate profile "
+                    f"[{_format_throughput_profile(profile)}]."
+                )
+            profiles_in_run.add(profile)
+            samples.setdefault(profile, []).append((throughput_gbps, message))
+
+    medians: Dict[ThroughputProfile, ThroughputProfileMedian] = {}
+    for profile, profile_samples in samples.items():
+        if len(profile_samples) != len(runs):
+            raise LisaException(
+                f"Throughput profile [{_format_throughput_profile(profile)}] "
+                f"reported [{len(profile_samples)}] samples across [{len(runs)}] "
+                "runs. Verify every matched sweep completes."
+            )
+        median_gbps = median(sample[0] for sample in profile_samples)
+        medians[profile] = (median_gbps, profile_samples[0][1])
+    return medians
+
+
+def _get_throughput_profile(
+    message: NetworkThroughputMessage,
+) -> ThroughputProfile:
+    if isinstance(message, NetworkUDPPerformanceMessage):
+        buffer_size = _to_decimal(message.send_buffer_size)
+    elif message.buffer_size_bytes > 0:
+        buffer_size = _to_decimal(message.buffer_size_bytes)
+    else:
+        buffer_size = _to_decimal(message.buffer_size)
+    return (
+        message.tool,
+        str(message.protocol_type or ""),
+        message.connections_num,
+        buffer_size,
+    )
+
+
+def _get_delivered_throughput(
+    message: NetworkThroughputMessage,
+) -> Decimal:
+    if isinstance(message, NetworkUDPPerformanceMessage):
+        return _to_decimal(message.rx_throughput_in_gbps)
+    if message.rx_throughput_in_gbps > 0:
+        return _to_decimal(message.rx_throughput_in_gbps)
+    if message.throughput_in_gbps > 0:
+        return _to_decimal(message.throughput_in_gbps)
+    return _to_decimal(message.tx_throughput_in_gbps)
+
+
+def _format_throughput_profile(profile: ThroughputProfile) -> str:
+    tool, protocol, connections, buffer_size = profile
+    return (
+        f"tool={tool}, protocol={protocol}, connections={connections}, "
+        f"buffer={buffer_size}"
+    )
+
+
+def _select_best_throughput_profile(
+    messages: List[NetworkThroughputMessage],
+) -> ThroughputProfile:
+    medians = _get_median_throughput_by_profile([messages])
+    if not medians:
+        raise LisaException(
+            "The passthrough baseline tuning sweep did not report any delivered "
+            "Gbps samples. Verify the remote peer and test NIC data path."
+        )
+    return max(medians.items(), key=lambda item: item[1][0])[0]
+
+
+def _filter_throughput_profile(
+    messages: List[NetworkThroughputMessage],
+    profile: ThroughputProfile,
+) -> List[NetworkThroughputMessage]:
+    matching = [
+        message for message in messages if _get_throughput_profile(message) == profile
+    ]
+    if len(matching) != 1:
+        raise LisaException(
+            f"Expected exactly one throughput sample for matched profile "
+            f"[{_format_throughput_profile(profile)}], found [{len(matching)}]."
+        )
+    return matching
 
 
 @TestSuiteMetadata(
@@ -58,7 +201,10 @@ WINDOWS_NTTTCP_RECEIVER_WAIT_TIMEOUT = 90
     category="performance",
     description="""
     This test suite is to validate linux network performance
-    for various NIC passthrough scenarios.
+    for various NIC passthrough scenarios. Measured host-to-guest cases compare
+    Linux L2 against the immediate Linux virtualization host using the same NIC,
+    independent remote peer, direction, and tool profile. Guest-to-guest cases
+    publish performance measurements without enforcing a baseline threshold.
     """,
     requirement=simple_requirement(
         supported_platform_type=SUPPORTED_PASSTHROUGH_PLATFORMS,
@@ -75,18 +221,358 @@ class NetworkPerformance(TestSuite):
 
     # Track baremetal host nodes for cleanup
     _baremetal_hosts: List[RemoteNode] = []
+    _link_speed_pattern = re.compile(
+        r"^(?P<speed>\d+(?:\.\d+)?)\s*(?P<unit>[GM](?:b/s|bps))$",
+        re.IGNORECASE,
+    )
+
+    def _assert_passthrough_baseline(
+        self,
+        test_result: TestResult,
+        baseline_runs: List[List[NetworkThroughputMessage]],
+        guest_runs: List[List[NetworkThroughputMessage]],
+        direction: str,
+        guest: RemoteNode,
+        guest_nic_name: str,
+        host: Node,
+        host_nic_name: str,
+        peer: RemoteNode,
+        peer_nic_name: str,
+    ) -> str:
+        baseline_medians = _get_median_throughput_by_profile(baseline_runs)
+        guest_medians = _get_median_throughput_by_profile(guest_runs)
+        if not baseline_medians:
+            raise LisaException(
+                f"No host throughput samples were reported for passthrough "
+                f"baseline validation in direction [{direction}]."
+            )
+
+        profile, (baseline_gbps, _) = max(
+            baseline_medians.items(), key=lambda item: item[1][0]
+        )
+        guest_profile = guest_medians.get(profile)
+        if guest_profile is None:
+            raise LisaException(
+                f"Guest throughput did not report the host's best matched profile "
+                f"[{_format_throughput_profile(profile)}] in direction "
+                f"[{direction}]. Verify host and guest runs use identical tool "
+                "parameters."
+            )
+
+        guest_gbps, guest_message = guest_profile
+        threshold_gbps = baseline_gbps * PASSTHROUGH_BASELINE_THRESHOLD
+        baseline_percent = guest_gbps / baseline_gbps * Decimal(100)
+        profile_description = _format_throughput_profile(profile)
+        result_summary = (
+            f"Passthrough {direction}: guest median {guest_gbps:.2f} Gbps "
+            f"({baseline_percent:.2f}% of Linux-host median "
+            f"{baseline_gbps:.2f} Gbps), threshold {threshold_gbps:.2f} Gbps, "
+            f"profile [{profile_description}]"
+        )
+        guest.log.info(
+            f"Passthrough measured-baseline summary for "
+            f"{guest_message.test_case_name}: direction={direction}, "
+            f"host_median={baseline_gbps} Gbps, guest_median={guest_gbps} Gbps, "
+            f"baseline_percent={baseline_percent}%, "
+            f"threshold={threshold_gbps} Gbps, profile=[{profile_description}], "
+            f"host_nic={host.name}:{host_nic_name}, "
+            f"guest_nic={guest.name}:{guest_nic_name}, "
+            f"peer_nic={peer.name}:{peer_nic_name}"
+        )
+        metric_suffix = direction.replace("-", "_")
+        for metric_name, metric_value, metric_relativity, metric_description in [
+            (
+                f"{PASSTHROUGH_HOST_BASELINE_METRIC_NAME}_{metric_suffix}",
+                baseline_gbps,
+                MetricRelativity.Parameter,
+                "Median throughput measured on the immediate Linux host before "
+                "passing the NIC to the guest.",
+            ),
+            (
+                f"{PASSTHROUGH_GUEST_MEDIAN_METRIC_NAME}_{metric_suffix}",
+                guest_gbps,
+                MetricRelativity.HigherIsBetter,
+                "Median guest throughput for the matched host baseline profile.",
+            ),
+            (
+                f"{PASSTHROUGH_BASELINE_PERCENT_METRIC_NAME}_{metric_suffix}",
+                baseline_percent,
+                MetricRelativity.HigherIsBetter,
+                "Guest median throughput as a percentage of the immediate "
+                "Linux-host baseline.",
+            ),
+        ]:
+            send_unified_perf_message(
+                node=guest,
+                test_result=test_result,
+                test_case_name=guest_message.test_case_name,
+                metric_name=metric_name,
+                metric_value=float(metric_value),
+                metric_unit=("%" if "percent" in metric_name else "Gbps"),
+                metric_description=metric_description,
+                metric_relativity=metric_relativity,
+                tool=guest_message.tool,
+                protocol_type=guest_message.protocol_type,
+            )
+
+        assert_that(guest_gbps).described_as(
+            f"Guest median throughput [{guest_gbps} Gbps] in direction "
+            f"[{direction}] must be at least "
+            f"{PASSTHROUGH_BASELINE_THRESHOLD_PERCENT:.0f}% of the immediate "
+            f"Linux-host median [{baseline_gbps} Gbps], threshold "
+            f"[{threshold_gbps} Gbps], profile [{profile_description}]."
+        ).is_greater_than_or_equal_to(threshold_gbps)
+        return result_summary
+
+    def _run_measured_passthrough_benchmark(
+        self,
+        node: Node,
+        test_result: TestResult,
+        log_path: Path,
+        variables: Dict[str, Any],
+        benchmark: PassthroughBenchmark,
+    ) -> None:
+        guest = cast(RemoteNode, node)
+        peer = self._get_passthrough_peer(variables)
+        host = self._get_linux_passthrough_host(test_result, node, peer)
+        peer_nic_name = self._get_host_nic_name(peer)
+        self._validate_physical_pci_nic(peer, peer_nic_name, "remote peer")
+        start_stop = node.features[StartStop]
+        host_with_address = cast(Any, host)
+        had_host_internal_address = hasattr(host, "internal_address")
+        original_host_internal_address = getattr(host, "internal_address", "")
+
+        guest_stopped = False
+        host_nic_name = ""
+        try:
+            start_stop.stop()
+            guest_stopped = True
+            host, host_nic_name = self._configure_passthrough_nic_for_host(node, host)
+            self._validate_physical_pci_nic(
+                host, host_nic_name, "immediate virtualization host"
+            )
+            baseline_runs, profiles = self._collect_host_baseline_runs(
+                benchmark=benchmark,
+                host=host,
+                host_nic_name=host_nic_name,
+                peer=peer,
+                peer_nic_name=peer_nic_name,
+            )
+        finally:
+            try:
+                if host_nic_name:
+                    self._release_passthrough_host_dhcp(host, host_nic_name)
+            finally:
+                if had_host_internal_address:
+                    host_with_address.internal_address = original_host_internal_address
+                elif hasattr(host, "internal_address"):
+                    del host_with_address.internal_address
+                if guest_stopped:
+                    start_stop.start()
+                    self._wait_for_guest_start(guest)
+
+        guest, guest_nic_name = self._configure_passthrough_nic_for_node(node, log_path)
+        guest_runs = self._collect_guest_throughput_runs(
+            benchmark=benchmark,
+            guest=guest,
+            guest_nic_name=guest_nic_name,
+            peer=peer,
+            peer_nic_name=peer_nic_name,
+            profiles=profiles,
+        )
+        result_summaries: List[str] = []
+        for direction in [PASSTHROUGH_GUEST_TO_PEER, PASSTHROUGH_PEER_TO_GUEST]:
+            result_summaries.append(
+                self._assert_passthrough_baseline(
+                    test_result=test_result,
+                    baseline_runs=baseline_runs[direction],
+                    guest_runs=guest_runs[direction],
+                    direction=direction,
+                    guest=guest,
+                    guest_nic_name=guest_nic_name,
+                    host=host,
+                    host_nic_name=host_nic_name,
+                    peer=peer,
+                    peer_nic_name=peer_nic_name,
+                )
+            )
+        test_result.set_status(test_result.status, " | ".join(result_summaries))
+
+    def _collect_host_baseline_runs(
+        self,
+        benchmark: PassthroughBenchmark,
+        host: Node,
+        host_nic_name: str,
+        peer: RemoteNode,
+        peer_nic_name: str,
+    ) -> Tuple[
+        Dict[str, List[List[NetworkThroughputMessage]]],
+        Dict[str, ThroughputProfile],
+    ]:
+        host.log.info(
+            f"Starting passthrough baseline tuning sweep from "
+            f"{host.name}:{host_nic_name} to {peer.name}:{peer_nic_name}"
+        )
+        guest_to_peer_sweep = benchmark(host, host_nic_name, peer, peer_nic_name, None)
+        host.log.info(
+            f"Starting passthrough baseline tuning sweep from "
+            f"{peer.name}:{peer_nic_name} to {host.name}:{host_nic_name}"
+        )
+        peer_to_guest_sweep = benchmark(peer, peer_nic_name, host, host_nic_name, None)
+        profiles = {
+            PASSTHROUGH_GUEST_TO_PEER: _select_best_throughput_profile(
+                guest_to_peer_sweep
+            ),
+            PASSTHROUGH_PEER_TO_GUEST: _select_best_throughput_profile(
+                peer_to_guest_sweep
+            ),
+        }
+        runs = {
+            PASSTHROUGH_GUEST_TO_PEER: [
+                _filter_throughput_profile(
+                    guest_to_peer_sweep, profiles[PASSTHROUGH_GUEST_TO_PEER]
+                )
+            ],
+            PASSTHROUGH_PEER_TO_GUEST: [
+                _filter_throughput_profile(
+                    peer_to_guest_sweep, profiles[PASSTHROUGH_PEER_TO_GUEST]
+                )
+            ],
+        }
+
+        for run_number in range(2, PASSTHROUGH_MEASUREMENT_RUN_COUNT + 1):
+            host.log.info(
+                f"Running Linux-host passthrough baseline sample "
+                f"{run_number}/{PASSTHROUGH_MEASUREMENT_RUN_COUNT}"
+            )
+            runs[PASSTHROUGH_GUEST_TO_PEER].append(
+                benchmark(
+                    host,
+                    host_nic_name,
+                    peer,
+                    peer_nic_name,
+                    profiles[PASSTHROUGH_GUEST_TO_PEER],
+                )
+            )
+            runs[PASSTHROUGH_PEER_TO_GUEST].append(
+                benchmark(
+                    peer,
+                    peer_nic_name,
+                    host,
+                    host_nic_name,
+                    profiles[PASSTHROUGH_PEER_TO_GUEST],
+                )
+            )
+        return runs, profiles
+
+    def _collect_guest_throughput_runs(
+        self,
+        benchmark: PassthroughBenchmark,
+        guest: RemoteNode,
+        guest_nic_name: str,
+        peer: RemoteNode,
+        peer_nic_name: str,
+        profiles: Dict[str, ThroughputProfile],
+    ) -> Dict[str, List[List[NetworkThroughputMessage]]]:
+        runs: Dict[str, List[List[NetworkThroughputMessage]]] = {
+            PASSTHROUGH_GUEST_TO_PEER: [],
+            PASSTHROUGH_PEER_TO_GUEST: [],
+        }
+        for run_number in range(1, PASSTHROUGH_MEASUREMENT_RUN_COUNT + 1):
+            guest.log.info(
+                f"Running guest passthrough throughput sample "
+                f"{run_number}/{PASSTHROUGH_MEASUREMENT_RUN_COUNT}"
+            )
+            runs[PASSTHROUGH_GUEST_TO_PEER].append(
+                benchmark(
+                    guest,
+                    guest_nic_name,
+                    peer,
+                    peer_nic_name,
+                    profiles[PASSTHROUGH_GUEST_TO_PEER],
+                )
+            )
+            runs[PASSTHROUGH_PEER_TO_GUEST].append(
+                benchmark(
+                    peer,
+                    peer_nic_name,
+                    guest,
+                    guest_nic_name,
+                    profiles[PASSTHROUGH_PEER_TO_GUEST],
+                )
+            )
+        return runs
+
+    def _get_iperf_udp_line_rate_bitrate_gbps(
+        self,
+        client: RemoteNode,
+        client_nic_name: str,
+        server: RemoteNode,
+        server_nic_name: str,
+    ) -> Decimal:
+        line_rate_gbps = min(
+            self._get_link_rate_gbps(client, client_nic_name),
+            self._get_link_rate_gbps(server, server_nic_name),
+        )
+        return line_rate_gbps * PASSTHROUGH_IPERF_UDP_BITRATE_MULTIPLIER
+
+    def _get_link_rate_gbps(self, node: RemoteNode, nic_name: str) -> Decimal:
+        if isinstance(node.os, Windows):
+            escaped_nic_name = nic_name.replace("'", "''")
+            speed = cast(
+                str,
+                node.tools[PowerShell].run_cmdlet(
+                    f"(Get-NetAdapter -Name '{escaped_nic_name}' "
+                    "-ErrorAction Stop).LinkSpeed",
+                    fail_on_error=False,
+                    force_run=True,
+                ),
+            ).strip()
+        else:
+            speed = (
+                node.tools[Ethtool]
+                .get_device_link_settings(nic_name)
+                .link_settings.get("Speed", "")
+                .strip()
+            )
+        matched_speed = self._link_speed_pattern.match(speed)
+        if not matched_speed:
+            raise SkippedException(
+                f"Cannot determine line rate for NIC [{node.name}:{nic_name}] "
+                f"from link speed value [{speed}]."
+            )
+
+        speed_value = Decimal(matched_speed.group("speed"))
+        if speed_value <= 0:
+            raise SkippedException(
+                f"NIC [{node.name}:{nic_name}] reported non-positive link speed "
+                f"[{speed}]. Verify the NIC link is up and reports a valid speed "
+                "before sizing the passthrough UDP offered load."
+            )
+        speed_unit = matched_speed.group("unit").lower()
+        if speed_unit in ["mb/s", "mbps"]:
+            return speed_value / Decimal(1000)
+        if speed_unit in ["gb/s", "gbps"]:
+            return speed_value
+        raise SkippedException(
+            f"Unsupported link speed unit [{speed_unit}] for NIC "
+            f"[{node.name}:{nic_name}]."
+        )
 
     # Network device passthrough tests between host and guest
     @TestCaseMetadata(
         description="""
-        This test case uses iperf3 to test passthrough tcp network throughput.
-        Run iperf server on physical server and client on VM
+        Measure bidirectional TCP iperf throughput on the immediate Linux host,
+        pass the same NIC to L2, and require matched L2 medians to reach 95% of
+        the host medians. The independent Linux peer is configured with the
+        passthrough_peer_* test variables.
         """,
         priority=3,
         timeout=TIMEOUT,
         requirement=simple_requirement(
             min_count=1,
-            supported_platform_type=SUPPORTED_PASSTHROUGH_PLATFORMS,
+            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_features=[StartStop],
             unsupported_os=[Windows],
         ),
     )
@@ -97,35 +583,48 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        server = self._get_host_as_server(variables)
-        self._skip_if_windows_server(server, "iperf3")
+        def run_iperf(
+            client: Node,
+            client_nic_name: str,
+            server: Node,
+            server_nic_name: str,
+            profile: Optional[ThroughputProfile],
+        ) -> List[NetworkThroughputMessage]:
+            del client_nic_name, server_nic_name
+            connections = [profile[2]] if profile else IPERF_TCP_CONCURRENCY
+            buffer_lengths = [int(profile[3])] if profile else IPERF_TCP_BUFFER_LENGTHS
+            messages: List[NetworkThroughputMessage] = perf_iperf(
+                test_result=result,
+                connections=connections,
+                buffer_length_list=buffer_lengths,
+                server=cast(RemoteNode, server),
+                client=cast(RemoteNode, client),
+                run_with_internal_address=True,
+                test_case_name="perf_tcp_iperf_passthrough_host_guest",
+            )
+            return messages
 
-        # Reboot guest into fresh state; never reboot the baremetal host.
-        cast(RemoteNode, node).reboot()
-
-        client, _ = self._configure_passthrough_nic_for_node(
-            node, log_path, host_node=server
-        )
-
-        perf_iperf(
+        self._run_measured_passthrough_benchmark(
+            node=node,
             test_result=result,
-            connections=IPERF_TCP_CONCURRENCY,
-            buffer_length_list=IPERF_TCP_BUFFER_LENGTHS,
-            server=server,
-            client=client,
-            run_with_internal_address=True,
+            log_path=log_path,
+            variables=variables,
+            benchmark=run_iperf,
         )
 
     @TestCaseMetadata(
         description="""
-        This test case uses iperf3 to test passthrough udp network throughput.
-        Run iperf server on physical host and client on vm with udp mode
+        Measure bidirectional UDP iperf throughput on the immediate Linux host,
+        pass the same NIC to L2, and require matched L2 medians to reach 95% of
+        the host medians. The independent Linux peer is configured with the
+        passthrough_peer_* test variables.
         """,
         priority=3,
         timeout=TIMEOUT,
         requirement=simple_requirement(
             min_count=1,
-            supported_platform_type=SUPPORTED_PASSTHROUGH_PLATFORMS,
+            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_features=[StartStop],
             unsupported_os=[Windows],
         ),
     )
@@ -136,24 +635,44 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        server = self._get_host_as_server(variables)
-        self._skip_if_windows_server(server, "iperf3")
+        udp_bitrate_gbps: Optional[Decimal] = None
 
-        # Reboot guest into fresh state; never reboot the baremetal host.
-        cast(RemoteNode, node).reboot()
+        def run_iperf(
+            client: Node,
+            client_nic_name: str,
+            server: Node,
+            server_nic_name: str,
+            profile: Optional[ThroughputProfile],
+        ) -> List[NetworkThroughputMessage]:
+            nonlocal udp_bitrate_gbps
+            if udp_bitrate_gbps is None:
+                udp_bitrate_gbps = self._get_iperf_udp_line_rate_bitrate_gbps(
+                    cast(RemoteNode, client),
+                    client_nic_name,
+                    cast(RemoteNode, server),
+                    server_nic_name,
+                )
+            connections = [profile[2]] if profile else IPERF_UDP_CONCURRENCY
+            buffer_lengths = [int(profile[3])] if profile else IPERF_UDP_BUFFER_LENGTHS
+            messages: List[NetworkThroughputMessage] = perf_iperf(
+                test_result=result,
+                connections=connections,
+                buffer_length_list=buffer_lengths,
+                server=cast(RemoteNode, server),
+                client=cast(RemoteNode, client),
+                udp_mode=True,
+                udp_total_bitrate_gbps=udp_bitrate_gbps,
+                run_with_internal_address=True,
+                test_case_name="perf_udp_iperf_passthrough_host_guest",
+            )
+            return messages
 
-        client, _ = self._configure_passthrough_nic_for_node(
-            node, log_path, host_node=server
-        )
-
-        perf_iperf(
+        self._run_measured_passthrough_benchmark(
+            node=node,
             test_result=result,
-            connections=IPERF_UDP_CONCURRENCY,
-            buffer_length_list=IPERF_UDP_BUFFER_LENGTHS,
-            server=server,
-            client=client,
-            udp_mode=True,
-            run_with_internal_address=True,
+            log_path=log_path,
+            variables=variables,
+            benchmark=run_iperf,
         )
 
     @TestCaseMetadata(
@@ -236,8 +755,10 @@ class NetworkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case uses ntttcp to test tcp network throughput.
-        We will run nttcp server of physical host and client on VM
+        Measure bidirectional TCP NTTTCP throughput on the immediate Linux host,
+        pass the same NIC to L2, and require matched L2 medians to reach 95% of
+        the host medians. The independent Linux peer is configured with the
+        passthrough_peer_* test variables.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -246,7 +767,8 @@ class NetworkPerformance(TestSuite):
                 node_count=1,
                 memory_mb=search_space.IntRange(min=8192),
             ),
-            supported_platform_type=SUPPORTED_PASSTHROUGH_PLATFORMS,
+            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_features=[StartStop],
         ),
     )
     def perf_tcp_ntttcp_passthrough_host_guest(
@@ -256,48 +778,49 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        server = self._get_host_as_server(variables)
+        tcp_connections = [
+            connection
+            for connection in NTTTCP_TCP_CONCURRENCY
+            if connection <= PASSTHROUGH_NTTTCP_MAX_CONNECTIONS_WITHOUT_HOST_REBOOT
+        ]
 
-        # Reboot guest into fresh state; never reboot the baremetal host.
-        cast(RemoteNode, node).reboot()
-
-        client, client_nic_name = self._configure_passthrough_nic_for_node(
-            node, log_path, host_node=server
-        )
-
-        if isinstance(server.os, Windows):
-            self._perf_ntttcp_with_windows_server(
+        def run_ntttcp(
+            client: Node,
+            client_nic_name: str,
+            server: Node,
+            server_nic_name: str,
+            profile: Optional[ThroughputProfile],
+        ) -> List[NetworkThroughputMessage]:
+            connections = [profile[2]] if profile else tcp_connections
+            messages: List[NetworkThroughputMessage] = perf_ntttcp(
                 test_result=result,
-                client=client,
-                server=server,
-                client_nic_name=client_nic_name,
-                udp_mode=False,
+                client=cast(RemoteNode, client),
+                server=cast(RemoteNode, server),
+                connections=connections,
                 test_case_name="perf_tcp_ntttcp_passthrough_host_guest",
-            )
-        else:
-
-            def refresh_passthrough_nics() -> Tuple[Optional[str], Optional[str]]:
-                _, refreshed_client_nic_name = self._configure_passthrough_nic_for_node(
-                    node, log_path, host_node=server
-                )
-                return refreshed_client_nic_name, None
-
-            perf_ntttcp(
-                test_result=result,
-                client=client,
-                server=server,
-                server_nic_name=self._get_host_nic_name(server),
+                server_nic_name=server_nic_name,
                 client_nic_name=client_nic_name,
-                skip_server_task_max=True,  # host: TasksMax reboot clears NIC DHCP
-                post_ntttcp_setup=refresh_passthrough_nics,
+                skip_server_task_max=True,
                 client_ntttcp_timeout_tolerance_seconds=(
                     self.NTTTCP_TCP_CLIENT_TIMEOUT_TOLERANCE_SECONDS
                 ),
             )
+            return messages
+
+        self._run_measured_passthrough_benchmark(
+            node=node,
+            test_result=result,
+            log_path=log_path,
+            variables=variables,
+            benchmark=run_ntttcp,
+        )
 
     @TestCaseMetadata(
         description="""
-        This test case uses ntttcp to test passthrough udp network throughput.
+        Measure bidirectional UDP NTTTCP throughput on the immediate Linux host,
+        pass the same NIC to L2, and require matched L2 medians to reach 95% of
+        the host medians. The independent Linux peer is configured with the
+        passthrough_peer_* test variables.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -306,7 +829,8 @@ class NetworkPerformance(TestSuite):
                 node_count=1,
                 memory_mb=search_space.IntRange(min=8192),
             ),
-            supported_platform_type=SUPPORTED_PASSTHROUGH_PLATFORMS,
+            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_features=[StartStop],
         ),
     )
     def perf_udp_1k_ntttcp_passthrough_host_guest(
@@ -316,40 +840,40 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         variables: Dict[str, Any],
     ) -> None:
-        server = self._get_host_as_server(variables)
-
-        # Reboot guest into fresh state; never reboot the baremetal host.
-        cast(RemoteNode, node).reboot()
-
-        client, client_nic_name = self._configure_passthrough_nic_for_node(
-            node, log_path, host_node=server
-        )
-
-        if isinstance(server.os, Windows):
-            self._perf_ntttcp_with_windows_server(
+        def run_ntttcp(
+            client: Node,
+            client_nic_name: str,
+            server: Node,
+            server_nic_name: str,
+            profile: Optional[ThroughputProfile],
+        ) -> List[NetworkThroughputMessage]:
+            connections = [profile[2]] if profile else NTTTCP_UDP_CONCURRENCY
+            messages: List[NetworkThroughputMessage] = perf_ntttcp(
                 test_result=result,
-                client=client,
-                server=server,
-                client_nic_name=client_nic_name,
+                client=cast(RemoteNode, client),
+                server=cast(RemoteNode, server),
                 udp_mode=True,
+                connections=connections,
                 test_case_name="perf_udp_1k_ntttcp_passthrough_host_guest",
-            )
-        else:
-            perf_ntttcp(
-                test_result=result,
-                client=client,
-                server=server,
-                server_nic_name=self._get_host_nic_name(server),
+                server_nic_name=server_nic_name,
                 client_nic_name=client_nic_name,
-                udp_mode=True,
-                # host: TasksMax reboot clears NIC DHCP state
                 skip_server_task_max=True,
             )
+            return messages
+
+        self._run_measured_passthrough_benchmark(
+            node=node,
+            test_result=result,
+            log_path=log_path,
+            variables=variables,
+            benchmark=run_ntttcp,
+        )
 
     # Network device passthrough tests between 2 guests
     @TestCaseMetadata(
         description="""
-        This test case uses iperf3 to test passthrough tcp network throughput.
+        Run TCP iperf between two passthrough guests and publish the measurements
+        without enforcing a line-rate or host-baseline threshold.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -387,7 +911,8 @@ class NetworkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case uses iperf3 to test passthrough udp network throughput.
+        Run UDP iperf between two passthrough guests and publish the measurements
+        without enforcing a line-rate or host-baseline threshold.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -411,8 +936,12 @@ class NetworkPerformance(TestSuite):
         client_node.reboot()
         server_node.reboot()
 
-        client, _ = self._configure_passthrough_nic_for_node(client_node, log_path)
-        server, _ = self._configure_passthrough_nic_for_node(server_node, log_path)
+        client, client_nic_name = self._configure_passthrough_nic_for_node(
+            client_node, log_path
+        )
+        server, server_nic_name = self._configure_passthrough_nic_for_node(
+            server_node, log_path
+        )
 
         perf_iperf(
             test_result=result,
@@ -421,6 +950,9 @@ class NetworkPerformance(TestSuite):
             server=server,
             client=client,
             udp_mode=True,
+            udp_total_bitrate_gbps=self._get_iperf_udp_line_rate_bitrate_gbps(
+                client, client_nic_name, server, server_nic_name
+            ),
             run_with_internal_address=True,
         )
 
@@ -504,8 +1036,8 @@ class NetworkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case uses ntttcp to test passthrough tcp network throughput
-        between two guest VMs.
+        Run TCP NTTTCP between two passthrough guests and publish the measurements
+        without enforcing a line-rate or host-baseline threshold.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -538,12 +1070,15 @@ class NetworkPerformance(TestSuite):
         )
 
         def refresh_passthrough_nics() -> Tuple[Optional[str], Optional[str]]:
+            nonlocal client_nic_name, server_nic_name
             _, refreshed_client_nic_name = self._configure_passthrough_nic_for_node(
                 client_node, log_path
             )
             _, refreshed_server_nic_name = self._configure_passthrough_nic_for_node(
                 server_node, log_path
             )
+            client_nic_name = refreshed_client_nic_name
+            server_nic_name = refreshed_server_nic_name
             return refreshed_client_nic_name, refreshed_server_nic_name
 
         perf_ntttcp(
@@ -560,8 +1095,8 @@ class NetworkPerformance(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        This test case uses ntttcp to test passthrough udp network throughput
-        between two guest VMs.
+        Run UDP NTTTCP between two passthrough guests and publish the measurements
+        without enforcing a line-rate or host-baseline threshold.
         """,
         priority=3,
         timeout=TIMEOUT,
@@ -613,14 +1148,7 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         host_node: Optional[RemoteNode] = None,
     ) -> Tuple[RemoteNode, str]:
-        ctx = self._get_passthrough_node_context(node)
-        if not ctx.passthrough_devices:
-            raise SkippedException("No passthrough devices found for node")
-
-        passthrough_dev = ctx.passthrough_devices[0]
-        if not passthrough_dev.device_list:
-            raise LisaException("passthrough_devices[0].device_list is empty")
-        device_addr_obj = passthrough_dev.device_list[0]
+        _, device_addr_obj = self._get_passthrough_nic_context(node)
         device_bdf = self._get_device_bdf(device_addr_obj)
 
         host_nic_name = ""
@@ -739,6 +1267,238 @@ class NetworkPerformance(TestSuite):
         test_node.internal_address = passthrough_nic_ip
 
         return test_node, interface_name
+
+    def _configure_passthrough_nic_for_host(
+        self,
+        node: Node,
+        host: Node,
+    ) -> Tuple[Node, str]:
+        _, device_addr_obj = self._get_passthrough_nic_context(node)
+        device_bdf = self._get_device_bdf(device_addr_obj)
+        if not device_bdf:
+            raise LisaException(
+                "Cannot resolve the selected passthrough NIC BDF on the Linux "
+                "host. Verify the Cloud Hypervisor device context contains PCI "
+                "domain, bus, slot, and function values."
+            )
+
+        def get_native_interface_info() -> str:
+            return host.execute(
+                cmd=(
+                    f'driver=$(basename "$(readlink '
+                    f'/sys/bus/pci/devices/{device_bdf}/driver 2>/dev/null)" '
+                    "2>/dev/null); "
+                    f"for path in /sys/bus/pci/devices/{device_bdf}/net/*; do "
+                    '[ -e "$path" ] || continue; '
+                    'iface=$(basename "$path"); '
+                    'carrier=$(cat "/sys/class/net/$iface/carrier" '
+                    "2>/dev/null || echo 0); "
+                    'echo "${driver:-none}|$iface|$carrier"; '
+                    "done"
+                ),
+                sudo=True,
+                shell=True,
+                no_info_log=True,
+                no_error_log=True,
+            ).stdout.strip()
+
+        interface_info = ""
+
+        def get_native_candidates() -> List[Tuple[bool, str]]:
+            candidates: List[Tuple[bool, str]] = []
+            for line in interface_info.splitlines():
+                parts = line.split("|")
+                if len(parts) == 3 and parts[0] not in ["none", "vfio-pci"]:
+                    candidates.append((parts[2] == "1", parts[1]))
+            return candidates
+
+        def is_native_driver_ready() -> bool:
+            nonlocal interface_info
+            interface_info = get_native_interface_info()
+            return bool(get_native_candidates())
+
+        check_till_timeout(
+            is_native_driver_ready,
+            timeout_message=(
+                f"wait for passthrough NIC [{device_bdf}] to rebind to its "
+                "native Linux driver after stopping the guest"
+            ),
+            timeout=PASSTHROUGH_HOST_NIC_REBIND_TIMEOUT_SECONDS,
+        )
+        candidates = get_native_candidates()
+        candidates.sort(key=lambda item: (not item[0], item[1]))
+        if not candidates:
+            raise LisaException(
+                f"Passthrough NIC [{device_bdf}] did not expose a native Linux "
+                f"network interface after stopping the guest. Observed: "
+                f"[{interface_info}]. Verify libvirt uses managed='yes'."
+            )
+        interface_name = candidates[0][1]
+        host.log.info(
+            f"Using immediate Linux-host NIC [{host.name}:{interface_name}] "
+            f"for passthrough baseline; BDF [{device_bdf}]"
+        )
+        host.execute(
+            cmd=f"ip link set {interface_name} up",
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Failed to bring up Linux-host baseline NIC [{interface_name}]. "
+                "Verify its native driver reattached after the guest stopped."
+            ),
+        )
+        self._wait_for_carrier(host, interface_name)
+        host.execute(
+            f"ip addr flush dev {interface_name} 2>/dev/null || true; "
+            f"ip route flush dev {interface_name} 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+        is_configured = False
+        try:
+            dhcp_result = self._run_dhcp_on_iface(
+                host, interface_name, keep_unmanaged=False
+            )
+            if dhcp_result.exit_code != 0:
+                self._raise_dhcp_failure(host, interface_name, dhcp_result)
+
+            interface_details = host.execute(
+                cmd=f"ip -4 -o addr show dev {interface_name} scope global",
+                sudo=True,
+                shell=True,
+            ).stdout
+            address_match = re.search(
+                r"\binet\s+(?P<ip>\d+(?:\.\d+){3})/", interface_details
+            )
+            if not address_match:
+                raise LisaException(
+                    f"Linux-host baseline NIC [{interface_name}] did not receive an "
+                    f"IPv4 address. Verify DHCP is available on the physical test "
+                    f"network. Interface details: [{interface_details[:500]}]"
+                )
+            cast(Any, host).internal_address = address_match.group("ip")
+            is_configured = True
+            return host, interface_name
+        finally:
+            if not is_configured:
+                self._release_passthrough_host_dhcp(host, interface_name)
+
+    def _release_passthrough_host_dhcp(self, host: Node, interface_name: str) -> None:
+        dhcp_pid = f"/run/dhclient-{interface_name}.pid"
+        dhcp_lease = f"/var/lib/dhcp/dhclient-{interface_name}.leases"
+        host.execute(
+            f"dhclient -r -pf {dhcp_pid} -lf {dhcp_lease} {interface_name} "
+            "2>/dev/null || true; "
+            f"if [ -s {dhcp_pid} ]; then "
+            f'kill "$(cat {dhcp_pid})" 2>/dev/null || true; fi; '
+            f"pkill -f '[d]hclient.*{interface_name}' 2>/dev/null || true; "
+            f"rm -f {dhcp_pid}; "
+            f"ip addr flush dev {interface_name} 2>/dev/null || true; "
+            f"ip route flush dev {interface_name} 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+
+    def _get_linux_passthrough_host(
+        self,
+        test_result: TestResult,
+        node: Node,
+        peer: RemoteNode,
+    ) -> Node:
+        environment = test_result.environment
+        if environment is None or environment.platform is None:
+            raise SkippedException(
+                "Measured passthrough validation requires the platform context. "
+                "Verify the test runs on Cloud Hypervisor."
+            )
+        platform = environment.platform
+        if platform.type_name() != CLOUD_HYPERVISOR:
+            raise SkippedException(
+                f"Measured passthrough validation requires an immediate Linux "
+                f"virtualization host, but platform [{platform.type_name()}] does "
+                "not expose one. Run this case on Cloud Hypervisor hosted by "
+                "bare-metal Linux or Linux L1VH."
+            )
+        host_node = getattr(platform, "host_node", None)
+        if not isinstance(host_node, Node) or isinstance(host_node.os, Windows):
+            raise SkippedException(
+                "Measured passthrough validation requires a Linux host that owns "
+                "the NIC before assigning it to L2."
+            )
+        if not node.features.is_supported(StartStop):
+            raise SkippedException(
+                "Measured passthrough validation must stop L2 to restore the NIC "
+                "to its Linux host, but StartStop is unavailable."
+            )
+
+        passthrough_context, _ = self._get_passthrough_nic_context(node)
+        if getattr(passthrough_context, "managed", "") != "yes":
+            raise SkippedException(
+                "Measured passthrough validation requires libvirt "
+                "managed='yes' so stopping L2 restores the NIC's native Linux "
+                "driver before baseline collection."
+            )
+
+        host_addresses = set(
+            host_node.execute(
+                "hostname -I 2>/dev/null || true",
+                shell=True,
+                no_info_log=True,
+            ).stdout.split()
+        )
+        if isinstance(host_node, RemoteNode):
+            host_addresses.add(
+                str(
+                    host_node.connection_info.get(
+                        constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS, ""
+                    )
+                )
+            )
+        peer_addresses = {
+            peer.internal_address,
+            str(
+                peer.connection_info.get(
+                    constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS, ""
+                )
+            ),
+        }
+        if {address for address in peer_addresses if address} & host_addresses:
+            raise SkippedException(
+                "The configured passthrough peer resolves to the Linux "
+                "virtualization host. Configure an independent remote server; "
+                "host-to-guest traffic is not a passthrough baseline."
+            )
+        return host_node
+
+    def _get_passthrough_nic_context(self, node: Node) -> Tuple[Any, Any]:
+        node_context = self._get_passthrough_node_context(node)
+        for passthrough_context in node_context.passthrough_devices:
+            if passthrough_context.pool_type.value != "pci_net":
+                continue
+            if not passthrough_context.device_list:
+                raise LisaException(
+                    "The passthrough NIC context has no selected host devices. "
+                    "Verify the PCI NIC device pool contains an available device."
+                )
+            return passthrough_context, passthrough_context.device_list[0]
+        raise SkippedException("No PCI NIC passthrough device is assigned to the node")
+
+    def _wait_for_guest_start(self, guest: RemoteNode) -> None:
+        address = guest.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
+        port = guest.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_PORT]
+        is_ready, error_code = wait_tcp_port_ready(
+            address,
+            port,
+            log=guest.log,
+            timeout=PASSTHROUGH_GUEST_START_TIMEOUT_SECONDS,
+        )
+        if not is_ready:
+            raise LisaException(
+                f"L2 guest [{guest.name}] did not become reachable at "
+                f"[{address}:{port}] after restoring passthrough ownership. TCP "
+                f"error [{error_code}]. Inspect the guest console and VFIO bind "
+                "state on the Linux host."
+            )
 
     def _refresh_passthrough_nic_address(
         self, node: RemoteNode, interface_name: str
@@ -1040,7 +1800,7 @@ class NetworkPerformance(TestSuite):
                 f"; if [ -s {dhcp_pid} ]; then"
                 f'  kill -9 "$(cat {dhcp_pid})" 2>/dev/null || true; fi'
                 f"; rm -f {dhcp_pid}"
-                f"; pkill -f 'dhclient.*{interface_name}' 2>/dev/null || true",
+                f"; pkill -f '[d]hclient.*{interface_name}' 2>/dev/null || true",
                 sudo=True,
                 shell=True,
             )
@@ -1162,6 +1922,47 @@ class NetworkPerformance(TestSuite):
             self._baremetal_hosts.append(server)
         return server
 
+    def _get_passthrough_peer(self, variables: Dict[str, Any]) -> RemoteNode:
+        ip = variables.get("passthrough_peer_ip", "")
+        username = variables.get("passthrough_peer_username", "")
+        password = variables.get("passthrough_peer_password", "")
+        private_key = variables.get("passthrough_peer_private_key_file", "")
+        if not (ip and username and (password or private_key)):
+            raise SkippedException(
+                "Independent passthrough peer details are not provided. Required: "
+                "passthrough_peer_ip, passthrough_peer_username, and either "
+                "passthrough_peer_password or passthrough_peer_private_key_file. "
+                "The peer IP must be assigned to the remote peer's dedicated "
+                "physical PCI test NIC."
+            )
+
+        peer = RemoteNode(
+            runbook=schema.Node(name="passthrough-peer"),
+            index=-1,
+            logger_name="passthrough-peer",
+            parent_logger=get_logger("passthrough-peer-platform"),
+        )
+        peer.set_connection_info(
+            address=ip,
+            public_address=ip,
+            public_port=22,
+            username=username,
+            password=password,
+            private_key_file=private_key,
+        )
+        peer.internal_address = ip
+        peer.initialize()
+        if isinstance(peer.os, Windows):
+            peer.close()
+            peer.cleanup()
+            raise SkippedException(
+                "Measured passthrough baselines currently require a Linux remote "
+                "peer so the same iperf and NTTTCP profiles run in both phases."
+            )
+        if peer not in self._baremetal_hosts:
+            self._baremetal_hosts.append(peer)
+        return peer
+
     def _skip_if_windows_server(self, server: RemoteNode, tool_name: str) -> None:
         if isinstance(server.os, Windows):
             if server in self._baremetal_hosts:
@@ -1182,16 +1983,21 @@ class NetworkPerformance(TestSuite):
         client_nic_name: str,
         udp_mode: bool,
         test_case_name: str,
-    ) -> None:
+    ) -> Tuple[List[NetworkThroughputMessage], str]:
         client_ntttcp = client.tools[Ntttcp]
         server_ntttcp = server.tools[Ntttcp]
         client_ntttcp.setup_system(udp_mode)
         server_ntttcp.setup_system(udp_mode, set_task_max=False)
+        ntttcp_messages: List[NetworkThroughputMessage] = []
+        server_nic_name = ""
 
         try:
             client_ip = client.tools[Ip]
             self._refresh_passthrough_nic_address(client, client_nic_name)
             client_mtu = client_ip.get_mtu(client_nic_name)
+            server_nic_name = self._get_windows_route_interface_name(
+                server, client.internal_address
+            )
             if udp_mode:
                 connections = NTTTCP_UDP_CONCURRENCY
                 max_server_threads = WINDOWS_NTTTCP_MAX_SERVER_THREADS
@@ -1306,7 +2112,7 @@ class NetworkPerformance(TestSuite):
                         f"Stderr: {receiver_result.stderr[:2000]}"
                     ) from parse_error
                 if udp_mode:
-                    notifier.notify(
+                    ntttcp_message: NetworkThroughputMessage = (
                         client_ntttcp.create_ntttcp_udp_performance_message(
                             parsed_server_result,
                             parsed_client_result,
@@ -1318,7 +2124,7 @@ class NetworkPerformance(TestSuite):
                         )
                     )
                 else:
-                    notifier.notify(
+                    ntttcp_message = (
                         client_ntttcp.create_ntttcp_tcp_performance_message(
                             parsed_server_result,
                             parsed_client_result,
@@ -1330,9 +2136,12 @@ class NetworkPerformance(TestSuite):
                             client_mtu,
                         )
                     )
+                notifier.notify(ntttcp_message)
+                ntttcp_messages.append(ntttcp_message)
         finally:
             client_ntttcp.restore_system(udp_mode)
             server_ntttcp.restore_system(udp_mode)
+        return ntttcp_messages, server_nic_name
 
     def _get_windows_route_source_ip(self, server: RemoteNode, remote_ip: str) -> str:
         escaped_remote_ip = remote_ip.replace("'", "''")
@@ -1368,41 +2177,164 @@ class NetworkPerformance(TestSuite):
             )
         return source_ip
 
+    def _get_windows_route_interface_name(
+        self, server: RemoteNode, remote_ip: str
+    ) -> str:
+        escaped_remote_ip = remote_ip.replace("'", "''")
+        interface_name = cast(
+            str,
+            server.tools[PowerShell].run_cmdlet(
+                "$route = Find-NetRoute -RemoteIPAddress "
+                f"'{escaped_remote_ip}' -ErrorAction Stop | Select-Object -First 1; "
+                "if ($route) { "
+                "  $adapter = Get-NetAdapter -InterfaceIndex $route.InterfaceIndex "
+                "    -ErrorAction Stop; "
+                "  if ($adapter) { $adapter.Name.ToString() } "
+                "}",
+                fail_on_error=False,
+                force_run=True,
+            ),
+        ).strip()
+        if not interface_name:
+            raise SkippedException(
+                f"Cannot determine the Windows adapter for route to {remote_ip}. "
+                "Verify the Windows host has a route on the passthrough data-path NIC."
+            )
+        return interface_name
+
     def _get_host_nic_name(self, node: RemoteNode) -> str:
-        ip = node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
-        command = "ip route show"
-        routes = node.execute(
-            cmd=command,
+        ip = (
+            node.internal_address
+            or node.connection_info[constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS]
+        )
+        addresses = node.execute(
+            cmd="ip -4 -o addr show",
             sudo=True,
             shell=True,
             expected_exit_code=0,
-            expected_exit_code_failure_message="Can not get IP route",
+            expected_exit_code_failure_message=(
+                f"Cannot list Linux interfaces while resolving data-plane IP [{ip}]."
+            ),
         ).stdout
-
         regex_pattern = re.compile(
-            r"^default.*?dev\s+(?P<interface>\S+).*?src\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s"
+            rf"^\d+:\s+(?P<interface>[^@\s]+)(?:@\S+)?\s+" rf"inet\s+{re.escape(ip)}/"
         )
-        matches = find_groups_in_lines(
-            lines=routes,
+        interface = find_group_in_lines(
+            lines=addresses,
             pattern=regex_pattern,
             single_line=True,
+        ).get("interface", "")
+        if not interface:
+            raise LisaException(
+                f"Cannot find a Linux interface with data-plane IP [{ip}] on "
+                f"node [{node.name}]. Configure passthrough_peer_ip with an address "
+                f"assigned to the peer's physical PCI test NIC. Interfaces: "
+                f"[{addresses[:1000]}]"
+            )
+        return interface
+
+    def _validate_physical_pci_nic(
+        self,
+        node: Node,
+        interface_name: str,
+        endpoint_role: str,
+    ) -> None:
+        nic_details_output = node.execute(
+            cmd=(
+                f"device_path=$(readlink -f /sys/class/net/{interface_name}/device "
+                "2>/dev/null); "
+                "subsystem=; bdf=; pci_class=; driver=; is_vf=false; "
+                "sriov_totalvfs=unavailable; sriov_numvfs=unavailable; "
+                'if [ -n "$device_path" ]; then '
+                'subsystem_path=$(readlink -f "$device_path/subsystem" '
+                "2>/dev/null); subsystem=${subsystem_path##*/}; "
+                "bdf=${device_path##*/}; "
+                'pci_class=$(cat "$device_path/class" 2>/dev/null); '
+                'driver_path=$(readlink -f "$device_path/driver" '
+                "2>/dev/null); driver=${driver_path##*/}; "
+                'if [ -e "$device_path/physfn" ]; then is_vf=true; fi; '
+                'if [ -r "$device_path/sriov_totalvfs" ]; then '
+                'sriov_totalvfs=$(cat "$device_path/sriov_totalvfs"); fi; '
+                'if [ -r "$device_path/sriov_numvfs" ]; then '
+                'sriov_numvfs=$(cat "$device_path/sriov_numvfs"); fi; fi; '
+                "printf '%s\\n' \"device_path=$device_path\" "
+                '"subsystem=$subsystem" "bdf=$bdf" '
+                '"pci_class=$pci_class" "driver=$driver" '
+                '"is_vf=$is_vf" "sriov_totalvfs=$sriov_totalvfs" '
+                '"sriov_numvfs=$sriov_numvfs"'
+            ),
+            sudo=True,
+            shell=True,
+            no_info_log=True,
+            no_error_log=True,
+        ).stdout.strip()
+        nic_details = dict(
+            line.split("=", maxsplit=1)
+            for line in nic_details_output.splitlines()
+            if "=" in line
         )
-        interface_name: str = ""
-        for match in matches:
-            match_ip = match.get("ip", "").strip()
-            if match_ip == ip:
-                interface_name = match.get("interface", "")
-                break
-        assert interface_name, f"Can't get {ip} interface name from: {routes}"
-        return interface_name
+        device_path = nic_details.get("device_path", "")
+        subsystem = nic_details.get("subsystem", "")
+        bdf = nic_details.get("bdf", "")
+        pci_class = nic_details.get("pci_class", "")
+        driver = nic_details.get("driver", "") or "unavailable"
+        is_vf = nic_details.get("is_vf", "false") == "true"
+        sriov_totalvfs = nic_details.get("sriov_totalvfs", "unavailable")
+        sriov_numvfs = nic_details.get("sriov_numvfs", "unavailable")
+
+        node.log.info(
+            f"{endpoint_role.capitalize()} data NIC "
+            f"[{node.name}:{interface_name}] PCI identity: BDF "
+            f"[{bdf or 'unavailable'}], class [{pci_class or 'unavailable'}], "
+            f"driver [{driver}], VF [{is_vf}]"
+        )
+        node.log.info(
+            f"{endpoint_role.capitalize()} data NIC "
+            f"[{node.name}:{interface_name}] SR-IOV state: sriov_totalvfs "
+            f"[{sriov_totalvfs}], sriov_numvfs [{sriov_numvfs}]"
+        )
+
+        is_pci_network_function = (
+            subsystem == "pci"
+            and re.fullmatch(
+                r"[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]", bdf
+            )
+            is not None
+            and pci_class.lower().startswith("0x02")
+        )
+        if not is_pci_network_function:
+            raise SkippedException(
+                f"The {endpoint_role} data NIC [{node.name}:{interface_name}] is "
+                "not a physical PCI network function. Configure the data-plane IP "
+                "on a dedicated physical PCI NIC before running this test. "
+                f"Resolved device path [{device_path or 'unavailable'}], subsystem "
+                f"[{subsystem or 'unavailable'}], class "
+                f"[{pci_class or 'unavailable'}]."
+            )
+        if is_vf:
+            raise SkippedException(
+                f"The {endpoint_role} data NIC [{node.name}:{interface_name}] at "
+                f"BDF [{bdf}] is an SR-IOV virtual function, not a physical "
+                "function. Configure the data-plane IP on a dedicated physical "
+                "PCI NIC before running this test."
+            )
+
+    def _get_cleanup_nodes(self, environment: Environment) -> List[Node]:
+        all_nodes = list(environment.nodes.list())
+        if (
+            environment.platform
+            and environment.platform.type_name() == CLOUD_HYPERVISOR
+        ):
+            platform_host = getattr(environment.platform, "host_node", None)
+            if isinstance(platform_host, Node) and platform_host not in all_nodes:
+                all_nodes.append(platform_host)
+        if self._baremetal_hosts:
+            all_nodes.extend(self._baremetal_hosts)
+        return all_nodes
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")
-
-        # Include baremetal hosts in cleanup.
-        all_nodes = list(environment.nodes.list())
-        if self._baremetal_hosts:
-            all_nodes.extend(self._baremetal_hosts)
+        all_nodes = self._get_cleanup_nodes(environment)
 
         def do_process_cleanup(process: str, node: Node) -> None:
             try:
@@ -1457,5 +2389,7 @@ class NetworkPerformance(TestSuite):
         run_in_parallel(cleanup_tasks)
         run_in_parallel([partial(do_sysctl_cleanup, x) for x in all_nodes])
 
-        # Clear the baremetal hosts list after cleanup
+        for external_host in self._baremetal_hosts:
+            external_host.close()
+            external_host.cleanup()
         self._baremetal_hosts.clear()

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -3,6 +3,7 @@
 import re
 from decimal import Decimal
 from functools import partial
+from ipaddress import AddressValueError, IPv4Address
 from pathlib import Path
 from statistics import median
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union, cast
@@ -37,7 +38,7 @@ from lisa.messages import (
 from lisa.operating_system import Windows
 from lisa.sut_orchestrator import CLOUD_HYPERVISOR, HYPERV, OPENVMM
 from lisa.testsuite import TestResult
-from lisa.tools import Dhclient, Ethtool, Kill, PowerShell, Sysctl
+from lisa.tools import Dhclient, Ethtool, Kill, Lagscope, Lsof, PowerShell, Sysctl
 from lisa.tools.ip import Ip
 from lisa.tools.iperf3 import (
     IPERF_TCP_BUFFER_LENGTHS,
@@ -331,12 +332,15 @@ class NetworkPerformance(TestSuite):
         log_path: Path,
         variables: Dict[str, Any],
         benchmark: PassthroughBenchmark,
+        prepare_ntttcp_tools: bool = False,
     ) -> None:
         guest = cast(RemoteNode, node)
         peer = self._get_passthrough_peer(variables)
         host = self._get_linux_passthrough_host(test_result, node, peer)
         peer_nic_name = self._get_host_nic_name(peer)
         self._validate_physical_pci_nic(peer, peer_nic_name, "remote peer")
+        if prepare_ntttcp_tools:
+            self._prepare_ntttcp_tools([guest, host, peer])
         start_stop = node.features[StartStop]
         host_with_address = cast(Any, host)
         had_host_internal_address = hasattr(host, "internal_address")
@@ -351,6 +355,7 @@ class NetworkPerformance(TestSuite):
             self._validate_physical_pci_nic(
                 host, host_nic_name, "immediate virtualization host"
             )
+            self._set_passthrough_peer_route(host, host_nic_name, peer)
             baseline_runs, profiles = self._collect_host_baseline_runs(
                 benchmark=benchmark,
                 host=host,
@@ -372,6 +377,7 @@ class NetworkPerformance(TestSuite):
                     self._wait_for_guest_start(guest)
 
         guest, guest_nic_name = self._configure_passthrough_nic_for_node(node, log_path)
+        self._set_passthrough_peer_route(guest, guest_nic_name, peer)
         guest_runs = self._collect_guest_throughput_runs(
             benchmark=benchmark,
             guest=guest,
@@ -397,6 +403,28 @@ class NetworkPerformance(TestSuite):
                 )
             )
         test_result.set_status(test_result.status, " | ".join(result_summaries))
+
+    def _prepare_ntttcp_tools(self, nodes: List[Node]) -> None:
+        for benchmark_node in nodes:
+            benchmark_node.tools[Ntttcp]
+            benchmark_node.tools[Lagscope]
+            benchmark_node.tools[Lsof]
+
+    def _set_passthrough_peer_route(
+        self, node: Node, interface_name: str, peer: RemoteNode
+    ) -> None:
+        source_address = cast(Any, node).internal_address
+        node.execute(
+            f"ip route replace {peer.internal_address}/32 "
+            f"dev {interface_name} src {source_address}",
+            sudo=True,
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Failed to route passthrough benchmark peer "
+                f"[{peer.internal_address}] through interface [{interface_name}]."
+            ),
+        )
 
     def _collect_host_baseline_runs(
         self,
@@ -813,6 +841,7 @@ class NetworkPerformance(TestSuite):
             log_path=log_path,
             variables=variables,
             benchmark=run_ntttcp,
+            prepare_ntttcp_tools=True,
         )
 
     @TestCaseMetadata(
@@ -867,6 +896,7 @@ class NetworkPerformance(TestSuite):
             log_path=log_path,
             variables=variables,
             benchmark=run_ntttcp,
+            prepare_ntttcp_tools=True,
         )
 
     # Network device passthrough tests between 2 guests
@@ -1831,7 +1861,7 @@ class NetworkPerformance(TestSuite):
                 )
                 dhcp_cmd = _wrap_aa(dhcp_cmd)
             else:
-                dhcp_cmd = f"dhcpcd -4 -1 -d {interface_name}"
+                dhcp_cmd = f"dhcpcd -4 -1 -d -G -C resolv.conf {interface_name}"
             dhcp_result = node.execute(
                 f"timeout -k 2s 30s {dhcp_cmd}",
                 sudo=True,
@@ -1953,6 +1983,14 @@ class NetworkPerformance(TestSuite):
                 "The peer IP must be assigned to the remote peer's dedicated "
                 "physical PCI test NIC."
             )
+        try:
+            ip = str(IPv4Address(ip))
+        except AddressValueError as identifier:
+            raise SkippedException(
+                f"passthrough_peer_ip [{ip}] is not a valid IPv4 address. "
+                "Configure the IPv4 address assigned to the remote peer's "
+                "dedicated physical PCI test NIC."
+            ) from identifier
 
         peer = RemoteNode(
             runbook=schema.Node(name="passthrough-peer"),

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -1861,7 +1861,7 @@ class NetworkPerformance(TestSuite):
                 )
                 dhcp_cmd = _wrap_aa(dhcp_cmd)
             else:
-                dhcp_cmd = f"dhcpcd -4 -1 -d -G -C resolv.conf {interface_name}"
+                dhcp_cmd = f"dhcpcd -4 -d -G -C resolv.conf {interface_name}"
             dhcp_result = node.execute(
                 f"timeout -k 2s 30s {dhcp_cmd}",
                 sudo=True,
@@ -2384,47 +2384,50 @@ class NetworkPerformance(TestSuite):
             platform_host = getattr(environment.platform, "host_node", None)
             if isinstance(platform_host, Node) and platform_host not in all_nodes:
                 all_nodes.append(platform_host)
-        if self._baremetal_hosts:
-            all_nodes.extend(self._baremetal_hosts)
+        for baremetal_host in self._baremetal_hosts:
+            if baremetal_host not in all_nodes:
+                all_nodes.append(baremetal_host)
         return all_nodes
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")
         all_nodes = self._get_cleanup_nodes(environment)
+        cleanup_processes = ["lagscope", "netperf", "netserver", "ntttcp", "iperf3"]
 
-        def do_process_cleanup(process: str, node: Node) -> None:
-            try:
-                if isinstance(node.os, Windows):
-                    escaped_process = process.replace("'", "''")
-                    node.tools[PowerShell].run_cmdlet(
-                        cmdlet=(
-                            f"$p = Get-Process -Name '{escaped_process}' "
-                            "-ErrorAction SilentlyContinue; "
-                            "if ($p) { $p | Stop-Process -Force "
-                            "-ErrorAction SilentlyContinue }"
-                        ),
-                        fail_on_error=False,
+        def do_process_cleanup(node: Node) -> None:
+            for process in cleanup_processes:
+                try:
+                    if isinstance(node.os, Windows):
+                        escaped_process = process.replace("'", "''")
+                        node.tools[PowerShell].run_cmdlet(
+                            cmdlet=(
+                                f"$p = Get-Process -Name '{escaped_process}' "
+                                "-ErrorAction SilentlyContinue; "
+                                "if ($p) { $p | Stop-Process -Force "
+                                "-ErrorAction SilentlyContinue }"
+                            ),
+                            fail_on_error=False,
+                        )
+                        continue
+
+                    kill = node.tools[Kill]
+                    kill.by_name(process, ignore_not_exist=True)
+                except LisaException as identifier_error:
+                    log.debug(
+                        f"Skipping Kill tool-based cleanup for '{process}' on "
+                        f"node '{node.name}': {identifier_error}"
                     )
-                    return
+                    if isinstance(node.os, Windows):
+                        continue
 
-                kill = node.tools[Kill]
-                kill.by_name(process, ignore_not_exist=True)
-            except LisaException as identifier_error:
-                log.debug(
-                    f"Skipping Kill tool-based cleanup for '{process}' on "
-                    f"node '{node.name}': {identifier_error}"
-                )
-                if isinstance(node.os, Windows):
-                    return
-
-                node.execute(
-                    cmd=(
-                        f"pids=$(pidof {process} 2>/dev/null || true); "
-                        '[ -z "$pids" ] || kill -9 $pids || true'
-                    ),
-                    shell=True,
-                    sudo=True,
-                )
+                    node.execute(
+                        cmd=(
+                            f"pids=$(pidof {process} 2>/dev/null || true); "
+                            '[ -z "$pids" ] || kill -9 $pids || true'
+                        ),
+                        shell=True,
+                        sudo=True,
+                    )
 
         def do_sysctl_cleanup(node: Node) -> None:
             if isinstance(node.os, Windows):
@@ -2437,12 +2440,7 @@ class NetworkPerformance(TestSuite):
                     f"Skipping sysctl cleanup on node '{node.name}': {sysctl_error}"
                 )
 
-        cleanup_tasks: List[Callable[[], None]] = []
-        for process in ["lagscope", "netperf", "netserver", "ntttcp", "iperf3"]:
-            for node in all_nodes:
-                cleanup_tasks.append(partial(do_process_cleanup, process, node))
-
-        run_in_parallel(cleanup_tasks)
+        run_in_parallel([partial(do_process_cleanup, node) for node in all_nodes])
         run_in_parallel([partial(do_sysctl_cleanup, x) for x in all_nodes])
 
         for external_host in self._baremetal_hosts:

--- a/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
+++ b/lisa/microsoft/testsuites/performance/networkperf_passthrough.py
@@ -1384,17 +1384,50 @@ class NetworkPerformance(TestSuite):
                 self._release_passthrough_host_dhcp(host, interface_name)
 
     def _release_passthrough_host_dhcp(self, host: Node, interface_name: str) -> None:
-        dhcp_pid = f"/run/dhclient-{interface_name}.pid"
-        dhcp_lease = f"/var/lib/dhcp/dhclient-{interface_name}.leases"
+        dhcp_client = host.tools[Dhclient].command
+        self._stop_dhcp_on_iface(host, interface_name, dhcp_client)
         host.execute(
-            f"dhclient -r -pf {dhcp_pid} -lf {dhcp_lease} {interface_name} "
-            "2>/dev/null || true; "
-            f"if [ -s {dhcp_pid} ]; then "
-            f'kill "$(cat {dhcp_pid})" 2>/dev/null || true; fi; '
-            f"pkill -f '[d]hclient.*{interface_name}' 2>/dev/null || true; "
-            f"rm -f {dhcp_pid}; "
             f"ip addr flush dev {interface_name} 2>/dev/null || true; "
             f"ip route flush dev {interface_name} 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+
+    def _stop_dhcp_on_iface(
+        self, node: Node, interface_name: str, dhcp_client: str
+    ) -> None:
+        if dhcp_client == "dhcpcd":
+            node.execute(
+                f"dhcpcd -k {interface_name} 2>/dev/null || true",
+                sudo=True,
+                shell=True,
+            )
+            return
+        if dhcp_client != "dhclient":
+            raise LisaException(
+                f"Cannot stop unsupported DHCP client [{dhcp_client}] on "
+                f"interface [{interface_name}]. Install dhclient or dhcpcd and "
+                "retry the passthrough benchmark."
+            )
+
+        dhcp_pid = f"/run/dhclient-{interface_name}.pid"
+        dhcp_lease = f"/var/lib/dhcp/dhclient-{interface_name}.leases"
+        node.execute(
+            f"dhclient -r -pf {dhcp_pid} -lf {dhcp_lease} {interface_name} "
+            "2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+        node.execute(
+            f"if [ -s {dhcp_pid} ]; then "
+            f'kill "$(cat {dhcp_pid})" 2>/dev/null || true; fi; '
+            f"rm -f {dhcp_pid}",
+            sudo=True,
+            shell=True,
+        )
+        node.execute(
+            f"pkill -f '[d]hclient.*[[:space:]]{interface_name}"
+            "([[:space:]]|$)' 2>/dev/null || true",
             sudo=True,
             shell=True,
         )
@@ -1707,14 +1740,12 @@ class NetworkPerformance(TestSuite):
     def _run_dhcp_on_iface(
         self, node: Node, interface_name: str, keep_unmanaged: bool = True
     ) -> Any:
-        """Run dhclient with safety guards and return its result."""
-        # Probe which DHCP client is available via the Dhclient tool.
-        # Our custom -sf hook is dhclient-specific; skip on images with only dhcpcd.
-        dhclient_tool = node.tools[Dhclient]
-        if dhclient_tool.command != "dhclient":
+        """Run the available DHCP client with safety guards."""
+        dhcp_client = node.tools[Dhclient].command
+        if dhcp_client not in ["dhclient", "dhcpcd"]:
             raise SkippedException(
-                f"Passthrough NIC DHCP requires dhclient; "
-                f"found '{dhclient_tool.command}' which is not supported."
+                f"Passthrough NIC DHCP found unsupported client [{dhcp_client}]. "
+                "Install dhclient or dhcpcd before running this test."
             )
         dhcp_pid = f"/run/dhclient-{interface_name}.pid"
         dhcp_lease = f"/var/lib/dhcp/dhclient-{interface_name}.leases"
@@ -1730,7 +1761,8 @@ class NetworkPerformance(TestSuite):
                 "fi'"
             )
 
-        self._install_dhclient_scripts(node, config_script)
+        if dhcp_client == "dhclient":
+            self._install_dhclient_scripts(node, config_script)
 
         # Isolate only the target interface from competing DHCP managers.
         # NM: mark this interface unmanaged instead of stopping the service.
@@ -1786,36 +1818,22 @@ class NetworkPerformance(TestSuite):
                 shell=True,
             )
         try:
-            # Release stale lease and kill leftover dhclient processes.
-            node.execute(
-                f"dhclient -r -pf {dhcp_pid} -lf {dhcp_lease}"
-                f" {interface_name} 2>/dev/null || true",
-                sudo=True,
-                shell=True,
-            )
-            node.execute(
-                f"if [ -s {dhcp_pid} ]; then"
-                f'  kill "$(cat {dhcp_pid})" 2>/dev/null || true; fi'
-                f"; sleep 1"
-                f"; if [ -s {dhcp_pid} ]; then"
-                f'  kill -9 "$(cat {dhcp_pid})" 2>/dev/null || true; fi'
-                f"; rm -f {dhcp_pid}"
-                f"; pkill -f '[d]hclient.*{interface_name}' 2>/dev/null || true",
-                sudo=True,
-                shell=True,
-            )
+            self._stop_dhcp_on_iface(node, interface_name, dhcp_client)
             node.execute(
                 f"ip addr flush dev {interface_name} 2>/dev/null || true",
                 sudo=True,
                 shell=True,
             )
-            # Real dhclient run with minimal config hook.
-            dhcp_cmd = (
-                f"dhclient -v -1 -4 -sf {config_script}"
-                f" -pf {dhcp_pid} -lf {dhcp_lease} {interface_name}"
-            )
+            if dhcp_client == "dhclient":
+                dhcp_cmd = (
+                    f"dhclient -v -1 -4 -sf {config_script}"
+                    f" -pf {dhcp_pid} -lf {dhcp_lease} {interface_name}"
+                )
+                dhcp_cmd = _wrap_aa(dhcp_cmd)
+            else:
+                dhcp_cmd = f"dhcpcd -4 -1 -d {interface_name}"
             dhcp_result = node.execute(
-                f"timeout -k 2s 30s {_wrap_aa(dhcp_cmd)}",
+                f"timeout -k 2s 30s {dhcp_cmd}",
                 sudo=True,
                 shell=True,
                 timeout=45,

--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -366,6 +366,7 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
             is_allow_set=True,
             items=[
                 schema.FeatureSettings.create(SerialConsole.name()),
+                schema.FeatureSettings.create(StartStop.name()),
                 security_profile_setting,
             ],
         )

--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -585,7 +585,9 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
             return
 
         if node_context.console_logger is not None:
-            node_context.console_logger.wait_for_close()
+            # A destroyed domain may not emit the stream hangup event, so abort
+            # the stale console stream before starting the domain again.
+            node_context.console_logger.close()
             node_context.console_logger = None
 
         self._create_domain_and_attach_logger(node_context)

--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -393,7 +393,6 @@ class Iperf3(Tool):
         test_result: "TestResult",
     ) -> NetworkUDPPerformanceMessage:
         client_udp_lost_list: List[Decimal] = []
-        client_intervals_throughput_list: List[Decimal] = []
         client_throughput_list: List[Decimal] = []
         for client_result_raw in client_result_list:
             # remove warning which will bring exception when load json
@@ -406,6 +405,7 @@ class Iperf3(Tool):
                 client_udp_lost_list.append(
                     Decimal(client_result["end"]["sum"]["lost_percent"])
                 )
+                client_intervals_throughput_list: List[Decimal] = []
                 for client_interval in client_result["intervals"]:
                     client_intervals_throughput_list.append(
                         client_interval["sum"]["bits_per_second"]
@@ -420,7 +420,6 @@ class Iperf3(Tool):
                     )
                 )
         server_udp_lost_list: List[Decimal] = []
-        server_intervals_throughput_list: List[Decimal] = []
         server_throughput_list: List[Decimal] = []
         for server_result_raw in server_result_list:
             server_result = json.loads(self._pre_handle(server_result_raw.stdout))
@@ -431,6 +430,7 @@ class Iperf3(Tool):
                 server_udp_lost_list.append(
                     Decimal(server_result["end"]["sum"]["lost_percent"])
                 )
+                server_intervals_throughput_list: List[Decimal] = []
                 for server_interval in server_result["intervals"]:
                     server_intervals_throughput_list.append(
                         server_interval["sum"]["bits_per_second"]
@@ -447,15 +447,11 @@ class Iperf3(Tool):
 
         other_fields: Dict[str, Any] = {}
         other_fields["tool"] = constants.NETWORK_PERFORMANCE_TOOL_IPERF
-        other_fields["tx_throughput_in_gbps"] = Decimal(
-            sum(client_throughput_list) / len(client_throughput_list)
-        )
+        other_fields["tx_throughput_in_gbps"] = Decimal(sum(client_throughput_list))
         other_fields["data_loss"] = Decimal(
             sum(client_udp_lost_list) / len(client_udp_lost_list)
         )
-        other_fields["rx_throughput_in_gbps"] = Decimal(
-            sum(server_throughput_list) / len(server_throughput_list)
-        )
+        other_fields["rx_throughput_in_gbps"] = Decimal(sum(server_throughput_list))
         other_fields["send_buffer_size"] = Decimal(buffer_length)
         other_fields["connections_num"] = connections_num
 

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -54,6 +54,8 @@ class Reboot(Tool):
     def _get_last_boot_time(self) -> datetime:
         try:
             last_boot_time = cast(datetime, _who_last(self.node.tools[Who]))
+        except FunctionTimedOut:
+            last_boot_time = self.node.tools[Uptime].since_time()
         except Exception:
             last_boot_time = self.node.tools[Uptime].since_time()
         return last_boot_time

--- a/selftests/test_libvirt_platform.py
+++ b/selftests/test_libvirt_platform.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from importlib import import_module
+from importlib.util import find_spec
+from typing import Any, cast
+from unittest import TestCase, skipUnless
+
+from lisa.features import StartStop
+
+
+class LibvirtPlatformTestCase(TestCase):
+    @skipUnless(
+        all(
+            find_spec(module_name) is not None
+            for module_name in ["libvirt", "libvirtaio", "pycdlib"]
+        ),
+        "libvirt optional dependencies are not installed",
+    )
+    def test_node_capability_includes_start_stop(self) -> None:
+        platform_module = cast(
+            Any, import_module("lisa.sut_orchestrator.libvirt.platform")
+        )
+        platform_type = platform_module.BaseLibvirtPlatform
+        platform = platform_type.__new__(platform_type)
+        host_capabilities = platform_module._HostCapabilities()
+        host_capabilities.core_count = 8
+
+        node_capabilities = platform._create_node_capabilities(host_capabilities)
+
+        feature_names = {feature.type for feature in node_capabilities.features.items}
+        self.assertIn(StartStop.name(), feature_names)

--- a/selftests/test_libvirt_platform.py
+++ b/selftests/test_libvirt_platform.py
@@ -3,8 +3,10 @@
 
 from importlib import import_module
 from importlib.util import find_spec
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest import TestCase, skipUnless
+from unittest.mock import MagicMock, patch
 
 from lisa.features import StartStop
 
@@ -30,3 +32,35 @@ class LibvirtPlatformTestCase(TestCase):
 
         feature_names = {feature.type for feature in node_capabilities.features.items}
         self.assertIn(StartStop.name(), feature_names)
+
+    @skipUnless(
+        all(
+            find_spec(module_name) is not None
+            for module_name in ["libvirt", "libvirtaio", "pycdlib"]
+        ),
+        "libvirt optional dependencies are not installed",
+    )
+    def test_restart_closes_stale_console_logger(self) -> None:
+        platform_module = cast(
+            Any, import_module("lisa.sut_orchestrator.libvirt.platform")
+        )
+        platform_type = platform_module.BaseLibvirtPlatform
+        platform = platform_type.__new__(platform_type)
+        domain = MagicMock()
+        domain.isActive.return_value = False
+        console_logger = MagicMock()
+        node_context = SimpleNamespace(
+            domain=domain,
+            console_logger=console_logger,
+        )
+        platform._create_domain_and_attach_logger = MagicMock()
+
+        with patch.object(
+            platform_module, "get_node_context", return_value=node_context
+        ):
+            platform.restart_domain_and_attach_logger(MagicMock())
+
+        console_logger.close.assert_called_once_with()
+        console_logger.wait_for_close.assert_not_called()
+        self.assertIsNone(node_context.console_logger)
+        platform._create_domain_and_attach_logger.assert_called_once_with(node_context)

--- a/selftests/test_networkperf_passthrough.py
+++ b/selftests/test_networkperf_passthrough.py
@@ -21,7 +21,7 @@ from microsoft.testsuites.performance.networkperf_passthrough import (
 
 from lisa.features import StartStop
 from lisa.messages import NetworkTCPPerformanceMessage, TransportProtocol
-from lisa.tools import Dhclient
+from lisa.tools import Dhclient, Lagscope, Lsof, Ntttcp
 from lisa.util import LisaException, SkippedException
 
 
@@ -116,6 +116,18 @@ class NetworkPerformancePassthroughTestCase(TestCase):
         with self.assertRaisesRegex(SkippedException, "passthrough_peer_ip"):
             suite._get_passthrough_peer(
                 {
+                    "passthrough_peer_username": "lisa",
+                    "passthrough_peer_private_key_file": "id_rsa",
+                }
+            )
+
+    def test_passthrough_peer_rejects_invalid_peer_ip(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+
+        with self.assertRaisesRegex(SkippedException, "not a valid IPv4 address"):
+            suite._get_passthrough_peer(
+                {
+                    "passthrough_peer_ip": "invalid; command",
                     "passthrough_peer_username": "lisa",
                     "passthrough_peer_private_key_file": "id_rsa",
                 }
@@ -273,7 +285,7 @@ sriov_numvfs=unavailable
 
         def execute(command: str, *_: Any, **__: Any) -> Any:
             result = MagicMock(exit_code=0, stdout="")
-            if "dhcpcd -4 -1 -d eth1" in command:
+            if "dhcpcd -4 -1 -d -G -C resolv.conf eth1" in command:
                 return dhcp_result
             return result
 
@@ -286,7 +298,8 @@ sriov_numvfs=unavailable
         suite._stop_dhcp_on_iface.assert_called_once_with(node, "eth1", "dhcpcd")
         self.assertTrue(
             any(
-                "timeout -k 2s 30s dhcpcd -4 -1 -d eth1" in item.args[0]
+                "timeout -k 2s 30s dhcpcd -4 -1 -d -G -C resolv.conf eth1"
+                in item.args[0]
                 for item in node.execute.call_args_list
             )
         )
@@ -342,6 +355,7 @@ sriov_numvfs=unavailable
         suite._configure_passthrough_nic_for_host = MagicMock(
             side_effect=configure_host_nic
         )
+        suite._set_passthrough_peer_route = MagicMock()
         suite._collect_host_baseline_runs = MagicMock(
             side_effect=LisaException("baseline collection failed")
         )
@@ -363,6 +377,9 @@ sriov_numvfs=unavailable
                 call(peer, "peer-data-nic", "remote peer"),
                 call(host, "host-data-nic", "immediate virtualization host"),
             ]
+        )
+        suite._set_passthrough_peer_route.assert_called_once_with(
+            host, "host-data-nic", peer
         )
         suite._release_passthrough_host_dhcp.assert_called_once_with(
             host, "host-data-nic"
@@ -390,6 +407,7 @@ sriov_numvfs=unavailable
         suite._configure_passthrough_nic_for_host = MagicMock(
             side_effect=configure_host_nic
         )
+        suite._set_passthrough_peer_route = MagicMock()
         suite._collect_host_baseline_runs = MagicMock(
             side_effect=LisaException("baseline collection failed")
         )
@@ -411,6 +429,40 @@ sriov_numvfs=unavailable
         start_stop.start.assert_called_once_with()
         suite._wait_for_guest_start.assert_called_once_with(guest)
         self.assertFalse(hasattr(host, "internal_address"))
+
+    def test_passthrough_peer_route_uses_data_interface_and_source(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        source_address = "192.0.2.11"
+        peer_address = "192.0.2.10"
+        node = MagicMock()
+        node.internal_address = source_address
+        peer = MagicMock()
+        peer.internal_address = peer_address
+
+        suite._set_passthrough_peer_route(node, "eth1", peer)
+
+        node.execute.assert_called_once_with(
+            f"ip route replace {peer_address}/32 dev eth1 src {source_address}",
+            sudo=True,
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Failed to route passthrough benchmark peer [{peer_address}] "
+                "through interface [eth1]."
+            ),
+        )
+
+    def test_ntttcp_tools_are_prepared_before_passthrough_handoff(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        nodes = [MagicMock(), MagicMock(), MagicMock()]
+
+        suite._prepare_ntttcp_tools(nodes)
+
+        for node in nodes:
+            self.assertEqual(
+                [call(Ntttcp), call(Lagscope), call(Lsof)],
+                node.tools.__getitem__.call_args_list,
+            )
 
     def test_passthrough_baseline_accepts_exactly_95_percent(self) -> None:
         summary = self._assert_baseline(

--- a/selftests/test_networkperf_passthrough.py
+++ b/selftests/test_networkperf_passthrough.py
@@ -21,6 +21,7 @@ from microsoft.testsuites.performance.networkperf_passthrough import (
 
 from lisa.features import StartStop
 from lisa.messages import NetworkTCPPerformanceMessage, TransportProtocol
+from lisa.tools import Dhclient
 from lisa.util import LisaException, SkippedException
 
 
@@ -231,6 +232,94 @@ sriov_numvfs=unavailable
 
         with self.assertRaisesRegex(SkippedException, "SR-IOV virtual function"):
             suite._validate_physical_pci_nic(node, "enp1s0f1", "remote peer")
+
+    def test_dhclient_cleanup_does_not_self_match(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+
+        suite._stop_dhcp_on_iface(node, "eth1", "dhclient")
+
+        commands = [item.args[0] for item in node.execute.call_args_list]
+        self.assertEqual(3, len(commands))
+        self.assertIn("dhclient -r", commands[0])
+        self.assertNotIn("pkill", commands[0])
+        self.assertIn("dhclient-eth1.pid", commands[1])
+        self.assertNotIn("pkill", commands[1])
+        self.assertEqual(
+            "pkill -f '[d]hclient.*[[:space:]]eth1([[:space:]]|$)' "
+            "2>/dev/null || true",
+            commands[2],
+        )
+
+    def test_dhcpcd_cleanup_releases_only_target_interface(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+
+        suite._stop_dhcp_on_iface(node, "eth1", "dhcpcd")
+
+        node.execute.assert_called_once_with(
+            "dhcpcd -k eth1 2>/dev/null || true",
+            sudo=True,
+            shell=True,
+        )
+
+    def test_dhcp_supports_dhcpcd(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        suite._install_dhclient_scripts = MagicMock()
+        suite._stop_dhcp_on_iface = MagicMock()
+        node = MagicMock()
+        node.tools = {Dhclient: SimpleNamespace(command="dhcpcd")}
+        dhcp_result = MagicMock(exit_code=0, stdout="configured")
+
+        def execute(command: str, *_: Any, **__: Any) -> Any:
+            result = MagicMock(exit_code=0, stdout="")
+            if "dhcpcd -4 -1 -d eth1" in command:
+                return dhcp_result
+            return result
+
+        node.execute.side_effect = execute
+
+        result = suite._run_dhcp_on_iface(node, "eth1")
+
+        self.assertIs(dhcp_result, result)
+        suite._install_dhclient_scripts.assert_not_called()
+        suite._stop_dhcp_on_iface.assert_called_once_with(node, "eth1", "dhcpcd")
+        self.assertTrue(
+            any(
+                "timeout -k 2s 30s dhcpcd -4 -1 -d eth1" in item.args[0]
+                for item in node.execute.call_args_list
+            )
+        )
+
+    def test_dhcp_preserves_dhclient_config_hook(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        suite._install_dhclient_scripts = MagicMock()
+        suite._stop_dhcp_on_iface = MagicMock()
+        node = MagicMock()
+        node.tools = {Dhclient: SimpleNamespace(command="dhclient")}
+        dhcp_result = MagicMock(exit_code=0, stdout="configured")
+
+        def execute(command: str, *_: Any, **__: Any) -> Any:
+            result = MagicMock(exit_code=0, stdout="")
+            if "dhclient -v -1 -4 -sf" in command:
+                return dhcp_result
+            return result
+
+        node.execute.side_effect = execute
+
+        result = suite._run_dhcp_on_iface(node, "eth1")
+
+        self.assertIs(dhcp_result, result)
+        suite._install_dhclient_scripts.assert_called_once_with(
+            node, "/usr/local/bin/lisa-dhclient-config"
+        )
+        suite._stop_dhcp_on_iface.assert_called_once_with(node, "eth1", "dhclient")
+        self.assertTrue(
+            any(
+                "aa-exec -p unconfined -- dhclient -v -1 -4 -sf" in item.args[0]
+                for item in node.execute.call_args_list
+            )
+        )
 
     def test_baseline_failure_restarts_guest_and_restores_host_address(self) -> None:
         suite = self._suite_type.__new__(self._suite_type)

--- a/selftests/test_networkperf_passthrough.py
+++ b/selftests/test_networkperf_passthrough.py
@@ -21,7 +21,7 @@ from microsoft.testsuites.performance.networkperf_passthrough import (
 
 from lisa.features import StartStop
 from lisa.messages import NetworkTCPPerformanceMessage, TransportProtocol
-from lisa.tools import Dhclient, Lagscope, Lsof, Ntttcp
+from lisa.tools import Dhclient, Kill, Lagscope, Lsof, Ntttcp, Sysctl
 from lisa.util import LisaException, SkippedException
 
 
@@ -275,7 +275,7 @@ sriov_numvfs=unavailable
             shell=True,
         )
 
-    def test_dhcp_supports_dhcpcd(self) -> None:
+    def test_dhcp_keeps_dhcpcd_running_for_lease_renewal(self) -> None:
         suite = self._suite_type.__new__(self._suite_type)
         suite._install_dhclient_scripts = MagicMock()
         suite._stop_dhcp_on_iface = MagicMock()
@@ -285,7 +285,7 @@ sriov_numvfs=unavailable
 
         def execute(command: str, *_: Any, **__: Any) -> Any:
             result = MagicMock(exit_code=0, stdout="")
-            if "dhcpcd -4 -1 -d -G -C resolv.conf eth1" in command:
+            if "dhcpcd -4 -d -G -C resolv.conf eth1" in command:
                 return dhcp_result
             return result
 
@@ -298,10 +298,12 @@ sriov_numvfs=unavailable
         suite._stop_dhcp_on_iface.assert_called_once_with(node, "eth1", "dhcpcd")
         self.assertTrue(
             any(
-                "timeout -k 2s 30s dhcpcd -4 -1 -d -G -C resolv.conf eth1"
-                in item.args[0]
+                "timeout -k 2s 30s dhcpcd -4 -d -G -C resolv.conf eth1" in item.args[0]
                 for item in node.execute.call_args_list
             )
+        )
+        self.assertFalse(
+            any("dhcpcd -4 -1" in item.args[0] for item in node.execute.call_args_list)
         )
 
     def test_dhcp_preserves_dhclient_config_hook(self) -> None:
@@ -463,6 +465,51 @@ sriov_numvfs=unavailable
                 [call(Ntttcp), call(Lagscope), call(Lsof)],
                 node.tools.__getitem__.call_args_list,
             )
+
+    def test_cleanup_nodes_deduplicate_baremetal_host(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+        environment = MagicMock()
+        environment.nodes.list.return_value = [node]
+        environment.platform = None
+        suite._baremetal_hosts = [node]
+
+        self.assertEqual([node], suite._get_cleanup_nodes(environment))
+
+    def test_after_case_cleans_processes_sequentially_per_node(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        nodes = [MagicMock(name="node-0"), MagicMock(name="node-1")]
+        kills = [MagicMock(), MagicMock()]
+        sysctls = [MagicMock(), MagicMock()]
+        for node, kill, sysctl in zip(nodes, kills, sysctls):
+            node.tools.__getitem__.side_effect = {
+                Kill: kill,
+                Sysctl: sysctl,
+            }.__getitem__
+        suite._get_cleanup_nodes = MagicMock(return_value=nodes)
+        suite._baremetal_hosts = []
+        task_counts = []
+
+        def run_tasks(tasks: Any) -> None:
+            task_counts.append(len(tasks))
+            for task in tasks:
+                task()
+
+        with patch(
+            "microsoft.testsuites.performance.networkperf_passthrough."
+            "run_in_parallel",
+            side_effect=run_tasks,
+        ):
+            suite.after_case(log=MagicMock(), environment=MagicMock())
+
+        self.assertEqual([2, 2], task_counts)
+        expected_processes = [
+            call(process, ignore_not_exist=True)
+            for process in ["lagscope", "netperf", "netserver", "ntttcp", "iperf3"]
+        ]
+        for kill, sysctl in zip(kills, sysctls):
+            self.assertEqual(expected_processes, kill.by_name.call_args_list)
+            sysctl.reset.assert_called_once_with()
 
     def test_passthrough_baseline_accepts_exactly_95_percent(self) -> None:
         summary = self._assert_baseline(

--- a/selftests/test_networkperf_passthrough.py
+++ b/selftests/test_networkperf_passthrough.py
@@ -1,0 +1,384 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+from microsoft.testsuites.performance.common import (
+    _set_iperf_udp_max_sessions,
+    get_nic_datapath,
+)
+from microsoft.testsuites.performance.networkperf_passthrough import (
+    NetworkPerformance,
+    _filter_throughput_profile,
+    _get_median_throughput_by_profile,
+    _select_best_throughput_profile,
+)
+
+from lisa.features import StartStop
+from lisa.messages import NetworkTCPPerformanceMessage, TransportProtocol
+from lisa.util import LisaException, SkippedException
+
+
+class NetworkPerformancePassthroughTestCase(TestCase):
+    _suite_type = cast(Any, NetworkPerformance).__wrapped__
+
+    def test_missing_nic_datapath_returns_empty(self) -> None:
+        node = MagicMock()
+        node.capability.network_interface = None
+
+        self.assertEqual("", get_nic_datapath(node))
+
+    def test_udp_session_tuning_skips_local_node(self) -> None:
+        node = MagicMock()
+        node.is_remote = False
+        node.tools.__getitem__.side_effect = AssertionError(
+            "local endpoint should not access the SSH tool"
+        )
+
+        _set_iperf_udp_max_sessions([node])
+
+        node.tools.__getitem__.assert_not_called()
+
+    def test_median_throughput_keeps_profiles_matched(self) -> None:
+        runs = [
+            [
+                self._create_tcp_message(1, 65536, throughput),
+                self._create_tcp_message(4, 65536, throughput * 2),
+            ]
+            for throughput in [Decimal("9"), Decimal("11"), Decimal("10")]
+        ]
+
+        medians = _get_median_throughput_by_profile(runs)
+
+        single_connection = next(
+            value for profile, value in medians.items() if profile[2] == 1
+        )
+        four_connections = next(
+            value for profile, value in medians.items() if profile[2] == 4
+        )
+        self.assertEqual(Decimal("10"), single_connection[0])
+        self.assertEqual(Decimal("20"), four_connections[0])
+
+    def test_median_throughput_distinguishes_buffer_sizes(self) -> None:
+        runs = [
+            [
+                self._create_tcp_message(1, 32768, Decimal("8")),
+                self._create_tcp_message(1, 65536, Decimal("10")),
+            ]
+            for _ in range(3)
+        ]
+
+        medians = _get_median_throughput_by_profile(runs)
+
+        self.assertEqual(2, len(medians))
+
+    def test_median_throughput_rejects_incomplete_sweep(self) -> None:
+        runs = [
+            [self._create_tcp_message(1, 65536, Decimal("10"))],
+            [self._create_tcp_message(1, 65536, Decimal("11"))],
+            [],
+        ]
+
+        with self.assertRaisesRegex(
+            LisaException, r"reported \[2\] samples across \[3\] runs"
+        ):
+            _get_median_throughput_by_profile(runs)
+
+    def test_tuning_sweep_selects_and_filters_best_profile(self) -> None:
+        messages = [
+            self._create_tcp_message(1, 65536, Decimal("10")),
+            self._create_tcp_message(4, 65536, Decimal("18")),
+        ]
+
+        profile = _select_best_throughput_profile(messages)
+        matching = _filter_throughput_profile(messages, profile)
+
+        self.assertEqual(4, profile[2])
+        self.assertEqual([messages[1]], matching)
+
+    def test_tuning_sweep_rejects_zero_throughput(self) -> None:
+        messages = [self._create_tcp_message(1, 65536, Decimal("0"))]
+
+        with self.assertRaisesRegex(
+            LisaException, "did not report any delivered Gbps samples"
+        ):
+            _select_best_throughput_profile(messages)
+
+    def test_passthrough_peer_requires_peer_ip(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+
+        with self.assertRaisesRegex(SkippedException, "passthrough_peer_ip"):
+            suite._get_passthrough_peer(
+                {
+                    "passthrough_peer_username": "lisa",
+                    "passthrough_peer_private_key_file": "id_rsa",
+                }
+            )
+
+    def test_passthrough_peer_uses_peer_ip_for_benchmark_traffic(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        suite._baremetal_hosts = []
+        peer = MagicMock()
+        peer.os = MagicMock()
+
+        with patch(
+            "microsoft.testsuites.performance.networkperf_passthrough.RemoteNode",
+            return_value=peer,
+        ):
+            result = suite._get_passthrough_peer(
+                {
+                    "passthrough_peer_ip": "192.0.2.10",
+                    "passthrough_peer_username": "lisa",
+                    "passthrough_peer_private_key_file": "id_rsa",
+                }
+            )
+
+        self.assertIs(peer, result)
+        self.assertEqual("192.0.2.10", peer.internal_address)
+        peer.set_connection_info.assert_called_once_with(
+            address="192.0.2.10",
+            public_address="192.0.2.10",
+            public_port=22,
+            username="lisa",
+            password="",
+            private_key_file="id_rsa",
+        )
+
+    def test_physical_pci_nic_accepts_pf_without_sriov_controls(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+        node.name = "peer"
+        node.execute.return_value.stdout = """\
+device_path=/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0
+subsystem=pci
+bdf=0000:01:00.0
+pci_class=0x020000
+driver=i40e
+is_vf=false
+sriov_totalvfs=unavailable
+sriov_numvfs=unavailable
+"""
+
+        suite._validate_physical_pci_nic(node, "enp1s0f0", "remote peer")
+
+        self.assertEqual(2, node.log.info.call_count)
+        self.assertIn("BDF [0000:01:00.0]", node.log.info.call_args_list[0].args[0])
+        self.assertIn(
+            "sriov_totalvfs [unavailable]", node.log.info.call_args_list[1].args[0]
+        )
+
+    def test_physical_pci_nic_accepts_pf_with_zero_total_vfs(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+        node.name = "peer"
+        node.execute.return_value.stdout = """\
+device_path=/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.0
+subsystem=pci
+bdf=0000:01:00.0
+pci_class=0x020000
+driver=i40e
+is_vf=false
+sriov_totalvfs=0
+sriov_numvfs=0
+"""
+
+        suite._validate_physical_pci_nic(node, "enp1s0f0", "remote peer")
+
+        self.assertIn(
+            "sriov_totalvfs [0], sriov_numvfs [0]",
+            node.log.info.call_args_list[1].args[0],
+        )
+
+    def test_physical_pci_nic_rejects_virtual_nic(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+        node.name = "peer"
+        node.execute.return_value.stdout = """\
+device_path=/sys/devices/virtual/net/eth0
+subsystem=virtual
+bdf=eth0
+pci_class=
+driver=hv_netvsc
+is_vf=false
+sriov_totalvfs=unavailable
+sriov_numvfs=unavailable
+"""
+
+        with self.assertRaisesRegex(
+            SkippedException, "not a physical PCI network function"
+        ):
+            suite._validate_physical_pci_nic(node, "eth0", "remote peer")
+
+    def test_physical_pci_nic_rejects_virtual_function(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        node = MagicMock()
+        node.name = "peer"
+        node.execute.return_value.stdout = """\
+device_path=/sys/devices/pci0000:00/0000:00:01.0/0000:01:00.1
+subsystem=pci
+bdf=0000:01:00.1
+pci_class=0x020000
+driver=iavf
+is_vf=true
+sriov_totalvfs=unavailable
+sriov_numvfs=unavailable
+"""
+
+        with self.assertRaisesRegex(SkippedException, "SR-IOV virtual function"):
+            suite._validate_physical_pci_nic(node, "enp1s0f1", "remote peer")
+
+    def test_baseline_failure_restarts_guest_and_restores_host_address(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        start_stop = MagicMock()
+        guest = MagicMock()
+        guest.features = {StartStop: start_stop}
+        peer = MagicMock()
+        host = MagicMock()
+        host.internal_address = "management-address"
+
+        suite._get_passthrough_peer = MagicMock(return_value=peer)
+        suite._get_linux_passthrough_host = MagicMock(return_value=host)
+        suite._get_host_nic_name = MagicMock(return_value="peer-data-nic")
+        suite._validate_physical_pci_nic = MagicMock()
+
+        def configure_host_nic(*_: Any) -> Any:
+            host.internal_address = "host-data-address"
+            return host, "host-data-nic"
+
+        suite._configure_passthrough_nic_for_host = MagicMock(
+            side_effect=configure_host_nic
+        )
+        suite._collect_host_baseline_runs = MagicMock(
+            side_effect=LisaException("baseline collection failed")
+        )
+        suite._release_passthrough_host_dhcp = MagicMock()
+        suite._wait_for_guest_start = MagicMock()
+
+        with self.assertRaisesRegex(LisaException, "baseline collection failed"):
+            suite._run_measured_passthrough_benchmark(
+                node=guest,
+                test_result=MagicMock(),
+                log_path=Path("."),
+                variables={},
+                benchmark=MagicMock(),
+            )
+
+        start_stop.stop.assert_called_once_with()
+        suite._validate_physical_pci_nic.assert_has_calls(
+            [
+                call(peer, "peer-data-nic", "remote peer"),
+                call(host, "host-data-nic", "immediate virtualization host"),
+            ]
+        )
+        suite._release_passthrough_host_dhcp.assert_called_once_with(
+            host, "host-data-nic"
+        )
+        start_stop.start.assert_called_once_with()
+        suite._wait_for_guest_start.assert_called_once_with(guest)
+        self.assertEqual("management-address", host.internal_address)
+
+    def test_baseline_failure_removes_temporary_local_host_address(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        start_stop = MagicMock()
+        guest = MagicMock()
+        guest.features = {StartStop: start_stop}
+        host = SimpleNamespace()
+
+        suite._get_passthrough_peer = MagicMock(return_value=MagicMock())
+        suite._get_linux_passthrough_host = MagicMock(return_value=host)
+        suite._get_host_nic_name = MagicMock(return_value="peer-data-nic")
+        suite._validate_physical_pci_nic = MagicMock()
+
+        def configure_host_nic(*_: Any) -> Any:
+            host.internal_address = "host-data-address"
+            return host, "host-data-nic"
+
+        suite._configure_passthrough_nic_for_host = MagicMock(
+            side_effect=configure_host_nic
+        )
+        suite._collect_host_baseline_runs = MagicMock(
+            side_effect=LisaException("baseline collection failed")
+        )
+        suite._release_passthrough_host_dhcp = MagicMock()
+        suite._wait_for_guest_start = MagicMock()
+
+        with self.assertRaisesRegex(LisaException, "baseline collection failed"):
+            suite._run_measured_passthrough_benchmark(
+                node=guest,
+                test_result=MagicMock(),
+                log_path=Path("."),
+                variables={},
+                benchmark=MagicMock(),
+            )
+
+        suite._release_passthrough_host_dhcp.assert_called_once_with(
+            host, "host-data-nic"
+        )
+        start_stop.start.assert_called_once_with()
+        suite._wait_for_guest_start.assert_called_once_with(guest)
+        self.assertFalse(hasattr(host, "internal_address"))
+
+    def test_passthrough_baseline_accepts_exactly_95_percent(self) -> None:
+        summary = self._assert_baseline(
+            baseline_gbps=Decimal("10"), guest_gbps=Decimal("9.5")
+        )
+
+        self.assertIn("95.00%", summary)
+
+    def test_passthrough_baseline_rejects_below_95_percent(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "must be at least 95%"):
+            self._assert_baseline(
+                baseline_gbps=Decimal("10"), guest_gbps=Decimal("9.49")
+            )
+
+    def _assert_baseline(self, baseline_gbps: Decimal, guest_gbps: Decimal) -> str:
+        suite = self._suite_type.__new__(self._suite_type)
+        baseline_runs = [
+            [self._create_tcp_message(1, 65536, baseline_gbps)] for _ in range(3)
+        ]
+        guest_runs = [
+            [self._create_tcp_message(1, 65536, guest_gbps)] for _ in range(3)
+        ]
+        guest = MagicMock(name="guest")
+        guest.name = "guest"
+        host = MagicMock(name="host")
+        host.name = "host"
+        peer = MagicMock(name="peer")
+        peer.name = "peer"
+
+        with patch(
+            "microsoft.testsuites.performance.networkperf_passthrough."
+            "send_unified_perf_message"
+        ):
+            summary: str = suite._assert_passthrough_baseline(
+                test_result=MagicMock(),
+                baseline_runs=baseline_runs,
+                guest_runs=guest_runs,
+                direction="guest-to-peer",
+                guest=guest,
+                guest_nic_name="guest-data-nic",
+                host=host,
+                host_nic_name="host-data-nic",
+                peer=peer,
+                peer_nic_name="peer-data-nic",
+            )
+            return summary
+
+    @staticmethod
+    def _create_tcp_message(
+        connections: int,
+        buffer_size: int,
+        throughput_gbps: Decimal,
+    ) -> NetworkTCPPerformanceMessage:
+        return NetworkTCPPerformanceMessage(
+            tool="iperf3",
+            protocol_type=TransportProtocol.Tcp,
+            connections_num=connections,
+            buffer_size_bytes=Decimal(buffer_size),
+            rx_throughput_in_gbps=throughput_gbps,
+        )


### PR DESCRIPTION
Add line-rate threshold validation for passthrough network performance tests.

Drive UDP iperf tests at the requested line rate so pass and fail decisions use the intended target.

Report the achieved line-rate percentage for passing tests so results expose the measured margin, not only failures.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
