### PR TITLE
Fix package tool errors and KillUserProcesses setup on Azure Linux/Mariner

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2252,7 +2252,7 @@ class CBLMariner(RPMDistro):
 
     def __init__(self, node: Any) -> None:
         super().__init__(node)
-        self._dnf_tool_name: str
+        self._dnf_tool_name: str = ""
 
     def _initialize_package_installation(self) -> None:
         self.set_kill_user_processes()
@@ -2265,6 +2265,12 @@ class CBLMariner(RPMDistro):
         self._dnf_tool_name = "tdnf -q"
 
     def _dnf_tool(self) -> str:
+        # The tool name is resolved lazily by _initialize_package_installation,
+        # which runs on the install path but not on the update path. Ensure it is
+        # resolved here so callers such as _update_packages work regardless of
+        # which path runs first.
+        if not self._dnf_tool_name:
+            self._initialize_package_installation()
         return self._dnf_tool_name
 
     def _package_exists(self, package: str) -> bool:

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2334,7 +2334,7 @@ class CBLMariner(RPMDistro):
         dropin_dir = self._node.get_pure_path("/etc/systemd/logind.conf.d")
         dropin_path = dropin_dir / "99-lisa-kill-user-processes.conf"
         self._node.execute(
-            f"mkdir -p {dropin_dir}",
+            f'mkdir -p "{dropin_dir}"',
             sudo=True,
             expected_exit_code=0,
             expected_exit_code_failure_message=f"Failed to create {dropin_dir}",

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2256,21 +2256,21 @@ class CBLMariner(RPMDistro):
 
     def _initialize_package_installation(self) -> None:
         self.set_kill_user_processes()
-
-        result = self._node.execute("command -v dnf", no_info_log=True, shell=True)
-        if result.exit_code == 0:
-            self._dnf_tool_name = "dnf"
-            return
-
-        self._dnf_tool_name = "tdnf -q"
+        # Resolve the package tool name (dnf or tdnf) for later use.
+        self._dnf_tool()
 
     def _dnf_tool(self) -> str:
-        # The tool name is resolved lazily by _initialize_package_installation,
-        # which runs on the install path but not on the update path. Ensure it is
-        # resolved here so callers such as _update_packages work regardless of
-        # which path runs first.
+        # Resolve the package tool name lazily on first use and cache it.
+        # _initialize_package_installation sets it on the install path, but
+        # callers such as _update_packages reach here without going through
+        # that path. Detect it directly here rather than calling
+        # _initialize_package_installation, which would restart systemd-logind
+        # as a side effect and could recurse back into this method.
         if not self._dnf_tool_name:
-            self._initialize_package_installation()
+            result = self._node.execute(
+                "command -v dnf", no_info_log=True, shell=True
+            )
+            self._dnf_tool_name = "dnf" if result.exit_code == 0 else "tdnf -q"
         return self._dnf_tool_name
 
     def _package_exists(self, package: str) -> bool:
@@ -2325,45 +2325,37 @@ class CBLMariner(RPMDistro):
     # Disable KillUserProcesses to avoid test processes being terminated when
     # the SSH session is reset
     def set_kill_user_processes(self) -> None:
-        logind_conf = "/etc/systemd/logind.conf"
-        if self._node.shell.exists(self._node.get_pure_path(logind_conf)):
-            # The stock logind.conf already contains a [Login] section, so a
-            # bare key can be appended to it.
-            sed = self._node.tools[Sed]
-            sed.append(
-                text="KillUserProcesses=no",
-                file=logind_conf,
-                sudo=True,
-            )
-        else:
-            # On some distros (e.g. Azure Linux 4.0) /etc/systemd/logind.conf
-            # does not exist by default, so appending to it fails. Write a
-            # systemd drop-in instead, which is honored without the base file
-            # and must carry its own [Login] section header.
-            from lisa.tools import Echo
+        # Write the setting as a systemd drop-in rather than editing
+        # /etc/systemd/logind.conf directly. A drop-in is honored uniformly
+        # across all Azure Linux/Mariner versions, including those where the
+        # base logind.conf does not exist by default (e.g. Azure Linux 4.0),
+        # and it must carry its own [Login] section header. The file is
+        # rewritten from scratch each time, so the operation is idempotent.
+        from lisa.tools import Echo
 
-            dropin_dir = "/etc/systemd/logind.conf.d"
-            dropin_file = f"{dropin_dir}/99-lisa-kill-user-processes.conf"
-            self._node.execute(
-                f"mkdir -p {dropin_dir}",
-                sudo=True,
-                expected_exit_code=0,
-                expected_exit_code_failure_message=(
-                    f"Failed to create {dropin_dir}"
-                ),
-            )
-            echo = self._node.tools[Echo]
-            echo.write_to_file(
-                "[Login]",
-                self._node.get_pure_path(dropin_file),
-                sudo=True,
-            )
-            echo.write_to_file(
-                "KillUserProcesses=no",
-                self._node.get_pure_path(dropin_file),
-                sudo=True,
-                append=True,
-            )
+        dropin_dir = "/etc/systemd/logind.conf.d"
+        dropin_file = f"{dropin_dir}/99-lisa-kill-user-processes.conf"
+        self._node.execute(
+            f"mkdir -p {dropin_dir}",
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=f"Failed to create {dropin_dir}",
+        )
+        echo = self._node.tools[Echo]
+        dropin_path = self._node.get_pure_path(dropin_file)
+        echo.write_to_file(
+            "[Login]",
+            dropin_path,
+            sudo=True,
+            ignore_error=False,
+        )
+        echo.write_to_file(
+            "KillUserProcesses=no",
+            dropin_path,
+            sudo=True,
+            append=True,
+            ignore_error=False,
+        )
         self._node.tools[Service].restart_service("systemd-logind")
 
     def _replace_default_entry(self, entry: str) -> None:

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -228,7 +228,8 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None: ...
+    def capture_system_information(self, saved_path: Path) -> None:
+        ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -739,7 +740,8 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix): ...
+class BSD(Posix):
+    ...
 
 
 class BMC(Posix):
