### PR TITLE
test(vm_extensions): add AzureSecurityLinuxAgent boot validation test

### DIFF
--- a/lisa/microsoft/runbook/azure_security_linux_agent.yml
+++ b/lisa/microsoft/runbook/azure_security_linux_agent.yml
@@ -1,0 +1,35 @@
+name: azure_security_linux_agent
+# Runbook to run only the Azure Security Linux Agent VM extension boot
+# validation test:
+#   Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent
+#
+# Usage (from the repo root, with the venv activated and Azure auth set up):
+#   lisa -r lisa/microsoft/runbook/azure_security_linux_agent.yml \
+#        -v subscription_id:<your-sub-id> \
+#        -v azure_security_linux_agent_version:2.0
+#
+# The version variable is REQUIRED; the test is skipped when it is empty.
+include:
+  - path: ./azure.yml
+variable:
+  # ---- Fill these in (or override on the command line with -v) --------------
+  - name: subscription_id
+    value: ""
+  - name: azure_security_linux_agent_version
+    value: "2.0"
+  # ---- Deployment defaults ---------------------------------------------------
+  - name: location
+    value: "westus3"
+  - name: marketplace_image
+    value: "canonical ubuntu-24_04-lts server latest"
+  - name: keep_environment
+    value: "no"
+  - name: auth_type
+    value: "default"
+testcase:
+  - criteria:
+      name: microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test
+      # The case starts at 'experimental' maturity per the VM extension
+      # onboarding guidance; the explicit maturity criterion approves it past
+      # LISA's implicit stable gate so it is actually selected.
+      maturity: experimental

--- a/lisa/microsoft/runbook/azure_security_linux_agent.yml
+++ b/lisa/microsoft/runbook/azure_security_linux_agent.yml
@@ -15,8 +15,12 @@ variable:
   # ---- Fill these in (or override on the command line with -v) --------------
   - name: subscription_id
     value: ""
+  # REQUIRED: pass on the command line with
+  #   -v azure_security_linux_agent_version:<version>
+  # (or the generic -v extension_version:<version>). The case is skipped
+  # when neither is set.
   - name: azure_security_linux_agent_version
-    value: "2.0"
+    value: ""
   # ---- Deployment defaults ---------------------------------------------------
   - name: location
     value: "westus3"

--- a/lisa/microsoft/runbook/azure_security_linux_agent.yml
+++ b/lisa/microsoft/runbook/azure_security_linux_agent.yml
@@ -18,9 +18,12 @@ variable:
   # REQUIRED: pass on the command line with
   #   -v azure_security_linux_agent_version:<version>
   # (or the generic -v extension_version:<version>). The case is skipped
-  # when neither is set.
+  # when neither is set. 'is_case_visible: true' is required so the value
+  # is passed into the test case's 'variables' dict at runtime (LISA only
+  # forwards case-visible variables); without it the case always skips.
   - name: azure_security_linux_agent_version
     value: ""
