### PR TITLE
core/dns: tolerate unattended-upgrade held-back packages on FDE/Ubunt…

### DIFF
--- a/lisa/microsoft/testsuites/core/dns.py
+++ b/lisa/microsoft/testsuites/core/dns.py
@@ -159,11 +159,12 @@ class Dns(TestSuite):
                     timeout=2400,
                 )
             if result.exit_code != 0:
+                combined_output = (result.stdout or "") + (result.stderr or "")
                 upgrade_succeeded = bool(
-                    self._upgrade_success_pattern.findall(result.stdout)
+                    self._upgrade_success_pattern.search(combined_output)
                 )
                 has_real_error = bool(
-                    self._upgrade_real_error_pattern.findall(result.stdout)
+                    self._upgrade_real_error_pattern.search(combined_output)
                 )
                 if upgrade_succeeded and not has_real_error:
                     # unattended-upgrade returns a non-zero exit code when it

--- a/lisa/microsoft/testsuites/core/dns.py
+++ b/lisa/microsoft/testsuites/core/dns.py
@@ -40,6 +40,18 @@ class Dns(TestSuite):
     _fail_to_install_package_pattern = re.compile(
         r"ModuleNotFoundError: No module named \'apt_inst\'", re.M
     )
+    # unattended-upgrade prints this once all applicable upgrades are applied.
+    _upgrade_success_pattern = re.compile(r"All upgrades installed", re.M)
+    # Genuine failures from apt/dpkg. unattended-upgrade returns a non-zero exit
+    # code when it only holds back packages (conffile prompts, blacklisted or
+    # pinned packages such as ubuntu-pro-client on FDE/Ubuntu Pro images), which
+    # is not a real failure; these markers distinguish an actual error.
+    _upgrade_real_error_pattern = re.compile(
+        r"^(?:dpkg: error|E: |Errors were encountered)|"
+        r"not fully installed|"
+        r"Sub-process /usr/bin/dpkg returned an error",
+        re.M,
+    )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         log.debug("after_case: mark node as dirty to avoid affecting other test cases")
@@ -147,8 +159,24 @@ class Dns(TestSuite):
                     timeout=2400,
                 )
             if result.exit_code != 0:
-                # make node as dirty, so the node will be not used in next test case
-                node.mark_dirty()
-                raise LisaException(
-                    "fail to run apt update && unattended-upgrade -d -v"
+                upgrade_succeeded = bool(
+                    self._upgrade_success_pattern.findall(result.stdout)
                 )
+                has_real_error = bool(
+                    self._upgrade_real_error_pattern.findall(result.stdout)
+                )
+                if upgrade_succeeded and not has_real_error:
+                    # unattended-upgrade returns a non-zero exit code when it
+                    # holds back packages (conffile prompts, blacklisted or
+                    # pinned packages such as ubuntu-pro-client on FDE/Ubuntu
+                    # Pro images) even though all applicable upgrades installed
+                    # successfully. This is not a failure for this test.
+                    node.log.info(
+                        "unattended-upgrade reported 'All upgrades installed' "
+                        f"with exit code {result.exit_code}; treating held-back "
+                        "packages as a non-fatal condition."
+                    )
+                else:
+                    raise LisaException(
+                        "fail to run apt update && unattended-upgrade -d -v"
+                    )


### PR DESCRIPTION
…u Pro images

verify_dns_name_resolution_after_upgrade failed with a false negative on Ubuntu 22.04 FDE Confidential VM images. `unattended-upgrade -d -v` returns a non-zero exit code whenever it holds back a package (conffile prompt, blacklisted or pinned package such as ubuntu-pro-client / ubuntu-advantage- tools), even though it prints "All upgrades installed" and every applicable upgrade — including the linux-*-azure-fde kernel stack — installed cleanly.

_upgrade_system() treated any non-zero exit as fatal and raised LisaException, failing the case even though DNS resolution succeeded at every checkpoint and the VM rebooted into the new kernel.

Fix: on a non-zero exit, treat the run as success when stdout contains "All upgrades installed" and no genuine apt/dpkg error marker is present (dpkg: error, E:, Errors were encountered, not fully installed, dpkg sub- process error). Only raise LisaException on a real error. A non-fatal held-back condition is now logged at INFO.


## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm 22.04.202307140

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm 22.04.202307140|Standard_DC2as_v6| PASSED |
