### PR TITLE
[AI Generated] BugFix: Add retry logic to nvidia-smi for NVML initialization delay

### DIFF
--- a/lisa/tools/gpu_smi.py
+++ b/lisa/tools/gpu_smi.py
@@ -5,7 +5,12 @@ import re
 from typing import List, Type
 
 from lisa.executable import Tool
-from lisa.util import LisaException, find_groups_in_lines
+from lisa.util import (
+    LisaException,
+    LisaTimeoutException,
+    check_till_timeout,
+    find_groups_in_lines,
+)
 
 
 class GpuSmi(Tool):
@@ -39,17 +44,62 @@ class NvidiaSmi(GpuSmi):
         return False
 
     def get_gpu_count(self) -> int:
-        result = self.run("-L")
-        if result.exit_code != 0 or (result.exit_code == 0 and result.stdout == ""):
-            result = self.run("-L", sudo=True)
+        # After driver installation and reboot, NVML may not be ready
+        # immediately. Exit code 9 means "NVML uninitialized" — a transient
+        # condition that resolves once the GPU finishes initialising.
+        # Retry with delays to accommodate large GPU SKUs (e.g. H100).
+        last_result = None
+
+        def _try_nvidia_smi() -> bool:
+            nonlocal last_result
+            result = self.run("-L", force_run=True)
             if result.exit_code != 0 or (result.exit_code == 0 and result.stdout == ""):
+                result = self.run("-L", sudo=True, force_run=True)
+            last_result = result
+            if result.exit_code == 0 and result.stdout != "":
+                return True
+            # Only retry on exit code 9 (NVML uninitialized); fail fast
+            # for non-transient errors (e.g. command not found, driver missing).
+            if result.exit_code not in (0, 9):
                 raise LisaException(
-                    f"nvidia-smi command exited with exit_code {result.exit_code}"
+                    f"nvidia-smi -L failed with non-transient exit_code "
+                    f"{result.exit_code}. stderr: '{result.stderr}'. "
+                    f"stdout: '{result.stdout}'"
                 )
+            self._log.debug(
+                f"nvidia-smi returned exit_code {result.exit_code}, "
+                f"waiting for NVML initialization..."
+            )
+            return False
+
+        try:
+            check_till_timeout(
+                _try_nvidia_smi,
+                timeout_message=(
+                    "nvidia-smi -L timed out waiting for NVML initialization. "
+                    "Verify the NVIDIA driver is installed and NVML is initialized."
+                ),
+                timeout=300,  # 10 attempts * 30s interval = 5 minutes max wait
+                interval=30,
+            )
+        except LisaTimeoutException:
+            if last_result is not None:
+                raise LisaException(
+                    "nvidia-smi -L failed after retries. "
+                    f"exit_code={last_result.exit_code}, "
+                    f"stderr='{last_result.stderr}', "
+                    f"stdout='{last_result.stdout}'. "
+                    "Verify the NVIDIA driver is installed "
+                    "and NVML is initialized."
+                ) from None
+            raise
+
+        if last_result is None:
+            raise LisaException("nvidia-smi -L was not executed")
         gpu_types = [x[0] for x in self.gpu_devices]
         device_count = 0
         for gpu_type in gpu_types:
-            device_count += result.stdout.count(gpu_type)
+            device_count += last_result.stdout.count(gpu_type)
 
         return device_count
 


### PR DESCRIPTION
## Problem

GPU tests fail intermittently with `nvidia-smi command exited with exit_code 9` (NVML Uninitialized). This occurs when NVML is not yet ready after GPU driver install + reboot, particularly on H100 (NCC40ads_H100_v5) and V100 (NC6s_v3) SKUs, and intermittently on T4 (NC4as_T4_v3).

## Root Cause

`NvidiaSmi.get_gpu_count()` in `lisa/tools/gpu_smi.py` had no retry logic. After driver installation and VM reboot, NVML may need additional time to initialize. The single-attempt call to `nvidia-smi -L` would fail with exit_code 9 and immediately raise a `LisaException`.

Additionally, LISA's tool execution layer (`executable.py`) caches command results by default. Any naive retry loop without `force_run=True` would return the same cached failure on every attempt.

## Fix

- Added retry loop to `get_gpu_count()`: up to 10 retries with 30-second delays (5 minutes max wait)
- Used `force_run=True` on each `self.run()` call to bypass LISA's tool result cache
- Added debug logging for each retry attempt

## Validation

- **Bug reproduced on T4**: Earlier run without `force_run=True` hit exit_code 9, confirmed cached retries failed → test FAILED
- **Fix validated**: 5/5 sequential runs on Standard_NC4as_T4_v3 / eastus2 all PASSED
- **Lint clean**: black, flake8, pylint (10/10), mypy — all pass