### PR TITLE
DPDK: Timeout related bugfixes

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -718,7 +718,6 @@ class DpdkTestpmd(Tool):
 
     def kill_previous_testpmd_command(self) -> None:
         # kill testpmd early
-        # try SIGINT first to get a clean termination with stats
         command_name = self.node.get_pure_path(self.command).name
 
         # try SIGINT first to get a clean termination with stats

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -47,6 +47,7 @@ from lisa.util import (
     SkippedException,
     UnsupportedDistroException,
     parse_version,
+    sleep,
 )
 from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 
@@ -691,14 +692,47 @@ class DpdkTestpmd(Tool):
         self.populate_performance_data()
         return result.stdout
 
-    def check_testpmd_is_running(self) -> bool:
-        pids = self.node.tools[Pidof].get_pids(self.command, sudo=True)
+    def check_testpmd_is_running(
+        self, tries: int = 10, want_dead: bool = False
+    ) -> bool:
+        # check if testpmd is running.
+        #
+        # Allow retrying a few times, and hinting whether you want
+        # the process to be dead or alive.
+        #
+        # avoid retry decorator to avoid raising more exceptions
+        command = self.node.get_pure_path(self.command).name
+        while tries > 0:
+            pids = self.node.tools[Pidof].get_pids(command, sudo=True)
+            if len(pids) > 0 and not want_dead:
+                return True
+            elif len(pids) == 0 and want_dead:
+                return False
+            tries -= 1
+            sleep(1)
         return len(pids) > 0
 
     def kill_previous_testpmd_command(self) -> None:
         # kill testpmd early
