### PR TITLE
gpu: remove SerialConsole feature requirement from gpu cases

### DIFF
--- a/lisa/microsoft/testsuites/gpu/gpusuite.py
+++ b/lisa/microsoft/testsuites/gpu/gpusuite.py
@@ -16,7 +16,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
-from lisa.features import Gpu, GpuEnabled, SerialConsole
+from lisa.features import Gpu, GpuEnabled
 from lisa.operating_system import (
     BSD,
     AlmaLinux,
@@ -79,7 +79,7 @@ class GpuTestSuite(TestSuite):
         """,
         timeout=TIMEOUT,
         requirement=simple_requirement(
-            supported_features=[GpuEnabled(), SerialConsole, AzureExtension],
+            supported_features=[GpuEnabled(), AzureExtension],
             unsupported_os=[AlmaLinux, Oracle, Suse],
         ),
         priority=1,
@@ -145,7 +145,7 @@ class GpuTestSuite(TestSuite):
         """,
         timeout=TIMEOUT,
         requirement=simple_requirement(
-            supported_features=[GpuEnabled(), SerialConsole, AzureExtension],
+            supported_features=[GpuEnabled(), AzureExtension],
             unsupported_os=[AlmaLinux, Oracle, Suse],
         ),
         priority=2,


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

This test invokes a reboot on GPU VMs and checks for kernel panics. Since it already verifies that serial console logs are supported, this requirement is redundant and can be removed.

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
