### PR TITLE
LISA: classify known MSHV startup incompatibilities as skips

### DIFF
--- a/lisa/microsoft/testsuites/mshv/mshv_root_stress_tests.py
+++ b/lisa/microsoft/testsuites/mshv/mshv_root_stress_tests.py
@@ -21,12 +21,20 @@ from lisa.tools import (
     QemuImg,
     Rm,
     Ssh,
+    Uname,
     Usermod,
     Wget,
 )
 from lisa.tools.lsblk import DiskInfo
 from lisa.tools.mkfs import FileSystem
-from lisa.util import SkippedException
+from lisa.util import LisaException, SkippedException
+from lisa.util.process import ExecutableResult, Process
+
+# Operational errors raised by remote command execution or file transfer that
+# best-effort diagnostics/cleanup should tolerate without masking real
+# programming errors. ``AssertionError`` covers LISA's ``expected_exit_code``
+# command assertion failures.
+_OPERATIONAL_ERRORS = (LisaException, AssertionError, OSError)
 
 
 @TestSuiteMetadata(
@@ -47,6 +55,19 @@ class MshvHostStressTestSuite(TestSuite):
 
     HYPERVISOR_FW_NAME = "hypervisor-fw"
     DISK_IMG_NAME = "vm_disk_img.raw"
+
+    # One shared, bounded grace (seconds) after launching the whole VM batch,
+    # used to let cloud-hypervisor processes that fail immediately (e.g. a
+    # VmCreate failure) exit before the batch is inspected. This grace is taken
+    # out of (not added to) the total keep-running duration, so it does not
+    # extend the test runtime.
+    STARTUP_GRACE_SECONDS = 5
+    # Time (seconds) to wait for an already-exited process to yield its result.
+    STARTUP_RESULT_TIMEOUT = 30
+    # Substrings that, together with a VmCreate error on the same log line,
+    # identify an EINVAL returned by the kernel for an unsupported VM
+    # configuration.
+    _EINVAL_INDICATORS = ("os error 22", "invalid argument", "einval")
 
     def before_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]
@@ -105,8 +126,10 @@ class MshvHostStressTestSuite(TestSuite):
         # property in sshd_config to a high number that is unlikely to be exceeded.
         node.tools[Ssh].set_max_session()
 
-        failures = 0
-        for config in configs:
+        passed = 0
+        skipped = 0
+        failed = 0
+        for config_id, config in enumerate(configs):
             times = config.get("iterations", self.DEFAULT_ITERS)
             cpus_per_vm = config.get("cpus_per_vm", self.DEFAULT_CPUS_PER_VM)
             mem_per_vm_mb = config.get("mem_per_vm_mb", self.DEFAULT_MEM_PER_VM_MB)
@@ -121,14 +144,27 @@ class MshvHostStressTestSuite(TestSuite):
                     log_path=log_path,
                     guest_vm_type=guest_vm_type,
                     igvm_path=igvm_path,
+                    config_id=config_id,
                 )
+                passed += 1
                 send_sub_test_result_message(
                     test_result=result,
                     test_case_name=test_name,
                     test_status=TestStatus.PASSED,
                 )
+            except SkippedException as e:
+                # An unsupported host/kernel/MSHV/cloud-hypervisor combination
+                # is not a product failure, so report the subtest as skipped.
+                skipped += 1
+                log.info(f"{test_name} SKIPPED: {e}")
+                send_sub_test_result_message(
+                    test_result=result,
+                    test_case_name=test_name,
+                    test_status=TestStatus.SKIPPED,
+                    test_message=repr(e),
+                )
             except Exception as e:
-                failures += 1
+                failed += 1
                 log.error(f"{test_name} FAILED: {e}")
                 send_sub_test_result_message(
                     test_result=result,
@@ -138,7 +174,20 @@ class MshvHostStressTestSuite(TestSuite):
                 )
         ch_tool: CloudHypervisor = node.tools[CloudHypervisor]
         ch_tool.save_dmesg_logs(node, log_path)
