### PR TITLE
LISA: classify exact CVM libvirt startup failures as skips

### DIFF
--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -8,7 +8,7 @@ import yaml
 
 # ExceptionGroup is built-in for Python 3.11+
 try:
-    from exceptiongroup import ExceptionGroup
+    from exceptiongroup import ExceptionGroup  # pylint: disable=redefined-builtin
 except ImportError:
     # Python 3.11+ has ExceptionGroup as a built-in
     pass
@@ -44,6 +44,18 @@ class StressNgTestSuite(TestSuite):
     TIME_OUT = 435600
     CONFIG_VARIABLE = "stress_ng_jobs"
 
+    @staticmethod
+    def _normalize_job_files(jobs: Any) -> List[str]:
+        if jobs is None:
+            return []
+
+        if isinstance(jobs, list):
+            candidates = jobs
+        else:
+            candidates = str(jobs).split(",")
+
+        return [str(job).strip() for job in candidates if str(job).strip()]
+
     @TestCaseMetadata(
         description="""
         Runs a stress-ng jobfile. The path to the jobfile must be specified
@@ -62,11 +74,9 @@ class StressNgTestSuite(TestSuite):
         result: TestResult,
     ) -> None:
         if self.CONFIG_VARIABLE in variables:
-            jobs = variables[self.CONFIG_VARIABLE]
-
-            # Convert job file configuration to a list if needed
-            if not isinstance(jobs, list):
-                jobs = [job.strip() for job in str(jobs).split(",")]
+            jobs = self._normalize_job_files(variables[self.CONFIG_VARIABLE])
+            if not jobs:
+                raise SkippedException("No jobfile provided for stress-ng")
 
             for job_file in jobs:
                 try:
@@ -179,9 +189,9 @@ class StressNgTestSuite(TestSuite):
         if self.CONFIG_VARIABLE not in variables:
             raise SkippedException("No jobfile provided for multi-VM stress test")
 
-        jobs = variables[self.CONFIG_VARIABLE]
-        if not isinstance(jobs, list):
-            jobs = [job.strip() for job in str(jobs).split(",")]
+        jobs = self._normalize_job_files(variables[self.CONFIG_VARIABLE])
+        if not jobs:
+            raise SkippedException("No jobfile provided for multi-VM stress test")
 
         # Execute each jobfile across all VMs
         for job_file in jobs:
@@ -316,6 +326,10 @@ class StressNgTestSuite(TestSuite):
                 node.shell.mkdir(remote_workspace, exist_ok=True)
 
                 # Deploy job file to remote node
+                if not Path(job_file).is_file():
+                    raise FileNotFoundError(
+                        f"stress-ng job file is not a file: {job_file}"
+                    )
                 remote_job_file = remote_workspace / job_file_name
                 node.shell.copy(PurePath(job_file), remote_job_file)
 

--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -7,8 +7,10 @@ import re
 import secrets
 import shutil
 import xml.etree.ElementTree as ET  # noqa: N817
-from pathlib import Path
-from typing import Any, List, Type, cast
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, List, Tuple, Type, cast
+
+import libvirt
 
 from lisa import schema
 from lisa.environment import Environment
@@ -20,8 +22,8 @@ from lisa.sut_orchestrator.libvirt.context import (
     get_node_context,
 )
 from lisa.sut_orchestrator.libvirt.platform import BaseLibvirtPlatform
-from lisa.tools import Ls, QemuImg
-from lisa.util import LisaException, parse_version
+from lisa.tools import Chown, Cp, Ls, QemuImg, Whoami
+from lisa.util import LisaException, SkippedException, parse_version
 from lisa.util.logger import Logger, filter_ansi_escape
 
 from .. import CLOUD_HYPERVISOR
@@ -29,6 +31,38 @@ from .console_logger import QemuConsoleLogger
 from .schema import BaseLibvirtNodeSchema, CloudHypervisorNodeSchema, DiskImageFormat
 
 CH_VERSION_PATTERN = re.compile(r"cloud-hypervisor (?P<ch_version>.+)")
+
+# Directory where the libvirt Cloud Hypervisor (ch) driver writes the per-domain
+# CH log/stderr. libvirt removes/overwrites these when it cleans up a domain that
+# exits during start, so they must be captured before that cleanup runs.
+CH_DOMAIN_LOG_DIR = PurePosixPath("/var/log/libvirt/ch")
+
+# Artifact name prefixes for diagnostics preserved into the LISA per-node log path.
+CH_DOMAIN_LOG_ARTIFACT_PREFIX = "ch-domain-"
+DOMAIN_START_ERROR_ARTIFACT_PREFIX = "domain-start-error-"
+DOMAIN_XML_ARTIFACT_PREFIX = "domain-"
+DOMAIN_START_EVIDENCE_ARTIFACT_PREFIX = "domain-start-evidence-"
+
+# Expected exceptions while collecting best-effort diagnostics. These are caught
+# and logged so that diagnostic collection never masks the original libvirt error,
+# while genuine programming errors (e.g. AttributeError/TypeError) still surface.
+# AssertionError is included because LISA tools (e.g. Cp/Chown) raise it to signal
+# an underlying host command failure.
+_DIAGNOSTIC_EXCEPTIONS = (
+    OSError,
+    AssertionError,
+    libvirt.libvirtError,
+    LisaException,
+)
+
+# Exact captured Cloud Hypervisor signature indicating the guest VM configuration
+# is not supported on this host. Only a "VmCreate" failure paired with an
+# EINVAL / "Invalid argument" / "os error 22" on the same line is treated as
+# unsupported; any other deployment error keeps its normal failure behavior.
+CH_UNSUPPORTED_VMCREATE_PATTERN = re.compile(
+    r"VmCreate\b[^\n]*?(?:invalid argument|os error 22|einval)",
+    re.IGNORECASE,
+)
 
 
 class CloudHypervisorPlatform(BaseLibvirtPlatform):
@@ -249,13 +283,22 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             )
             start_domain_and_attach_logger()
 
-        self._run_libvirt_operation_with_reconnect(
-            operation=start_domain_and_attach_logger,
-            retry_operation=retry_start_domain_and_attach_logger,
-            operation_description="domain start and console attach",
-            vm_name=node_context.vm_name,
-            log=self._log,
-        )
+        try:
+            self._run_libvirt_operation_with_reconnect(
+                operation=start_domain_and_attach_logger,
+                retry_operation=retry_start_domain_and_attach_logger,
+                operation_description="domain start and console attach",
+                vm_name=node_context.vm_name,
+                log=self._log,
+            )
+        except libvirt.libvirtError as ex:
+            # The domain may have exited during createWithFlags before it ever
+            # became active. Only a genuine start failure (domain inactive) is
+            # eligible for diagnostics/skip classification; a failure raised
+            # after the domain became active (e.g. console attach/openConsole)
+            # is re-raised unchanged.
+            self._handle_domain_start_failure(node_context, ex)
+            raise
 
         if len(node_context.passthrough_devices) > 0:
             # Once libvirt domain is created, check if driver attached to device
@@ -264,6 +307,236 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
             self.device_pool._verify_device_passthrough_post_boot(
                 node_context=node_context,
             )
+
+    def _is_domain_active(self, node_context: NodeContext) -> bool:
+        domain = node_context.domain
+        if domain is None:
+            return False
+        try:
+            return bool(cast(Any, domain).isActive())
+        except libvirt.libvirtError:
+            return False
+
+    def _handle_domain_start_failure(
+        self,
+        node_context: NodeContext,
+        error: libvirt.libvirtError,
+    ) -> None:
+        """
+        Preserve domain-start diagnostics for artifact publication and, only for
+        a Confidential VM (CVM) guest whose captured Cloud Hypervisor log matches
+        the exact unsupported-VmCreate signature, raise SkippedException.
+        Otherwise return so the original deployment error keeps its normal
+        failure behavior.
+        """
+        if self._is_domain_active(node_context):
+            # The domain is active, so the failure originated from console
+            # attach/openConsole rather than starting the guest. This is not a
+            # start failure and must not be classified as unsupported.
+            self._log.debug(
+                f"Domain {node_context.vm_name} is active; treating '{error}' as "
+                "a console-attach failure, not a start failure."
+            )
+            return
+
+        try:
+            (
+                artifacts,
+                evidence,
+                ch_log_content,
+            ) = self._preserve_domain_start_diagnostics(node_context, error, self._log)
+        except _DIAGNOSTIC_EXCEPTIONS as ex:
+            # Diagnostic collection must never mask the original libvirt error.
+            self._log.warning(
+                f"Failed to collect domain-start diagnostics for "
+                f"{node_context.vm_name}: {ex}"
+            )
+            return
+
+        # Only a Confidential VM guest with the exact CH VmCreate/EINVAL signature
+        # is classified as an unsupported configuration.
+        if node_context.guest_vm_type is not GuestVmType.ConfidentialVM:
+            return
+
+        match = CH_UNSUPPORTED_VMCREATE_PATTERN.search(ch_log_content)
+        if not match:
+            return
+
+        signature = match.group(0).strip()
+        artifact_names = (
+            ", ".join(sorted(path.name for path in artifacts.values())) or "<none>"
+        )
+        evidence_summary = (
+            "; ".join(f"{key}={value}" for key, value in evidence.items())
+            or "<unavailable>"
+        )
+        raise SkippedException(
+            "Cloud Hypervisor reported the Confidential VM (CVM) guest "
+            "configuration is not supported on this host (captured signature: "
+            f"'{signature}'). Runtime evidence: {evidence_summary}. Preserved "
+            f"artifacts: {artifact_names}."
+        ) from error
+
+    def _preserve_domain_start_diagnostics(
+        self,
+        node_context: NodeContext,
+        error: Exception,
+        log: Logger,
+    ) -> Tuple[Dict[str, Path], Dict[str, str], str]:
+        """
+        Preserve auditable domain-start diagnostics into the node's LISA log
+        directory before libvirt cleanup removes them. Collects, best-effort:
+        the per-domain Cloud Hypervisor log/stderr, the domain XML, the
+        domain-start error, and runtime evidence (CH, kernel and libvirt
+        versions). Works even when the domain never became active and no console
+        is available.
+
+        Returns the map of preserved artifact name -> local path, the collected
+        runtime evidence, and the CH log text content (used to classify the
+        failure).
+        """
+        vm_name = node_context.vm_name
+        artifacts: Dict[str, Path] = {}
+        evidence: Dict[str, str] = {}
+        ch_log_content = ""
+
+        # Derive the node's LISA log directory from the console log path so the
+        # diagnostics land next to the other per-node artifacts (e.g.
+        # ch-console.log). Fall back to the host node's log path if unset.
+        if node_context.console_log_file_path:
+            local_log_dir = Path(node_context.console_log_file_path).parent
+        else:
+            local_log_dir = self.host_node.local_log_path
+
+        try:
+            local_log_dir.mkdir(parents=True, exist_ok=True)
+        except _DIAGNOSTIC_EXCEPTIONS as e:
+            log.warning(f"Failed to create log directory {local_log_dir}: {e}")
+            return artifacts, evidence, ch_log_content
+
+        # Collect runtime evidence where safely obtainable.
+        evidence = self._collect_runtime_evidence(log)
+
+        # Record the domain-start error itself, even if the CH log or XML are gone.
+        start_error_path = (
+            local_log_dir / f"{DOMAIN_START_ERROR_ARTIFACT_PREFIX}{vm_name}.log"
+        )
+        try:
+            start_error_path.write_text(
+                f"Domain '{vm_name}' failed to start during createWithFlags "
+                f"before becoming active:\n{error}\n",
+                encoding="utf-8",
+            )
+            artifacts["start_error"] = start_error_path
+        except _DIAGNOSTIC_EXCEPTIONS as e:
+            log.warning(f"Failed to write domain-start error log: {e}")
+
+        # Record the collected runtime evidence as an auditable artifact.
+        evidence_path = (
+            local_log_dir / f"{DOMAIN_START_EVIDENCE_ARTIFACT_PREFIX}{vm_name}.txt"
+        )
+        try:
+            evidence_path.write_text(
+                "\n".join(f"{key}: {value}" for key, value in evidence.items()) + "\n",
+                encoding="utf-8",
+            )
+            artifacts["evidence"] = evidence_path
+        except _DIAGNOSTIC_EXCEPTIONS as e:
+            log.warning(f"Failed to write domain-start evidence log: {e}")
+
+        # Preserve the domain XML so the exact configuration is auditable.
+        self._preserve_domain_xml(node_context, local_log_dir, artifacts, log)
+
+        # Preserve the per-domain CH log/stderr before libvirt removes it.
+        ch_log_content = self._preserve_ch_domain_log(
+            node_context, local_log_dir, artifacts, log
+        )
+
+        return artifacts, evidence, ch_log_content
+
+    def _collect_runtime_evidence(self, log: Logger) -> Dict[str, str]:
+        evidence: Dict[str, str] = {}
+        getters = (
+            ("cloud_hypervisor_version", self._get_vmm_version),
+            ("kernel_version", self._get_host_kernel_version),
+            ("libvirt_version", self._get_libvirt_version),
+        )
+        for key, getter in getters:
+            try:
+                value = getter()
+            except _DIAGNOSTIC_EXCEPTIONS + (IndexError, ValueError) as e:
+                # IndexError/ValueError guard against empty/malformed version
+                # output while parsing so evidence collection never masks the
+                # original libvirt failure.
+                log.warning(f"Failed to collect {key}: {e}")
+                value = "<unavailable>"
+            evidence[key] = value or "<unknown>"
+        return evidence
+
+    def _preserve_domain_xml(
+        self,
+        node_context: NodeContext,
+        local_log_dir: Path,
+        artifacts: Dict[str, Path],
+        log: Logger,
+    ) -> None:
+        domain = node_context.domain
+        if domain is None:
+            return
+        try:
+            xml_text = cast(str, cast(Any, domain).XMLDesc(0))
+        except libvirt.libvirtError as e:
+            log.warning(f"Failed to read domain XML for {node_context.vm_name}: {e}")
+            return
+        if not xml_text:
+            return
+        xml_path = (
+            local_log_dir / f"{DOMAIN_XML_ARTIFACT_PREFIX}{node_context.vm_name}.xml"
+        )
+        try:
+            xml_path.write_text(xml_text, encoding="utf-8")
+            artifacts["domain_xml"] = xml_path
+        except _DIAGNOSTIC_EXCEPTIONS as e:
+            log.warning(f"Failed to write domain XML artifact: {e}")
+
+    def _preserve_ch_domain_log(
+        self,
+        node_context: NodeContext,
+        local_log_dir: Path,
+        artifacts: Dict[str, Path],
+        log: Logger,
+    ) -> str:
+        vm_name = node_context.vm_name
+        ch_log_content = ""
+        host_ch_log = CH_DOMAIN_LOG_DIR / f"{vm_name}.log"
+        try:
+            if not self.host_node.tools[Ls].path_exists(str(host_ch_log), sudo=True):
+                log.debug(f"No CH domain log found at {host_ch_log} for {vm_name}")
+                return ch_log_content
+
+            dst = local_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{vm_name}.log"
+            # Stage the root-owned CH log into the host working path with sudo,
+            # fix ownership, then copy back so this works for both local and
+            # remote hosts (same pattern as _capture_libvirt_logs).
+            temp_path = self.host_node.working_path / f"{vm_name}-ch.log"
+            try:
+                self.host_node.tools[Cp].copy(host_ch_log, temp_path, sudo=True)
+                user = self.host_node.tools[Whoami].get_username()
+                self.host_node.tools[Chown].change_owner(temp_path, user)
+                self.host_node.shell.copy_back(temp_path, dst)
+                artifacts["ch_log"] = dst
+                ch_log_content = dst.read_text(encoding="utf-8", errors="replace")
+                log.debug(f"Preserved CH domain log for {vm_name} to {dst}")
+            finally:
+                # Remove the staged temp copy from the host working path.
+                try:
+                    self.host_node.shell.remove(temp_path)
+                except _DIAGNOSTIC_EXCEPTIONS as e:
+                    log.warning(f"Failed to remove staged CH log temp {temp_path}: {e}")
+        except _DIAGNOSTIC_EXCEPTIONS as e:
+            log.warning(f"Failed to preserve CH domain log for {vm_name}: {e}")
+
+        return ch_log_content
 
     def _attach_console_logger(self, node_context: NodeContext) -> None:
         domain = cast(Any, node_context.domain)

--- a/selftests/test_ch_platform.py
+++ b/selftests/test_ch_platform.py
@@ -1,0 +1,354 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Optional, Tuple
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import libvirt
+
+from lisa.sut_orchestrator.libvirt.ch_platform import (
+    CH_DOMAIN_LOG_ARTIFACT_PREFIX,
+    DOMAIN_START_ERROR_ARTIFACT_PREFIX,
+    DOMAIN_START_EVIDENCE_ARTIFACT_PREFIX,
+    DOMAIN_XML_ARTIFACT_PREFIX,
+    CloudHypervisorPlatform,
+)
+from lisa.sut_orchestrator.libvirt.context import GuestVmType, NodeContext
+from lisa.sut_orchestrator.libvirt.platform import BaseLibvirtPlatform
+from lisa.tools import Chown, Cp, Ls, Whoami
+from lisa.util import SkippedException
+
+VM_NAME = "lisa-TEST-0"
+DOMAIN_XML = f"<domain type='hyperv'><name>{VM_NAME}</name></domain>"
+START_ERROR = "internal error: failed to boot guest VM"
+EXACT_SIGNATURE_LOG = (
+    "cloud-hypervisor: VmCreate(Kernel returned errno: "
+    "Invalid argument (os error 22))\n"
+)
+
+
+class CloudHypervisorPlatformTestCase(TestCase):
+    def _make_host_node(
+        self,
+        tmp: Path,
+        ch_log_content: str,
+        ch_log_exists: bool,
+        chown_error: Optional[BaseException] = None,
+    ) -> Any:
+        """
+        Build a mocked host node that emulates the per-domain CH log capture
+        (Ls/Cp/Whoami/Chown tools + shell.copy_back + shell.remove).
+        """
+        ls_tool = MagicMock()
+        ls_tool.path_exists.return_value = ch_log_exists
+        cp_tool = MagicMock()
+        whoami_tool = MagicMock()
+        whoami_tool.get_username.return_value = "tester"
+        chown_tool = MagicMock()
+        if chown_error is not None:
+            chown_tool.change_owner.side_effect = chown_error
+
+        tools = {Ls: ls_tool, Cp: cp_tool, Whoami: whoami_tool, Chown: chown_tool}
+
+        def copy_back(src: Any, dst: Any) -> None:
+            Path(dst).parent.mkdir(parents=True, exist_ok=True)
+            Path(dst).write_text(ch_log_content, encoding="utf-8")
+
+        host_node = MagicMock()
+        host_node.tools.__getitem__.side_effect = lambda key: tools[key]
+        host_node.shell.copy_back.side_effect = copy_back
+        host_node.working_path = tmp / "working"
+        host_node.local_log_path = tmp / "hostlog"
+        return host_node
+
+    def _make_platform(self, host_node: Any) -> CloudHypervisorPlatform:
+        platform = CloudHypervisorPlatform.__new__(CloudHypervisorPlatform)
+        platform.host_node = host_node
+        platform._log = MagicMock()
+        platform.device_pool = MagicMock()
+        # Deterministic runtime evidence for artifacts / skip reason.
+        setattr(
+            platform,
+            "_get_vmm_version",
+            MagicMock(return_value="cloud-hypervisor msft/v52.0.127"),
+        )
+        setattr(
+            platform,
+            "_get_host_kernel_version",
+            MagicMock(return_value="6.18.34.mshv2"),
+        )
+        setattr(platform, "_get_libvirt_version", MagicMock(return_value="11.2.0"))
+        return platform
+
+    def _make_node_context(
+        self,
+        tmp: Path,
+        guest_vm_type: GuestVmType,
+        domain_active: bool,
+        xml: str = DOMAIN_XML,
+    ) -> NodeContext:
+        node_context = NodeContext()
+        node_context.vm_name = VM_NAME
+        node_context.guest_vm_type = guest_vm_type
+        node_context.console_log_file_path = str(tmp / "node-log" / "qemu-console.log")
+
+        domain = MagicMock()
+        domain.isActive.return_value = domain_active
+        domain.XMLDesc.return_value = xml
+        if not domain_active:
+            # Domain exits during createWithFlags before it becomes active.
+            domain.createWithFlags.side_effect = libvirt.libvirtError(START_ERROR)
+        node_context.domain = domain
+        return node_context
+
+    def _start_and_capture(
+        self,
+        ch_log_content: str,
+        ch_log_exists: bool = True,
+        guest_vm_type: GuestVmType = GuestVmType.ConfidentialVM,
+        domain_active: bool = False,
+        console_attach_error: Optional[BaseException] = None,
+        chown_error: Optional[BaseException] = None,
+    ) -> Tuple[BaseException, Path, Any]:
+        tmp_dir = TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        tmp = Path(tmp_dir.name)
+        host_node = self._make_host_node(
+            tmp, ch_log_content, ch_log_exists, chown_error
+        )
+        platform = self._make_platform(host_node)
+        node_context = self._make_node_context(tmp, guest_vm_type, domain_active)
+        node_log_dir = Path(node_context.console_log_file_path).parent
+
+        # Console attach is not exercised by libvirt in unit tests.
+        setattr(
+            platform,
+            "_attach_console_logger",
+            MagicMock(side_effect=console_attach_error),
+        )
+
+        try:
+            platform._create_domain_and_attach_logger(node_context)
+        except BaseException as ex:  # noqa: B036
+            return ex, node_log_dir, host_node
+        raise AssertionError("Expected domain start to raise an exception.")
+
+    def test_immediate_start_failure_preserves_all_artifacts(self) -> None:
+        # A non-signature CVM start failure preserves CH log, domain XML,
+        # evidence and error artifacts, removes the staged temp copy, and retains
+        # the original failure (not a skip).
+        ch_log = "cloud-hypervisor: starting\nunexpected diagnostic output\n"
+        ex, node_log_dir, host_node = self._start_and_capture(ch_log)
+
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertTrue(ch_artifact.exists())
+        self.assertEqual(ch_artifact.read_text(encoding="utf-8"), ch_log)
+
+        xml_artifact = node_log_dir / f"{DOMAIN_XML_ARTIFACT_PREFIX}{VM_NAME}.xml"
+        self.assertTrue(xml_artifact.exists())
+        self.assertEqual(xml_artifact.read_text(encoding="utf-8"), DOMAIN_XML)
+
+        evidence_artifact = (
+            node_log_dir / f"{DOMAIN_START_EVIDENCE_ARTIFACT_PREFIX}{VM_NAME}.txt"
+        )
+        self.assertTrue(evidence_artifact.exists())
+        evidence_text = evidence_artifact.read_text(encoding="utf-8")
+        self.assertIn("msft/v52.0.127", evidence_text)
+        self.assertIn("6.18.34.mshv2", evidence_text)
+        self.assertIn("11.2.0", evidence_text)
+
+        error_artifact = (
+            node_log_dir / f"{DOMAIN_START_ERROR_ARTIFACT_PREFIX}{VM_NAME}.log"
+        )
+        self.assertTrue(error_artifact.exists())
+        self.assertIn(START_ERROR, error_artifact.read_text(encoding="utf-8"))
+
+        # The staged root-owned temp copy is removed after copy-back.
+        host_node.shell.remove.assert_called_once_with(
+            host_node.working_path / f"{VM_NAME}-ch.log"
+        )
+
+    def test_exact_vmcreate_einval_signature_is_cvm_skipped(self) -> None:
+        # The exact captured CH signature on a CVM guest is classified as
+        # unsupported, and the skip reason names artifacts and evidence.
+        ex, node_log_dir, _ = self._start_and_capture(EXACT_SIGNATURE_LOG)
+
+        self.assertIsInstance(ex, SkippedException)
+        message = str(ex)
+        self.assertIn("Confidential VM", message)
+        self.assertIn("not supported", message)
+        self.assertIn("VmCreate", message)
+        self.assertIn(f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log", message)
+        self.assertIn(f"{DOMAIN_XML_ARTIFACT_PREFIX}{VM_NAME}.xml", message)
+        self.assertIn("msft/v52.0.127", message)
+
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertTrue(ch_artifact.exists())
+
+    def test_standard_guest_same_signature_stays_failure(self) -> None:
+        # The same exact signature on a Standard (non-CVM) guest must re-raise the
+        # original libvirt failure, not skip. Diagnostics are still preserved.
+        ex, node_log_dir, _ = self._start_and_capture(
+            EXACT_SIGNATURE_LOG, guest_vm_type=GuestVmType.Standard
+        )
+
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+        self.assertIn(START_ERROR, str(ex))
+
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertTrue(ch_artifact.exists())
+
+    def test_active_domain_console_failure_not_classified(self) -> None:
+        # A failure raised after the domain is active (console attach/openConsole)
+        # must not be treated as a start failure, even for a CVM guest with the
+        # exact signature available: no skip, no diagnostics.
+        console_error = libvirt.libvirtError("openConsole: operation failed")
+        ex, node_log_dir, host_node = self._start_and_capture(
+            EXACT_SIGNATURE_LOG,
+            domain_active=True,
+            console_attach_error=console_error,
+        )
+
+        self.assertIs(ex, console_error)
+        self.assertNotIsInstance(ex, SkippedException)
+
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertFalse(ch_artifact.exists())
+        # No CH log staging/copy is attempted for an active-domain failure.
+        host_node.shell.copy_back.assert_not_called()
+
+    def test_near_miss_signature_stays_failure(self) -> None:
+        # "VmCreate" with a different errno must NOT be classified as unsupported.
+        ch_log = (
+            "cloud-hypervisor: VmCreate(Kernel returned errno: "
+            "Permission denied (os error 13))\n"
+        )
+        ex, _, _ = self._start_and_capture(ch_log)
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+
+    def test_einval_without_vmcreate_stays_failure(self) -> None:
+        # "Invalid argument" without a VmCreate failure is an unknown error.
+        ch_log = "cloud-hypervisor: DeviceManager: Invalid argument (os error 22)\n"
+        ex, _, _ = self._start_and_capture(ch_log)
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+
+    def test_missing_ch_log_stays_failure_and_records_error(self) -> None:
+        # When no CH log exists, the deployment error is retained and the
+        # domain-start error/evidence/XML are still recorded for diagnostics.
+        ex, node_log_dir, host_node = self._start_and_capture("", ch_log_exists=False)
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+
+        self.assertTrue(
+            (
+                node_log_dir / f"{DOMAIN_START_ERROR_ARTIFACT_PREFIX}{VM_NAME}.log"
+            ).exists()
+        )
+        self.assertTrue(
+            (node_log_dir / f"{DOMAIN_XML_ARTIFACT_PREFIX}{VM_NAME}.xml").exists()
+        )
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertFalse(ch_artifact.exists())
+        # No staging when the CH log does not exist.
+        host_node.shell.remove.assert_not_called()
+
+    def test_ch_log_command_assertion_error_does_not_mask_original(self) -> None:
+        # LISA host tools (Cp/Chown) raise AssertionError on command failure.
+        # This must be treated as an expected diagnostic failure: warn, preserve
+        # the original libvirt error, and never skip. Even a CVM guest with the
+        # exact signature stays a failure because the CH log could not be read.
+        ex, node_log_dir, host_node = self._start_and_capture(
+            EXACT_SIGNATURE_LOG,
+            chown_error=AssertionError("chown command failed"),
+        )
+
+        self.assertIsInstance(ex, libvirt.libvirtError)
+        self.assertNotIsInstance(ex, SkippedException)
+        self.assertIn(START_ERROR, str(ex))
+
+        # The CH log was not preserved (command failed) but the staged temp copy
+        # is still cleaned up.
+        ch_artifact = node_log_dir / f"{CH_DOMAIN_LOG_ARTIFACT_PREFIX}{VM_NAME}.log"
+        self.assertFalse(ch_artifact.exists())
+        host_node.shell.remove.assert_called_once_with(
+            host_node.working_path / f"{VM_NAME}-ch.log"
+        )
+
+    def test_diagnostic_collection_failure_does_not_mask_original_error(self) -> None:
+        # If diagnostic collection itself fails with an expected exception, the
+        # original libvirt error must still be raised (never masked or skipped).
+        with TemporaryDirectory() as tmp_name:
+            tmp = Path(tmp_name)
+            host_node = self._make_host_node(tmp, EXACT_SIGNATURE_LOG, True)
+            platform = self._make_platform(host_node)
+            node_context = self._make_node_context(
+                tmp, GuestVmType.ConfidentialVM, domain_active=False
+            )
+            setattr(platform, "_attach_console_logger", MagicMock())
+            preserve = MagicMock(side_effect=OSError("disk full"))
+            setattr(platform, "_preserve_domain_start_diagnostics", preserve)
+
+            with self.assertRaises(libvirt.libvirtError) as ctx:
+                platform._create_domain_and_attach_logger(node_context)
+
+            self.assertNotIsInstance(ctx.exception, SkippedException)
+            self.assertIn(START_ERROR, str(ctx.exception))
+
+    def test_delete_node_preserves_console_log_and_cleans_up(self) -> None:
+        # Cleanup must remain reliable: the console log is preserved when present
+        # and cleanup is always delegated to the base implementation.
+        with TemporaryDirectory() as tmp_name:
+            tmp = Path(tmp_name)
+            node_log_dir = tmp / "node-log"
+            node_log_dir.mkdir(parents=True)
+            console_path = tmp / "qemu-console.log"
+            console_path.write_text("console output", encoding="utf-8")
+
+            node_context = NodeContext()
+            node_context.vm_name = VM_NAME
+            node_context.console_log_file_path = str(console_path)
+
+            node = MagicMock()
+            node.name = VM_NAME
+            node.local_log_path = node_log_dir
+            node.get_context.return_value = node_context
+
+            platform = self._make_platform(MagicMock())
+            log = MagicMock()
+
+            with patch.object(BaseLibvirtPlatform, "_delete_node") as base_delete:
+                platform._delete_node(node, log)
+
+            base_delete.assert_called_once_with(node, log)
+            self.assertTrue((node_log_dir / "ch-console.log").exists())
+
+    def test_delete_node_cleans_up_when_console_copy_fails(self) -> None:
+        # Even if console-log preservation fails, cleanup is still delegated.
+        with TemporaryDirectory() as tmp_name:
+            tmp = Path(tmp_name)
+            node_context = NodeContext()
+            node_context.vm_name = VM_NAME
+            # Point at a non-existent file so preservation is skipped safely.
+            node_context.console_log_file_path = str(tmp / "missing-console.log")
+
+            node = MagicMock()
+            node.name = VM_NAME
+            node.local_log_path = tmp / "node-log"
+            node.get_context.return_value = node_context
+
+            platform = self._make_platform(MagicMock())
+            log = MagicMock()
+
+            with patch.object(BaseLibvirtPlatform, "_delete_node") as base_delete:
+                platform._delete_node(node, log)
+
+            base_delete.assert_called_once_with(node, log)

--- a/selftests/test_stress_ng_suite.py
+++ b/selftests/test_stress_ng_suite.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from lisa.microsoft.testsuites.stress.stress_ng_suite import StressNgTestSuite
+from lisa.util import SkippedException
+
+
+class StressNgSuiteTestCase(TestCase):
+    _suite_type = cast(Any, StressNgTestSuite).__wrapped__
+
+    def setUp(self) -> None:
+        self.suite = self._suite_type.__new__(self._suite_type)
+
+    def test_normalize_job_files_filters_blank_entries(self) -> None:
+        result = self.suite._normalize_job_files("one.job, , two.job ,,")
+
+        self.assertEqual(["one.job", "two.job"], result)
+
+    def test_stress_ng_jobfile_skips_when_missing(self) -> None:
+        with self.assertRaises(SkippedException):
+            self.suite.stress_ng_jobfile(
+                MagicMock(),
+                {},
+                MagicMock(),
+                MagicMock(),
+            )
+
+    def test_multi_vm_stress_test_skips_when_only_blank_entries(self) -> None:
+        with self.assertRaises(SkippedException):
+            self.suite.multi_vm_stress_test(
+                MagicMock(),
+                {"stress_ng_jobs": " , "},
+                MagicMock(),
+                MagicMock(),
+            )
+
+    def test_multi_vm_stress_test_runs_each_valid_job_file(self) -> None:
+        run_job = MagicMock()
+        self.suite._run_stress_ng_job = run_job
+        environment = MagicMock()
+        log = MagicMock()
+        result = MagicMock()
+
+        self.suite.multi_vm_stress_test(
+            log,
+            {"stress_ng_jobs": "one.job, ,two.job"},
+            environment,
+            result,
+        )
+
+        self.assertEqual(
+            [
+                ("one.job", environment, result, log),
+                ("two.job", environment, result, log),
+            ],
+            [call.args for call in run_job.call_args_list],
+        )


### PR DESCRIPTION
Preserve per-domain Cloud Hypervisor logs, XML, and start errors before libvirt cleanup.
Classify only Confidential VM startup failures with exact same-line VmCreate + EINVAL / os error 22 evidence as skips.
Keep unknown and standard guest failures visible.
Treat a blank optional multi-VM stress-ng jobfile as an explicit skip instead of uploading `.`.
Validation: focused selftests, targeted formatting/lint, and end-to-end Confidential VM checks with only expected skips.