### PR TITLE
fix(network): exclude InfiniBand NICs from skip_if_pci_only_nics guard

### DIFF
--- a/lisa/microsoft/testsuites/network/common.py
+++ b/lisa/microsoft/testsuites/network/common.py
@@ -409,9 +409,19 @@ def skip_if_no_synthetic_nics(node: Node) -> None:
 
 
 def skip_if_pci_only_nics(environment: Environment) -> None:
-    """Skip test if any node has PCI-only NICs (AN without synthetic pairing)."""
+    """Skip test if any node has PCI-only NICs (AN without synthetic pairing).
+
+    InfiniBand NICs are PCI passthrough by design and are not part of the
+    SRIOV/AN Ethernet disable/enable path, so they are excluded from this check.
+    """
     for node in environment.nodes.list():
         for nic in node.nics.nics.values():
+            # InfiniBand NICs are always PCI-only (no synthetic pairing) and are
+            # not the target of SRIOV disable/enable tests. Skipping on them would
+            # incorrectly skip VMs that also have a valid synthetic+VF Ethernet
+            # pair, so exclude them here (consistent with get_pci_nics(exclude_ib)).
+            if nic.is_infiniband:
+                continue
             if nic.is_pci_only_nic:
                 raise SkippedException(
                     f"SRIOV disable/enable test not applicable for "


### PR DESCRIPTION
`skip_if_pci_only_nics()` now ignores InfiniBand interfaces when deciding whether to skip SRIOV disable/enable tests. Only genuine PCI-only **Ethernet** data NICs (Accelerated Networking without synthetic pairing) trigger the skip.

On ND/GPU SKUs that carry both a synthetic+VF Ethernet pair and InfiniBand NICs, `verify_sriov_disable_enable_pci` was being incorrectly skipped:

> SkippedException: SRIOV disable/enable test not applicable for PCI-only NIC ib0 on node ...

The `is_pci_only_nic` property returns `True` for any NIC with a PCI slot, no `lower` device, and a non-`hv_netvsc` module — which is exactly how IB NICs (`ib0`–`ib3`, mlx5) present. So the presence of unrelated IB interfaces caused the guard to skip VMs that actually had a fully testable SRIOV pair (e.g. `eth0` synthetic + `eth1` VF, same MAC).

Skip NICs where `nic.is_infiniband` before the `is_pci_only_nic` check, consistent with the existing `exclude_ib` convention already used by `get_pci_nics(exclude_ib=True)` and `get_device_slots(exclude_ib=True)`.

- IB-equipped Ethernet-SRIOV VMs now correctly run `verify_sriov_disable_enable_pci` instead of being skipped.
- Pure PCI-only Ethernet configurations (no synthetic pairing) still skip as intended.
- No change to non-IB SKUs.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [X] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
Sriov, Infiniband, NetworkInterface

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_ND128isr_GB300_v6| PASSED|
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D2s_v4| PASSED|
