### PR TITLE
azure: exclude Internal_ VM sizes from fallback selector

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -185,8 +185,8 @@ VM_SIZE_FALLBACK_PATTERNS = [
     # Third priority: Standard VM sizes
     # e.g., Standard_D64s_v5, Standard_F32as_v6, Standard_E16ads_v5
     re.compile(r"^Standard_[A-Z]+\d+[a-z]*_v\d+$"),
-    # Catch-all for any remaining VM sizes
-    re.compile(r".*"),
+    # Catch-all for any remaining VM sizes (excluding "internal" sizes)
+    re.compile(r"^(?!.*[Ii]nternal).*$"),
 ]
 
 # VM sizes that have been retired by Azure and must not be deployed.


### PR DESCRIPTION
### Summary

The catch-all pattern in `VM_SIZE_FALLBACK_PATTERNS` in
`lisa/sut_orchestrator/azure/platform_.py` currently matches every VM size,
so the auto-selector can fall back onto sizes whose name starts with
`Internal_` (e.g. `Internal_DC2eds_v6`).

For some of these sizes ARM advertises `AcceleratedNetworkingEnabled=True`,
so LISA's capability builder marks the size as SR-IOV capable and the
requirement matcher happily picks it. In practice the guest cannot bring
up the VF and the test then fails at runtime — these sizes are not intended
for general auto-selection.

### Change

Tighten the last (catch-all) entry in `VM_SIZE_FALLBACK_PATTERNS` so it
skips any name containing `Internal` / `internal`:

```python
# Catch-all for any remaining VM sizes (excluding "internal" sizes)
re.compile(r"^(?!.*[Ii]nternal).*$"),
```

Public sizes are unaffected — they are still matched by the earlier
priority patterns or by this catch-all itself.

### Test

Ran `Sriov.verify_sriov_basic` with `security_profile: cvm` in a
subscription/region whose only CVM+SR-IOV capable size was
`Internal_DC2eds_v6`.

- Before the fix: LISA auto-picked `Internal_DC2eds_v6`, deployment
  succeeded, guest VF setup failed at runtime → test FAILED.
- After the fix: `Internal_DC2eds_v6` is filtered out of the sorted
  candidate list; no other candidate satisfied the requirement in that
  subscription/region → test was SKIPPED with a clear
  `Requirement mismatch` reason instead of running on an unsupported size.

Also verified other public sizes (`Standard_D*_v*`, `Standard_E*_v*`,
`Standard_DC*ads_SPO_v6`, etc.) are still matched by the tightened
catch-all and appear in the sorted candidate list as before.
