### PR TITLE
fix(libvirt): give cloud-hypervisor source build a dedicated timeout

### DIFF
--- a/lisa/sut_orchestrator/libvirt/transformers.py
+++ b/lisa/sut_orchestrator/libvirt/transformers.py
@@ -28,6 +28,10 @@ CLOUD_HYPERVISOR_RELEASE_REF_PATTERN = re.compile(r"^v\d+(?:\.\d+)*(?:[-+].*)?$"
 # Rustup downloads the full Rust toolchain. Bare-metal lab network throughput can
 # be slow enough to exceed the generic 600-second command timeout.
 RUSTUP_INSTALL_TIMEOUT_SECONDS = 1800
+# A from-scratch release build of cloud-hypervisor compiles vendored native crates
+# (openssl-src, zstd-sys, libssh2-sys) that can exceed the generic 600-second
+# command timeout on a cold cache or a slow bare-metal agent.
+CLOUD_HYPERVISOR_BUILD_TIMEOUT_SECONDS = 1800
 
 
 @dataclass_json()
@@ -488,6 +492,7 @@ class CloudHypervisorSourceInstaller(CloudHypervisorInstaller):
             shell=True,
             sudo=False,
             cwd=code_path,
+            timeout=CLOUD_HYPERVISOR_BUILD_TIMEOUT_SECONDS,
             expected_exit_code=0,
             expected_exit_code_failure_message="Failed to build cloud-hypervisor",
         )


### PR DESCRIPTION
CloudHypervisorSourceInstaller ran `cargo build --release` with LISA's default 600-second command timeout. A cold, from-scratch release build compiles vendored native crates -- openssl-src (which builds OpenSSL from C source), zstd-sys and libssh2-sys -- that can exceed 600s on a slow bare-metal agent or a cold cache.

Observed in  job the build was killed at 600.223s while only 140/243 crates in, raising "AssertionError: Failed to build cloud-hypervisor" and failing the job before any test ran.

Add CLOUD_HYPERVISOR_BUILD_TIMEOUT_SECONDS = 1800 (mirroring RUSTUP_INSTALL_TIMEOUT_SECONDS) and pass it to the build execute so a legitimately-long build is not killed prematurely.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
