### PR TITLE
storage: fix disk requirement for premium ssd random lun hot add test

### DIFF
--- a/lisa/microsoft/testsuites/core/storage.py
+++ b/lisa/microsoft/testsuites/core/storage.py
@@ -558,7 +558,7 @@ class Storage(TestSuite):
         """,
         priority=2,
         timeout=TIME_OUT,
-        requirement=simple_requirement(disk=DiskStandardSSDLRS()),
+        requirement=simple_requirement(disk=DiskPremiumSSDLRS()),
     )
     def verify_hot_add_disk_serial_random_lun_premium_ssd(
         self, log: Logger, node: Node


### PR DESCRIPTION
verify_hot_add_disk_serial_random_lun_premium_ssd declared a StandardSSDLRS disk requirement while the test body adds PremiumSSDLRS disks. Align the simple_requirement with the disk type actually exercised so the test provisions and validates premium SSD hot-add correctly.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest


## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D2ds_v5| PASSED|
