### PR TITLE
deps: remove PyGObject dependency

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install libgirepository-2.0-dev libcairo2-dev ${{ matrix.additional-sys-deps }}
-        if: startsWith(matrix.os, 'ubuntu')
+          if [ -n "${{ matrix.additional-sys-deps }}" ]; then
+            sudo apt install ${{ matrix.additional-sys-deps }}
+          fi
+        if: startsWith(matrix.os, 'ubuntu') && matrix.additional-sys-deps
 
       - name: Install Nox
         run: pip install nox toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ azure = [
     "cachetools ~= 5.2.0",
     "Pillow >= 12.2.0; python_version >= '3.10'",
     "Pillow; python_version < '3.10'",
-    "PyGObject < 3.58.0; platform_system == 'Linux'",
     "pycdlib ~= 1.12.0",
 ]
 

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -9,8 +9,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  apt_packages:
-    - libgirepository1.0-dev
 
 python:
   install:


### PR DESCRIPTION
## Summary
Remove the `PyGObject` dependency entirely. Supersedes #4622 and #4627.

## Why
- PyGObject is **not imported anywhere** in LISA — it was only carried as a
  transitive/optional requirement in the `azure` extra (added in 2021 for an
  azure-mgmt-* transitive need that no longer exists).
- It is the **sole reason** for the `libgirepository*` / `libcairo2-dev`
  system packages. Once PyGObject resolved to 3.52+ (which needs
  `girepository-2.0` / GLib >= 2.80), those packages broke both CI and the
  Read the Docs build (`ubuntu-22.04` only ships `libgirepository1.0-dev`).

## Changes
- `pyproject.toml`: drop `PyGObject` from the `azure` extra.
- `.github/workflows/continuous-integration-workflow.yml`: stop installing
  `libgirepository1.0-dev` / `libcairo2-dev`; only install
  `matrix.additional-sys-deps` (keeps `libvirt-dev`).
- `readthedocs.yaml`: drop `apt_packages` (girepository no longer needed).

## Validation (Ubuntu 24.04, no girepository/cairo system libs)
- `pip install .[azure,docs,aws]` succeeds; PyGObject is **not** installed.
- LISA + Azure SDK imports (compute / network / resource / storage / identity) pass.
- `sphinx-build` docs: `build succeeded`.