-        assert_that(failures).is_equal_to(0)
+
+        # Any failing subtest fails the parent. If nothing failed but every
+        # configured subtest was skipped for the same unsupported combination,
+        # the parent is skipped rather than passed, consistent with LISA
+        # conventions. Mixed pass/skip results simply pass.
+        assert_that(failed).described_as(
+            f"{failed} of {len(configs)} mshv stress subtest(s) failed"
+        ).is_equal_to(0)
+        if passed == 0 and skipped > 0:
+            raise SkippedException(
+                "All configured mshv stress subtests were skipped because the "
+                "host/kernel/MSHV/cloud-hypervisor combination does not support "
+                "creating the requested VM configuration."
+            )
         return
 
     def _mshv_stress_vm_create(
@@ -151,6 +200,7 @@ class MshvHostStressTestSuite(TestSuite):
         log_path: Path,
         guest_vm_type: str = "NON-CVM",
         igvm_path: str = "",
+        config_id: int = 0,
     ) -> None:
         log.info(
             f"MSHV stress VM create: times={times}, cpus_per_vm={cpus_per_vm}, mem_per_vm_mb={mem_per_vm_mb}"  # noqa: E501
@@ -160,77 +210,305 @@ class MshvHostStressTestSuite(TestSuite):
         disk_img_copy_path = self._get_disk_img_copy_path(node, log)
         threads = node.tools[Lscpu].get_thread_count()
         vm_count = int(threads / cpus_per_vm)
-        failures = 0
-        for test_iter in range(times):
-            log.info(f"Test iteration {test_iter + 1} of {times}")
-            node.tools[Free].log_memory_stats_mb()
-            procs = []
-            for i in range(vm_count):
-                vm_disk_img_path = disk_img_copy_path / f"VM{i}_{self.DISK_IMG_NAME}"
-                vm_log_file_path = disk_img_copy_path / f"CH_VM{i}.log"
-                is_os_disk_present = node.tools[Ls].path_exists(str(vm_disk_img_path))
-                if not is_os_disk_present:
-                    node.tools[Cp].copy(
-                        disk_img_path,
-                        vm_disk_img_path,
-                        sudo=True,
-                        timeout=1200,
-                    )
-                log.info(f"Starting VM {i}")
-                ch_tool: CloudHypervisor = node.tools[CloudHypervisor]
-                p = ch_tool.start_vm_async(
-                    kernel=hypervisor_fw_path,
-                    cpus=cpus_per_vm,
-                    memory_mb=mem_per_vm_mb,
-                    disk_path=str(vm_disk_img_path),
-                    sudo=True,
-                    guest_vm_type=guest_vm_type,
-                    igvm_path=igvm_path,
-                    log_file=str(vm_log_file_path),
-                )
-                if not p:
-                    node.shell.copy_back(
-                        vm_log_file_path,
-                        log_path / vm_log_file_path,
-                    )
-                assert_that(p).described_as(f"Failed to create VM {i}").is_not_none()
-                procs.append(p)
+        disk_img_files = [
+            disk_img_copy_path / f"VM{i}_{self.DISK_IMG_NAME}" for i in range(vm_count)
+        ]
+        # Track every per-iteration log created so cleanup can preserve and
+        # remove all of them. Names are unique per config *and* per iteration
+        # (CH_VM{i}_cfg{config_id}_iter{n}.log) so a later iteration, a later
+        # config, or the final cleanup can never overwrite earlier evidence.
+        created_logs: List[PurePath] = []
+        # Count of VMs that die only after the keep-running period across all
+        # iterations. These unknown/intermittent failures do not stop the run;
+        # the config is failed once, after every iteration has completed.
+        pre_stop_failures = 0
+        try:
+            for test_iter in range(times):
+                log.info(f"Test iteration {test_iter + 1} of {times}")
                 node.tools[Free].log_memory_stats_mb()
-                assert_that(p.is_running()).described_as(
-                    f"VM {i} failed to start"
-                ).is_true()
+                procs: List[Process] = []
+                log_files: List[PurePath] = []
+                try:
+                    # Launch the whole VM batch promptly, without any per-VM
+                    # blocking wait, so VMs run concurrently.
+                    for i in range(vm_count):
+                        vm_disk_img_path = disk_img_files[i]
+                        vm_log_file_path = (
+                            disk_img_copy_path
+                            / f"CH_VM{i}_cfg{config_id}_iter{test_iter}.log"
+                        )
+                        log_files.append(vm_log_file_path)
+                        created_logs.append(vm_log_file_path)
+                        is_os_disk_present = node.tools[Ls].path_exists(
+                            str(vm_disk_img_path)
+                        )
+                        if not is_os_disk_present:
+                            node.tools[Cp].copy(
+                                disk_img_path,
+                                vm_disk_img_path,
+                                sudo=True,
+                                timeout=1200,
+                            )
+                        log.info(f"Starting VM {i}")
+                        ch_tool: CloudHypervisor = node.tools[CloudHypervisor]
+                        p = ch_tool.start_vm_async(
+                            kernel=hypervisor_fw_path,
+                            cpus=cpus_per_vm,
+                            memory_mb=mem_per_vm_mb,
+                            disk_path=str(vm_disk_img_path),
+                            sudo=True,
+                            guest_vm_type=guest_vm_type,
+                            igvm_path=igvm_path,
+                            log_file=str(vm_log_file_path),
+                        )
+                        # Track the process before any check so cleanup can tear
+                        # it (and every earlier VM) down if a later step raises.
+                        procs.append(p)
+                    node.tools[Free].log_memory_stats_mb()
 
-            # keep the VMs running for a while
-            sleep_time = 10
-            if guest_vm_type == "CVM":
-                # CVM guest take little more time to boot
-                # 20 seconds per VM (with default 1024M)
-                sleep_time = 20 * vm_count
-            time.sleep(sleep_time)
+                    # Original total keep-running duration (do not extend it).
+                    sleep_time = 10
+                    if guest_vm_type == "CVM":
+                        # CVM guest take little more time to boot
+                        # 20 seconds per VM (with default 1024M)
+                        sleep_time = 20 * vm_count
 
-            for i in range(len(procs)):
-                p = procs[i]
-                if not p.is_running():
-                    log.info(f"VM {i} was not running")
-                    failures += 1
-                    continue
-                log.info(f"Killing VM {i}")
-                p.kill()
+                    # One shared, bounded startup grace for the whole batch,
+                    # taken out of the keep-running duration.
+                    grace = min(self.STARTUP_GRACE_SECONDS, sleep_time)
+                    time.sleep(grace)
+                    self._check_early_exits(
+                        procs, log_files, node, log_path, log, guest_vm_type, "startup"
+                    )
 
-            if guest_vm_type == "CVM":
-                # CVM guest killing takes sometime
-                sleep_time = 20
-                time.sleep(sleep_time)
+                    # Keep the VMs running for the remainder of the duration.
+                    remaining = sleep_time - grace
+                    if remaining > 0:
+                        time.sleep(remaining)
 
-            node.tools[Free].log_memory_stats_mb()
+                    # Re-inspect at pre-stop so a VM that exited *after* the
+                    # startup grace is still captured and classified exactly.
+                    # An unknown failure here is counted (not raised) so the
+                    # remaining iterations still run and the config is failed
+                    # once at the end, matching the original behavior.
+                    pre_stop_failures += self._check_early_exits(
+                        procs, log_files, node, log_path, log, guest_vm_type, "pre-stop"
+                    )
 
-        for i in range(vm_count):
-            disk_img_file = disk_img_copy_path / f"VM{i}_{self.DISK_IMG_NAME}"
-            node.tools[Rm].remove_file(str(disk_img_file), sudo=True)
-            vm_log_file = disk_img_copy_path / f"CH_VM{i}.log"
-            node.tools[Rm].remove_file(str(vm_log_file), sudo=True)
+                    for i, p in enumerate(procs):
+                        # Never signal a process that has already exited (e.g. a
+                        # VM counted as a pre-stop failure above).
+                        if p.is_running():
+                            log.info(f"Killing VM {i}")
+                            p.kill()
 
-        assert_that(failures).is_equal_to(0)
+                    if guest_vm_type == "CVM":
+                        # CVM guest killing takes sometime
+                        time.sleep(20)
+
+                    node.tools[Free].log_memory_stats_mb()
+                finally:
+                    # Ensure any VM still running in this iteration (including
+                    # already-running VMs when a later one failed or skipped) is
+                    # torn down before the next iteration or before propagating.
+                    self._kill_running_procs(procs, log)
+
+            # All iterations have run. Fail the config now if any VM died
+            # unexpectedly after its keep-running period during the run.
+            assert_that(pre_stop_failures).described_as(
+                f"{pre_stop_failures} VM(s) exited unexpectedly after the "
+                "keep-running period across all iterations"
+            ).is_equal_to(0)
+        finally:
+            self._cleanup_vm_artifacts(
+                node, disk_img_files, created_logs, log_path, log
+            )
+
+    def _check_early_exits(
+        self,
+        procs: List[Process],
+        log_files: List[PurePath],
+        node: Node,
+        log_path: Path,
+        log: Logger,
+        guest_vm_type: str,
+        phase: str,
+    ) -> int:
+        # Inspect, capture and classify every process that has already exited.
+        #
+        # Hard (unknown) failures dominate an unsupported classification within
+        # a single batch. How a hard failure is surfaced depends on the phase:
+        #   * "startup": fail fast -- raise LisaException immediately so we do
+        #     not keep creating VMs on a host that cannot even start them.
+        #   * "pre-stop"/post-run: a VM that dies only after the keep-running
+        #     period is an intermittent/unknown failure. Do NOT raise; return
+        #     the count so the caller can keep running the remaining iterations
+        #     and fail the whole config once, after all iterations complete.
+        # Exact CVM unsupported signatures are always skipped immediately, but
+        # only when no hard failure in the same batch dominates them.
+        unsupported_message: Optional[str] = None
+        hard_failures: List[str] = []
+        for i, p in enumerate(procs):
+            if p.is_running():
+                continue
+            log.info(f"VM {i} exited during the {phase} window")
+            result = p.wait_result(timeout=self.STARTUP_RESULT_TIMEOUT)
+            # Always preserve the exited VM's log before deciding pass/skip/fail.
+            self._preserve_vm_log(node, log_files[i], log_path, log)
+            output = f"{result.stdout}\n{result.stderr}"
+            # Only confidential VMs (CVM) treat a VmCreate + EINVAL on the same
+            # line as an unsupported host/kernel/MSHV combination. For standard
+            # (NON-CVM) VMs any early exit is a genuine failure.
+            if guest_vm_type == "CVM" and self._matches_unsupported_vm_create(output):
+                unsupported_message = self._format_unsupported_message(
+                    i, result, node, log
+                )
+                continue
+            hard_failures.append(
+                f"VM {i} exited during {phase} with exit code "
+                f"{result.exit_code}. cloud-hypervisor output: "
+                f"{output.strip()[-2000:]}"
+            )
+        if hard_failures:
+            # Hard failures dominate an unsupported classification in this batch.
+            if phase == "startup":
+                raise LisaException("; ".join(hard_failures))
+            for message in hard_failures:
+                log.error(message)
+            return len(hard_failures)
+        if unsupported_message is not None:
+            raise SkippedException(unsupported_message)
+        return 0
+
+    def _matches_unsupported_vm_create(self, output: str) -> bool:
+        # The unsupported signature must have VmCreate and an EINVAL indicator on
+        # the *same* line/context; matches split across lines are near misses
+        # and must not be treated as unsupported.
+        if not output:
+            return False
+        for line in output.splitlines():
+            lowered = line.lower()
+            if "vmcreate" in lowered and any(
+                indicator in lowered for indicator in self._EINVAL_INDICATORS
+            ):
+                return True
+        return False
+
+    def _format_unsupported_message(
+        self,
+        index: int,
+        result: ExecutableResult,
+        node: Node,
+        log: Logger,
+    ) -> str:
+        details = [
+            f"VM {index} could not be created: cloud-hypervisor reported "
+            "VmCreate with EINVAL (Invalid argument / os error 22). The current "
+            "host/kernel/MSHV/cloud-hypervisor combination does not support "
+            "creating the requested confidential VM (CVM) configuration."
+        ]
+        if result.exit_code is not None:
+            details.append(f"cloud-hypervisor exit code: {result.exit_code}")
+        try:
+            kernel = node.tools[Uname].get_linux_information().kernel_version_raw
+            if kernel:
+                details.append(f"kernel: {kernel}")
+        except LisaException as e:
+            log.debug(f"Unable to collect kernel version for skip evidence: {e}")
+        output = f"{result.stdout}\n{result.stderr}".strip()
+        if output:
+            details.append(f"cloud-hypervisor output: {output[-1000:]}")
+        return " | ".join(details)
+
+    def _preserve_vm_log(
+        self,
+        node: Node,
+        remote_log_path: PurePath,
+        log_path: Path,
+        log: Logger,
+    ) -> None:
+        # cloud-hypervisor runs under sudo, so its --log-file is root-owned and
+        # cannot be read by the SSH user that copy_back runs as. Stage a
+        # world-readable copy in the user-owned working path first, then copy it
+        # back. Any failure to preserve evidence must be visible as a warning.
+        local_name = PurePath(remote_log_path).name
+        # Stage under a distinct name so the staged copy can never collide with
+        # the original log. When the disk-image copy path falls back to the
+        # working path, remote_log_path already lives under node.working_path;
+        # a plain same-name staged copy would then equal the original and the
+        # cleanup below would delete the very evidence we are trying to keep.
+        # The ".staged_" prefix guarantees staged != remote_log_path, so staging
+        # cleanup only ever removes the staged copy and always retains the
+        # original for a later retry.
+        staged = node.working_path / f".staged_{local_name}"
+        try:
+            if not node.tools[Ls].path_exists(str(remote_log_path), sudo=True):
+                log.debug(f"VM log not present, nothing to preserve: {remote_log_path}")
+                return
+            # Assert the staging commands actually succeed (expected_exit_code
+            # raises AssertionError otherwise) so we never copy_back a stale or
+            # missing file and silently believe evidence was preserved.
+            node.execute(
+                f"cp -f '{remote_log_path}' '{staged}'",
+                sudo=True,
+                shell=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    f"failed to stage VM log {remote_log_path}"
+                ),
+            )
+            node.execute(
+                f"chmod a+r '{staged}'",
+                sudo=True,
+                shell=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    f"failed to make staged VM log readable: {staged}"
+                ),
+            )
+            local_path = log_path / local_name
+            node.shell.copy_back(staged, local_path)
+            log.debug(f"Preserved VM log {remote_log_path} -> {local_path}")
+        except _OPERATIONAL_ERRORS as e:
+            # Leave the original remote log in place so the final cleanup pass
+            # can retry preserving it.
+            log.warning(f"Failed to preserve VM log {remote_log_path}: {e}")
+        finally:
+            # Only the distinct staged copy is removed here; the original log is
+            # never touched by staging.
+            self._best_effort_remove(node, staged, log)
+
+    def _kill_running_procs(self, procs: List[Process], log: Logger) -> None:
+        for i, p in enumerate(procs):
+            try:
+                if p is not None and p.is_running():
+                    log.info(f"Cleaning up running VM {i}")
+                    p.kill()
+            except _OPERATIONAL_ERRORS as e:
+                log.debug(f"Failed to kill VM {i} during cleanup: {e}")
+
+    def _best_effort_remove(self, node: Node, path: PurePath, log: Logger) -> None:
+        try:
+            node.tools[Rm].remove_file(str(path), sudo=True)
+        except _OPERATIONAL_ERRORS as e:
+            log.debug(f"Failed to remove {path} during cleanup: {e}")
+
+    def _cleanup_vm_artifacts(
+        self,
+        node: Node,
+        disk_img_files: List[PurePath],
+        created_logs: List[PurePath],
+        log_path: Path,
+        log: Logger,
+    ) -> None:
+        # Preserve every per-iteration log (unique names, so earlier failure
+        # evidence is never overwritten) before removing it, then drop the disk
+        # copies.
+        for log_file in created_logs:
+            self._preserve_vm_log(node, log_file, log_path, log)
+            self._best_effort_remove(node, log_file, log)
+        for disk_img_file in disk_img_files:
+            self._best_effort_remove(node, disk_img_file, log)
 
     def _get_disk_img_copy_path(self, node: Node, log: Logger) -> PurePath:
         # The guest disk image is copied once per concurrent VM, so we need
