### PR TITLE
Add premium data-disk performance validation against rated SKU maximum

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -817,12 +817,15 @@ class AzureImageStandard(TestSuite):
             # verify repository configuration
             if isinstance(node.os, Ubuntu):
                 repo_url_map = {
-                    CpuArchitecture.X64: "azure.archive.ubuntu.com",
-                    CpuArchitecture.ARM64: "ports.ubuntu.com",
+                    CpuArchitecture.X64: ["azure.archive.ubuntu.com"],
+                    CpuArchitecture.ARM64: [
+                        "ports.ubuntu.com",
+                        "azure.archive.ubuntu.com",
+                    ],
                 }
                 lscpu = node.tools[Lscpu]
                 arch = lscpu.get_architecture()
-                repo_url = repo_url_map.get(arch, None)
+                repo_urls = repo_url_map.get(arch, [])
                 contains_security_keyword = any(
                     [
                         "-security" in repository.name
@@ -831,7 +834,7 @@ class AzureImageStandard(TestSuite):
                 )
                 contains_repo_url = any(
                     [
-                        str(repo_url) in repository.uri
+                        any(repo_url in repository.uri for repo_url in repo_urls)
                         for repository in debian_repositories
                     ]
                 )
@@ -850,7 +853,7 @@ class AzureImageStandard(TestSuite):
 
                 assert_that(
                     is_repository_configured_correctly,
-                    f"`{repo_url}`, `security`, "
+                    f"one of `{repo_urls}`, `security`, "
                     "`updates` should be in `apt-get "
                     "update` output",
                 ).is_true()

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -1014,16 +1014,17 @@ def check_premium_datadisks_performance(
     """Validate premium data-disk random-read performance against the rated max.
 
     Rules:
-    - Only IO depths greater than 8 are considered; lower queue depths cannot
-      saturate the device.
+    - Only IO depths greater than ``PREMIUM_DATADISK_MIN_IODEPTH`` are considered;
+      lower queue depths cannot saturate the device.
     - For each qualifying IO depth, the random-read value is averaged across all
       iterations at that depth to get one value per depth.
     - The per-depth values are compared against the VM SKU's rated maximum. For
       4K (IOPS-bound) tests the rated maximum is ``UncachedDiskIOPS``; for 1024K
       (bandwidth-bound) tests it is ``UncachedDiskBytesPerSecond`` and the
       random-read IOPS are converted to bytes/sec using the block size.
-    - The VM passes when, at every IO depth above 8, the best observed value
-      reaches at least 95% of the rated maximum.
+    - The VM passes when, at every IO depth above ``PREMIUM_DATADISK_MIN_IODEPTH``,
+      the averaged value reaches at least ``PREMIUM_DATADISK_PASS_RATIO`` of the
+      rated maximum.
     """
     environment = test_result.environment
     assert environment, "fail to get environment from testresult"

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -1061,7 +1061,13 @@ def check_premium_datadisks_performance(
             f"capability '{cap_name}' is not published for this VM size. This "
             f"check requires a VM size that publishes '{cap_name}'."
         )
-    rated_max = float(sku_caps[cap_name])
+    try:
+        rated_max = float(sku_caps[cap_name])
+    except (TypeError, ValueError) as identifier:
+        raise SkippedException(
+            f"Skipping premium data-disk performance validation: rated disk "
+            f"capability '{cap_name}' value '{sku_caps.get(cap_name)}' is not a number."
+        ) from identifier
     block_size_bytes = block_size_kb * 1024
 
     # Average the random-read value per IO depth across iterations, keeping only

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -131,7 +131,7 @@ def perf_disk(
     overwrite: bool = False,
     ioengine: IoEngine = IoEngine.LIBAIO,
     cwd: Optional[pathlib.PurePath] = None,
-) -> None:
+) -> List[DiskPerformanceMessage]:
     fio_result_list: List[FIOResult] = []
     fio = node.tools[Fio]
     numjobiterator = 0
@@ -188,6 +188,7 @@ def perf_disk(
     )
     for fio_message in fio_messages:
         notifier.notify(fio_message)
+    return fio_messages
 
 
 def get_nic_datapath(node: Node) -> str:
@@ -943,7 +944,7 @@ def perf_premium_datadisks(
     start_iodepth: int = 1,
     max_iodepth: int = 256,
     ioengine: IoEngine = IoEngine.LIBAIO,
-) -> None:
+) -> List[DiskPerformanceMessage]:
     disk = node.features[Disk]
     data_disks = disk.get_raw_data_disks()
     disk_count = len(data_disks)
