### PR TITLE
Process: fix delta_only, match only up to keyword

### DIFF
--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -584,7 +584,10 @@ class Process:
             # check if buffer contains the keyword
             find_pos = self.log_buffer_offset if delta_only else 0
             if self.log_buffer.getvalue().find(keyword, find_pos) >= 0:
-                self.log_buffer_offset = len(self.log_buffer.getvalue())
+                next_chunk = self.log_buffer.getvalue().find(keyword, find_pos) + len(
+                    keyword
+                )
+                self.log_buffer_offset = next_chunk
                 return True
 
             time.sleep(interval)


### PR DESCRIPTION
## Description

Fixes issue in delta_only where the next keyword check would discard any data present in the buffer. This would cause a keyword search to potentially discard data needed for the next keyword. This would also prevent the caller from finding any data that arrived if the keyword was already present after the first call to wait_output.

New behavior: the next search will search from the end of the last keyword, not the end of the entire buffer.

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd

**Impacted LISA Features:**
Process

**Tested Azure Marketplace Images:**
Canonical:ubuntu-24_04-lts:server:latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner test result summary
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner     TOTAL    : 4
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner     QUEUED   : 0
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner     ASSIGNED : 0
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner     RUNNING  : 0
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner     FAILED   : 0
2026-07-23 05:35:14.222[33476][INFO] lisa.RootRunner     PASSED   : 4
2026-07-23 05:35:14.222[33476][INFO] lisa.RootRunner     SKIPPED  : 0
...
2026-07-23 05:35:14.227[33476][INFO] lisa. completed in 1572.093 sec