### PR TITLE
deps: bump PyGObject dependency

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install libgirepository1.0-dev libcairo2-dev ${{ matrix.additional-sys-deps }}
+          sudo apt install libgirepository-2.0-dev libcairo2-dev ${{ matrix.additional-sys-deps }}
         if: startsWith(matrix.os, 'ubuntu')
 
       - name: Install Nox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ azure = [
     "cachetools ~= 5.2.0",
     "Pillow >= 12.2.0; python_version >= '3.10'",
     "Pillow; python_version < '3.10'",
-    "PyGObject <= 3.50.0; platform_system == 'Linux'",
+    "PyGObject < 3.58.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]
 


### PR DESCRIPTION
PyGObject looks to follow semantic versioning and the release notes back this up[0]. There's no increase in system dependencies from 3.50, either, with 3.57 still only requiring glib 2.80+ and libffi 3+. I'm interested in this as Fedora 44+ provides a new PyGObject than 3.50

[0] https://gitlab.gnome.org/GNOME/pygobject/-/blob/3.57.0/NEWS

Note: I couldn't find any use of PyGObject in the project, is it still needed? Grepping for "from gi" and "import gi" came up with no hits and I believe that's the module it provides.