### PR TITLE
Add NestedVirtualization requirement to MshvHostTestSuite

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_root_tests.py
@@ -16,6 +16,7 @@ from lisa import (
     TestSuiteMetadata,
     simple_requirement,
 )
+from lisa.features import NestedVirtualization
 from lisa.operating_system import CBLMariner
 from lisa.testsuite import TestResult
 from lisa.tools import (
@@ -41,7 +42,10 @@ from lisa.util.perf_timer import create_timer
     Microsoft Hypervisor (MSHV) root partition. This test suite contains tests
     to check health of mshv root node.
     """,
-    requirement=simple_requirement(supported_os=[CBLMariner]),
+    requirement=simple_requirement(
+        supported_os=[CBLMariner],
+        supported_features=[NestedVirtualization],
+    ),
 )
 class MshvHostTestSuite(TestSuite):
     mshvdiag_dmesg_pattern = re.compile(r"\[\s+\d+.\d+\]\s+mshv_diag:.*$")


### PR DESCRIPTION
## Description

This PR fixes ADO bug

MshvHostTestSuite was previously selected on CBLMariner nodes even when nested virtualization support was not available. In those cases, the suite entered before_case and skipped with "MSHV_DIAG not enabled", which was a misleading reason.

This change updates the suite requirement to include NestedVirtualization so unsupported nodes are filtered during test selection itself. As a result, the suite runs only on eligible environments and skip behavior is clearer.
## Related Issue

- bug - 62680911

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
