### PR TITLE
fix(gpu): report actual vs expected GPU PCI count in provision-check assertion

### DIFF
--- a/lisa/microsoft/testsuites/gpu/gpusuite.py
+++ b/lisa/microsoft/testsuites/gpu/gpusuite.py
@@ -427,7 +427,8 @@ def _gpu_provision_check(min_pci_count: int, node: Node, log: Logger) -> None:
     init_gpu = lspci.get_gpu_devices(force_run=True)
     log.debug(f"Initial GPU count {len(init_gpu)}")
     assert_that(len(init_gpu)).described_as(
-        "Number of GPU PCI device is not greater than 0"
+        f"Detected GPU PCI device count {len(init_gpu)} is less than the "
+        f"expected minimum {min_pci_count}"
     ).is_greater_than_or_equal_to(min_pci_count)
 
     node.reboot()


### PR DESCRIPTION
## What
Replace the static GPU provisioning assertion message in `_gpu_provision_check` with a dynamic one that reports the actual detected GPU PCI device count and the expected minimum.

## Why
The assertion checks `len(init_gpu) >= min_pci_count`, but the failure message was hardcoded to "Number of GPU PCI device is not greater than 0". This is misleading: when `min_pci_count > 0`, the reported reason didn't match the actual check, making triage harder (e.g. detected 2 GPUs but expected 4 still printed "not greater than 0"). The message should reflect the real detected and expected values.

## How
Update the `.described_as(...)` text to include `len(init_gpu)` (detected count) and `min_pci_count` (expected minimum):

> Detected GPU PCI device count {n} is less than the expected minimum {min}

No change to the assertion logic (`is_greater_than_or_equal_to(min_pci_count)`) or control flow.

## Impact
- Clearer, accurate failure diagnostics for GPU provisioning checks.
- No behavioral change to which cases pass or fail.

## Testing
- GPU provisioning validation on a GPU SKU.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
- verify_gpu_provision

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
Gpu

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest


## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_NC4as_T4_v3| PASSED|