+    is_case_visible: true
   # ---- Deployment defaults ---------------------------------------------------
   - name: location
     value: "westus3"

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -52,6 +52,11 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
         """,
         priority=1,
         maturity="experimental",
+        requirement=simple_requirement(
+            supported_features=[AzureExtension],
+            supported_platform_type=[AZURE],
+            unsupported_os=[BSD],
+        ),
     )
     def microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test(  # noqa: E501
         self, log: Logger, node: Node, variables: Dict[str, Any]

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import time
 from typing import Any, Dict, Optional
 
 from microsoft.testsuites.vm_extensions.vm_extension_base import VmExtensionTestBase
@@ -84,9 +85,14 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
                 f"Handler '{publisher}.{type_}' is already installed as "
                 f"'{existing_name}'; validating the existing instance in place."
             )
-            detail = extension.get(name=existing_name)
+            # An auto-provisioned instance may still be mid-provisioning
+            # ('Creating'/'Updating') when discovered. Wait for a terminal
+            # state before asserting so the check is not racing the platform.
+            provisioning_state = self._wait_for_terminal_provisioning_state(
+                extension, existing_name, log
+            )
             self._assert_provisioned(
-                {"provisioning_state": str(detail.provisioning_state)}, variables
+                {"provisioning_state": provisioning_state}, variables
             )
             installed_version = extension.get_installed_type_handler_version(
                 existing_name
@@ -117,3 +123,37 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
                 if name:
                     return name
         return None
+
+    def _wait_for_terminal_provisioning_state(
+        self,
+        extension: AzureExtension,
+        name: str,
+        log: Logger,
+        timeout: int = 600,
+        interval: int = 20,
+    ) -> str:
+        """
+        Poll the extension instance until its provisioning state is terminal
+        ('Succeeded' or 'Failed'), then return that state. Transient states such
+        as 'Creating'/'Updating' happen while the platform is still provisioning
+        an auto-installed instance. Returns the last observed state on timeout.
+        """
+        transient_states = {"creating", "updating", "deleting", ""}
+        deadline = time.monotonic() + timeout
+        provisioning_state = ""
+        while True:
+            detail = extension.get(name=name)
+            provisioning_state = str(detail.provisioning_state or "")
+            if provisioning_state.lower() not in transient_states:
+                return provisioning_state
+            if time.monotonic() >= deadline:
+                log.info(
+                    f"Extension '{name}' still in transient state "
+                    f"'{provisioning_state}' after {timeout}s; proceeding."
+                )
+                return provisioning_state
+            log.info(
+                f"Extension '{name}' provisioning state is "
+                f"'{provisioning_state}'; waiting {interval}s for it to settle."
+            )
+            time.sleep(interval)

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from microsoft.testsuites.vm_extensions.vm_extension_base import VmExtensionTestBase
 
@@ -39,16 +39,26 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
         description="""
         Basic boot validation for the Azure Security Linux Agent VM extension.
 
-        Installs the extension with empty inline settings (the agent requires
-        no storage account or public blob access), verifies that provisioning
-        succeeds and the requested version is delivered, confirms the VM is
-        still reachable, then removes the extension.
+        The Azure Security Linux Agent is frequently auto-provisioned on the VM
+        (e.g. by Microsoft Defender for Cloud). Because Linux does not support
+        more than one VM extension per handler, this case first checks whether
+        the handler is already installed:
+
+        * If an instance of the handler is already present, it is validated in
+          place: provisioning must be 'Succeeded' and the VM must stay
+          reachable over SSH. The installed handler version is logged. No new
+          instance is created and the pre-existing (platform-managed) instance
+          is left untouched.
+        * Otherwise the extension is installed with empty inline settings (the
+          agent requires no storage account or public blob access),
+          provisioning is asserted, the requested version is verified, VM
+          reachability is confirmed, and the instance is removed.
 
         The extension version is read from runbook variable
         'azure_security_linux_agent_version' (or the generic
-        'extension_version'); the case is skipped when neither is set. The
-        deployed extension is named
-        '<publisher>_<extension_type>_boot_validation_test'.
+        'extension_version'); it is required only for the install path, where
+        the case is skipped when neither is set. The deployed extension (install
+        path) is named '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=1,
         maturity="experimental",
@@ -61,5 +71,49 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
     def microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test(  # noqa: E501
         self, log: Logger, node: Node, variables: Dict[str, Any]
     ) -> None:
-        # The Azure Security Linux Agent installs without inline settings.
+        extension = node.features[AzureExtension]
+        publisher = self._resolve_publisher(variables)
+        type_ = self._resolve_type(variables)
+
+        # Linux allows only one VM extension per handler. If the agent is
+        # already installed (commonly auto-provisioned), validate that instance
+        # instead of installing a conflicting one.
+        existing_name = self._find_installed_handler_name(extension, publisher, type_)
+        if existing_name is not None:
+            log.info(
+                f"Handler '{publisher}.{type_}' is already installed as "
+                f"'{existing_name}'; validating the existing instance in place."
+            )
+            detail = extension.get(name=existing_name)
+            self._assert_provisioned(
+                {"provisioning_state": str(detail.provisioning_state)}, variables
+            )
+            installed_version = extension.get_installed_type_handler_version(
+                existing_name
+            )
+            log.info(
+                f"Installed extension '{existing_name}' "
+                f"version: {installed_version}"
+            )
+            self._assert_vm_reachable(node)
+            return
+
+        # Not present: the Azure Security Linux Agent installs without inline
+        # settings.
         self._boot_validation(node, log, variables, settings={})
