### PR TITLE
IsolatedResource: update sizes

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -3163,6 +3163,7 @@ class IsolatedResource(AzureFeatureMixin, features.IsolatedResource):
             "Standard_M192idms_v2",
             "Standard_F72s_v2",
             "Standard_M128ms",
+            "Standard_E192ids_v6",
             # add custom vm sizes below,
         ]
     )


### PR DESCRIPTION
## Description

Updates IsolatedResource list to include additional isolated sizes.

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_dpdk_testpmd_hotplug_sender_netvsc_pmd

**Impacted LISA Features:**

IsolatedResource

**Tested Azure Marketplace Images:**
Canonical:ubuntu-24_04-lts:server:latest

## Test Results

2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_sender_netvsc_pmd: PASSED   
2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner test result summary
2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner     TOTAL    : 1
2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner     QUEUED   : 0
2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner     ASSIGNED : 0
2026-07-16 16:24:30.505[3428][INFO] lisa.RootRunner     RUNNING  : 0
2026-07-16 16:24:30.506[3428][INFO] lisa.RootRunner     FAILED   : 0
2026-07-16 16:24:30.506[3428][INFO] lisa.RootRunner     PASSED   : 1
2026-07-16 16:24:30.506[3428][INFO] lisa.RootRunner     SKIPPED  : 0

| Image | VM Size | Result |
|-------|---------|--------|
| Canonical:ubuntu-24_04-lts:server:latest | Standard_E192ids_v6| 1 / 0 / 0 |
