### PR TITLE
test(vm_extensions): add RunCommand v1/v2 boot validation test cases

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
@@ -71,11 +71,13 @@ def run_extension_boot_validation(
     set or is malformed. The deployed extension is named
     '<publisher>_<extension_type>_boot_validation_test'.
     """
-    publisher: str = variables.get("extension_publisher", default_publisher).strip()
-    extension_type: str = variables.get(
-        "extension_type", default_extension_type
+    publisher: str = str(
+        variables.get("extension_publisher", default_publisher)
     ).strip()
-    version: str = variables.get("extension_version", "").strip()
+    extension_type: str = str(
+        variables.get("extension_type", default_extension_type)
+    ).strip()
+    version: str = str(variables.get("extension_version", "")).strip()
 
     if not version:
         raise SkippedException(
@@ -89,9 +91,11 @@ def run_extension_boot_validation(
 
     # Skip if extension_version is not a valid 'Major.Minor' or
     # 'Major.Minor.Patch' value. Reuse AzureExtension's validator, which raises
-    # LisaException on a malformed version, and turn that into a skip.
+    # LisaException on a malformed version, and turn that into a skip. Use the
+    # normalized 'Major.Minor' value for installation (Azure installs by
+    # Major.Minor even when a patch version is supplied).
     try:
-        extension.normalize_type_handler_version(version)
+        install_version, _ = extension.normalize_type_handler_version(version)
     except LisaException:
         raise SkippedException(
             f"Runbook variable 'extension_version'='{version}' is not a valid "
@@ -108,7 +112,7 @@ def run_extension_boot_validation(
             name=extension_name,
             publisher=publisher,
             type_=extension_type,
-            type_handler_version=version,
+            type_handler_version=install_version,
             auto_upgrade_minor_version=True,
             settings=settings,
             protected_settings=protected_settings or {},

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
@@ -7,7 +7,7 @@ from assertpy import assert_that
 from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import BlobType
 
-from lisa import Node
+from lisa import Logger, Node
 from lisa.environment import Environment
 from lisa.sut_orchestrator import AZURE
 from lisa.sut_orchestrator.azure.common import (
@@ -43,6 +43,69 @@ def create_and_verify_vmaccess_extension_run(
     assert_that(result["provisioning_state"]).described_as(
         "Expected the extension to succeed"
     ).is_equal_to("Succeeded")
+
+
+def run_extension_boot_validation(
+    node: Node,
+    log: Logger,
+    variables: Dict[str, Any],
+    default_publisher: str,
+    default_extension_type: str,
+    settings: Dict[str, Any],
+    protected_settings: Optional[Dict[str, Any]] = None,
+    cleanup: bool = True,
+) -> None:
+    """
+    Shared boot-validation flow for VM extensions.
+
+    Installs the extension with the provided inline settings, asserts that
+    provisioning succeeds, and optionally removes it. Extensions managed by the
+    Compute Resource Provider (e.g. RunCommand v2 / RunCommandHandlerLinux)
+    cannot be deleted with a normal 'Delete VM Extension' operation, so callers
+    pass cleanup=False for those and rely on resource group teardown instead.
+
+    The publisher and type are read from the runbook variables
+    extension_publisher and extension_type, defaulting to the values passed by
+    the caller. The extension_version runbook variable is required; the test is
+    skipped if it is not set. The deployed extension is named
+    '<publisher>_<extension_type>_boot_validation_test'.
+    """
+    publisher: str = variables.get("extension_publisher", default_publisher).strip()
+    extension_type: str = variables.get(
+        "extension_type", default_extension_type
+    ).strip()
+    version: str = variables.get("extension_version", "").strip()
+
+    if not version:
+        raise SkippedException(
+            "Required runbook variable 'extension_version' is missing or "
+            "empty. Please set it in the runbook before running this test case."
+        )
+
+    extension_name = f"{publisher}_{extension_type}_boot_validation_test"
+
+    extension = node.features[AzureExtension]
+    if cleanup:
+        extension.delete(name=extension_name, ignore_not_found=True)
+
+    try:
+        log.info(f"Installing extension '{extension_name}'...")
+        result = extension.create_or_update(
+            name=extension_name,
+            publisher=publisher,
+            type_=extension_type,
+            type_handler_version=version,
+            auto_upgrade_minor_version=True,
+            settings=settings,
+            protected_settings=protected_settings or {},
+        )
+
+        assert_that(result["provisioning_state"]).described_as(
+            "Expected the extension to succeed"
+        ).is_equal_to("Succeeded")
+    finally:
+        if cleanup:
+            extension.delete(name=extension_name, ignore_not_found=True)
 
 
 def execute_command(file_name: str, expected_exit_code: int, node: Node) -> None:

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
@@ -52,7 +52,6 @@ def run_extension_boot_validation(
     default_publisher: str,
     default_extension_type: str,
     settings: Dict[str, Any],
-    protected_settings: Optional[Dict[str, Any]] = None,
     cleanup: bool = True,
 ) -> None:
     """
@@ -115,7 +114,6 @@ def run_extension_boot_validation(
             type_handler_version=install_version,
             auto_upgrade_minor_version=True,
             settings=settings,
-            protected_settings=protected_settings or {},
         )
 
         assert_that(result["provisioning_state"]).described_as(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/common.py
@@ -21,7 +21,7 @@ from lisa.sut_orchestrator.azure.common import (
 from lisa.sut_orchestrator.azure.features import AzureExtension
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.sut_orchestrator.azure.tools import Waagent
-from lisa.util import SkippedException, parse_version
+from lisa.util import LisaException, SkippedException, parse_version
 
 
 def create_and_verify_vmaccess_extension_run(
@@ -66,8 +66,9 @@ def run_extension_boot_validation(
 
     The publisher and type are read from the runbook variables
     extension_publisher and extension_type, defaulting to the values passed by
-    the caller. The extension_version runbook variable is required; the test is
-    skipped if it is not set. The deployed extension is named
+    the caller. The extension_version runbook variable is required and must be a
+    'Major.Minor' or 'Major.Minor.Patch' value; the test is skipped if it is not
+    set or is malformed. The deployed extension is named
     '<publisher>_<extension_type>_boot_validation_test'.
     """
     publisher: str = variables.get("extension_publisher", default_publisher).strip()
@@ -85,6 +86,19 @@ def run_extension_boot_validation(
     extension_name = f"{publisher}_{extension_type}_boot_validation_test"
 
     extension = node.features[AzureExtension]
+
+    # Skip if extension_version is not a valid 'Major.Minor' or
+    # 'Major.Minor.Patch' value. Reuse AzureExtension's validator, which raises
+    # LisaException on a malformed version, and turn that into a skip.
+    try:
+        extension.normalize_type_handler_version(version)
+    except LisaException:
+        raise SkippedException(
+            f"Runbook variable 'extension_version'='{version}' is not a valid "
+            "'Major.Minor' or 'Major.Minor.Patch' version. Please set a valid "
+            "version in the runbook before running this test case."
+        )
+
     if cleanup:
         extension.delete(name=extension_name, ignore_not_found=True)
 

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -12,12 +12,12 @@ from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
     execute_command,
     retrieve_storage_account_name_and_key,
     retrieve_storage_blob_url,
+    run_extension_boot_validation,
 )
 
 from lisa import (
     Logger,
     Node,
-    SkippedException,
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
@@ -118,41 +118,14 @@ class RunCommandV1Tests(TestSuite):
     def microsoft_cplat_core_runcommandlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
-        publisher: str = variables.get(
-            "extension_publisher", "Microsoft.CPlat.Core"
-        ).strip()
-        extension_type: str = variables.get("extension_type", "RunCommandLinux").strip()
-        version: str = variables.get("extension_version", "").strip()
-
-        if not version:
-            raise SkippedException(
-                "Required runbook variable 'extension_version' is missing or "
-                "empty. Please set it in the runbook before running this test "
-                "case."
-            )
-
-        extension_name = f"{publisher}_{extension_type}_boot_validation_test"
-        settings = {"commandToExecute": "echo 'RCv1 boot validation success'"}
-
-        extension = node.features[AzureExtension]
-        extension.delete(name=extension_name, ignore_not_found=True)
-
-        try:
-            log.info(f"Installing extension '{extension_name}'...")
-            result = extension.create_or_update(
-                name=extension_name,
-                publisher=publisher,
-                type_=extension_type,
-                type_handler_version=version,
-                auto_upgrade_minor_version=True,
-                settings=settings,
-            )
-
-            assert_that(result["provisioning_state"]).described_as(
-                "Expected the extension to succeed"
-            ).is_equal_to("Succeeded")
-        finally:
-            extension.delete(name=extension_name, ignore_not_found=True)
+        run_extension_boot_validation(
+            node=node,
+            log=log,
+            variables=variables,
+            default_publisher="Microsoft.CPlat.Core",
+            default_extension_type="RunCommandLinux",
+            settings={"commandToExecute": "echo 'RCv1 boot validation success'"},
+        )
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -17,6 +17,7 @@ from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
 from lisa import (
     Logger,
     Node,
+    SkippedException,
     TestCaseMetadata,
     TestSuite,
     TestSuiteMetadata,
@@ -98,6 +99,62 @@ def _create_and_verify_extension_run(
     ),
 )
 class RunCommandV1Tests(TestSuite):
+    @TestCaseMetadata(
+        description="""
+        Basic boot validation for the Run Command v1 VM extension.
+
+        Installs the extension with a single inline commandToExecute and no file
+        uris, so it needs no storage account or public blob access. Verifies that
+        provisioning succeeds, then removes the extension.
+
+        The extension publisher, type and version are read from runbook variables
+        (extension_publisher, extension_type, extension_version), defaulting to the
+        Run Command v1 extension. The deployed extension is named
+        '<publisher>_<extension_type>_boot_validation_test'.
+        """,
+        priority=5,
+    )
+    def microsoft_azure_extensions_runcommandv1_boot_validation_test(
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        publisher: str = variables.get(
+            "extension_publisher", "Microsoft.CPlat.Core"
+        ).strip()
+        extension_type: str = variables.get(
+            "extension_type", "RunCommandLinux"
+        ).strip()
+        version: str = variables.get("extension_version", "").strip()
+
+        if not version:
+            raise SkippedException(
+                "Required runbook variable 'extension_version' is missing or "
+                "empty. Please set it in the runbook before running this test "
+                "case."
+            )
+
+        extension_name = f"{publisher}_{extension_type}_boot_validation_test"
+        settings = {"commandToExecute": "echo 'RCv1 boot validation success'"}
+
+        extension = node.features[AzureExtension]
+        extension.delete(name=extension_name, ignore_not_found=True)
+
+        try:
+            log.info(f"Installing extension '{extension_name}'...")
+            result = extension.create_or_update(
+                name=extension_name,
+                publisher=publisher,
+                type_=extension_type,
+                type_handler_version=version,
+                auto_upgrade_minor_version=True,
+                settings=settings,
+            )
+
+            assert_that(result["provisioning_state"]).described_as(
+                "Expected the extension to succeed"
+            ).is_equal_to("Succeeded")
+        finally:
+            extension.delete(name=extension_name, ignore_not_found=True)
+
     @TestCaseMetadata(
         description="""
         Runs the Run Command v2 VM extension with a public Azure storage file uri.

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -114,6 +114,7 @@ class RunCommandV1Tests(TestSuite):
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=5,
+        maturity="preview",
     )
     def microsoft_cplat_core_runcommandlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -115,7 +115,7 @@ class RunCommandV1Tests(TestSuite):
         """,
         priority=5,
     )
-    def microsoft_azure_extensions_runcommandv1_boot_validation_test(
+    def microsoft_cplat_core_runcommandlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         publisher: str = variables.get(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -120,9 +120,7 @@ class RunCommandV1Tests(TestSuite):
         publisher: str = variables.get(
             "extension_publisher", "Microsoft.CPlat.Core"
         ).strip()
-        extension_type: str = variables.get(
-            "extension_type", "RunCommandLinux"
-        ).strip()
+        extension_type: str = variables.get("extension_type", "RunCommandLinux").strip()
         version: str = variables.get("extension_version", "").strip()
 
         if not version:

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -107,9 +107,10 @@ class RunCommandV1Tests(TestSuite):
         uris, so it needs no storage account or public blob access. Verifies that
         provisioning succeeds, then removes the extension.
 
-        The extension publisher, type and version are read from runbook variables
-        (extension_publisher, extension_type, extension_version), defaulting to the
-        Run Command v1 extension. The deployed extension is named
+        The extension publisher and type are read from runbook variables
+        (extension_publisher, extension_type), defaulting to the Run Command v1
+        extension. The extension_version runbook variable is required; the test
+        is skipped if it is not set. The deployed extension is named
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=5,

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -104,7 +104,7 @@ class RunCommandV1Tests(TestSuite):
         Basic boot validation for the Run Command v1 VM extension.
 
         Installs the extension with a single inline commandToExecute and no file
-        uris, so it needs no storage account or public blob access. Verifies that
+        URIs, so it needs no storage account or public blob access. Verifies that
         provisioning succeeds, then removes the extension.
 
         The extension publisher and type are read from runbook variables

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -116,9 +116,10 @@ class RunCommandV2Tests(TestSuite):
         'Delete VM Extension' operation, so no explicit cleanup is done here; the
         resource group teardown removes it.
 
-        The extension publisher, type and version are read from runbook variables
-        (extension_publisher, extension_type, extension_version), defaulting to the
-        Run Command v2 extension. The deployed extension is named
+        The extension publisher and type are read from runbook variables
+        (extension_publisher, extension_type), defaulting to the Run Command v2
+        extension. The extension_version runbook variable is required; the test
+        is skipped if it is not set. The deployed extension is named
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=5,

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -124,7 +124,7 @@ class RunCommandV2Tests(TestSuite):
         """,
         priority=5,
     )
-    def microsoft_azure_extensions_runcommandv2_boot_validation_test(
+    def microsoft_cplat_core_runcommandhandlerlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
         publisher: str = variables.get(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -10,6 +10,7 @@ from microsoft.testsuites.vm_extensions.runtime_extensions.common import (
     create_and_verify_vmaccess_extension_run,
     execute_command,
     retrieve_storage_blob_url,
+    run_extension_boot_validation,
 )
 
 from lisa import (
@@ -127,44 +128,22 @@ class RunCommandV2Tests(TestSuite):
     def microsoft_cplat_core_runcommandhandlerlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
-        publisher: str = variables.get(
-            "extension_publisher", "Microsoft.CPlat.Core"
-        ).strip()
-        extension_type: str = variables.get(
-            "extension_type", "RunCommandHandlerLinux"
-        ).strip()
-        version: str = variables.get("extension_version", "").strip()
-
-        if not version:
-            raise SkippedException(
-                "Required runbook variable 'extension_version' is missing or "
-                "empty. Please set it in the runbook before running this test "
-                "case."
-            )
-
-        extension_name = f"{publisher}_{extension_type}_boot_validation_test"
-        settings = {
-            "source": {
-                "CommandId": "RunShellScript",
-                "script": "echo 'RCv2 boot validation success'",
-            }
-        }
-
-        extension = node.features[AzureExtension]
-
-        log.info(f"Installing extension '{extension_name}'...")
-        result = extension.create_or_update(
-            name=extension_name,
-            publisher=publisher,
-            type_=extension_type,
-            type_handler_version=version,
-            auto_upgrade_minor_version=True,
-            settings=settings,
+        run_extension_boot_validation(
+            node=node,
+            log=log,
+            variables=variables,
+            default_publisher="Microsoft.CPlat.Core",
+            default_extension_type="RunCommandHandlerLinux",
+            settings={
+                "source": {
+                    "CommandId": "RunShellScript",
+                    "script": "echo 'RCv2 boot validation success'",
+                }
+            },
+            # RunCommand v2 is CRP-managed and cannot be deleted; resource
+            # group teardown handles cleanup.
+            cleanup=False,
         )
-
-        assert_that(result["provisioning_state"]).described_as(
-            "Expected the extension to succeed"
-        ).is_equal_to("Succeeded")
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -105,6 +105,68 @@ class RunCommandV2Tests(TestSuite):
 
     @TestCaseMetadata(
         description="""
+        Basic boot validation for the Run Command v2 VM extension.
+
+        Installs the extension with a single inline RunShellScript command and no
+        script uris, so it needs no storage account or public blob access. Verifies
+        that provisioning succeeds.
+
+        The RunCommand v2 (RunCommandHandlerLinux) extension is managed by the
+        Compute Resource Provider and cannot be removed with a normal
+        'Delete VM Extension' operation, so no explicit cleanup is done here; the
+        resource group teardown removes it.
+
+        The extension publisher, type and version are read from runbook variables
+        (extension_publisher, extension_type, extension_version), defaulting to the
+        Run Command v2 extension. The deployed extension is named
+        '<publisher>_<extension_type>_boot_validation_test'.
+        """,
+        priority=5,
+    )
+    def microsoft_azure_extensions_runcommandv2_boot_validation_test(
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        publisher: str = variables.get(
+            "extension_publisher", "Microsoft.CPlat.Core"
+        ).strip()
+        extension_type: str = variables.get(
+            "extension_type", "RunCommandHandlerLinux"
+        ).strip()
+        version: str = variables.get("extension_version", "").strip()
+
+        if not version:
+            raise SkippedException(
+                "Required runbook variable 'extension_version' is missing or "
+                "empty. Please set it in the runbook before running this test "
+                "case."
+            )
+
+        extension_name = f"{publisher}_{extension_type}_boot_validation_test"
+        settings = {
+            "source": {
+                "CommandId": "RunShellScript",
+                "script": "echo 'RCv2 boot validation success'",
+            }
+        }
+
+        extension = node.features[AzureExtension]
+
+        log.info(f"Installing extension '{extension_name}'...")
+        result = extension.create_or_update(
+            name=extension_name,
+            publisher=publisher,
+            type_=extension_type,
+            type_handler_version=version,
+            auto_upgrade_minor_version=True,
+            settings=settings,
+        )
+
+        assert_that(result["provisioning_state"]).described_as(
+            "Expected the extension to succeed"
+        ).is_equal_to("Succeeded")
+
+    @TestCaseMetadata(
+        description="""
         Runs the Run Command v2 VM extension with a pre-existing ifconfig script.
         """,
         priority=1,

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -124,6 +124,7 @@ class RunCommandV2Tests(TestSuite):
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=5,
+        maturity="preview",
     )
     def microsoft_cplat_core_runcommandhandlerlinux_boot_validation_test(
         self, log: Logger, node: Node, variables: Dict[str, Any]

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py
@@ -109,7 +109,7 @@ class RunCommandV2Tests(TestSuite):
         Basic boot validation for the Run Command v2 VM extension.
 
         Installs the extension with a single inline RunShellScript command and no
-        script uris, so it needs no storage account or public blob access. Verifies
+        script URIs, so it needs no storage account or public blob access. Verifies
         that provisioning succeeds.
 
         The RunCommand v2 (RunCommandHandlerLinux) extension is managed by the


### PR DESCRIPTION
## What
Adds minimal, self-contained boot validation test cases for the Run Command v1 and Run Command v2 VM extensions, mirroring the CustomScript boot validation test added in #4580.

- `RunCommandV1Tests.microsoft_cplat_core_runcommandlinux_boot_validation_test` (`lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py`)
- `RunCommandV2Tests.microsoft_cplat_core_runcommandhandlerlinux_boot_validation_test` (`lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv2.py`)

## Details
- Installs the extension with a single inline command and no file/script uris — so it requires no storage account and no public blob access.
  - v1 uses `commandToExecute: "echo 'RCv1 boot validation success'"`.
  - v2 uses `source: { CommandId: "RunShellScript", script: "echo 'RCv2 boot validation success'" }`.
- Asserts `provisioning_state == "Succeeded"`.
- v1 removes the extension when done (`RunCommandLinux` is user-managed and deletable).
- v2 does not delete the extension: `RunCommandHandlerLinux` is managed by the Compute Resource Provider and cannot be removed with a normal `Delete VM Extension` operation, so cleanup is handled by resource group teardown (same pattern as the existing v2 cases).
- Publisher and type are read from runbook variables (`extension_publisher`, `extension_type`), defaulting to the respective Run Command extension. `extension_version` is required — the test is skipped if it is not set (same version-handling pattern as `GenericVmExtension.verify_vm_extension_install_uninstall`).
- Both cases share a common helper, `run_extension_boot_validation()` in `common.py`, which reads publisher/type from runbook variables (with caller-provided defaults), requires `extension_version` (the test is skipped if it is not set), installs the extension, asserts provisioning succeeds, and optionally deletes it (`cleanup=False` for the CRP-managed v2). The helper is generic so future extensions can reuse it.
- Deployed extension instance name follows `<publisher>_<extension_type>_boot_validation_test`
## Testing
Ran end-to-end on Azure (Ubuntu 22.04, real VM deploy):

```
2026-07-17 12:20:24.886[28324][INFO] lisa.RootRunner RunCommandV1Tests.microsoft_cplat_core_runcommandlinux_boot_validation_test: PASSED
2026-07-17 12:20:24.886[28324][INFO] lisa.RootRunner     TOTAL    : 1
2026-07-17 12:20:24.886[28324][INFO] lisa.RootRunner     FAILED   : 0
2026-07-17 12:20:24.886[28324][INFO] lisa.RootRunner     PASSED   : 1
2026-07-17 12:20:24.886[28324][INFO] lisa.RootRunner     SKIPPED  : 0

```
```
2026-07-17 12:15:50.935[15568][INFO] lisa.RootRunner RunCommandV2Tests.microsoft_cplat_core_runcommandhandlerlinux_boot_validation_test: PASSED
2026-07-17 12:15:50.935[15568][INFO] lisa.RootRunner     TOTAL    : 1
2026-07-17 12:15:50.935[15568][INFO] lisa.RootRunner     FAILED   : 0
2026-07-17 12:15:50.935[15568][INFO] lisa.RootRunner     PASSED   : 1
2026-07-17 12:15:50.935[15568][INFO] lisa.RootRunner     SKIPPED  : 0
```



Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
