### PR TITLE
Fix fresh environment tracking for guest tests

### DIFF
--- a/lisa/runners/lisa_runner.py
+++ b/lisa/runners/lisa_runner.py
@@ -436,6 +436,9 @@ class LisaRunner(BaseRunner):
         tested_environment = environment
         if self._guest_enabled:
             tested_environment = environment.get_guest_environment()
+            # Guest environments are transient wrappers, so mark the scheduled
+            # parent as used as well.
+            environment.is_new = False
 
         test_suite.start(
             environment=tested_environment,


### PR DESCRIPTION
Mark the scheduled parent environment as used when dispatching a transient guest wrapper.
This prevents use_new_environment cases from reusing the same parent while preserving normal environment reuse and retry resets. Guest-enabled runs schedule work against a parent environment but execute the test suite with a transient wrapper returned by get_guest_environment(). TestSuite.start() marks the environment it receives as no longer new, so only the wrapper was updated while the scheduled parent incorrectly remained is_new=True.

The scheduler evaluates use_new_environment against the parent flag. Leaving that flag set allowed later guest test cases that require an unused environment to select the same parent again, defeating test isolation and risking state leakage between cases.

Mark the parent environment as used when dispatching its guest wrapper. This preserves the existing non-guest path, while the normal environment reset lifecycle can still restore is_new for retry or redeployment.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