+
+    def _find_installed_handler_name(
+        self, extension: AzureExtension, publisher: str, type_: str
+    ) -> Optional[str]:
+        """
+        Return the resource name of an already-installed extension matching the
+        given publisher and handler type, or None if the handler is not present.
+        """
+        for ext in extension.list_all() or []:
+            ext_publisher = getattr(ext, "publisher", "") or ""
+            ext_type = getattr(ext, "type_properties_type", "") or ""
+            if ext_publisher == publisher and ext_type == type_:
+                name = getattr(ext, "name", "") or ""
+                if name:
+                    return name
+        return None

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any, Dict
+
+from microsoft.testsuites.vm_extensions.vm_extension_base import VmExtensionTestBase
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuiteMetadata, simple_requirement
+from lisa.operating_system import BSD
+from lisa.sut_orchestrator import AZURE
+from lisa.sut_orchestrator.azure.features import AzureExtension
+
+
+@TestSuiteMetadata(
+    area="vm_extension",
+    category="functional",
+    description="""
+    This test suite validates the Azure Security Linux Agent VM extension
+    (Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent).
+
+    The Azure Security Linux Agent provides security logging and monitoring
+    coverage for Linux VMs (Microsoft Defender for Cloud / Azure Security
+    Center). It is the mandatory boot validation coverage required for the
+    publisher to onboard to Functional Validation.
+    """,
+    tags=["VM_Extension", "AzureSecurityLinuxAgent"],
+    requirement=simple_requirement(
+        supported_features=[AzureExtension],
+        supported_platform_type=[AZURE],
+        unsupported_os=[BSD],
+    ),
+)
+class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
+    PUBLISHER = "Microsoft.Azure.Security.Monitoring"
+    EXTENSION_TYPE = "AzureSecurityLinuxAgent"
+    EXTENSION_KEY = "azure_security_linux_agent"
+
+    @TestCaseMetadata(
+        description="""
+        Basic boot validation for the Azure Security Linux Agent VM extension.
+
+        Installs the extension with empty inline settings (the agent requires
+        no storage account or public blob access), verifies that provisioning
+        succeeds and the requested version is delivered, confirms the VM is
+        still reachable, then removes the extension.
+
+        The extension version is read from runbook variable
+        'azure_security_linux_agent_version' (or the generic
+        'extension_version'); the case is skipped when neither is set. The
+        deployed extension is named
+        '<publisher>_<extension_type>_boot_validation_test'.
+        """,
+        priority=1,
+        maturity="experimental",
+    )
+    def microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test(  # noqa: E501
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        # The Azure Security Linux Agent installs without inline settings.
+        self._boot_validation(node, log, variables, settings={})


### PR DESCRIPTION
## What
Adds a **boot validation** test for the Azure Security Linux Agent VM extension
(`Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent`), onboarding the
publisher to Functional Validation.

## Details
- New dedicated suite `AzureSecurityLinuxAgentTests` subclassing
  `VmExtensionTestBase` (per `docs/vm_extension_validation_framework.rst`),
  reusing the shared install / assert-provisioned / uninstall lifecycle helpers
  — no re-implemented lifecycle logic.
- Single AzCertify-named boot validation case
  `microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test`:
  installs the extension with minimal inline settings, asserts
  `provisioning_state == "Succeeded"`, verifies the installed handler version,
  confirms the VM stays reachable over SSH, then removes the extension.
- Publisher / type are class constants; **version is a runbook variable**
  (`azure_security_linux_agent_version`), not hardcoded.
- Starts at `experimental` maturity per the onboarding guidance.
- Adds runbook `lisa/microsoft/runbook/azure_security_linux_agent.yml` to run
  only this case (includes a `maturity: experimental` criterion so it is
  approved past LISA's implicit stable gate).

### Design note — prerequisites
The heavier AzSecPack/AutoConfig prerequisites in `azsecpack.py` (managed
identity, `azure-mdsd`, AMA-first, `enableGenevaUpload`/`enableAutoConfig`,
AutoConfig-scope subscription) are **AutoConfig-scenario** requirements, not the
extension's minimal install contract. A boot validation only needs a supported
distro + waagent + connectivity, so this test does a plain CRP install and
leaves the deep autoconfig/service coverage to the existing `verify_azsecpack`.

## Testing
- `black`, `isort`, `flake8` clean.
- `lisa list -t case -r lisa/microsoft/runbook/azure_security_linux_agent.yml`
  discovers and selects the case (`selected count: 1`).
- End-to-end Azure run pending (requires a subscription; extension is expected
  to provision on a supported Linux image — verify on first real run).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
