### PR TITLE
[AI Generated] BugFix: handle missing SIG OS disk size

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -3013,14 +3013,12 @@ class AzurePlatform(Platform):
 
     def _get_sig_os_disk_size(self, shared_image: SharedImageGallerySchema) -> int:
         found_image = self._get_sig_version(shared_image)
-        assert found_image.storage_profile, "'storage_profile' must not be 'None'"
-        assert (
-            found_image.storage_profile.os_disk_image
-        ), "'os_disk_image' must not be 'None'"
-        assert (
-            found_image.storage_profile.os_disk_image.size_in_gb
-        ), "'size_in_gb' must not be 'None'"
-        return int(found_image.storage_profile.os_disk_image.size_in_gb)
+        storage_profile = found_image.storage_profile
+        assert storage_profile, "'storage_profile' must not be 'None'"
+        os_disk_image = storage_profile.os_disk_image
+        assert os_disk_image, "'os_disk_image' must not be 'None'"
+        size_in_gb = os_disk_image.size_in_gb
+        return int(size_in_gb) if size_in_gb is not None else 0
 
     def _get_cgi_os_disk_size(
         self, community_gallery_image: CommunityGalleryImageSchema

--- a/selftests/azure/test_prepare.py
+++ b/selftests/azure/test_prepare.py
@@ -2,8 +2,10 @@
 # Licensed under the MIT license.
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.case import TestCase
+from unittest.mock import patch
 
 from azure.mgmt.compute.models import ResourceSku  # type: ignore
 
@@ -32,6 +34,22 @@ class AzurePrepareTestCase(TestCase):
         locations = ["westus3", "eastus", "notreal"]
         for location in locations:
             self._platform.get_location_info(location, self._log)
+
+    def test_get_sig_os_disk_size(self) -> None:
+        shared_image = common.SharedImageGallerySchema()
+        for size_in_gb, expected_size in [(None, 0), (64, 64)]:
+            with self.subTest(size_in_gb=size_in_gb):
+                gallery_image: Any = SimpleNamespace(
+                    storage_profile=SimpleNamespace(
+                        os_disk_image=SimpleNamespace(size_in_gb=size_in_gb)
+                    )
+                )
+                with patch.object(
+                    self._platform, "_get_sig_version", return_value=gallery_image
+                ):
+                    actual_size = self._platform._get_sig_os_disk_size(shared_image)
+
+                self.assertEqual(expected_size, actual_size)
 
     def test_load_capability(self) -> None:
         # capability can be loaded correct


### PR DESCRIPTION
Treat omitted SIG osDiskImage.sizeInGB metadata as unknown so the configured OS disk size remains authoritative, with coverage for missing and populated values.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
