### PR TITLE
Fix Texinfo source fallback

### DIFF
--- a/lisa/tools/texinfo.py
+++ b/lisa/tools/texinfo.py
@@ -26,11 +26,23 @@ class Texinfo(Tool):
     def _install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
         try:
-            posix_os.install_packages("texinfo", timeout=2000)
+            if posix_os.is_package_in_repo("texinfo"):
+                posix_os.install_packages("texinfo", timeout=2000)
+            else:
+                self._install_from_src_with_dependencies(posix_os)
         except MissingPackagesException:
-            posix_os.install_packages(["perl", "perl-Data-Dumper"])
-            self._install_from_src()
+            self._install_from_src_with_dependencies(posix_os)
         return self._check_exists()
+
+    def _install_from_src_with_dependencies(self, posix_os: Posix) -> None:
+        source_packages = [
+            package
+            for package in ["perl", "perl-Data-Dumper"]
+            if posix_os.is_package_in_repo(package)
+        ]
+        if source_packages:
+            posix_os.install_packages(source_packages)
+        self._install_from_src()
 
     def _install_from_src(self) -> None:
         tool_path = self.get_tool_path()


### PR DESCRIPTION
Check distro package availability before installing texinfo so images without a candidate package use the source-build fallback instead of failing during apt install.

Install only available fallback dependency packages before building from source, which keeps Ubuntu images from failing on RPM-only package names such as perl-Data-Dumper.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
