### PR TITLE
Fix docker-compose install: bump to v2.29.7 for Docker API 1.44+ compatibility

### DIFF
--- a/lisa/tools/docker_compose.py
+++ b/lisa/tools/docker_compose.py
@@ -53,8 +53,8 @@ class DockerCompose(Tool):
         hardware = uname_tool.get_linux_information().hardware_platform
         filename = "docker-compose"
         wget_tool.run(
-            "https://github.com/docker/compose/releases/download/v2.14.2"
-            f"/docker-compose-Linux-{hardware} -O {filename}",
+            "https://github.com/docker/compose/releases/download/v2.29.7"
+            f"/docker-compose-linux-{hardware} -O {filename}",
             sudo=True,
         )
         self.node.execute(f"sudo chmod +x {filename}")


### PR DESCRIPTION


Problem:
        verify_docker_compose_wordpress_app (and other docker-compose tests) fail with:

    The DockerCompose tool hardcoded the standalone binary v2.14.2 (Dec 2022), which negotiates Docker API 1.42. Newer Docker Engine builds (v25+) dropped support for API < 1.44, so the pinned client is rejected before any container is created.

Root Cause:
    Stale version pin in docker_compose.py:55-59. All install paths (Redhat, CBLMariner, generic Posix fallback) route through _install_from_source(), so every affected distro hit the failure.

Change:
    Bumped docker-compose from v2.14.2 → v2.29.7 (negotiates API ≥ 1.44).
    Updated the release asset name from docker-compose-Linux-{hardware} → docker-compose-linux-{hardware} (Compose v2 renamed the asset to lowercase linux; the old capitalized path 404s on the new release).

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
- verify_docker_compose_wordpress_app

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D2lds_v5| PASSED |