@@ -760,7 +762,8 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix): ...
+class Linux(Posix):
+    ...
 
 
 class CoreOs(Linux):
@@ -1686,7 +1689,8 @@ class Zscaler(FreeBSD):
         return re.compile("^ZscalerOS|zscaleros$")
 
 
-class OpenBSD(BSD): ...
+class OpenBSD(BSD):
+    ...
 
 
 @dataclass

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2329,16 +2329,11 @@ class CBLMariner(RPMDistro):
         # base logind.conf does not exist by default (e.g. Azure Linux 4.0),
         # and it must carry its own [Login] section header. The file is
         # rewritten from scratch each time, so the operation is idempotent.
-        from lisa.tools import Echo
+        from lisa.tools import Echo, Mkdir
 
         dropin_dir = self._node.get_pure_path("/etc/systemd/logind.conf.d")
         dropin_path = dropin_dir / "99-lisa-kill-user-processes.conf"
-        self._node.execute(
-            f'mkdir -p "{dropin_dir}"',
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=f"Failed to create {dropin_dir}",
-        )
+        self._node.tools[Mkdir].create_directory(str(dropin_dir), sudo=True)
         echo = self._node.tools[Echo]
         echo.write_to_file(
             "[Login]",

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2331,8 +2331,8 @@ class CBLMariner(RPMDistro):
         # rewritten from scratch each time, so the operation is idempotent.
         from lisa.tools import Echo
 
-        dropin_dir = "/etc/systemd/logind.conf.d"
-        dropin_file = f"{dropin_dir}/99-lisa-kill-user-processes.conf"
+        dropin_dir = self._node.get_pure_path("/etc/systemd/logind.conf.d")
+        dropin_path = dropin_dir / "99-lisa-kill-user-processes.conf"
         self._node.execute(
             f"mkdir -p {dropin_dir}",
             sudo=True,
@@ -2340,7 +2340,6 @@ class CBLMariner(RPMDistro):
             expected_exit_code_failure_message=f"Failed to create {dropin_dir}",
         )
         echo = self._node.tools[Echo]
-        dropin_path = self._node.get_pure_path(dropin_file)
         echo.write_to_file(
             "[Login]",
             dropin_path,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2325,12 +2325,45 @@ class CBLMariner(RPMDistro):
     # Disable KillUserProcesses to avoid test processes being terminated when
     # the SSH session is reset
     def set_kill_user_processes(self) -> None:
-        sed = self._node.tools[Sed]
-        sed.append(
-            text="KillUserProcesses=no",
-            file="/etc/systemd/logind.conf",
-            sudo=True,
-        )
+        logind_conf = "/etc/systemd/logind.conf"
+        if self._node.shell.exists(self._node.get_pure_path(logind_conf)):
+            # The stock logind.conf already contains a [Login] section, so a
+            # bare key can be appended to it.
+            sed = self._node.tools[Sed]
+            sed.append(
+                text="KillUserProcesses=no",
+                file=logind_conf,
+                sudo=True,
+            )
+        else:
+            # On some distros (e.g. Azure Linux 4.0) /etc/systemd/logind.conf
+            # does not exist by default, so appending to it fails. Write a
+            # systemd drop-in instead, which is honored without the base file
+            # and must carry its own [Login] section header.
+            from lisa.tools import Echo
+
+            dropin_dir = "/etc/systemd/logind.conf.d"
+            dropin_file = f"{dropin_dir}/99-lisa-kill-user-processes.conf"
+            self._node.execute(
+                f"mkdir -p {dropin_dir}",
+                sudo=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    f"Failed to create {dropin_dir}"
+                ),
+            )
+            echo = self._node.tools[Echo]
+            echo.write_to_file(
+                "[Login]",
+                self._node.get_pure_path(dropin_file),
+                sudo=True,
+            )
+            echo.write_to_file(
+                "KillUserProcesses=no",
+                self._node.get_pure_path(dropin_file),
+                sudo=True,
+                append=True,
+            )
         self._node.tools[Service].restart_service("systemd-logind")
 
     def _replace_default_entry(self, entry: str) -> None:

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -228,8 +228,7 @@ class OperatingSystem:
     def name(self) -> str:
         return self.__class__.__name__
 
-    def capture_system_information(self, saved_path: Path) -> None:
-        ...
+    def capture_system_information(self, saved_path: Path) -> None: ...
 
     @classmethod
     def _get_detect_string(cls, node: Any) -> Iterable[str]:
@@ -740,8 +739,7 @@ class Posix(OperatingSystem, BaseClassMixin):
         return package_name
 
 
-class BSD(Posix):
-    ...
+class BSD(Posix): ...
 
 
 class BMC(Posix):
@@ -762,8 +760,7 @@ class MacOS(Posix):
         return re.compile("^Darwin$")
 
 
-class Linux(Posix):
-    ...
+class Linux(Posix): ...
 
 
 class CoreOs(Linux):
@@ -1689,8 +1686,7 @@ class Zscaler(FreeBSD):
         return re.compile("^ZscalerOS|zscaleros$")
 
 
-class OpenBSD(BSD):
-    ...
+class OpenBSD(BSD): ...
 
 
 @dataclass
@@ -2267,9 +2263,7 @@ class CBLMariner(RPMDistro):
         # _initialize_package_installation, which would restart systemd-logind
         # as a side effect and could recurse back into this method.
         if not self._dnf_tool_name:
-            result = self._node.execute(
-                "command -v dnf", no_info_log=True, shell=True
-            )
+            result = self._node.execute("command -v dnf", no_info_log=True, shell=True)
             self._dnf_tool_name = "dnf" if result.exit_code == 0 else "tdnf -q"
         return self._dnf_tool_name
 


### PR DESCRIPTION
## Description

Fixes two issues that hit Azure Linux / CBL-Mariner nodes during package operations:

1. **`_dnf_tool` AttributeError** — `_dnf_tool_name` was only declared as a type
   annotation and never assigned a default. Any code path that called `_dnf_tool()`
   before the install path ran (e.g. `_update_packages`, `clean_package_cache`,
   `repolist`) crashed with an `AttributeError`. Now `_dnf_tool_name` is initialized
   to `""` and resolved lazily inside `_dnf_tool()` (`dnf` if present, otherwise
   `tdnf -q`), with the result cached. Detection happens directly here instead of
   calling `_initialize_package_installation()`, which avoids an unintended
   `systemd-logind` restart and a possible recursion.

2. **`set_kill_user_processes` failed on Azure Linux 4.0** — the code appended
   `KillUserProcesses=no` to `/etc/systemd/logind.conf` with `sed`, but on Azure
   Linux 4.0 that file doesn't exist by default, so the append failed and the
   setting was never applied. Now the setting is always written as a systemd
   drop-in (`/etc/systemd/logind.conf.d/99-lisa-kill-user-processes.conf`) with its
   own `[Login]` header. Drop-ins work uniformly across all Mariner/Azure Linux
   versions (even when the base file is missing), the file is rewritten each time so
   the operation is idempotent, and writes now fail loudly instead of being silently
   ignored.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_os_update|verify_repository_installed

**Impacted LISA Features:**
CBLMariner (operating_system) - package install/update and KillUserProcesses setup

**Tested Azure Marketplace Images:**
- microsoftcblmariner cbl-mariner 2-gen2 latest
- microsoftcblmariner azurelinux-3 3-gen2 latest
- Azure Linux 4.0 image 

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| microsoftcblmariner cbl-mariner 2-gen2 latest | Standard_D2s_v5 | PASSED |
| microsoftcblmariner azurelinux-3 3-gen2 latest | Standard_D2s_v5 | PASSED |
| Azure Linux 4.0 image | Standard_D2s_v5 | PASSED |