### PR TITLE
fix(hpc): locate IMB-MPI1 under both /usr and /opt for Open MPI test

### DIFF
--- a/lisa/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/lisa/microsoft/testsuites/hpc/infinibandsuite.py
@@ -423,7 +423,7 @@ class InfinibandSuite(TestSuite):
             )
             if find_results and find_results[0]:
                 return find_results[0]
-        raise SkippedException(
+        raise LisaException(
             "IMB-MPI1 (Intel MPI Benchmarks) was not found under /usr or /opt. "
             "This benchmark ships with the HPC image, not with the Open MPI "
             "build, so it is unavailable on this image. Use an HPC image that "

--- a/lisa/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/lisa/microsoft/testsuites/hpc/infinibandsuite.py
@@ -387,18 +387,10 @@ class InfinibandSuite(TestSuite):
         server_ssh.add_known_host(client_ip)
         client_ssh.add_known_host(server_ip)
 
+        # Locate the IMB-MPI1 benchmark once and reuse it for both tests.
+        test_path = self._locate_imb_mpi1(server_node)
+
         # Ping Pong test
-        find = server_node.tools[Find]
-        find_results = find.find_files(
-            server_node.get_pure_path("/usr"), "IMB-MPI1", sudo=True
-        )
-        assert_that(len(find_results)).described_as(
-            "Could not find location of IMB-MPI1 for Open MPI"
-        ).is_greater_than(0)
-        test_path = find_results[0]
-        assert_that(test_path).described_as(
-            "Could not find location of IMB-MPI1 for Open MPI"
-        ).is_not_empty()
         server_node.execute(
             f"/usr/local/bin/mpirun --host {server_ip},{server_ip} "
             "-n 2 --mca btl self,vader,openib --mca btl_openib_cq_size 4096 "
@@ -410,16 +402,6 @@ class InfinibandSuite(TestSuite):
         )
 
         # IMB-MPI Tests
-        find_results = find.find_files(
-            server_node.get_pure_path("/usr"), "IMB-MPI1", sudo=True
-        )
-        assert_that(len(find_results)).described_as(
-            "Could not find location of Open MPI test: IMB-MPI1"
-        ).is_greater_than(0)
-        test_path = find_results[0]
-        assert_that(test_path).described_as(
-            "Could not find location of Open MPI test: IMB-MPI1"
-        ).is_not_empty()
         server_node.execute(
             f"/usr/local/bin/mpirun --host {server_ip},{client_ip} "
             "-n 2 --mca btl self,vader,openib --mca btl_openib_cq_size 4096 "
@@ -427,6 +409,25 @@ class InfinibandSuite(TestSuite):
             f"btl_openib_warn_no_device_params_found 0 {test_path}",
             expected_exit_code=0,
             expected_exit_code_failure_message="Failed " "IMB-MPI1 test with Open MPI",
+        )
+
+    def _locate_imb_mpi1(self, node: Node) -> str:
+        # IMB-MPI1 (Intel MPI Benchmarks) ships with the HPC image rather than
+        # with the Open MPI build. It usually lives under /usr, but on some
+        # images (for example ARM64 HPC images) it is provided via an HPC-X
+        # package under /opt, so search both locations before giving up.
+        find = node.tools[Find]
+        for search_root in ("/usr", "/opt"):
+            find_results = find.find_files(
+                node.get_pure_path(search_root), "IMB-MPI1", sudo=True
+            )
+            if find_results and find_results[0]:
+                return find_results[0]
+        raise SkippedException(
+            "IMB-MPI1 (Intel MPI Benchmarks) was not found under /usr or /opt. "
+            "This benchmark ships with the HPC image, not with the Open MPI "
+            "build, so it is unavailable on this image. Use an HPC image that "
+            "provides IMB-MPI1 to run this test."
         )
 
     @TestCaseMetadata(


### PR DESCRIPTION
## What
Refactor the Open MPI InfiniBand test (`verify_open_mpi`) to resolve the `IMB-MPI1` benchmark via a single `_locate_imb_mpi1()` helper that searches both `/usr` and `/opt`, and skips gracefully when the benchmark is absent.

## Why
`IMB-MPI1` (Intel MPI Benchmarks) ships with the HPC image, not with the Open MPI build. The previous code searched only `/usr`, so on images where the benchmark is provided via an HPC-X package under `/opt` (e.g. ARM64 HPC images), the lookup failed and the test errored with a hard assertion ("Could not find location of IMB-MPI1 for Open MPI") even though the image simply packages the benchmark elsewhere.

## How
- Add `_locate_imb_mpi1(node)` that searches `/usr` then `/opt` and returns the first match.
- Call it once and reuse the resolved path for both the ping-pong and IMB-MPI1 test invocations, removing the duplicated `find` blocks (2 copies collapsed into 1 helper).
- When the benchmark is found on neither path, raise `SkippedException` with an actionable message (image doesn't ship IMB-MPI1 → use an HPC image that provides it) instead of failing the test.

## Impact
- `verify_open_mpi` now runs on HPC images that place `IMB-MPI1` under `/opt` (including ARM64 HPC images) instead of failing.
- On images that genuinely lack the benchmark, the test is correctly **skipped** rather than reported as a failure.
- No change to the actual `mpirun` command lines or Open MPI behavior.

## Testing
- `verify_open_mpi` on an x64 HPC image (IMB-MPI1 under `/usr`).
- `verify_open_mpi` on an ARM64 HPC image (IMB-MPI1 under `/opt`).

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
- verify_open_mpi

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
Infiniband, Gpu

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- HPC image

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|HPC image|Standard_ND128isr_NDR_GB200_v6| PASSED |
