### PR TITLE
DPDK: deprecate run_testpmd_concurrent for hotplug tests

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -17,7 +17,7 @@ from lisa.tools import Git, Lscpu, Tar, Wget
 from lisa.tools.lscpu import CpuArchitecture
 from lisa.util import UnsupportedDistroException
 
-DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
+DPDK_STABLE_GIT_REPO = "https://github.com/dpdk/dpdk-stable.git"
 
 # azure routing table magic subnet prefix
 # signals 'route all traffic on this subnet'

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -521,7 +521,12 @@ class Dpdk(TestSuite):
         # use multiple queues on receiver only to avoid
         # losing the connection when AN is disabled on it.
         kit_cmd_pairs = generate_send_receive_run_info(
-            pmd, sender, receiver, multiple_queues=(False, True), stats_period=5
+            pmd,
+            sender,
+            receiver,
+            multiple_queues=(False, True),
+            extra_args=("--burst=5", ""),
+            stats_period=5,
         )
         run_testpmd_hotplug(
             kit_cmd_pairs=kit_cmd_pairs,

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -518,6 +518,8 @@ class Dpdk(TestSuite):
         receiver.switch_sriov = True
         sender.switch_sriov = False
 
+        # use multiple queues on receiver only to avoid
+        # losing the connection with AN is disabled.
         kit_cmd_pairs = generate_send_receive_run_info(
             pmd, sender, receiver, multiple_queues=(False, True), stats_period=5
         )

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -519,7 +519,7 @@ class Dpdk(TestSuite):
         sender.switch_sriov = False
 
         # use multiple queues on receiver only to avoid
-        # losing the connection with AN is disabled.
+        # losing the connection when AN is disabled on it.
         kit_cmd_pairs = generate_send_receive_run_info(
             pmd, sender, receiver, multiple_queues=(False, True), stats_period=5
         )
@@ -547,7 +547,7 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
         testpmd = test_kit.testpmd
         test_nic = node.nics.get_secondary_nic()
-        testpmd_cmd = testpmd.generate_testpmd_command([test_nic], 0, "txonly")
+        testpmd_cmd = testpmd.generate_testpmd_command([test_nic], 0, "txonly", pmd=pmd)
         kit_cmd_pairs = {
             test_kit: testpmd_cmd,
         }
@@ -862,7 +862,7 @@ class Dpdk(TestSuite):
         # allow configuring for different platforms
         mtu_size = 4000
         try:
-            snd, rcv = verify_dpdk_send_receive_multi_txrx_queue(
+            verify_dpdk_send_receive_multi_txrx_queue(
                 environment,
                 log,
                 variables,

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -25,7 +25,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     init_nodes_concurrent,
     initialize_node_resources,
     run_dpdk_symmetric_mp,
-    run_testpmd_concurrent,
+    run_testpmd_hotplug,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
     verify_dpdk_mutliple_ports,
@@ -518,10 +518,13 @@ class Dpdk(TestSuite):
         receiver.switch_sriov = True
         sender.switch_sriov = False
 
-        kit_cmd_pairs = generate_send_receive_run_info(pmd, sender, receiver)
-
-        run_testpmd_concurrent(
-            kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
+        kit_cmd_pairs = generate_send_receive_run_info(
+            pmd, sender, receiver, multiple_queues=(False, True), stats_period=5
+        )
+        run_testpmd_hotplug(
+            kit_cmd_pairs=kit_cmd_pairs,
+            sender=sender,
+            receiver=receiver,
         )
 
         hotplug_pps_set = receiver.testpmd.get_mean_rx_pps_sriov_hotplug()
@@ -547,9 +550,7 @@ class Dpdk(TestSuite):
             test_kit: testpmd_cmd,
         }
 
-        run_testpmd_concurrent(
-            kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
-        )
+        run_testpmd_hotplug(kit_cmd_pairs=kit_cmd_pairs, sender=test_kit)
 
         hotplug_pps_set = testpmd.get_mean_tx_pps_sriov_hotplug()
         self._check_rx_or_tx_pps_sriov_hotplug("TX", hotplug_pps_set)

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -551,6 +551,7 @@ class DpdkTestpmd(Tool):
         service_cores: int = 1,
         mtu: int = 0,
         mbuf_size: int = 0,
+        stats_period: int = 2,
     ) -> str:
         #   testpmd \
         #   -l <core-list> \
@@ -642,7 +643,7 @@ class DpdkTestpmd(Tool):
             and bool(self.get_dpdk_version() > "23.7.0")
         ):
             extra_args += " --txonly-multi-flow"
-        else:
+        elif mode == "txonly":
             self.node.log.debug(
                 "note: skipping use of testpmd txonly-multi-flow flag "
                 "before dpdk 24.11. perf on receive side may be suboptimal."
@@ -665,7 +666,8 @@ class DpdkTestpmd(Tool):
         return (
             f"{self._testpmd_install_path} {core_list} "
             f"{nic_includes} {debug_logging} -- --forward-mode={mode} "
-            f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
+            f"-a --stats-period {stats_period} --nb-cores={forwarding_cores}"
+            f" {extra_args}"
         )
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:
@@ -743,7 +745,7 @@ class DpdkTestpmd(Tool):
 
             # reset node connections (quicker and less risky than netvsc reset)
             self.node.close()
-            if not self.check_testpmd_is_running():
+            if not self.check_testpmd_is_running(tries=10, want_dead=True):
                 return
 
             self.node.log.debug(
@@ -751,7 +753,7 @@ class DpdkTestpmd(Tool):
             )
             # if this somehow didn't kill it, reset netvsc
             self.node.tools[Modprobe].reload("hv_netvsc")
-            if self.check_testpmd_is_running():
+            if self.check_testpmd_is_running(tries=10, want_dead=True):
                 raise LisaException("Testpmd has hung, killing the test.")
             else:
                 self.node.log.debug(

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -13,6 +13,7 @@ from microsoft.testsuites.dpdk.common import (
     Installer,
     OsPackageDependencies,
     PackageManagerInstall,
+    Pmd,
     TarDownloader,
     get_debian_backport_repo_args,
     is_url_for_git_repo,
@@ -471,10 +472,11 @@ class DpdkTestpmd(Tool):
             return False
 
     def generate_testpmd_include(
-        self, node_nic: NicInfo, vdev_id: int, force_netvsc: bool = False
+        self,
+        node_nic: NicInfo,
+        vdev_id: int,
+        pmd: Pmd,
     ) -> str:
-        # handle generating different flags for pmds/device combos for testpmd
-
         # MANA and mlnx both don't require these arguments if all VFs are in use.
         # We have a primary nic to exclude in our tests, so we include the
         # test nic by either bus address and mac (MANA)
@@ -501,8 +503,8 @@ class DpdkTestpmd(Tool):
             pmd_name = "net_failsafe"
             pmd_flags = f"dev({node_nic.pci_slot}),dev(iface={node_nic.name},force=1)"
         elif self.is_mana:
-            # mana selects by mac, just return the vdev info directly
-            if node_nic.module_name == "uio_hv_generic" or force_netvsc:
+            # MANA netvsc mode selects by mac.
+            if pmd == Pmd.NETVSC:
                 return f' --vdev="{node_nic.pci_slot},mac={node_nic.mac_addr}" '
             # if mana_ib is present, use mana friendly args
             elif self.node.tools[Modprobe].module_exists("mana_ib"):
@@ -518,34 +520,19 @@ class DpdkTestpmd(Tool):
                 # reset include flag for MANA since there is only one interface
                 include_flag = ""
         else:
+            if pmd == Pmd.NETVSC:
+                return include_flag
             # mlnx setup for failsafe
             pmd_name = "net_vdev_netvsc"
             pmd_flags = f"iface={node_nic.name},force=1"
-        if node_nic.module_name == "hv_netvsc":
-            # primary/upper/master nic is bound to hv_netvsc
-            # when using net_failsafe implicitly or explicitly.
-            # Set up net_failsafe/net_vdev_netvsc args here
-            return f'--vdev="{pmd_name}{vdev_id},{pmd_flags}" ' + include_flag
-        elif node_nic.module_name == "uio_hv_generic":
-            # if using netvsc pmd, just let -w or -a select
-            # which device to use. No other args are needed.
-            return include_flag
-        else:
-            # if we're all the way through and haven't picked a pmd, something
-            # has gone wrong. fail fast
-            raise LisaException(
-                (
-                    f"Unknown driver({node_nic.module_name}) bound to "
-                    f"{node_nic.name}/{node_nic.lower}."
-                    "Cannot generate testpmd include arguments."
-                )
-            )
+        return f'--vdev="{pmd_name}{vdev_id},{pmd_flags}" ' + include_flag
 
     def generate_testpmd_command(
         self,
         nic_to_include: List[NicInfo],
         vdev_id: int,
         mode: str,
+        pmd: Pmd = Pmd.FAILSAFE,
         extra_args: str = "",
         multiple_queues: bool = False,
         service_cores: int = 1,
@@ -580,7 +567,7 @@ class DpdkTestpmd(Tool):
         # generate the flags for which devices to include in the tests
         nic_include_infos = []
         for nic in nic_to_include:
-            nic_include_infos += [self.generate_testpmd_include(nic, vdev_id)]
+            nic_include_infos += [self.generate_testpmd_include(nic, vdev_id, pmd=pmd)]
             vdev_id += 1
 
         # infer core count to assign based on number of queues

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -269,6 +269,7 @@ def generate_send_receive_run_info(
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
     multiple_queues: Union[bool, Tuple[bool, bool]] = False,
+    extra_args: Union[str, Tuple[str, str]] = "",
     use_service_cores: int = 1,
     set_mtu: int = 0,
     stats_period: int = 2,
@@ -296,12 +297,18 @@ def generate_send_receive_run_info(
         snd_mq = multiple_queues
         rcv_mq = multiple_queues
 
+    if isinstance(extra_args, tuple):
+        snd_args, rcv_args = extra_args
+    else:
+        snd_args = f" {extra_args}"
+        rcv_args = extra_args
+
     snd_cmd = sender.testpmd.generate_testpmd_command(
         [snd_nic],
         0,
         "txonly",
         pmd=pmd,
-        extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
+        extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr} {snd_args}",
         multiple_queues=snd_mq,
         service_cores=use_service_cores,
         mtu=set_mtu,
@@ -318,6 +325,7 @@ def generate_send_receive_run_info(
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
         stats_period=stats_period,
+        extra_args=rcv_args,
     )
 
     kit_cmd_pairs = {

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -300,6 +300,7 @@ def generate_send_receive_run_info(
         [snd_nic],
         0,
         "txonly",
+        pmd=pmd,
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         multiple_queues=snd_mq,
         service_cores=use_service_cores,
@@ -311,6 +312,7 @@ def generate_send_receive_run_info(
         [rcv_nic],
         0,
         "rxonly",
+        pmd=pmd,
         multiple_queues=rcv_mq,
         service_cores=use_service_cores,
         mtu=set_mtu,
@@ -385,6 +387,7 @@ def generate_testpmd_multiple_port_command(
             [sender_nic],
             0,
             "txonly",
+            pmd=pmd,
             extra_args=f"--tx-ip={sender_nic.ip_addr},{receiver_nic.ip_addr}",
             multiple_queues=multiple_queues,
             service_cores=use_service_cores,
@@ -395,7 +398,7 @@ def generate_testpmd_multiple_port_command(
         kit_cmd_pairs[sender] = snd_cmd
         # receiver needs multiple ports, so only generate the include.
         receiver_include = receiver.testpmd.generate_testpmd_include(
-            receiver_nics[sender_subnet], i
+            receiver_nics[sender_subnet], i, pmd=pmd
         )
         # and save it
         receiver_includes += [receiver_include]
@@ -405,6 +408,7 @@ def generate_testpmd_multiple_port_command(
         list([receiver_nics[key] for key in receiver_nics]),
         0,
         "rxonly",
+        pmd=pmd,
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
@@ -674,7 +678,7 @@ def verify_dpdk_build(
     test_nic = node.nics.get_secondary_nic()
 
     testpmd_cmd = testpmd.generate_testpmd_command(
-        [test_nic], 0, "txonly", multiple_queues=multiple_queues
+        [test_nic], 0, "txonly", pmd=pmd, multiple_queues=multiple_queues
     )
     testpmd.run_for_n_seconds(testpmd_cmd, 10)
     tx_pps = testpmd.get_mean_tx_pps()
@@ -1288,10 +1292,10 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     # generate the dpdk include arguments to add to our commandline
     include_devices = [
         fwd_kit.testpmd.generate_testpmd_include(
-            subnet_a_nics[forwarder], dpdk_port_a, force_netvsc=True
+            subnet_a_nics[forwarder], dpdk_port_a, pmd=Pmd.NETVSC
         ),
         fwd_kit.testpmd.generate_testpmd_include(
-            subnet_b_nics[forwarder], dpdk_port_b, force_netvsc=True
+            subnet_b_nics[forwarder], dpdk_port_b, pmd=Pmd.NETVSC
         ),
     ]
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1,7 +1,5 @@
 import itertools
 import re
-import time
-from collections import deque
 from decimal import Decimal
 from enum import Enum
 from functools import partial
@@ -74,8 +72,9 @@ from lisa.tools import (
 )
 from lisa.tools.hugepages import HugePageSize
 from lisa.tools.lscpu import CpuArchitecture
+from lisa.util import sleep
 from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
-from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
+from lisa.util.parallel import run_in_parallel
 
 
 # DPDK added new flags in 19.11 that some tests rely on for send/recv
@@ -111,7 +110,7 @@ class UnsupportedPackageVersionException(LisaException):
         return message
 
 
-# container class for test resources to be passed to run_testpmd_concurrent
+# container class for test resources
 class DpdkTestResources:
     def __init__(
         self, _node: Node, _testpmd: DpdkTestpmd, _rdma_core: Installer
@@ -200,13 +199,73 @@ def _ping_all_nodes_in_environment(environment: Environment) -> None:
         ).is_true()
 
 
+def testpmd_start_process(kit: DpdkTestResources, cmd: str) -> Process:
+    proc = kit.node.execute_async(cmd, sudo=True, shell=True)
+    proc.wait_output("start packet forwarding", timeout=30)
+    return proc
+
+
+# run the send/receive hotplug test.
+def run_testpmd_hotplug(
+    kit_cmd_pairs: Dict[DpdkTestResources, str],
+    sender: DpdkTestResources,
+    receiver: Optional[DpdkTestResources] = None,
+) -> None:
+    processes: Dict[DpdkTestResources, Process] = {}
+
+    collect_from = receiver if receiver else sender
+    all_kits = [sender]
+    if receiver:
+        all_kits += [receiver]
+        processes[receiver] = testpmd_start_process(receiver, kit_cmd_pairs[receiver])
+
+    processes[sender] = testpmd_start_process(sender, kit_cmd_pairs[sender])
+
+    # let it run for a bit
+    sleep(10)
+
+    # switch_sriov(... wait=True) has become really expensive,
+    # and it can easily timeout if things aren't perfect.
+    # So: we'll avoid all of that and just start processes and wait for output.
+    # We can assume things went well as long as we see
+    # these debug messages from testpmd.
+    collect_from.nic_controller.switch_sriov(
+        enable=False, wait=False, reset_connections=False
+    )
+    # wait for the hot unplug
+    processes[collect_from].wait_output(
+        "HN_DRIVER: netvsc_hotadd_callback(): Device notification type=1"
+    )
+
+    # let it run for a bit
+    sleep(10)
+
+    # turn sriov on again without waiting or resetting everything
+    collect_from.nic_controller.switch_sriov(
+        enable=True, wait=False, reset_connections=False
+    )
+    # wait for the hot plug
+    processes[collect_from].wait_output(
+        "HN_DRIVER: netvsc_hotplug_retry(): Found matching MAC address, adding device",
+        delta_only=True,
+    )
+
+    # let it run for a bit
+    sleep(30)
+    # kill testpmd and process the output
+    for kit in all_kits:
+        kit.testpmd.kill_previous_testpmd_command()
+        kit.testpmd.process_testpmd_output(processes[kit].wait_result(timeout=120))
+
+
 def generate_send_receive_run_info(
     pmd: Pmd,
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
-    multiple_queues: bool = False,
+    multiple_queues: Union[bool, Tuple[bool, bool]] = False,
     use_service_cores: int = 1,
     set_mtu: int = 0,
+    stats_period: int = 2,
 ) -> Dict[DpdkTestResources, str]:
     snd_nic, rcv_nic = [x.node.nics.get_secondary_nic() for x in [sender, receiver]]
     # for MTU test: check that we can fetch the max MTU size for the NIC
@@ -223,24 +282,34 @@ def generate_send_receive_run_info(
             )
     else:
         maxmtu_int = 0
+
+    # handle case where one is mq and not the other
+    if isinstance(multiple_queues, tuple):
+        snd_mq, rcv_mq = multiple_queues
+    else:
+        snd_mq = multiple_queues
+        rcv_mq = multiple_queues
+
     snd_cmd = sender.testpmd.generate_testpmd_command(
         [snd_nic],
         0,
         "txonly",
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
-        multiple_queues=multiple_queues,
+        multiple_queues=snd_mq,
         service_cores=use_service_cores,
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
+        stats_period=stats_period,
     )
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         [rcv_nic],
         0,
         "rxonly",
-        multiple_queues=multiple_queues,
+        multiple_queues=rcv_mq,
         service_cores=use_service_cores,
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
+        stats_period=stats_period,
     )
 
     kit_cmd_pairs = {
@@ -528,72 +597,6 @@ def check_send_receive_compatibility(test_kits: List[DpdkTestResources]) -> None
                 kit.testpmd.get_dpdk_version(),
                 "-tx-ip flag for ip forwarding",
             )
-
-
-def run_testpmd_concurrent(
-    node_cmd_pairs: Dict[DpdkTestResources, str],
-    seconds: int,
-    log: Logger,
-    hotplug_sriov: bool = False,
-) -> Dict[DpdkTestResources, str]:
-    output: Dict[DpdkTestResources, str] = dict()
-
-    task_manager = start_testpmd_concurrent(node_cmd_pairs, seconds, log, output)
-    if hotplug_sriov:
-        time.sleep(10)  # run testpmd for a bit before disabling sriov
-
-        test_kits = node_cmd_pairs.keys()
-
-        # disable sriov (and wait for change to apply)
-        for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(
-                enable=False, wait=True, reset_connections=False
-            )
-
-        # let run for a bit with SRIOV disabled
-        time.sleep(10)
-
-        # re-enable sriov
-        for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(
-                enable=True, wait=True, reset_connections=False
-            )
-
-        # run for a bit with SRIOV re-enabled
-        time.sleep(10)
-
-        # kill the commands to collect the output early and terminate before timeout
-        for node_resources in test_kits:
-            node_resources.testpmd.kill_previous_testpmd_command()
-
-    task_manager.wait_for_all_workers()
-
-    return output
-
-
-def start_testpmd_concurrent(
-    node_cmd_pairs: Dict[DpdkTestResources, str],
-    seconds: int,
-    log: Logger,
-    output: Dict[DpdkTestResources, str],
-) -> TaskManager[Tuple[DpdkTestResources, str]]:
-    cmd_pairs_as_tuples = deque(node_cmd_pairs.items())
-
-    def _collect_dict_result(result: Tuple[DpdkTestResources, str]) -> None:
-        output[result[0]] = result[1]
-
-    def _run_command_with_testkit(
-        run_kit: Tuple[DpdkTestResources, str],
-    ) -> Tuple[DpdkTestResources, str]:
-        testkit, cmd = run_kit
-        return (testkit, testkit.testpmd.run_for_n_seconds(cmd, seconds))
-
-    task_manager = run_in_parallel_async(
-        [partial(_run_command_with_testkit, x) for x in cmd_pairs_as_tuples],
-        _collect_dict_result,
-    )
-
-    return task_manager
 
 
 def init_nodes_concurrent(
@@ -965,7 +968,7 @@ def do_parallel_cleanup(environment: Environment) -> None:
     def _parallel_cleanup(node: Node) -> None:
         interface = node.features[NetworkInterface]
         if not interface.is_enabled_sriov():
-            interface.switch_sriov(enable=True, wait=False, reset_connections=True)
+            interface.switch_sriov(enable=True, wait=False, reset_connections=False)
             # cleanup temporary hugepage and driver changes
         try:
             node.reboot()

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1736,8 +1736,11 @@ def run_dpdk_symmetric_mp(
         for nic in node.nics.nics.values()
         if nic != node.nics.get_primary_nic() and nic.lower
     ][:2]
+
+    # make sure ping is installed _before_ the test starts.
     ping = node.tools[Ping]
-    ping.install()
+    if not ping.exists:
+        ping.install()
 
     # initialize for netvsc, we rely on the debug messages in this test
     # to identify the hotplug events.

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -744,7 +744,7 @@ def verify_dpdk_send_receive(
         kit_cmd_pairs[receiver],
         receive_timeout,
         constants.SIGINT,
-        kill_timeout=receive_timeout,
+        kill_timeout=receive_timeout + 10,
     )
     receive_result.wait_output("start packet forwarding")
     sender_result = sender.node.tools[Timeout].start_with_timeout(

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -201,7 +201,11 @@ def _ping_all_nodes_in_environment(environment: Environment) -> None:
 
 def testpmd_start_process(kit: DpdkTestResources, cmd: str) -> Process:
     proc = kit.node.execute_async(cmd, sudo=True, shell=True)
-    proc.wait_output("start packet forwarding", timeout=30)
+    # Note: This is an extremely long timeout for this command...
+    # But some timeout here is better than none here.
+    # The hotplug tests have really long timeouts, but testpmd
+    # should be able to start within a few seconds.
+    proc.wait_output("start packet forwarding", timeout=60)
     return proc
 
 
@@ -255,7 +259,9 @@ def run_testpmd_hotplug(
     # kill testpmd and process the output
     for kit in all_kits:
         kit.testpmd.kill_previous_testpmd_command()
-        kit.testpmd.process_testpmd_output(processes[kit].wait_result(timeout=120))
+        kit.testpmd.process_testpmd_output(
+            processes[kit].wait_result(timeout=120)
+        )  # allow time for SIGINT/SIGKILL shutdown and stats flush
 
 
 def generate_send_receive_run_info(

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -988,7 +988,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     f"into status [{enable}]"
                 ).is_equal_to(enable)
 
-    @retry(HttpResponseError, tries=3, delay=30)
+    @retry(HttpResponseError, tries=3, delay=30)  # type: ignore
     def switch_sriov(
         self, enable: bool, wait: bool = True, reset_connections: bool = True
     ) -> None:

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -988,6 +988,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     f"into status [{enable}]"
                 ).is_equal_to(enable)
 
+    @retry(HttpResponseError, tries=3, delay=30)
     def switch_sriov(
         self, enable: bool, wait: bool = True, reset_connections: bool = True
     ) -> None:

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -574,6 +574,7 @@ class Process:
     ) -> bool:
         # check if stdout buffers contain the string "keyword" to determine if
         # it is running
+        last_search_len = 0
         start_time = time.time()
         while time.time() - start_time < timeout:
             # LogWriter only flushes if "\n" is written, so we need to flush
@@ -583,16 +584,16 @@ class Process:
 
             # check if buffer contains the keyword
             find_pos = self.log_buffer_offset if delta_only else 0
-            if self.log_buffer.getvalue().find(keyword, find_pos) >= 0:
-                next_chunk = self.log_buffer.getvalue().find(keyword, find_pos) + len(
-                    keyword
-                )
+            found_at_index = self.log_buffer.getvalue().find(keyword, find_pos)
+            last_search_len = len(self.log_buffer.getvalue())
+            if found_at_index >= 0:
+                next_chunk = found_at_index + len(keyword)
                 self.log_buffer_offset = next_chunk
                 return True
 
             time.sleep(interval)
 
-        self.log_buffer_offset = len(self.log_buffer.getvalue())
+        self.log_buffer_offset = last_search_len
 
         if error_on_missing:
             raise LisaException(

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -584,7 +584,10 @@ class Process:
             # check if buffer contains the keyword
             find_pos = self.log_buffer_offset if delta_only else 0
             if self.log_buffer.getvalue().find(keyword, find_pos) >= 0:
-                self.log_buffer_offset = len(self.log_buffer.getvalue())
+                next_chunk = self.log_buffer.getvalue().find(keyword, find_pos) + len(
+                    keyword
+                )
+                self.log_buffer_offset = next_chunk
                 return True
 
             time.sleep(interval)


### PR DESCRIPTION
## Description

Gets rid of old abstraction that didn't allow direct monitoring of testpmd processes.

It is replaced with new functions specifically for each version of the test. We are violating the DRY ethos here in favor of readability and maintaining direct control over the processes.

This allows implementing the hotplug tests in a cleaner way, which also ends up being faster and more reliable in practice.

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_dpdk_testpmd_hotplug_sender_netvsc_pmd|verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd|verify_dpdk_l3fwd_ntttcp_tcp_hotplug

**Impacted LISA Features:**
Dpdk

**Tested Azure Marketplace Images:**
Canonical:ubuntu-24_04-lts:server:latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
