### PR TITLE
test(vm_extensions): add CustomScript boot validation test case

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -18,6 +18,7 @@ from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
 from lisa import (
     Logger,
     Node,
+    SkippedException,
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
@@ -127,25 +128,29 @@ class CustomScriptTests(TestSuite):
         extension_type: str = variables.get("extension_type", "CustomScript").strip()
         version: str = variables.get("extension_version", "").strip()
 
+        if not version:
+            raise SkippedException(
+                "Required runbook variable 'extension_version' is missing or "
+                "empty. Please set it in the runbook before running this test "
+                "case."
+            )
+
         extension_name = f"{publisher}_{extension_type}_boot_validation_test"
         settings = {"commandToExecute": "echo 'CSE test success'"}
-
-        create_kwargs: Dict[str, Any] = {
-            "name": extension_name,
-            "publisher": publisher,
-            "type_": extension_type,
-            "auto_upgrade_minor_version": True,
-            "settings": settings,
-        }
-        if version:
-            create_kwargs["type_handler_version"] = version
 
         extension = node.features[AzureExtension]
         extension.delete(name=extension_name, ignore_not_found=True)
 
         try:
             log.info(f"Installing extension '{extension_name}'...")
-            result = extension.create_or_update(**create_kwargs)
+            result = extension.create_or_update(
+                name=extension_name,
+                publisher=publisher,
+                type_=extension_type,
+                type_handler_version=version,
+                auto_upgrade_minor_version=True,
+                settings=settings,
+            )
 
             assert_that(result["provisioning_state"]).described_as(
                 "Expected the extension to succeed"

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -116,7 +116,7 @@ class CustomScriptTests(TestSuite):
         Custom Script extension. The deployed extension is named
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
-        priority=1,
+        priority=5,
     )
     def microsoft_azure_extensions_customscript_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -133,21 +133,22 @@ class CustomScriptTests(TestSuite):
         extension = node.features[AzureExtension]
         extension.delete(name=extension_name, ignore_not_found=True)
 
-        log.info(f"Installing extension '{extension_name}'...")
-        result = extension.create_or_update(
-            name=extension_name,
-            publisher=publisher,
-            type_=extension_type,
-            type_handler_version=version,
-            auto_upgrade_minor_version=True,
-            settings=settings,
-        )
+        try:
+            log.info(f"Installing extension '{extension_name}'...")
+            result = extension.create_or_update(
+                name=extension_name,
+                publisher=publisher,
+                type_=extension_type,
+                type_handler_version=version,
+                auto_upgrade_minor_version=True,
+                settings=settings,
+            )
 
-        assert_that(result["provisioning_state"]).described_as(
-            "Expected the extension to succeed"
-        ).is_equal_to("Succeeded")
-
-        extension.delete(name=extension_name, ignore_not_found=True)
+            assert_that(result["provisioning_state"]).described_as(
+                "Expected the extension to succeed"
+            ).is_equal_to("Succeeded")
+        finally:
+            extension.delete(name=extension_name, ignore_not_found=True)
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -125,24 +125,27 @@ class CustomScriptTests(TestSuite):
             "extension_publisher", "Microsoft.Azure.Extensions"
         ).strip()
         extension_type: str = variables.get("extension_type", "CustomScript").strip()
-        version: str = variables.get("extension_version", "2.1").strip()
+        version: str = variables.get("extension_version", "").strip()
 
         extension_name = f"{publisher}_{extension_type}_boot_validation_test"
         settings = {"commandToExecute": "echo 'CSE test success'"}
+
+        create_kwargs: Dict[str, Any] = {
+            "name": extension_name,
+            "publisher": publisher,
+            "type_": extension_type,
+            "auto_upgrade_minor_version": True,
+            "settings": settings,
+        }
+        if version:
+            create_kwargs["type_handler_version"] = version
 
         extension = node.features[AzureExtension]
         extension.delete(name=extension_name, ignore_not_found=True)
 
         try:
             log.info(f"Installing extension '{extension_name}'...")
-            result = extension.create_or_update(
-                name=extension_name,
-                publisher=publisher,
-                type_=extension_type,
-                type_handler_version=version,
-                auto_upgrade_minor_version=True,
-                settings=settings,
-            )
+            result = extension.create_or_update(**create_kwargs)
 
             assert_that(result["provisioning_state"]).described_as(
                 "Expected the extension to succeed"

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -105,6 +105,52 @@ class CustomScriptTests(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        Basic boot validation for the Custom Script VM extension.
+
+        Installs the extension with a single inline commandToExecute and no file
+        uris, so it needs no storage account or public blob access. Verifies that
+        provisioning succeeds, then removes the extension.
+
+        The extension publisher, type and version are read from runbook variables
+        (extension_publisher, extension_type, extension_version), defaulting to the
+        Custom Script extension. The deployed extension is named
+        '<publisher>_<extension_type>_boot_validation_test'.
+        """,
+        priority=1,
+    )
+    def microsoft_azure_extensions_customscript_boot_validation_test(
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        publisher: str = variables.get(
+            "extension_publisher", "Microsoft.Azure.Extensions"
+        ).strip()
+        extension_type: str = variables.get("extension_type", "CustomScript").strip()
+        version: str = variables.get("extension_version", "2.1").strip()
+
+        extension_name = f"{publisher}_{extension_type}_boot_validation_test"
+        settings = {"commandToExecute": "echo 'CSE test success'"}
+
+        extension = node.features[AzureExtension]
+        extension.delete(name=extension_name, ignore_not_found=True)
+
+        log.info(f"Installing extension '{extension_name}'...")
+        result = extension.create_or_update(
+            name=extension_name,
+            publisher=publisher,
+            type_=extension_type,
+            type_handler_version=version,
+            auto_upgrade_minor_version=True,
+            settings=settings,
+        )
+
+        assert_that(result["provisioning_state"]).described_as(
+            "Expected the extension to succeed"
+        ).is_equal_to("Succeeded")
+
+        extension.delete(name=extension_name, ignore_not_found=True)
+
+    @TestCaseMetadata(
+        description="""
         Runs the Custom Script VM extension with a public Azure storage file uri.
 
         Downgrading priority from 1 to 5. Due to the requirement for blob public access,


### PR DESCRIPTION
## What
Adds a minimal, self-contained **Custom Script VM extension boot validation** test case to `CustomScriptTests` (`lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py`).

## Details
- Installs the extension with a single inline `commandToExecute` (`echo 'CSE test success'`) and **no** `fileUris` — so it requires **no storage account and no public blob access** (unlike the existing public/private cases that were downgraded to priority 5 due to blob public-access restrictions).
- Asserts `provisioning_state == "Succeeded"`, then removes the extension.
- Publisher / type / version are read from runbook variables (`extension_publisher`, `extension_type`, `extension_version`), defaulting to the Custom Script extension — same pattern as `GenericVmExtension.verify_vm_extension_install_uninstall`.
- Deployed extension instance name follows `<publisher>_<extension_type>_boot_validation_test`.

## Testing
Ran end-to-end on Azure (Ubuntu 22.04, real VM deploy):
```
CustomScriptTests.microsoft_azure_extensions_customscript_boot_validation_test: PASSED
FAILED: 0  PASSED: 1  SKIPPED: 0
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>