### PR TITLE
Add DNF package management and reboot integrity tests for Fedora

### DIFF
--- a/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
+++ b/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
@@ -299,11 +299,11 @@ class FedoraCloudValidation(TestSuite):
             "tree-log replay",
         ]
 
-        def check_unmount_errors() -> None:
+        def check_unmount_errors(boot_id: str = "") -> None:
             journalctl = node.tools[Journalctl]
-            # Fetch full boot journal (no_of_lines=0 skips head truncation) to
-            # catch both kernel FS errors and user-space fsck output.
-            boot_logs = journalctl.first_n_logs_from_boot(no_of_lines=0)
+            boot_logs = journalctl.first_n_logs_from_boot(
+                boot_id=boot_id, no_of_lines=0
+            )
             matches = [
                 line
                 for line in boot_logs.splitlines()
@@ -320,4 +320,5 @@ class FedoraCloudValidation(TestSuite):
         reboot = node.tools[Reboot]
         reboot.reboot()
 
-        check_unmount_errors()
+        check_unmount_errors(boot_id="-1")
+        check_unmount_errors()  # check again after reboot to ensure no new errors

--- a/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
+++ b/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
@@ -23,7 +23,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.operating_system import Fedora
-from lisa.tools import Cat, Reboot
+from lisa.tools import Cat, Journalctl, Reboot
 from lisa.util import check_till_timeout
 
 
@@ -291,16 +291,26 @@ class FedoraCloudValidation(TestSuite):
         Reboot and assert no filesystem corruption or recovery errors
         in the journal.
         """
+        corruption_keywords = [
+            "corrupt",
+            "run fsck",
+            "recovery",
+            "recovering",
+            "tree-log replay",
+        ]
 
         def check_unmount_errors() -> None:
-            error_check = node.execute(
-                "journalctl --boot --no-pager"
-                " | grep -iv 'recovery algorithm'"
-                " | grep -iE '(corrupt|run fsck|recovery|recovering|tree-log replay)'",
-                shell=True,
-                no_error_log=True,
-            )
-            assert_that(error_check.stdout.strip()).described_as(
+            journalctl = node.tools[Journalctl]
+            # Fetch full boot journal (no_of_lines=0 skips head truncation) to
+            # catch both kernel FS errors and user-space fsck output.
+            boot_logs = journalctl.first_n_logs_from_boot(no_of_lines=0)
+            matches = [
+                line
+                for line in boot_logs.splitlines()
+                if any(kw in line.lower() for kw in corruption_keywords)
+                and "recovery algorithm" not in line.lower()
+            ]
+            assert_that(matches).described_as(
                 "No filesystem corruption or recovery errors"
                 " should appear in journalctl"
             ).is_empty()

--- a/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
+++ b/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
@@ -5,7 +5,8 @@
 Fedora Cloud Validation Tests
 
 This test suite validates Fedora cloud image configuration and
-functionality. Tests cover OS identification and service status validation.
+functionality. Tests cover OS identification, service status validation,
+package management, and reboot integrity.
 """
 
 from logging import Logger
@@ -22,7 +23,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.operating_system import Fedora
-from lisa.tools import Cat
+from lisa.tools import Cat, Reboot
 from lisa.util import check_till_timeout
 
 
@@ -33,7 +34,8 @@ from lisa.util import check_till_timeout
     Fedora Cloud Image Validation Tests.
 
     Validates Fedora cloud image configuration across cloud platforms.
-    Tests cover: OS identification and service status validation.
+    Tests cover: OS identification, service status validation,
+    package management, and reboot integrity.
     """,
 )
 class FedoraCloudValidation(TestSuite):
@@ -170,3 +172,142 @@ class FedoraCloudValidation(TestSuite):
             ).is_equal_to("running")
 
         node.log.info("No failed services detected")
+
+    @TestCaseMetadata(
+        description="""
+        Verify DNF package install and remove operations work correctly.
+
+        Tests package installation, RPM database verification, config file
+        modification detection, and package removal via DNF.
+
+        Requires a fresh environment because packages are installed and removed,
+        leaving the OS in a modified state unsuitable for other tests.
+        """,
+        priority=1,
+        requirement=simple_requirement(supported_os=[Fedora]),
+        use_new_environment=True,
+    )
+    def verify_package_install_remove(self, node: Node) -> None:
+        """
+        Test packages (autofs and mc) install, RPM verify, and remove cycle via DNF.
+        """
+        # Test packages that are commonly available but not pre-installed
+        test_packages = ["autofs", "mc"]
+
+        # Ensure packages are absent before testing install — guards against
+        # image variants that may pre-install these packages.
+        for package in test_packages:
+            node.execute(f"dnf remove -y {package}", sudo=True, no_error_log=True)
+
+        for package in test_packages:
+            install_result = node.execute(
+                f"dnf install -y {package}",
+                sudo=True,
+                timeout=240,  # 4 min: DNF resolves deps + downloads
+            )
+            assert_that(install_result.exit_code).described_as(
+                f"DNF install of {package} must succeed"
+            ).is_equal_to(0)
+
+            dnf_list = node.execute(
+                f"dnf list --installed {package}", no_error_log=True
+            )
+            assert_that(dnf_list.exit_code).described_as(
+                f"DNF must list {package} as installed"
+            ).is_equal_to(0)
+
+            rpm_result = node.execute(f"rpm -q {package}")
+            assert_that(rpm_result.exit_code).described_as(
+                f"Package {package} must be in RPM database after install"
+            ).is_equal_to(0)
+
+            # Use --noconfig for autofs whose postinstall scriptlet modifies its
+            # own config files (would cause a false failure on the clean check).
+            verify_result = node.execute(
+                f"rpm --verify --noconfig {package}", sudo=True
+            )
+            assert_that(verify_result.exit_code).described_as(
+                f"RPM verification of {package} (non-config files) must pass"
+                " on a clean install"
+            ).is_equal_to(0)
+
+            last_config = node.execute(f"rpm -qlc {package} | tail -n1", shell=True)
+            if last_config.stdout.strip():
+                config_path = last_config.stdout.strip()
+                node.execute(f"touch '{config_path}'", sudo=True)
+                verify_modified = node.execute(
+                    f"rpm --verify {package}", no_error_log=True, sudo=True
+                )
+                # rpm --verify returns a bitmask (e.g. 8 for mtime); assert non-zero
+                assert_that(verify_modified.exit_code).described_as(
+                    f"rpm --verify {package} must report failure"
+                    " after config file modification"
+                ).is_not_equal_to(0)
+            else:
+                node.log.debug(
+                    f"{package} has no config files; skipping modification check"
+                )
+
+            node.log.debug(f"Package {package} installed and verified")
+
+        remove_result = node.execute(
+            f"dnf remove -y {' '.join(test_packages)}", sudo=True
+        )
+        assert_that(remove_result.exit_code).described_as(
+            "DNF remove must succeed"
+        ).is_equal_to(0)
+
+        for package in test_packages:
+            dnf_check = node.execute(
+                f"dnf list --installed {package}", no_error_log=True
+            )
+            assert_that(dnf_check.exit_code).described_as(
+                f"Package {package} must not be listed as installed after removal"
+            ).is_not_equal_to(0)
+
+            rpm_check = node.execute(f"rpm -q {package}", no_error_log=True)
+            assert_that(rpm_check.exit_code).described_as(
+                f"Package {package} must not be in RPM database after removal"
+            ).is_not_equal_to(0)
+
+        node.log.debug(f"Package install/remove test passed for {test_packages}")
+
+    @TestCaseMetadata(
+        description="""
+        Verify system can reboot cleanly without mount point issues.
+
+        Tests system reboot and validates no filesystem corruption or
+        recovery errors appear in journalctl before and after reboot.
+
+        Requires a fresh environment to ensure a clean boot journal
+        baseline unaffected by prior test activity.
+        """,
+        priority=1,
+        requirement=simple_requirement(supported_os=[Fedora]),
+        use_new_environment=True,
+    )
+    def verify_reboot_and_mounts(self, node: Node) -> None:
+        """
+        Reboot and assert no filesystem corruption or recovery errors
+        in the journal.
+        """
+
+        def check_unmount_errors() -> None:
+            error_check = node.execute(
+                "journalctl --boot --no-pager"
+                " | grep -iv 'recovery algorithm'"
+                " | grep -iE '(corrupt|run fsck|recovery|recovering|tree-log replay)'",
+                shell=True,
+                no_error_log=True,
+            )
+            assert_that(error_check.stdout.strip()).described_as(
+                "No filesystem corruption or recovery errors"
+                " should appear in journalctl"
+            ).is_empty()
+
+        check_unmount_errors()
+
+        reboot = node.tools[Reboot]
+        reboot.reboot()
+
+        check_unmount_errors()


### PR DESCRIPTION

## Description
Add DNF package management and reboot integrity tests for Fedora
- verify_package_install_remove: installs autofs and mc via DNF, verifies RPM database presence, rpm --verify clean state, config file modification detection, and clean removal
- verify_reboot_and_mounts: reboots the node and checks journalctl for filesystem corruption or recovery error patterns

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_package_install_remove|verify_reboot_and_mounts | 
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->
FedoraCloudValidation

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- WestUS3/Fedora-5e266ba4-2250-406d-adad-5d73860d958f/Fedora-Cloud-43-x64/latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Fedora-Cloud-43-x64 (WestUS3 community gallery)       |  Standard_D2s_v3       | PASSED |

verify_package_install_remove — PASSED (60.1s)
verify_reboot_and_mounts — PASSED (53.1s)
