### PR TITLE
Add dual NIC passthrough validation

### DIFF
--- a/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
+++ b/lisa/microsoft/testsuites/device_passthrough/functional_tests.py
@@ -47,7 +47,9 @@ SUPPORTED_PASSTHROUGH_PLATFORMS = [CLOUD_HYPERVISOR, HYPERV, OPENVMM]
 class DevicePassthroughFunctionalTests(TestSuite):
     @TestCaseMetadata(
         description="""
-            Check if passthrough device is visible to guest.
+            Check if all passthrough devices requested in the runbook are visible
+            to the guest.
+
             This testcase supports the CLOUD_HYPERVISOR, HYPERV, and OPENVMM
             platforms of LISA. Please refer below runbook snippet.
 
@@ -68,14 +70,15 @@ class DevicePassthroughFunctionalTests(TestSuite):
 
             We will check if sufficient devices are visible to guest or not.
             Platform will create device pool based on given device/vendor id.
-            'device_passthrough' section will tell platform to create node
-            with appropriate num of devices being passthrough. Based on pool_type
-            value, platform will try to get devices from pool and assign it to node.
+            The 'device_passthrough' section tells the platform how many devices
+            to assign. Based on the pool_type value, the platform gets devices
+            from the pool and assigns them to the node.
+            The count can be any positive value supported by the device pool.
 
-            Testcase will verify if needed devices are present on node by reading
-            the runtime passthrough device context. It will resolve vendor/device
-            ids for assigned host devices and check how many matching devices are
-            present on the guest.
+            Testcase verifies every device assigned by the platform. It reads the
+            runtime passthrough device context, resolves the vendor/device ids for
+            all assigned host devices, and checks that the guest contains at least
+            the same number of matching devices.
         """,
         priority=4,
         requirement=simple_requirement(
@@ -109,37 +112,69 @@ class DevicePassthroughFunctionalTests(TestSuite):
                 "No host node is available for passthrough device validation"
             )
 
-        expected_devices: Dict[Tuple[str, str, str], int] = {}
+        expected_devices: Dict[Tuple[str, str], Dict[str, int]] = {}
+        pool_counts: Dict[str, Dict[str, int]] = {}
         for passthrough_context in node_context.passthrough_devices:
             pool_type = str(passthrough_context.pool_type.value)
-            if not passthrough_context.device_list:
+            requested_count = passthrough_context.requested_count
+            assigned_count = len(passthrough_context.device_list)
+            if requested_count <= 0:
                 raise LisaException(
-                    f"No devices assigned to node for pool type: {pool_type}"
+                    f"Invalid requested device count '{requested_count}' for "
+                    f"pool type '{pool_type}'. Set device_passthrough.count to "
+                    "a positive value in the runbook."
                 )
+            if assigned_count < requested_count:
+                raise LisaException(
+                    f"Passthrough device allocation for pool type '{pool_type}' "
+                    f"requested {requested_count} device(s), but assigned "
+                    f"{assigned_count}. Inspect the platform device-allocation logs."
+                )
+            counts = pool_counts.setdefault(
+                pool_type,
+                {"requested": 0, "assigned": 0},
+            )
+            counts["requested"] += requested_count
+            counts["assigned"] += assigned_count
             for host_device in passthrough_context.device_list:
                 vendor_device_id = self._vendor_device_from_host_device(
                     platform_name, platform, host_node, host_device
                 )
                 key = (
-                    pool_type,
                     vendor_device_id["vendor_id"],
                     vendor_device_id["device_id"],
                 )
-                expected_devices[key] = expected_devices.get(key, 0) + 1
+                expected_pool_counts = expected_devices.setdefault(key, {})
+                expected_pool_counts[pool_type] = (
+                    expected_pool_counts.get(pool_type, 0) + 1
+                )
 
-        for (pool_type, ven_id, dev_id), expected_count in expected_devices.items():
+        for (ven_id, dev_id), expected_pool_counts in expected_devices.items():
+            expected_count = sum(expected_pool_counts.values())
             devices = lspci.get_devices_by_vendor_device_id(
                 vendor_id=ven_id,
                 device_id=dev_id,
                 force_run=True,
             )
-            if len(devices) < expected_count:
-                raise LisaException(
-                    f"Passthrough device validation failed for "
-                    f"pool_type '{pool_type}': Found {len(devices)} "
-                    f"device(s) but expected {expected_count}. "
-                    f"Vendor/Device ID: {ven_id}:{dev_id}"
+            matching_guest_count = len(devices)
+            if matching_guest_count < expected_count:
+                pool_details = ", ".join(
+                    f"{pool_type}={count}"
+                    for pool_type, count in sorted(expected_pool_counts.items())
                 )
+                raise LisaException(
+                    f"Passthrough device validation failed: Found "
+                    f"{matching_guest_count} device(s) but expected "
+                    f"{expected_count} for Vendor/Device ID {ven_id}:{dev_id}. "
+                    f"Assigned pool counts: {pool_details}."
+                )
+
+        result.message = "Passthrough devices tested: " + "; ".join(
+            f"{pool_type}: requested={counts['requested']}, "
+            f"assigned={counts['assigned']}, "
+            f"verified={counts['assigned']}"
+            for pool_type, counts in sorted(pool_counts.items())
+        )
 
     @staticmethod
     def _get_platform_name(platform: Platform, node: Node) -> str:

--- a/lisa/sut_orchestrator/hyperv/context.py
+++ b/lisa/sut_orchestrator/hyperv/context.py
@@ -17,6 +17,7 @@ class DevicePassthroughContext:
     device_list: List[DeviceAddressSchema] = field(
         default_factory=list,
     )
+    requested_count: int = 0
 
 
 @dataclass

--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -561,6 +561,14 @@ Get-VM | ForEach-Object {{
     ) -> None:
         if not node_runbook.device_passthrough:
             return
+        for config in node_runbook.device_passthrough:
+            if config.count <= 0:
+                raise LisaException(
+                    "Hyper-V device_passthrough count must be greater than 0 "
+                    f"for pool type '{config.pool_type.value}'. Set "
+                    "device_passthrough.count to a positive value in the runbook."
+                )
+
         hv.enable_device_passthrough(name=vm_name)
 
         for config in node_runbook.device_passthrough:

--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -574,5 +574,6 @@ Get-VM | ForEach-Object {{
             )
             device_context = DevicePassthroughContext()
             device_context.pool_type = config.pool_type
+            device_context.requested_count = config.count
             device_context.device_list = devices
             node_context.passthrough_devices.append(device_context)

--- a/lisa/sut_orchestrator/libvirt/context.py
+++ b/lisa/sut_orchestrator/libvirt/context.py
@@ -42,6 +42,7 @@ class DevicePassthroughContext:
         default_factory=list,
     )
     managed: str = ""
+    requested_count: int = 0
 
 
 @dataclass

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -640,6 +640,7 @@ class LibvirtDevicePool(BaseDevicePool):
             device_context = DevicePassthroughContext()
             device_context.managed = config.managed
             device_context.pool_type = config.pool_type
+            device_context.requested_count = config.count
             devices = self.request_devices(config.pool_type, config.count)
             device_context.device_list = devices
             node_context.passthrough_devices.append(device_context)

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -637,6 +637,14 @@ class LibvirtDevicePool(BaseDevicePool):
         if not node_runbook.device_passthrough:
             return
         for config in node_runbook.device_passthrough:
+            if config.count <= 0:
+                raise LisaException(
+                    "Libvirt device_passthrough count must be greater than 0 "
+                    f"for pool type '{config.pool_type.value}'. Set "
+                    "device_passthrough.count to a positive value in the runbook."
+                )
+
+        for config in node_runbook.device_passthrough:
             device_context = DevicePassthroughContext()
             device_context.managed = config.managed
             device_context.pool_type = config.pool_type

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -38,6 +38,7 @@ class DevicePassthroughContext:
     pool_type: HostDevicePoolType = HostDevicePoolType.PCI_NIC
     device_list: List[DeviceAddressSchema] = field(default_factory=list)
     managed: str = ""
+    requested_count: int = 0
 
 
 @dataclass

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -498,6 +498,7 @@ class OpenVmmController:
                     device_context = DevicePassthroughContext(
                         managed=config.managed,
                         pool_type=config.pool_type,
+                        requested_count=config.count,
                         device_list=[
                             DeviceAddressSchema(
                                 domain=device.domain,


### PR DESCRIPTION
- Record the requested runbook count in the runtime passthrough context for:
  - Cloud Hypervisor/libvirt
  - Hyper-V
  - OpenVMM
- Validate that each passthrough request has a positive device count.
- Reject invalid libvirt and Hyper-V counts before allocating devices or modifying the VM.
- Fail the functional test when fewer devices are assigned than requested.
- Allow additional assigned devices when a complete IOMMU group must be passed through.
- Verify that every assigned vendor/device ID is visible in the guest.
- Aggregate identical vendor/device IDs globally so one guest device cannot satisfy multiple assigned entries.
- Report requested, assigned, and verified counts by pool type in passed console and HTML results.

Example:

`Passthrough devices tested: pci_net: requested=2, assigned=2, verified=2`

Existing resource-exhaustion behavior is preserved, and this change does not modify two-guest performance tests or runner requirement precedence.


## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
