### PR TITLE
Azure: resolve SIG OS disk size for VHD-sourced gallery images

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -3014,13 +3014,37 @@ class AzurePlatform(Platform):
     def _get_sig_os_disk_size(self, shared_image: SharedImageGallerySchema) -> int:
         found_image = self._get_sig_version(shared_image)
         assert found_image.storage_profile, "'storage_profile' must not be 'None'"
-        assert (
-            found_image.storage_profile.os_disk_image
-        ), "'os_disk_image' must not be 'None'"
-        assert (
-            found_image.storage_profile.os_disk_image.size_in_gb
-        ), "'size_in_gb' must not be 'None'"
-        return int(found_image.storage_profile.os_disk_image.size_in_gb)
+        os_disk_image = found_image.storage_profile.os_disk_image
+        assert os_disk_image, "'os_disk_image' must not be 'None'"
+        # Azure populates size_in_gb only when the gallery image version is
+        # created from a managed image/disk/snapshot. For versions created from
+        # a VHD blob it stays None, so fall back to reading the size from the OS
+        # disk image's source VHD blob, and finally to a default size. Check for
+        # None explicitly so a genuine 0 is not treated as "not provided".
+        if os_disk_image.size_in_gb is not None:
+            return int(os_disk_image.size_in_gb)
+        source = os_disk_image.source
+        source_uri = getattr(source, "uri", "") if source else ""
+        if source_uri:
+            try:
+                return self._get_vhd_os_disk_size(source_uri)
+            except Exception as ex:
+                # Strip any query string (e.g. SAS token) from the URI and log
+                # only the exception type; the exception message itself may also
+                # embed the URI/SAS token, so it is not logged.
+                safe_uri = source_uri.split("?", 1)[0]
+                self._log.debug(
+                    "failed to read OS disk size from source VHD "
+                    f"'{safe_uri}': {type(ex).__name__}"
+                )
+        # Final fallback: neither size_in_gb nor a readable source VHD is
+        # available to determine the actual OS disk size.
+        default_os_disk_size = 30
+        self._log.debug(
+            "could not determine SIG OS disk size; using default "
+            f"{default_os_disk_size}GB."
+        )
+        return default_os_disk_size
 
     def _get_cgi_os_disk_size(
         self, community_gallery_image: CommunityGalleryImageSchema


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
