### PR TITLE
Fix: prevent needrestart prompt from hanging CVM attestation tool ins…

### DIFF
--- a/lisa/microsoft/testsuites/cvm/cvm_attestation_tool.py
+++ b/lisa/microsoft/testsuites/cvm/cvm_attestation_tool.py
@@ -102,9 +102,24 @@ class AzureCVMAttestationTests(Tool):
 
     def _install(self) -> bool:
         self._clone_repo()
+        # install.sh runs apt via its own inner `sudo`, which resets the
+        # environment and drops NEEDRESTART_MODE/DEBIAN_FRONTEND. On Ubuntu
+        # 22.04+ that makes needrestart show the interactive "Which services
+        # should be restarted?" dialog, hanging the install until it times out.
+        # Force needrestart into automatic mode by appending the setting to the
+        # end of its config file (last assignment wins in the perl config);
+        # this is read from disk and so survives the inner sudo.
+        needrestart_conf = "/etc/needrestart/needrestart.conf"
         self.node.execute(
-            "sudo ./install.sh",
+            f"test -f {needrestart_conf} && "
+            f"echo '$nrconf{{restart}} = \"a\";' >> {needrestart_conf} || true",
             shell=True,
+            sudo=True,
+        )
+        self.node.execute(
+            "./install.sh",
+            shell=True,
+            sudo=True,
             cwd=self.attestation_dir,
         )
         return self._check_exists()


### PR DESCRIPTION
…tall on Ubuntu 22.04+

Problem
AzureCVMAttestationTestSuite.verify_azure_cvm_attestation_report fails during tool setup with:

On Ubuntu 22.04+, the tool's install.sh runs apt-get install, which triggers needrestart in interactive mode. It renders a whiptail dialog — "Daemons using outdated libraries — Which services should be restarted?" — that blocks on stdin. Because LISA runs non-interactively (no TTY), the dialog never gets input and the command runs until the 600s timeout, failing the test before any attestation logic executes.

Root cause
The hang is inside AzureCVMAttestationTests._install(), not in the attestation logic. install.sh invokes apt through its own inner sudo, which resets the environment (env_reset in sudoers). This strips process-level mitigations like NEEDRESTART_MODE=a / DEBIAN_FRONTEND=noninteractive, so they don't reach the apt call that spawns needrestart.

Fix
Before running install.sh, force needrestart into automatic mode by appending $nrconf{restart} = "a"; to the end of /etc/needrestart/needrestart.conf. This is read from disk on every needrestart invocation (immune to the inner-sudo env reset), and as a perl config the last assignment wins — guaranteeing the override regardless of the packaged default. Also moved sudo from the inline command string to the sudo=True parameter for consistency with LISA conventions.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
- verify_azure_cvm_attestation_report

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-confidential-vm-focal 20_04-lts-cvm latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-confidential-vm-focal 20_04-lts-cvm latest|Standard_DC2as_v6| PASSED / FAILED / SKIPPED |