-        self.node.tools[Kill].by_name(self.command, ignore_not_exist=True)
-        if self.check_testpmd_is_running():
+        # try SIGINT first to get a clean termination with stats
+        command_name = self.node.get_pure_path(self.command).name
+
+        # try SIGINT first to get a clean termination with stats
+        self.node.tools[Kill].by_name(
+            command_name, signum=SIGINT, ignore_not_exist=True
+        )
+        # check if testpmd is running, retry a few times to let it terminate gracefully
+        if self.check_testpmd_is_running(tries=10, want_dead=True):
+            # attempt to SIGKILL instead of SIGINT
+            # doesn't give us the same exit data about send/recv/drop stats
+            self.node.log.debug(
+                "Testpmd did not respond to SIGINT, attempting SIGKILL."
+            )
+            self.node.tools[Kill].by_name(command_name, ignore_not_exist=True)
+
+            if not self.check_testpmd_is_running(tries=10, want_dead=True):
+                return
+
             self.node.log.debug(
                 "Testpmd is not responding to signals, "
                 "attempt network connection reset."

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -44,10 +44,11 @@ from lisa.tools import (
 )
 from lisa.util import (
     LisaException,
+    LisaTimeoutException,
     SkippedException,
     UnsupportedDistroException,
+    check_till_timeout,
     parse_version,
-    sleep,
 )
 from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
 
@@ -695,21 +696,24 @@ class DpdkTestpmd(Tool):
     def check_testpmd_is_running(
         self, tries: int = 10, want_dead: bool = False
     ) -> bool:
-        # check if testpmd is running.
-        #
-        # Allow retrying a few times, and hinting whether you want
-        # the process to be dead or alive.
-        #
-        # avoid retry decorator to avoid raising more exceptions
         command = self.node.get_pure_path(self.command).name
-        while tries > 0:
+        pids: List[str] = []
+
+        def _condition() -> bool:
+            nonlocal pids
             pids = self.node.tools[Pidof].get_pids(command, sudo=True)
-            if len(pids) > 0 and not want_dead:
-                return True
-            elif len(pids) == 0 and want_dead:
-                return False
-            tries -= 1
-            sleep(1)
+            return (len(pids) == 0) if want_dead else (len(pids) > 0)
+
+        try:
+            check_till_timeout(
+                _condition,
+                f"testpmd state wait timed out (want_dead={want_dead})",
+                timeout=tries,
+                interval=1,
+            )
+        except LisaTimeoutException:
+            pass
+
         return len(pids) > 0
 
     def kill_previous_testpmd_command(self) -> None:

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -969,8 +969,10 @@ def do_parallel_cleanup(environment: Environment) -> None:
             # cleanup temporary hugepage and driver changes
         try:
             node.reboot()
-        except LisaException:
-            node.log.debug("Cleanup reboot failed. Marking node for deletion.")
+        except LisaException as e:
+            node.log.debug(
+                f"Cleanup reboot failed. Marking node for deletion. {str(e)}"
+            )
             node.mark_dirty()
 
     run_in_parallel(

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -968,7 +968,7 @@ def do_parallel_cleanup(environment: Environment) -> None:
             interface.switch_sriov(enable=True, wait=False, reset_connections=True)
             # cleanup temporary hugepage and driver changes
         try:
-            node.reboot(time_out=60)
+            node.reboot()
         except LisaException:
             node.log.debug("Timeout during cleanup reboot. Marking node for deletion.")
             node.mark_dirty()

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -970,7 +970,7 @@ def do_parallel_cleanup(environment: Environment) -> None:
         try:
             node.reboot()
         except LisaException:
-            node.log.debug("Timeout during cleanup reboot. Marking node for deletion.")
+            node.log.debug("Cleanup reboot failed. Marking node for deletion.")
             node.mark_dirty()
 
     run_in_parallel(

--- a/lisa/microsoft/testsuites/dpdk/rdmacore.py
+++ b/lisa/microsoft/testsuites/dpdk/rdmacore.py
@@ -202,14 +202,14 @@ class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
         # we don't actually want enabled for these dpdk tests.
         #
         # this ends up preventing login via ssh for like 3 minutes
-        # while it times out and restarts.
+        # while it times out and restarts during the next boot.
         #
         # We're only using rdma for the ib verbs,
         # so we can safely just mask this service.
         mask_result = node.execute("systemctl mask rdma-ndd.service", sudo=True)
         if mask_result.exit_code != 0:
             node.log.debug(
-                "Failed to mask rdma-ndd.service (exit_code=%s). "
-                "stdout: %s, stderr: %s"
-                % (mask_result.exit_code, mask_result.stdout, mask_result.stderr)
+                "Failed to mask rdma-ndd.service "
+                f"(exit_code={mask_result.exit_code}). "
+                f"stdout: {mask_result.stdout}, stderr: {mask_result.stderr}"
             )

--- a/lisa/microsoft/testsuites/dpdk/rdmacore.py
+++ b/lisa/microsoft/testsuites/dpdk/rdmacore.py
@@ -1,3 +1,5 @@
+from pathlib import PurePath
+
 from assertpy import assert_that
 from microsoft.testsuites.dpdk.common import (
     DependencyInstaller,
@@ -198,3 +200,15 @@ class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
             sudo=True,
         )
         make.make_install(self.asset_path)
+        # rdma-core installs some systemd services for infiniband that
+        # we don't actually want enabled for these dpdk tests.
+        # Specifically rdma-ndd.service, it has to wait for cloud-init,
+        # but also has to run before network-pre...
+        # this ends up preventing login via ssh for like 3 minutes while it times out and restarts.
+        # we're only using rdma for the ib verbs, so we can safely just mask this service.
+        mask_result = node.execute("systemctl mask rdma-ndd.service", sudo=True)
+        if mask_result.exit_code != 0:
+            node.log.debug(
+                "Failed to mask rdma-ndd.service (exit_code=%s). stdout: %s, stderr: %s"
+                % (mask_result.exit_code, mask_result.stdout, mask_result.stderr)
+            )

--- a/lisa/microsoft/testsuites/dpdk/rdmacore.py
+++ b/lisa/microsoft/testsuites/dpdk/rdmacore.py
@@ -1,5 +1,3 @@
-from pathlib import PurePath
-
 from assertpy import assert_that
 from microsoft.testsuites.dpdk.common import (
     DependencyInstaller,
@@ -139,19 +137,19 @@ class RdmaCorePackageManagerInstall(PackageManagerInstall):  # type: ignore[misc
 # implement SourceInstall for DPDK
 class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
     def _check_if_installed(self) -> bool:
+        # check if pkg-config info is available
         try:
-            package_manager_install = self._os.package_exists("rdma-core")
-            # _get_installed_version for source install throws
-            # if package is not found. So we don't need the result,
-            # if the function doesn't throw, the version was found.
             _ = self.get_installed_version()
-            # this becomes '(not package manager installed) and
-            #                _get_installed_version() doesn't throw'
-            return not package_manager_install
         except AssertionError:
-            # _get_installed_version threw an AssertionError
-            # so PkgConfig info was not found
+            # get_installed_version threw an AssertionError
+            # PkgConfig info was not found;
+            # so it's not a source installation.
             return False
+
+        # check if the package was installed from apt, dnf, etc.
+        package_manager_install = self._os.package_exists("rdma-core")
+        # we don't want it to be installed from the package manager.
+        return not package_manager_install
 
     def _setup_node(self) -> None:
         if isinstance(self._os, (Debian, Fedora, Suse)):
@@ -202,13 +200,17 @@ class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
         make.make_install(self.asset_path)
         # rdma-core installs some systemd services for infiniband that
         # we don't actually want enabled for these dpdk tests.
-        # Specifically rdma-ndd.service, it has to wait for cloud-init,
-        # but also has to run before network-pre...
-        # this ends up preventing login via ssh for like 3 minutes while it times out and restarts.
-        # we're only using rdma for the ib verbs, so we can safely just mask this service.
-        mask_result = node.execute("systemctl mask rdma-ndd.service", sudo=True)
+        #
+        # this ends up preventing login via ssh for like 3 minutes
+        # while it times out and restarts.
+        #
+        # We're only using rdma for the ib verbs,
+        # so we can safely just mask this service.
+        mask_cmd = "systemctl mask rdma-ndd.service"
+        mask_result = node.execute(mask_cmd, sudo=True, shell=True)
         if mask_result.exit_code != 0:
             node.log.debug(
-                "Failed to mask rdma-ndd.service (exit_code=%s). stdout: %s, stderr: %s"
+                "Failed to mask rdma-ndd.service (exit_code=%s). "
+                "stdout: %s, stderr: %s"
                 % (mask_result.exit_code, mask_result.stdout, mask_result.stderr)
             )

--- a/lisa/microsoft/testsuites/dpdk/rdmacore.py
+++ b/lisa/microsoft/testsuites/dpdk/rdmacore.py
@@ -206,8 +206,7 @@ class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
         #
         # We're only using rdma for the ib verbs,
         # so we can safely just mask this service.
-        mask_cmd = "systemctl mask rdma-ndd.service"
-        mask_result = node.execute(mask_cmd, sudo=True, shell=True)
+        mask_result = node.execute("systemctl mask rdma-ndd.service", sudo=True)
         if mask_result.exit_code != 0:
             node.log.debug(
                 "Failed to mask rdma-ndd.service (exit_code=%s). "


### PR DESCRIPTION
## Description

This PR contains commits for fixing several reliablity issues related to the DPDK tests and timeouts.

- Environments are frequently marked dirty when they should not be due to a short timeout during cleanup.
- Reboots take much longer once rdma-core is installed, causing test timeouts.
- Kill function did not attempt SIGINT first, resulting in erroneous test failures _unless_ the test timed out for one of the above reasons.

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**

verify_dpdk_build_failsafe|verify_dpdk_build_netvsc|verify_dpdk_send_receive_failsafe|verify_dpdk_send_receive_netvsc|verify_dpdk_send_receive_multi_txrx_queue_failsafe|verify_dpdk_send_receive_multi_txrx_queue_netvsc

**Impacted LISA Features:**
Dpdk, RdmaCoreInstaller

**Tested Azure Marketplace Images:**

Canonical:ubuntu-24_04-lts:server:latest


## Test Results

2026-07-16 17:15:03.643[8180][INFO] lisa.RootRunner ________________________________________
2026-07-16 17:15:03.643[8180][INFO] lisa.RootRunner                      Dpdk.verify_dpdk_build_netvsc: PASSED   
2026-07-16 17:15:03.643[8180][INFO] lisa.RootRunner                    Dpdk.verify_dpdk_build_failsafe: SKIPPED  skipped: Failsafe PMD test on MANA is not supported.
2026-07-16 17:15:03.643[8180][INFO] lisa.RootRunner Dpdk.verify_dpdk_send_receive_multi_txrx_queue_failsafe: PASSED   
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner Dpdk.verify_dpdk_send_receive_multi_txrx_queue_netvsc: PASSED   
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner             Dpdk.verify_dpdk_send_receive_failsafe: PASSED   
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner               Dpdk.verify_dpdk_send_receive_netvsc: PASSED   
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner test result summary
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     TOTAL    : 6
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     QUEUED   : 0
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     ASSIGNED : 0
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     RUNNING  : 0
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     FAILED   : 0
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     PASSED   : 5
2026-07-16 17:15:03.644[8180][INFO] lisa.RootRunner     SKIPPED  : 1


| Image | VM Size | Result |
|-------|---------|--------|
| Canonical:ubuntu-24_04-lts:server:latest | Standard_F72s_v2 | 5 / 0 / 1|
