### PR TITLE
schema: allow comma-separated maturity criteria

### DIFF
--- a/lisa/schema.py
+++ b/lisa/schema.py
@@ -1750,20 +1750,43 @@ class Criteria:
         default=None,
         metadata=field_metadata(validate=ListableValidator(str), allow_none=True),
     )
-    # maturity filters tests by lifecycle stage.
+    # maturity filters tests by lifecycle stage. It accepts a single value, a
+    # list, or a single comma/space separated string (e.g. from a "-v" override
+    # or a pipeline), which is normalized to a list in __post_init__. Each value
+    # is validated there against the known maturity levels.
     maturity: Optional[Union[str, List[str]]] = field(
         default=None,
         metadata=field_metadata(
-            validate=ListableValidator(
-                str,
-                validate.OneOf(constants.TESTCASE_MATURITY_LEVELS),
-            ),
+            validate=ListableValidator(str),
             allow_none=True,
         ),
     )
 
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
-        strip_strs(self, ["name", "area", "category", "tags", "maturity"])
+        strip_strs(self, ["name", "area", "category", "tags"])
+        self.maturity = self._normalize_maturity(self.maturity)
+
+    @staticmethod
+    def _normalize_maturity(
+        maturity: Optional[Union[str, List[str]]],
+    ) -> Optional[Union[str, List[str]]]:
+        if maturity is None:
+            return None
+        # split a single "stable,preview" (or space separated) string into a
+        # list, so a single command-line/pipeline value can select multiple.
+        if isinstance(maturity, str):
+            parts = [p for p in maturity.replace(",", " ").split() if p]
+            if not parts:
+                return None
+            maturity = parts[0] if len(parts) == 1 else parts
+        values = maturity if isinstance(maturity, list) else [maturity]
+        for value in values:
+            if value not in constants.TESTCASE_MATURITY_LEVELS:
+                raise LisaException(
+                    f"invalid maturity '{value}', must be one of "
+                    f"{constants.TESTCASE_MATURITY_LEVELS}"
+                )
+        return maturity
 
 
 @dataclass_json()


### PR DESCRIPTION
Criteria.maturity now accepts a single comma/space separated string (e.g. from a -v override or pipeline) and normalizes it to a list, validating each value against the known maturity levels. Empty string becomes no filter. Single value and real list inputs are unchanged (backward compatible).

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
