### PR TITLE
mshv : Fix host test capability detection

### DIFF
--- a/lisa/microsoft/testsuites/kexec/kexec_suite.py
+++ b/lisa/microsoft/testsuites/kexec/kexec_suite.py
@@ -69,7 +69,7 @@ class KexecSuite(TestSuite):
         kexec as a reboot mechanism.
         """
         # Check systemctl availability early
-        if node.execute("which systemctl", shell=True).exit_code != 0:
+        if node.execute("command -v systemctl", shell=True).exit_code != 0:
             raise SkippedException("systemctl not available on this system")
 
         self._run_kexec_test(node, log, result, use_systemctl=True)
@@ -130,7 +130,7 @@ class KexecSuite(TestSuite):
                 "kexec running-guests test requires at least one guest peer node"
             )
 
-        if target_node.execute("which systemctl", shell=True).exit_code != 0:
+        if target_node.execute("command -v systemctl", shell=True).exit_code != 0:
             raise SkippedException("systemctl not available on this system")
 
         peer_boot_ids = self._record_peer_boot_ids(peer_nodes, log)
@@ -327,7 +327,7 @@ class KexecSuite(TestSuite):
 
         Raises SkippedException if installation fails.
         """
-        kexec_check = node.execute("which kexec", shell=True)
+        kexec_check = node.execute("command -v kexec", shell=True)
         if kexec_check.exit_code == 0:
             log.debug("kexec tool is already installed")
             return
@@ -339,7 +339,7 @@ class KexecSuite(TestSuite):
         node.os.install_packages("kexec-tools")
 
         # Verify installation
-        verify_check = node.execute("which kexec", shell=True)
+        verify_check = node.execute("command -v kexec", shell=True)
         if verify_check.exit_code != 0:
             raise SkippedException(
                 "Failed to install kexec-tools package. "
@@ -669,7 +669,9 @@ class KexecSuite(TestSuite):
         if kexec_marker not in cmdline_after:
             # Gather diagnostic info from previous boot logs
             diagnostic_info = ""
-            has_journalctl = node.execute("which journalctl", shell=True).exit_code == 0
+            has_journalctl = (
+                node.execute("command -v journalctl", shell=True).exit_code == 0
+            )
             if has_journalctl:
                 try:
                     # Check previous boot (-b-1) for kexec evidence
@@ -712,7 +714,7 @@ class KexecSuite(TestSuite):
 
     def _check_system_health(self, node: RemoteNode, log: Logger) -> None:
         """Check basic system health after reboot."""
-        has_systemctl = node.execute("which systemctl", shell=True).exit_code == 0
+        has_systemctl = node.execute("command -v systemctl", shell=True).exit_code == 0
         if has_systemctl:
             result = node.execute("systemctl is-system-running", sudo=True)
             state = result.stdout.strip()

--- a/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
+++ b/lisa/microsoft/testsuites/rust_vmm_mshv/rust_vmm_mshv_test.py
@@ -32,10 +32,10 @@ class RustVmmTestSuite(TestSuite):
             raise SkippedException(f"{node.os} is not supported.")
 
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
-        if not virtualization_enabled:
+        mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)
+        if not virtualization_enabled and not mshv_exists:
             raise SkippedException("Virtualization is not enabled in hardware")
 
-        mshv_exists = node.tools[Ls].path_exists(path="/dev/mshv", sudo=True)
         if not mshv_exists:
             raise SkippedException(
                 "Rust Vmm MSHV test can be run with MSHV wrapper (/dev/mshv) only."


### PR DESCRIPTION
Use POSIX command -v probes so minimal Azure Linux images can discover installed kexec and systemd utilities without the optional which package.

Accept /dev/mshv as proof that MSHV virtualization is available when nested Hyper-V masks VT-x or AMD-V in lscpu output.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
