### PR TITLE
docs: fix Read the Docs build for PyGObject girepository-2.0

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -6,11 +6,15 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
   apt_packages:
-    - libgirepository1.0-dev
+    # PyGObject >= 3.52 requires girepository-2.0 (shipped by GLib >= 2.80),
+    # not the old libgirepository1.0-dev. Mirrors the CI workflow. This
+    # package is only available on Ubuntu 24.04+, hence the os bump above.
+    - libgirepository-2.0-dev
+    - libcairo2-dev
 
 python:
   install:


### PR DESCRIPTION
PyGObject was bumped to < 3.58.0 (commit 4bb0985), which resolves to >= 3.52 that requires girepository-2.0 (GLib >= 2.80) instead of the old libgirepository1.0-dev. CI was updated to libgirepository-2.0-dev but readthedocs.yaml was missed, so the RTD build on ubuntu-22.04 failed to build PyGObject from source. Bump the RTD image to ubuntu-24.04 and install libgirepository-2.0-dev + libcairo2-dev to match CI.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
