### PR TITLE
ci: keep Python 3.9 in test matrix with argcomplete compatibility pin

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -69,7 +69,10 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
 
       - name: Install Nox
-        run: pip install nox toml
+        # argcomplete >= 3.6 uses Python 3.10 union-type syntax. Keep the
+        # nox CLI importable on the Python 3.9 matrix jobs while allowing
+        # newer jobs to use the unconstrained latest version.
+        run: python -m pip install nox toml "argcomplete<3.6; python_version < '3.10'"
         if: matrix.nox-session
 
       - name: Run Nox


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
