### PR TITLE
Installer: fix check_installed to not re-download assets on re-use

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -186,7 +186,7 @@ class Installer:
     # First we download the assets to ensure asset_path is set
     # even if we end up skipping re-installation
     def _setup_node(self) -> None:
-        self._download_assets()
+        pass
 
     # check if the package is already installed:
     # Is the package installed from source? Or from the package manager?
@@ -230,6 +230,7 @@ class Installer:
     def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
         self._setup_node()
         if self._should_install():
+            self._download_assets()
             self._uninstall()
             self._install_dependencies()
             self._install()


### PR DESCRIPTION
## Description

Fixes issue that led to dpdk-common's Installer class re-downloading assets for every test case. The new behavior prevents the second invocation from re-downloading assets. There are less opportunites for failed test cases due to throttling.

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED  

**Impacted LISA Features:**
Dpdk.common.Installer

**Tested Azure Marketplace Images:**
Canonical:ubuntu-24_04-lts:server:latest
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED   
2026-07-23 05:35:14.221[33476][INFO] lisa.RootRunner Dpdk.verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd: PASSED  
