### PR TITLE
azure: bypass fallback sort when vm_size is explicitly set

### DIFF
--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -3211,10 +3211,16 @@ class AzurePlatform(Platform):
             ) = self._get_available_azure_capabilities(candidate_caps, log)
 
             # Sort available vm sizes to match. Awaitable doesn't need to be
-            # sorted.
-            available_capabilities = self.get_sorted_vm_sizes(
-                available_capabilities, log
-            )
+            # sorted. Skip sorting when the runbook explicitly requested a
+            # vm_size: the candidate list is already restricted to the
+            # requested size(s), and get_sorted_vm_sizes also acts as a
+            # fallback-pattern filter, which would drop explicitly-requested
+            # sizes if they don't match any pattern (e.g. `Internal_*`).
+            node_runbook = req.get_extended_runbook(AzureNodeSchema, AZURE)
+            if not node_runbook.vm_size:
+                available_capabilities = self.get_sorted_vm_sizes(
+                    available_capabilities, log
+                )
             available_candidates.append([req, available_capabilities])
             awaitable_candidates.append(
                 [req, available_capabilities + awaitable_capabilities]


### PR DESCRIPTION
### What
Skip `get_sorted_vm_sizes` in `_get_azure_capabilities` when the runbook explicitly requests `vm_size`.

### Why
Follow-up to #4619.

`get_sorted_vm_sizes` uses `VM_SIZE_FALLBACK_PATTERNS` as a bucket filter: any capability whose `vm_size` doesn't match any pattern is silently dropped from the returned candidate list. That's fine for the auto-selection path (the intent), but it breaks the case where the runbook explicitly requests a `vm_size:` whose name matches none of the buckets.

After #4619 tightened the catch-all bucket to exclude names containing `Internal`, an explicit `vm_size: Internal_...` in a runbook is dropped by `get_sorted_vm_sizes` before it can be considered for deployment. The test then skips with a generic "unknown reason" message even though the user asked for that exact size.

### How
Skip the sort when `vm_size:` is set on the node requirement. Sorting a candidate list built from a user-supplied `vm_size` provides no ordering benefit (each token spawns its own environment with a single-SKU candidate list); the only behavior the sort added in that case was the fallback-pattern filter side-effect, which is unwanted here. Quota checks and requirement matching still run as before.

The auto-selection path (no `vm_size` set) is unchanged and still honors `VM_SIZE_FALLBACK_PATTERNS`.

### Verification

Ran `Sriov.verify_sriov_basic` across five `VMSize` configurations in Azure `westus`. Each row below is one environment LISA created — a single env per single `vm_size`, one env per token for CSV. **No SKU was silently dropped by the fallback filter in any run.**

| # | VMSize input | Env / SKU | Image / SecurityProfile | Outcome | Reason |
|---|---|---|---|---|---|
| 1 | *(empty — auto-select)* | `generated_0` / auto-picked non-CVM | Ubuntu 26.04 CVM / cvm | SKIPPED | `security_profile: requires [cvm] but VM supports [secureboot, none]`. Auto path unchanged — sort still runs, `Internal_*` still excluded from catch-all. |
| 2 | `Internal_DC2eds_v6` | `generated_0` / `Internal_DC2eds_v6` | Ubuntu 26.04 CVM / cvm | FAILED | **Deployed** (would have been silently SKIPPED pre-fix). Runtime `AssertionError` on VF count — separate SR-IOV/guest issue, not platform. ✅ Fix confirmed for single explicit `Internal_*`. |
| 3 | `Standard_DC2eds_v6,Internal_DC2eds_v6` | `generated_0` / `Standard_DC2eds_v6` | Ubuntu 26.04 CVM / cvm | SKIPPED | `data_path: requires [not(Sriov)] but VM supports [Synthetic]` — legitimate capability mismatch. |
| 3 | `Standard_DC2eds_v6,Internal_DC2eds_v6` | `generated_1` / `Internal_DC2eds_v6` | Ubuntu 26.04 CVM / cvm | FAILED | Deployed; runtime `AssertionError` on VF count. ✅ CSV mixing standard + `Internal_*` — both honored, order preserved. |
| 4 | `Standard_D2s_v3,Standard_D4s_v3` | `generated_0` / `Standard_D2s_v3` | Ubuntu 24.04 / default | **PASSED** | Deployed & test ran end-to-end. |
| 4 | `Standard_D2s_v3,Standard_D4s_v3` | `generated_1` / `Standard_D4s_v3` | Ubuntu 24.04 / default | **PASSED** | Deployed & test ran end-to-end. ✅ CSV non-CVM — both passed, user-declared order preserved. |
| 5 | `Standard_DC2eds_v6,Standard_DC4eds_v6` | `generated_0` / `Standard_DC2eds_v6` | Ubuntu 26.04 CVM / cvm | SKIPPED | `data_path: requires [Sriov] but VM supports [Synthetic]` — real capability mismatch, not the sort filter. |
| 5 | `Standard_DC2eds_v6,Standard_DC4eds_v6` | `generated_1` / `Standard_DC4eds_v6` | Ubuntu 26.04 CVM / cvm | SKIPPED | Same reason — capability mismatch. Both honored by the platform. |

**Takeaways:**
- No silent drops for any explicit `vm_size` (single or CSV).
- User-declared order preserved for CSV.
- Auto-select path unchanged: sort still runs; `Internal_*` still excluded from fallback catch-all.
