### PR TITLE
fix(network): raise timeout to 7200s for max-nics stop/start stress tests on large VMs

### DIFF
--- a/lisa/microsoft/testsuites/network/stress.py
+++ b/lisa/microsoft/testsuites/network/stress.py
@@ -157,6 +157,9 @@ class Stress(TestSuite):
         5. Repeat step 3 and 4 for 10 times.
         """,
         priority=2,
+        # Each of the 10 reboot cycles can take several minutes on large VMs
+        # (e.g. GB200-class SKUs), so the default 3600s timeout is insufficient.
+        timeout=7200,
         requirement=simple_requirement(
             network_interface=schema.NetworkInterfaceOptionSettings(
                 nic_count=IntRange(min=2, choose_max_value=True),
@@ -189,6 +192,9 @@ class Stress(TestSuite):
         5. Repeat step 3 and 4 for 10 times.
         """,
         priority=2,
+        # Each of the 10 restart cycles can take several minutes on large VMs
+        # (e.g. GB200-class SKUs), so the default 3600s timeout is insufficient.
+        timeout=7200,
         requirement=simple_requirement(
             network_interface=schema.NetworkInterfaceOptionSettings(
                 nic_count=IntRange(min=2, choose_max_value=True),
@@ -222,6 +228,9 @@ class Stress(TestSuite):
         5. Repeat step 3 and 4 for 10 times.
         """,
         priority=2,
+        # Each of the 10 stop/start cycles can take several minutes on large VMs
+        # (e.g. GB200-class SKUs), so the default 3600s timeout is insufficient.
+        timeout=7200,
         requirement=simple_requirement(
             network_interface=schema.NetworkInterfaceOptionSettings(
                 nic_count=IntRange(min=2, choose_max_value=True),


### PR DESCRIPTION
…ests on large VMs

### Problem

`stress_synthetic_with_max_nics_stop_start_from_platform` fails with `TimeoutError: time out in 3600 seconds` on large VMs such as `Standard_ND128is_GB300_v6` (GB200 NVL, ARM64).

The failure is **not** a product bug — the VM stops/starts and re-enumerates NICs correctly on every cycle. The test simply runs out of wall-clock time:

- The test loops **10 times** doing `StartStop.stop()` + `StartStop.start()` + NIC verification.
- On large GB200-class SKUs each cycle takes ~7 min (deallocate ~2.5 min, allocate/boot + NIC check ~4.5 min).
- The `@TestCaseMetadata` had **no `timeout=`**, so it inherited the framework default of **3600 s (1 hour)**.
- 10 cycles need ~72 min. The run completed **8 of 10** cycles cleanly, then was killed mid-loop by the 1-hour timeout.

### Fix

Add an explicit `timeout=7200` to the three synthetic max-nics stress tests that loop 10× over platform stop/start or restart:

- `stress_synthetic_provision_with_max_nics_reboot`
- `stress_synthetic_with_max_nics_reboot_from_platform`
- `stress_synthetic_with_max_nics_stop_start_from_platform`

This matches the pattern already used by `stress_sriov_disable_enable` (`timeout=4500`) in the same suite, sizing the timeout for slow large VMs without reducing iteration count / coverage.


## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
stress_synthetic_with_max_nics_stop_start_from_platform|stress_synthetic_with_max_nics_reboot_from_platform|stress_synthetic_provision_with_max_nics_reboot

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
StartStop, NetworkInterface

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical:ubuntu-24_04-lts:server-arm64:latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical:ubuntu-24_04-lts:server-arm64:latest|Standard_D64plds_v6| PASSED / FAILED / SKIPPED |