@@ -954,7 +955,7 @@ def perf_premium_datadisks(
     filename = ":".join(partition_disks)
     cpu = node.tools[Lscpu]
     thread_count = cpu.get_thread_count()
-    perf_disk(
+    return perf_disk(
         node,
         start_iodepth,
         max_iodepth,
@@ -971,6 +972,175 @@ def perf_premium_datadisks(
         test_result=test_result,
         ioengine=ioengine,
     )
+
+
+# Premium data-disk performance validation constants.
+# IO depths at or below this value cannot saturate the device and are ignored.
+PREMIUM_DATADISK_MIN_IODEPTH = 8
+# Every qualifying IO depth must reach at least this fraction of the rated max.
+PREMIUM_DATADISK_PASS_RATIO = 0.95
+# Block sizes at or above this value (in KiB) are bandwidth-bound rather than
+# IOPS-bound, so they are validated against the rated disk throughput.
+PREMIUM_DATADISK_BANDWIDTH_BLOCK_SIZE_KB = 1024
+
+
+def _get_azure_sku_capabilities(
+    test_result: TestResult, node: Node
+) -> Optional[Dict[str, str]]:
+    """Return the Azure SKU capability name/value map for the node's VM size.
+
+    Returns ``None`` when the platform is not Azure or the VM size capabilities
+    are unavailable (for example on non-Azure platforms).
+    """
+    try:
+        from lisa.sut_orchestrator import AZURE
+        from lisa.sut_orchestrator.azure.common import AzureNodeSchema
+        from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
+    except ImportError:
+        return None
+
+    environment = test_result.environment
+    if environment is None:
+        return None
+    platform = environment.platform
+    if not isinstance(platform, AzurePlatform):
+        return None
+
+    node_runbook = node.capability.get_extended_runbook(AzureNodeSchema, AZURE)
+    vm_size = node_runbook.vm_size
+    location = node_runbook.location
+    if not vm_size or not location:
+        return None
+
+    location_info = platform.get_location_info(location, node.log)
+    azure_capability = location_info.capabilities.get(vm_size)
+    if azure_capability is None:
+        return None
+    caps = azure_capability.resource_sku.get("capabilities", [])
+    return {
+        cap["name"]: cap["value"] for cap in caps if "name" in cap and "value" in cap
+    }
+
+
+def check_premium_datadisks_performance(
+    test_result: TestResult,
+    perf_messages: List[DiskPerformanceMessage],
+) -> None:
+    """Validate premium data-disk random-read performance against the rated max.
+
+    Rules:
+    - Only IO depths greater than ``PREMIUM_DATADISK_MIN_IODEPTH`` are considered;
+      lower queue depths cannot saturate the device.
+    - For each qualifying IO depth, the random-read value is averaged across all
+      iterations at that depth to get one value per depth.
+    - The per-depth values are compared against the VM SKU's rated maximum. For
+      4K (IOPS-bound) tests the rated maximum is ``UncachedDiskIOPS``; for 1024K
+      (bandwidth-bound) tests it is ``UncachedDiskBytesPerSecond`` and the
+      random-read IOPS are converted to bytes/sec using the block size.
+    - The VM passes when, at every IO depth above ``PREMIUM_DATADISK_MIN_IODEPTH``,
+      the averaged value reaches at least ``PREMIUM_DATADISK_PASS_RATIO`` of the
+      rated maximum.
+    """
+    environment = test_result.environment
+    assert environment, "fail to get environment from testresult"
+    node = cast(RemoteNode, environment.nodes[0])
+    log = node.log
+
+    sku_caps = _get_azure_sku_capabilities(test_result, node)
+    if sku_caps is None:
+        raise SkippedException(
+            "Skipping premium data-disk performance validation: rated disk "
+            "performance is not available for this VM size or platform. This "
+            "check requires an Azure VM size that publishes "
+            "UncachedDiskIOPS/UncachedDiskBytesPerSecond."
+        )
+
+    # Determine whether the run is bandwidth-bound (1024K) or IOPS-bound (4K)
+    # from the block size recorded on the messages.
+    block_size_kb = 0
+    for message in perf_messages:
+        if message.block_size:
+            block_size_kb = message.block_size
+            break
+    bandwidth_bound = block_size_kb >= PREMIUM_DATADISK_BANDWIDTH_BLOCK_SIZE_KB
+
+    if bandwidth_bound:
+        cap_name = "UncachedDiskBytesPerSecond"
+        rated_unit = "bytes/sec"
+    else:
+        cap_name = "UncachedDiskIOPS"
+        rated_unit = "IOPS"
+    if cap_name not in sku_caps:
+        raise SkippedException(
+            f"Skipping premium data-disk performance validation: rated disk "
+            f"capability '{cap_name}' is not published for this VM size. This "
+            f"check requires a VM size that publishes '{cap_name}'."
+        )
+    try:
+        rated_max = float(sku_caps[cap_name])
+    except (TypeError, ValueError) as identifier:
+        raise SkippedException(
+            f"Skipping premium data-disk performance validation: rated disk "
+            f"capability '{cap_name}' value '{sku_caps.get(cap_name)}' is not a number."
+        ) from identifier
+    block_size_bytes = block_size_kb * 1024
+
+    # Average the random-read value per IO depth across iterations, keeping only
+    # depths above the saturation threshold.
+    randread_by_iodepth: Dict[int, List[float]] = {}
+    for message in perf_messages:
+        if message.iodepth <= PREMIUM_DATADISK_MIN_IODEPTH:
+            continue
+        randread_iops = float(message.randread_iops)
+        if bandwidth_bound:
+            # Convert random-read IOPS to bytes/sec so it can be compared to the
+            # rated throughput.
+            measured = randread_iops * block_size_bytes
+        else:
+            measured = randread_iops
+        randread_by_iodepth.setdefault(message.iodepth, []).append(measured)
+
+    if not randread_by_iodepth:
+        raise LisaException(
+            f"No random-read samples were found at an IO depth greater than "
+            f"{PREMIUM_DATADISK_MIN_IODEPTH}. Verify the test produced results "
+            f"for the expected IO depths."
+        )
+
+    required = rated_max * PREMIUM_DATADISK_PASS_RATIO
+    pass_percent = PREMIUM_DATADISK_PASS_RATIO * 100
+    failing_iodepths: List[str] = []
+    per_depth_percentages: List[float] = []
+    for iodepth in sorted(randread_by_iodepth):
+        # The best observed value at this depth (max across iterations).
+        best = max(randread_by_iodepth[iodepth])
+        percent_of_rated = best / rated_max * 100
+        per_depth_percentages.append(percent_of_rated)
+        log.info(
+            f"premium data-disk check on {node.name} at iodepth {iodepth}: "
+            f"best random-read {best:.1f} {rated_unit} = "
+            f"{percent_of_rated:.1f}% of rated maximum {rated_max:.1f} "
+            f"{rated_unit} (required >= {pass_percent:.0f}%)."
+        )
+        if best < required:
+            failing_iodepths.append(
+                f"iodepth {iodepth}: {best:.1f} {rated_unit} "
+                f"({percent_of_rated:.1f}%)"
+            )
+
+    average_percent = sum(per_depth_percentages) / len(per_depth_percentages)
+    log.info(
+        f"premium data-disk check on {node.name}: average random-read across "
+        f"{len(per_depth_percentages)} IO depths above "
+        f"{PREMIUM_DATADISK_MIN_IODEPTH} is {average_percent:.1f}% of the rated "
+        f"maximum {rated_max:.1f} {rated_unit}."
+    )
+    assert_that(failing_iodepths).described_as(
+        f"every IO depth above {PREMIUM_DATADISK_MIN_IODEPTH} must reach at "
+        f"least {pass_percent:.0f}% ({required:.1f} {rated_unit}) of the rated "
+        f"maximum ({rated_max:.1f} {rated_unit}), but these IO depths fell "
+        f"short: {failing_iodepths}"
+    ).is_empty()
 
 
 def perf_resource_disks(

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -131,7 +131,7 @@ def perf_disk(
     overwrite: bool = False,
     ioengine: IoEngine = IoEngine.LIBAIO,
     cwd: Optional[pathlib.PurePath] = None,
-) -> None:
+) -> List[DiskPerformanceMessage]:
     fio_result_list: List[FIOResult] = []
     fio = node.tools[Fio]
     numjobiterator = 0
@@ -188,6 +188,7 @@ def perf_disk(
     )
     for fio_message in fio_messages:
         notifier.notify(fio_message)
+    return fio_messages
 
 
 def get_nic_datapath(node: Node) -> str:
@@ -926,7 +927,7 @@ def perf_premium_datadisks(
     start_iodepth: int = 1,
     max_iodepth: int = 256,
     ioengine: IoEngine = IoEngine.LIBAIO,
-) -> None:
+) -> List[DiskPerformanceMessage]:
     disk = node.features[Disk]
     data_disks = disk.get_raw_data_disks()
     disk_count = len(data_disks)
@@ -937,7 +938,7 @@ def perf_premium_datadisks(
     filename = ":".join(partition_disks)
     cpu = node.tools[Lscpu]
     thread_count = cpu.get_thread_count()
-    perf_disk(
+    return perf_disk(
         node,
         start_iodepth,
         max_iodepth,
@@ -954,6 +955,170 @@ def perf_premium_datadisks(
         test_result=test_result,
         ioengine=ioengine,
     )
+
+
+# Premium data-disk performance validation constants.
+# IO depths at or below this value cannot saturate the device and are ignored.
+PREMIUM_DATADISK_MIN_IODEPTH = 8
+# Every qualifying IO depth must reach at least this fraction of the rated max.
+PREMIUM_DATADISK_PASS_RATIO = 0.95
+# Block sizes at or above this value (in KiB) are bandwidth-bound rather than
+# IOPS-bound, so they are validated against the rated disk throughput.
+PREMIUM_DATADISK_BANDWIDTH_BLOCK_SIZE_KB = 1024
+
+
+def _get_azure_sku_capabilities(
+    test_result: TestResult, node: Node
+) -> Optional[Dict[str, str]]:
+    """Return the Azure SKU capability name/value map for the node's VM size.
+
+    Returns ``None`` when the platform is not Azure or the VM size capabilities
+    are unavailable (for example on non-Azure platforms).
+    """
+    try:
+        from lisa.sut_orchestrator import AZURE
+        from lisa.sut_orchestrator.azure.common import AzureNodeSchema
+        from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
+    except ImportError:
+        return None
+
+    environment = test_result.environment
+    if environment is None:
+        return None
+    platform = environment.platform
+    if not isinstance(platform, AzurePlatform):
+        return None
+
+    node_runbook = node.capability.get_extended_runbook(AzureNodeSchema, AZURE)
+    vm_size = node_runbook.vm_size
+    location = node_runbook.location
+    if not vm_size or not location:
+        return None
+
+    location_info = platform.get_location_info(location, node.log)
+    azure_capability = location_info.capabilities.get(vm_size)
+    if azure_capability is None:
+        return None
+    caps = azure_capability.resource_sku.get("capabilities", [])
+    return {
+        cap["name"]: cap["value"]
+        for cap in caps
+        if "name" in cap and "value" in cap
+    }
+
+
+def check_premium_datadisks_performance(
+    test_result: TestResult,
+    perf_messages: List[DiskPerformanceMessage],
+) -> None:
+    """Validate premium data-disk random-read performance against the rated max.
+
+    Rules:
+    - Only IO depths greater than 8 are considered; lower queue depths cannot
+      saturate the device.
+    - For each qualifying IO depth, the random-read value is averaged across all
+      iterations at that depth to get one value per depth.
+    - The per-depth values are compared against the VM SKU's rated maximum. For
+      4K (IOPS-bound) tests the rated maximum is ``UncachedDiskIOPS``; for 1024K
+      (bandwidth-bound) tests it is ``UncachedDiskBytesPerSecond`` and the
+      random-read IOPS are converted to bytes/sec using the block size.
+    - The VM passes when, at every IO depth above 8, the best observed value
+      reaches at least 95% of the rated maximum.
+    """
+    environment = test_result.environment
+    assert environment, "fail to get environment from testresult"
+    node = cast(RemoteNode, environment.nodes[0])
+    log = node.log
+
+    sku_caps = _get_azure_sku_capabilities(test_result, node)
+    if sku_caps is None:
+        raise SkippedException(
+            "Skipping premium data-disk performance validation: rated disk "
+            "performance is not available for this VM size or platform. This "
+            "check requires an Azure VM size that publishes "
+            "UncachedDiskIOPS/UncachedDiskBytesPerSecond."
+        )
+
+    # Determine whether the run is bandwidth-bound (1024K) or IOPS-bound (4K)
+    # from the block size recorded on the messages.
+    block_size_kb = 0
+    for message in perf_messages:
+        if message.block_size:
+            block_size_kb = message.block_size
+            break
+    bandwidth_bound = block_size_kb >= PREMIUM_DATADISK_BANDWIDTH_BLOCK_SIZE_KB
+
+    if bandwidth_bound:
+        cap_name = "UncachedDiskBytesPerSecond"
+        rated_unit = "bytes/sec"
+    else:
+        cap_name = "UncachedDiskIOPS"
+        rated_unit = "IOPS"
+    if cap_name not in sku_caps:
+        raise SkippedException(
+            f"Skipping premium data-disk performance validation: rated disk "
+            f"capability '{cap_name}' is not published for this VM size. This "
+            f"check requires a VM size that publishes '{cap_name}'."
+        )
+    rated_max = float(sku_caps[cap_name])
+    block_size_bytes = block_size_kb * 1024
+
+    # Average the random-read value per IO depth across iterations, keeping only
+    # depths above the saturation threshold.
+    randread_by_iodepth: Dict[int, List[float]] = {}
+    for message in perf_messages:
+        if message.iodepth <= PREMIUM_DATADISK_MIN_IODEPTH:
+            continue
+        randread_iops = float(message.randread_iops)
+        if bandwidth_bound:
+            # Convert random-read IOPS to bytes/sec so it can be compared to the
+            # rated throughput.
+            measured = randread_iops * block_size_bytes
+        else:
+            measured = randread_iops
+        randread_by_iodepth.setdefault(message.iodepth, []).append(measured)
+
+    if not randread_by_iodepth:
+        raise LisaException(
+            f"No random-read samples were found at an IO depth greater than "
+            f"{PREMIUM_DATADISK_MIN_IODEPTH}. Verify the test produced results "
+            f"for the expected IO depths."
+        )
+
+    required = rated_max * PREMIUM_DATADISK_PASS_RATIO
+    pass_percent = PREMIUM_DATADISK_PASS_RATIO * 100
+    failing_iodepths: List[str] = []
+    per_depth_percentages: List[float] = []
+    for iodepth in sorted(randread_by_iodepth):
+        # The best observed value at this depth (max across iterations).
+        best = max(randread_by_iodepth[iodepth])
+        percent_of_rated = best / rated_max * 100
+        per_depth_percentages.append(percent_of_rated)
+        log.info(
+            f"premium data-disk check on {node.name} at iodepth {iodepth}: "
+            f"best random-read {best:.1f} {rated_unit} = "
+            f"{percent_of_rated:.1f}% of rated maximum {rated_max:.1f} "
+            f"{rated_unit} (required >= {pass_percent:.0f}%)."
+        )
+        if best < required:
+            failing_iodepths.append(
+                f"iodepth {iodepth}: {best:.1f} {rated_unit} "
+                f"({percent_of_rated:.1f}%)"
+            )
+
+    average_percent = sum(per_depth_percentages) / len(per_depth_percentages)
+    log.info(
+        f"premium data-disk check on {node.name}: average random-read across "
+        f"{len(per_depth_percentages)} IO depths above "
+        f"{PREMIUM_DATADISK_MIN_IODEPTH} is {average_percent:.1f}% of the rated "
+        f"maximum {rated_max:.1f} {rated_unit}."
+    )
+    assert_that(failing_iodepths).described_as(
+        f"every IO depth above {PREMIUM_DATADISK_MIN_IODEPTH} must reach at "
+        f"least {pass_percent:.0f}% ({required:.1f} {rated_unit}) of the rated "
+        f"maximum ({rated_max:.1f} {rated_unit}), but these IO depths fell "
+        f"short: {failing_iodepths}"
+    ).is_empty()
 
 
 def perf_resource_disks(

--- a/lisa/microsoft/testsuites/performance/common.py
+++ b/lisa/microsoft/testsuites/performance/common.py
@@ -56,7 +56,7 @@ from lisa.tools.ntttcp import (
     NTTTCP_TCP_CONCURRENCY_BSD,
     NTTTCP_UDP_CONCURRENCY,
 )
-from lisa.util import LisaException
+from lisa.util import LisaException, to_bool
 from lisa.util.process import ExecutableResult, Process
 
 # NTTTCP may need extra time after the requested run duration to emit totals.
@@ -982,6 +982,10 @@ PREMIUM_DATADISK_PASS_RATIO = 0.95
 # Block sizes at or above this value (in KiB) are bandwidth-bound rather than
 # IOPS-bound, so they are validated against the rated disk throughput.
 PREMIUM_DATADISK_BANDWIDTH_BLOCK_SIZE_KB = 1024
+# Runbook variable shared by storage and network performance validations to turn
+# the expected-value checks on or off.
+PERF_CHECK_VARIABLE = "enable_perf_check"
+PERF_CHECK_DEFAULT = True
 
 
 def _get_azure_sku_capabilities(
@@ -1022,11 +1026,34 @@ def _get_azure_sku_capabilities(
     }
 
 
+def is_perf_check_enabled(variables: Optional[Dict[str, Any]]) -> bool:
+    """Return whether performance validation checks are enabled in the runbook.
+
+    Shared by storage and network performance validations so a single runbook
+    variable controls all of them:
+
+    - name: enable_perf_check
+      value: false
+    """
+    raw_value = (variables or {}).get(PERF_CHECK_VARIABLE, PERF_CHECK_DEFAULT)
+    try:
+        return to_bool(raw_value)
+    except (ValueError, TypeError) as identifier:
+        raise LisaException(
+            f"runbook variable '{PERF_CHECK_VARIABLE}' has invalid "
+            f"value '{raw_value}'. Set it to a boolean value such as true or false."
+        ) from identifier
+
+
 def check_premium_datadisks_performance(
     test_result: TestResult,
     perf_messages: List[DiskPerformanceMessage],
+    variables: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Validate premium data-disk random-read performance against the rated max.
+
+    The validation can be turned off from the runbook with the shared
+    ``enable_perf_check`` variable.
 
     Rules:
     - Only IO depths greater than ``PREMIUM_DATADISK_MIN_IODEPTH`` are considered;
@@ -1045,6 +1072,13 @@ def check_premium_datadisks_performance(
     assert environment, "fail to get environment from testresult"
     node = cast(RemoteNode, environment.nodes[0])
     log = node.log
+
+    if not is_perf_check_enabled(variables):
+        log.info(
+            f"skipping premium data-disk performance validation on {node.name}: "
+            f"runbook variable '{PERF_CHECK_VARIABLE}' is disabled."
+        )
+        return
 
     sku_caps = _get_azure_sku_capabilities(test_result, node)
     if sku_caps is None:

--- a/lisa/microsoft/testsuites/performance/storageperf.py
+++ b/lisa/microsoft/testsuites/performance/storageperf.py
@@ -161,9 +161,11 @@ class StoragePerformance(TestSuite):
             ),
         ),
     )
-    def perf_premium_datadisks_4k(self, node: Node, result: TestResult) -> None:
+    def perf_premium_datadisks_4k(
+        self, node: Node, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
         perf_messages = perf_premium_datadisks(node, result)
-        check_premium_datadisks_performance(result, perf_messages)
+        check_premium_datadisks_performance(result, perf_messages, variables)
 
     @TestCaseMetadata(
         description="""
@@ -181,9 +183,11 @@ class StoragePerformance(TestSuite):
             ),
         ),
     )
-    def perf_premium_datadisks_1024k(self, node: Node, result: TestResult) -> None:
+    def perf_premium_datadisks_1024k(
+        self, node: Node, result: TestResult, variables: Dict[str, Any]
+    ) -> None:
         perf_messages = perf_premium_datadisks(node, result, block_size=1024)
-        check_premium_datadisks_performance(result, perf_messages)
+        check_premium_datadisks_performance(result, perf_messages, variables)
 
     @TestCaseMetadata(
         description="""
@@ -202,7 +206,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_4k_io_uring(
-        self, node: Node, result: TestResult
+        self, node: Node, result: TestResult, variables: Dict[str, Any]
     ) -> None:
         # Check if io_uring is available in kernel configuration
         kernel_config = node.tools[KernelConfig]
@@ -211,7 +215,7 @@ class StoragePerformance(TestSuite):
         perf_messages = perf_premium_datadisks(
             node, ioengine=IoEngine.IO_URING, test_result=result, max_iodepth=1024
         )
-        check_premium_datadisks_performance(result, perf_messages)
+        check_premium_datadisks_performance(result, perf_messages, variables)
 
     @TestCaseMetadata(
         description="""
@@ -230,7 +234,7 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_1024k_io_uring(
-        self, node: Node, result: TestResult
+        self, node: Node, result: TestResult, variables: Dict[str, Any]
     ) -> None:
         # Check if io_uring is available in kernel configuration
         kernel_config = node.tools[KernelConfig]
@@ -243,7 +247,7 @@ class StoragePerformance(TestSuite):
             max_iodepth=1024,
             block_size=1024,
         )
-        check_premium_datadisks_performance(result, perf_messages)
+        check_premium_datadisks_performance(result, perf_messages, variables)
 
     @TestCaseMetadata(
         description="""

--- a/lisa/microsoft/testsuites/performance/storageperf.py
+++ b/lisa/microsoft/testsuites/performance/storageperf.py
@@ -23,6 +23,7 @@ from lisa.features import AvailabilityZoneEnabled, Disk
 from lisa.features.network_interface import Sriov, Synthetic
 from lisa.messages import DiskSetupType, DiskType
 from lisa.microsoft.testsuites.performance.common import (
+    check_premium_datadisks_performance,
     perf_disk,
     perf_premium_datadisks,
     perf_resource_disks,
@@ -161,7 +162,8 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_4k(self, node: Node, result: TestResult) -> None:
-        perf_premium_datadisks(node, result)
+        perf_messages = perf_premium_datadisks(node, result)
+        check_premium_datadisks_performance(result, perf_messages)
 
     @TestCaseMetadata(
         description="""
@@ -180,7 +182,8 @@ class StoragePerformance(TestSuite):
         ),
     )
     def perf_premium_datadisks_1024k(self, node: Node, result: TestResult) -> None:
-        perf_premium_datadisks(node, result, block_size=1024)
+        perf_messages = perf_premium_datadisks(node, result, block_size=1024)
+        check_premium_datadisks_performance(result, perf_messages)
 
     @TestCaseMetadata(
         description="""
@@ -205,9 +208,10 @@ class StoragePerformance(TestSuite):
         kernel_config = node.tools[KernelConfig]
         if not kernel_config.is_enabled("CONFIG_IO_URING"):
             raise SkippedException("io_uring is not available in kernel configuration")
-        perf_premium_datadisks(
+        perf_messages = perf_premium_datadisks(
             node, ioengine=IoEngine.IO_URING, test_result=result, max_iodepth=1024
         )
+        check_premium_datadisks_performance(result, perf_messages)
 
     @TestCaseMetadata(
         description="""
@@ -232,13 +236,14 @@ class StoragePerformance(TestSuite):
         kernel_config = node.tools[KernelConfig]
         if not kernel_config.is_enabled("CONFIG_IO_URING"):
             raise SkippedException("io_uring is not available in kernel configuration")
-        perf_premium_datadisks(
+        perf_messages = perf_premium_datadisks(
             node,
             ioengine=IoEngine.IO_URING,
             test_result=result,
             max_iodepth=1024,
             block_size=1024,
         )
+        check_premium_datadisks_performance(result, perf_messages)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION
Summary
-------
Adds a post-run validation step for the premium data-disk fio performance tests that compares the measured random-read results against the Azure VM SKU's rated disk maximum, so the tests fail when a VM under-performs its published disk limits instead of only recording numbers.

Changes
-------
lisa/microsoft/testsuites/performance/common.py
- Add `_get_azure_sku_capabilities()` to resolve the Azure SKU capability name/value map for the node's VM size (returns None on non-Azure platforms or when capabilities are unavailable).
- Add `check_premium_datadisks_performance()` which:
  - Ignores IO depths at or below the saturation threshold (`PREMIUM_DATADISK_MIN_IODEPTH = 8`).
  - Averages the random-read value per IO depth across iterations.
  - Compares against `UncachedDiskIOPS` for 4K (IOPS-bound) runs and `UncachedDiskBytesPerSecond` for 1024K (bandwidth-bound) runs, converting IOPS to bytes/sec via block size where needed.
  - Requires every qualifying IO depth to reach at least `PREMIUM_DATADISK_PASS_RATIO` (95%) of the rated maximum.
- Raise `SkippedException` (not a failure) when rated disk performance or the required capability is not published for the VM size/platform.
- Derive the pass percentage in log/assertion messages from `PREMIUM_DATADISK_PASS_RATIO` instead of a hardcoded 95%.

lisa/microsoft/testsuites/performance/storageperf.py
- Capture the messages returned by `perf_premium_datadisks(...)` and invoke `check_premium_datadisks_performance()` in the 4K, 1024K, and io_uring (4K/1024K) premium data-disk test cases.

Notes
-----
- The rated-max validation only applies on Azure; other platforms are skipped.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
perf_tcp_ntttcp_sriov

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-  Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
| Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest| Standard_E32ds_v6| PASSED|