@@ -264,7 +542,7 @@ class MshvHostStressTestSuite(TestSuite):
                 fs_type=FileSystem.ext4,
                 format_=True,
             )
-        except Exception as e:
+        except _OPERATIONAL_ERRORS as e:
             log.info(
                 f"Failed to mount {candidate} at {mount_point}: {e}; "
                 "falling back to working path."

--- a/selftests/test_mshv_root_stress_tests.py
+++ b/selftests/test_mshv_root_stress_tests.py
@@ -1,0 +1,535 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import os
+import sys
+from pathlib import Path, PurePath
+from types import SimpleNamespace
+from typing import Any, List, cast
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+# The mshv test suite modules import their siblings via the top-level
+# ``microsoft`` namespace (e.g. ``from microsoft.testsuites.mshv...``), which
+# only resolves when the worktree's ``lisa`` package directory is on sys.path.
+# Insert it (ahead of any installed copy) so the suite under test is imported
+# from this worktree.
+_LISA_PKG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "lisa"))
+if _LISA_PKG_DIR not in sys.path:
+    sys.path.insert(0, _LISA_PKG_DIR)
+
+from microsoft.testsuites.mshv import (  # noqa: E402
+    mshv_root_stress_tests as mshv_module,
+)
+from microsoft.testsuites.mshv.mshv_root_stress_tests import (  # noqa: E402
+    MshvHostStressTestSuite,
+)
+
+from lisa.messages import TestStatus  # noqa: E402
+from lisa.util import LisaException, SkippedException  # noqa: E402
+
+# A single log line carrying the exact unsupported VmCreate + EINVAL signature.
+_UNSUPPORTED_LINE = (
+    "cloud-hypervisor: Error booting VM: VmBoot(VmCreate(Kernel returned "
+    "errno: Invalid argument (os error 22)))"
+)
+_UNSUPPORTED_OUTPUT = (
+    f"{_UNSUPPORTED_LINE}\nthread 'vmm' panicked at vmm/src/vm.rs:1445"
+)
+
+
+class MshvHostStressTestSuiteTestCase(TestCase):
+    _suite_type = cast(Any, MshvHostStressTestSuite).__wrapped__
+
+    def _new_suite(self) -> Any:
+        return self._suite_type.__new__(self._suite_type)
+
+    def _make_result(
+        self, stdout: str = "", stderr: str = "", exit_code: int = 1
+    ) -> SimpleNamespace:
+        return SimpleNamespace(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+    def _make_node(self) -> MagicMock:
+        node = MagicMock()
+        node.get_working_path.return_value = PurePath("/home/user")
+        node.working_path = PurePath("/home/user")
+        node.tools = {
+            mshv_module.Ls: MagicMock(),
+            mshv_module.Cp: MagicMock(),
+            mshv_module.Rm: MagicMock(),
+            mshv_module.Free: MagicMock(),
+            mshv_module.Lscpu: MagicMock(),
+            mshv_module.Uname: MagicMock(),
+            mshv_module.CloudHypervisor: MagicMock(),
+        }
+        node.tools[mshv_module.Ls].path_exists.return_value = True
+        node.tools[
+            mshv_module.Uname
+        ].get_linux_information.return_value = SimpleNamespace(
+            kernel_version_raw="6.6.0-mshv"
+        )
+        return node
+
+    def _run_iterations(
+        self,
+        suite: Any,
+        node: MagicMock,
+        *,
+        times: int = 1,
+        cpus_per_vm: int = 1,
+        thread_count: int = 1,
+        guest_vm_type: str = "NON-CVM",
+        config_id: int = 0,
+    ) -> None:
+        suite._get_disk_img_copy_path = MagicMock(
+            return_value=PurePath("/mnt/resource")
+        )
+        node.tools[mshv_module.Lscpu].get_thread_count.return_value = thread_count
+        suite._mshv_stress_vm_create(
+            times=times,
+            cpus_per_vm=cpus_per_vm,
+            mem_per_vm_mb=1024,
+            log=MagicMock(),
+            node=node,
+            log_path=Path("."),
+            guest_vm_type=guest_vm_type,
+            config_id=config_id,
+        )
+
+    # ------------------------------------------------------------------
+    # (1) batching + timing: launch the whole batch, one shared grace,
+    #     original total keep-running duration preserved.
+    # ------------------------------------------------------------------
+    def test_batch_launches_before_grace_and_preserves_duration(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+
+        procs = [MagicMock(name=f"p{i}") for i in range(3)]
+        for p in procs:
+            p.is_running.return_value = True
+
+        events: List[Any] = []
+        proc_iter = iter(procs)
+
+        def start_side(**kwargs: Any) -> MagicMock:
+            events.append(("start", kwargs["log_file"]))
+            return next(proc_iter)
+
+        node.tools[mshv_module.CloudHypervisor].start_vm_async.side_effect = start_side
+
+        def sleep_side(duration: float) -> None:
+            events.append(("sleep", duration))
+
+        with patch.object(mshv_module.time, "sleep", sleep_side):
+            self._run_iterations(suite, node, thread_count=3, cpus_per_vm=1)
+
+        starts = [e for e in events if e[0] == "start"]
+        sleeps = [e[1] for e in events if e[0] == "sleep"]
+        first_sleep_idx = next(idx for idx, e in enumerate(events) if e[0] == "sleep")
+
+        # The whole batch is launched before any wait (no per-VM blocking).
+        self.assertEqual(len(starts), 3)
+        self.assertTrue(all(events[i][0] == "start" for i in range(first_sleep_idx)))
+        # Total keep-running duration for NON-CVM stays at the original 10s
+        # (grace + remainder), not vm_count * 10s.
+        self.assertEqual(sleeps, [5, 5])
+        self.assertEqual(sum(sleeps), 10)
+        for p in procs:
+            # Killed by the main stop loop (the finally net may re-kill mocks
+            # whose is_running() stays True; real processes report not-running).
+            self.assertTrue(p.kill.called)
+
+    # ------------------------------------------------------------------
+    # (2) CVM gating + same-line matching
+    # ------------------------------------------------------------------
+    def test_matches_unsupported_requires_same_line(self) -> None:
+        suite = self._new_suite()
+        self.assertTrue(suite._matches_unsupported_vm_create(_UNSUPPORTED_LINE))
+        self.assertTrue(suite._matches_unsupported_vm_create(_UNSUPPORTED_OUTPUT))
+        self.assertTrue(
+            suite._matches_unsupported_vm_create(
+                "boot error: VmCreate(Kernel returned errno: EINVAL)"
+            )
+        )
+        # Near miss: VmCreate and the EINVAL indicator on different lines.
+        self.assertFalse(
+            suite._matches_unsupported_vm_create(
+                "VmCreate failed to build the VM\nlater: open: os error 22"
+            )
+        )
+        # VmCreate with a non-EINVAL error.
+        self.assertFalse(
+            suite._matches_unsupported_vm_create("VmCreate(KvmError(os error 12))")
+        )
+        self.assertFalse(suite._matches_unsupported_vm_create(""))
+
+    def test_cvm_early_exit_with_signature_is_skipped(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        proc = MagicMock()
+        proc.is_running.return_value = False
+        proc.wait_result.return_value = self._make_result(stderr=_UNSUPPORTED_OUTPUT)
+
+        with self.assertRaises(SkippedException) as ctx:
+            suite._check_early_exits(
+                [proc],
+                [PurePath("/mnt/resource/CH_VM0_iter0.log")],
+                node,
+                Path("."),
+                MagicMock(),
+                "CVM",
+                "startup",
+            )
+        message = str(ctx.exception)
+        self.assertIn("VmCreate", message)
+        self.assertIn("6.6.0-mshv", message)
+
+    def test_non_cvm_early_exit_with_signature_fails(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        proc = MagicMock()
+        proc.is_running.return_value = False
+        proc.wait_result.return_value = self._make_result(stderr=_UNSUPPORTED_OUTPUT)
+
+        with self.assertRaises(LisaException) as ctx:
+            suite._check_early_exits(
+                [proc],
+                [PurePath("/mnt/resource/CH_VM0_iter0.log")],
+                node,
+                Path("."),
+                MagicMock(),
+                "NON-CVM",
+                "startup",
+            )
+        # Standard VMs never treat the signature as unsupported.
+        self.assertNotIsInstance(ctx.exception, SkippedException)
+
+    def test_cvm_hard_failure_dominates_unsupported(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        unsupported = MagicMock()
+        unsupported.is_running.return_value = False
+        unsupported.wait_result.return_value = self._make_result(
+            stderr=_UNSUPPORTED_OUTPUT
+        )
+        hard_fail = MagicMock()
+        hard_fail.is_running.return_value = False
+        hard_fail.wait_result.return_value = self._make_result(
+            stderr="thread 'vmm' panicked: GuestMemory error", exit_code=101
+        )
+
+        with self.assertRaises(LisaException) as ctx:
+            suite._check_early_exits(
+                [unsupported, hard_fail],
+                [
+                    PurePath("/mnt/resource/CH_VM0_iter0.log"),
+                    PurePath("/mnt/resource/CH_VM1_iter0.log"),
+                ],
+                node,
+                Path("."),
+                MagicMock(),
+                "CVM",
+                "startup",
+            )
+        self.assertNotIsInstance(ctx.exception, SkippedException)
+
+    # ------------------------------------------------------------------
+    # (3) post-start race: a VM that exits after the startup grace must be
+    #     captured at the pre-stop check, but counted (not raised) so later
+    #     iterations still run.
+    # ------------------------------------------------------------------
+    def test_post_start_exit_classified_at_pre_stop(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        proc = MagicMock()
+        # Running at startup, exited by the pre-stop check.
+        proc.is_running.side_effect = [True, False]
+        proc.wait_result.return_value = self._make_result(
+            stderr="thread 'vmm' panicked: late crash", exit_code=134
+        )
+        log_files = [PurePath("/mnt/resource/CH_VM0_iter0.log")]
+
+        # First pass sees it running -> nothing counted, nothing raised.
+        self.assertEqual(
+            suite._check_early_exits(
+                [proc], log_files, node, Path("."), MagicMock(), "NON-CVM", "startup"
+            ),
+            0,
+        )
+        # Second pass sees the late exit and counts it as a deferred failure
+        # instead of raising, so the caller can keep running.
+        self.assertEqual(
+            suite._check_early_exits(
+                [proc], log_files, node, Path("."), MagicMock(), "NON-CVM", "pre-stop"
+            ),
+            1,
+        )
+
+    def test_pre_stop_crash_defers_failure_until_all_iterations_run(self) -> None:
+        # A VM that crashes after its keep-running period in iteration 1 must
+        # not stop the run: later iterations still execute and the config fails
+        # only after every iteration has completed.
+        suite = self._new_suite()
+        node = self._make_node()
+
+        # proc0 is running at startup, then found dead at pre-stop in iter 1.
+        proc0 = MagicMock(name="p0")
+        calls = {"n": 0}
+
+        def proc0_running() -> bool:
+            calls["n"] += 1
+            # Only the startup check (first call) sees it running.
+            return calls["n"] == 1
+
+        proc0.is_running.side_effect = proc0_running
+        proc0.wait_result.return_value = self._make_result(
+            stderr="thread 'vmm' panicked: late crash", exit_code=134
+        )
+        # proc1 (iteration 2) stays healthy for the whole iteration.
+        proc1 = MagicMock(name="p1")
+        proc1.is_running.return_value = True
+        node.tools[mshv_module.CloudHypervisor].start_vm_async.side_effect = [
+            proc0,
+            proc1,
+        ]
+
+        with patch.object(mshv_module.time, "sleep", lambda _d: None):
+            with self.assertRaises(AssertionError) as ctx:
+                self._run_iterations(suite, node, times=2, thread_count=1)
+
+        # Both iterations ran -- iteration 2 started despite the iter-1 crash.
+        self.assertEqual(
+            node.tools[mshv_module.CloudHypervisor].start_vm_async.call_count, 2
+        )
+        # The already-exited VM is never signalled; the healthy one is torn down.
+        proc0.kill.assert_not_called()
+        self.assertTrue(proc1.kill.called)
+        # Failure is reported only after completing all iterations.
+        self.assertIn(
+            "exited unexpectedly after the keep-running period",
+            str(ctx.exception),
+        )
+
+    # ------------------------------------------------------------------
+    # (5) iteration-unique log names
+    # ------------------------------------------------------------------
+    def test_unique_log_names_across_iterations(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        procs = [MagicMock(name=f"p{i}") for i in range(2)]
+        for p in procs:
+            p.is_running.return_value = True
+        node.tools[mshv_module.CloudHypervisor].start_vm_async.side_effect = procs
+
+        with patch.object(mshv_module.time, "sleep", lambda _d: None):
+            self._run_iterations(suite, node, times=2, thread_count=1)
+
+        log_files = [
+            call.kwargs["log_file"]
+            for call in node.tools[
+                mshv_module.CloudHypervisor
+            ].start_vm_async.call_args_list
+        ]
+        self.assertEqual(len(log_files), 2)
+        self.assertEqual(len(set(log_files)), 2)
+        self.assertTrue(any("CH_VM0_cfg0_iter0" in f for f in log_files))
+        self.assertTrue(any("CH_VM0_cfg0_iter1" in f for f in log_files))
+
+        removed = [
+            call.args[0]
+            for call in node.tools[mshv_module.Rm].remove_file.call_args_list
+        ]
+        self.assertTrue(any("CH_VM0_cfg0_iter0" in r for r in removed))
+        self.assertTrue(any("CH_VM0_cfg0_iter1" in r for r in removed))
+
+    def test_unique_log_names_across_configs(self) -> None:
+        # Two configs that would otherwise produce identical per-iteration log
+        # names must still get distinct artifact names via the config
+        # discriminator, so a later config cannot overwrite earlier evidence.
+        suite = self._new_suite()
+        node = self._make_node()
+        procs = [MagicMock(name=f"p{i}") for i in range(2)]
+        for p in procs:
+            p.is_running.return_value = True
+        node.tools[mshv_module.CloudHypervisor].start_vm_async.side_effect = procs
+
+        with patch.object(mshv_module.time, "sleep", lambda _d: None):
+            self._run_iterations(suite, node, times=1, thread_count=1, config_id=0)
+            self._run_iterations(suite, node, times=1, thread_count=1, config_id=1)
+
+        log_files = [
+            call.kwargs["log_file"]
+            for call in node.tools[
+                mshv_module.CloudHypervisor
+            ].start_vm_async.call_args_list
+        ]
+        self.assertEqual(len(log_files), 2)
+        self.assertEqual(len(set(log_files)), 2)
+        self.assertTrue(any("CH_VM0_cfg0_iter0" in f for f in log_files))
+        self.assertTrue(any("CH_VM0_cfg1_iter0" in f for f in log_files))
+
+    # ------------------------------------------------------------------
+    # (4) root-owned CH logs are staged/made readable before copy_back;
+    #     preservation failures surface as warnings.
+    # ------------------------------------------------------------------
+    def test_preserve_root_owned_log_stages_before_copy_back(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        log = MagicMock()
+
+        suite._preserve_vm_log(
+            node, PurePath("/mnt/resource/CH_VM0_iter0.log"), Path("artifacts"), log
+        )
+
+        commands = [call.args[0] for call in node.execute.call_args_list]
+        self.assertTrue(any(cmd.startswith("cp -f ") for cmd in commands))
+        self.assertTrue(any(cmd.startswith("chmod a+r ") for cmd in commands))
+        for call in node.execute.call_args_list:
+            self.assertTrue(call.kwargs.get("sudo"))
+            # Staging must assert success so a failed cp/chmod cannot be
+            # mistaken for preserved evidence.
+            self.assertEqual(call.kwargs.get("expected_exit_code"), 0)
+        # copy_back reads the staged, user-readable copy (never the root file)
+        # and the staged name is distinct from the original log name.
+        node.shell.copy_back.assert_called_once()
+        staged_arg = node.shell.copy_back.call_args.args[0]
+        self.assertEqual(
+            PurePath(staged_arg), PurePath("/home/user/.staged_CH_VM0_iter0.log")
+        )
+
+    def test_preserve_root_owned_log_warns_on_failure(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+        node.shell.copy_back.side_effect = OSError("permission denied")
+        log = MagicMock()
+
+        suite._preserve_vm_log(
+            node, PurePath("/mnt/resource/CH_VM0_iter0.log"), Path("."), log
+        )
+
+        log.warning.assert_called_once()
+
+    def test_preserve_retains_original_when_staging_under_working_path(self) -> None:
+        # When the disk-image copy path falls back to node.working_path, the
+        # remote log already lives under working_path. Staging must use a
+        # distinct name so a copy_back failure never removes the original log
+        # (its only remaining evidence) as if it were the staged copy.
+        suite = self._new_suite()
+        node = self._make_node()
+        node.working_path = PurePath("/home/user")
+        remote_log_path = PurePath("/home/user/CH_VM0_cfg0_iter0.log")
+        node.shell.copy_back.side_effect = OSError("transport closed")
+        log = MagicMock()
+
+        suite._preserve_vm_log(node, remote_log_path, Path("."), log)
+
+        removed = [
+            call.args[0]
+            for call in node.tools[mshv_module.Rm].remove_file.call_args_list
+        ]
+        # The staged copy is cleaned up, but the original log is never removed.
+        staged = str(node.working_path / ".staged_CH_VM0_cfg0_iter0.log")
+        self.assertIn(staged, removed)
+        self.assertNotIn(str(remote_log_path), removed)
+        log.warning.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # (6) parent subtest reporting semantics
+    # ------------------------------------------------------------------
+    def _run_parent(self, side_effects: List[Any]) -> MagicMock:
+        suite = self._new_suite()
+        suite._mshv_stress_vm_create = MagicMock(side_effect=side_effects)
+        self._worker_mock = suite._mshv_stress_vm_create
+
+        configs = [{"iterations": i + 1} for i in range(len(side_effects))]
+        node = MagicMock()
+        ssh = MagicMock()
+        ch = MagicMock()
+        node.tools = {mshv_module.Ssh: ssh, mshv_module.CloudHypervisor: ch}
+
+        send_mock = MagicMock()
+        with patch.object(mshv_module, "send_sub_test_result_message", send_mock):
+            self._parent_error: Any = None
+            try:
+                suite.stress_mshv_vm_create(
+                    log=MagicMock(),
+                    node=node,
+                    variables={MshvHostStressTestSuite.CONFIG_VARIABLE: configs},
+                    log_path=Path("."),
+                    result=MagicMock(),
+                )
+            except BaseException as e:  # noqa: B036
+                self._parent_error = e
+        ch.save_dmesg_logs.assert_called_once()
+        return send_mock
+
+    def test_parent_mixed_pass_skip_fail_reports_and_fails(self) -> None:
+        send_mock = self._run_parent(
+            [None, SkippedException("unsupported"), LisaException("boom")]
+        )
+        statuses = [call.kwargs["test_status"] for call in send_mock.call_args_list]
+        self.assertEqual(
+            statuses, [TestStatus.PASSED, TestStatus.SKIPPED, TestStatus.FAILED]
+        )
+        self.assertIsInstance(self._parent_error, AssertionError)
+
+    def test_parent_pass_and_skip_without_failures_passes(self) -> None:
+        send_mock = self._run_parent([None, SkippedException("unsupported")])
+        statuses = [call.kwargs["test_status"] for call in send_mock.call_args_list]
+        self.assertEqual(statuses, [TestStatus.PASSED, TestStatus.SKIPPED])
+        self.assertIsNone(self._parent_error)
+
+    def test_parent_all_skipped_skips_parent(self) -> None:
+        send_mock = self._run_parent(
+            [SkippedException("unsupported"), SkippedException("unsupported")]
+        )
+        statuses = [call.kwargs["test_status"] for call in send_mock.call_args_list]
+        self.assertEqual(statuses, [TestStatus.SKIPPED, TestStatus.SKIPPED])
+        self.assertIsInstance(self._parent_error, SkippedException)
+
+    def test_parent_passes_distinct_config_ids(self) -> None:
+        # The parent must hand each config a distinct discriminator so the
+        # worker can build collision-free artifact names across configs.
+        self._run_parent([None, None, None])
+        config_ids = [
+            call.kwargs["config_id"] for call in self._worker_mock.call_args_list
+        ]
+        self.assertEqual(config_ids, [0, 1, 2])
+
+    # ------------------------------------------------------------------
+    # (6) reliable partial cleanup when a later VM fails
+    # ------------------------------------------------------------------
+    def test_partial_cleanup_on_later_vm_failure(self) -> None:
+        suite = self._new_suite()
+        node = self._make_node()
+
+        procs = [MagicMock(name=f"p{i}") for i in range(3)]
+        procs[0].is_running.return_value = True
+        procs[1].is_running.return_value = True
+        # The third VM exits early with a non-signature failure (NON-CVM).
+        procs[2].is_running.return_value = False
+        procs[2].wait_result.return_value = self._make_result(
+            stderr="thread 'vmm' panicked: boom", exit_code=101
+        )
+        node.tools[mshv_module.CloudHypervisor].start_vm_async.side_effect = procs
+
+        with patch.object(mshv_module.time, "sleep", lambda _d: None):
+            with self.assertRaises(LisaException):
+                self._run_iterations(suite, node, thread_count=3, cpus_per_vm=1)
+
+        # Already-running VMs are torn down; the exited one is not re-killed.
+        procs[0].kill.assert_called_once()
+        procs[1].kill.assert_called_once()
+        procs[2].kill.assert_not_called()
+
+        removed = [
+            call.args[0]
+            for call in node.tools[mshv_module.Rm].remove_file.call_args_list
+        ]
+        for i in range(3):
+            disk = str(PurePath("/mnt/resource") / f"VM{i}_{suite.DISK_IMG_NAME}")
+            log_file = str(PurePath("/mnt/resource") / f"CH_VM{i}_cfg0_iter0.log")
+            self.assertIn(disk, removed)
+            self.assertIn(log_file, removed)
+        # Evidence for the failing VM is preserved (staged + copied back).
+        self.assertGreaterEqual(node.shell.copy_back.call_count, 1)


### PR DESCRIPTION
Public-safe summary:
- Add one shared startup grace and two-phase exit checks.
- Preserve unique CH logs and reliable cleanup.
- Only exact confidential-VM VmCreate + EINVAL / os error 22 becomes skipped.
- Unknown failures stay failed.
- All configured stress iterations keep their prior execution semantics.
- 17 focused selftests plus formatting/lint and end-to-end confidential-VM validation passed, with only the evidence-backed unsupported case skipped.