### PR TITLE
Make Cloud Hypervisor virtio topology configurable

### DIFF
--- a/lisa/sut_orchestrator/libvirt/ch_platform.py
+++ b/lisa/sut_orchestrator/libvirt/ch_platform.py
@@ -144,6 +144,19 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         assert isinstance(node.capability.core_count, int)
         vcpu_count = node.capability.core_count
         vcpu.text = str(vcpu_count)
+        node_runbook = node.capability.get_extended_runbook(
+            CloudHypervisorNodeSchema, CLOUD_HYPERVISOR
+        )
+        network_queue_count = (
+            node_runbook.network_queue_count
+            if node_runbook.network_queue_count is not None
+            else vcpu_count
+        )
+        disk_queue_count = (
+            node_runbook.disk_queue_count
+            if node_runbook.disk_queue_count is not None
+            else vcpu_count
+        )
 
         os = ET.SubElement(domain, "os")
 
@@ -206,21 +219,21 @@ class CloudHypervisorPlatform(BaseLibvirtPlatform):
         network_model.attrib["type"] = "virtio"
 
         network_driver = ET.SubElement(network_interface, "driver")
-        network_driver.attrib["queues"] = str(vcpu_count)
-        network_driver.attrib["iommu"] = "on"
+        network_driver.attrib["queues"] = str(network_queue_count)
+        network_driver.attrib["iommu"] = "on" if node_runbook.enable_iommu else "off"
 
         self._add_virtio_disk_xml(
             node_context,
             devices,
             node_context.os_disk_file_path,
-            vcpu_count,
+            disk_queue_count,
         )
 
         self._add_virtio_disk_xml(
             node_context,
             devices,
             node_context.cloud_init_file_path,
-            vcpu_count,
+            disk_queue_count,
         )
 
         xml = ET.tostring(domain, "unicode")

--- a/lisa/sut_orchestrator/libvirt/schema.py
+++ b/lisa/sut_orchestrator/libvirt/schema.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 from dataclasses_json import dataclass_json
 
+from lisa import schema
 from lisa.sut_orchestrator.util.schema import (
     CloudInitSchema,
     DevicePassthroughSchema,
@@ -150,3 +151,23 @@ class CloudHypervisorNodeSchema(BaseLibvirtNodeSchema):
     kernel: Optional[KernelSchema] = None
     # Optional extra kernel boot parameters for the guest.
     kernel_boot_parameters: str = ""
+    # Defaults to the guest vCPU count when omitted.
+    network_queue_count: Optional[int] = field(
+        default=None,
+        metadata=schema.field_metadata(
+            field_function=schema.fields.Int,
+            validate=schema.validate.Range(min=1),
+            allow_none=True,
+        ),
+    )
+    # Defaults to the guest vCPU count when omitted.
+    disk_queue_count: Optional[int] = field(
+        default=None,
+        metadata=schema.field_metadata(
+            field_function=schema.fields.Int,
+            validate=schema.validate.Range(min=1),
+            allow_none=True,
+        ),
+    )
+    # Preserve the existing virtio NIC IOMMU behavior when omitted.
+    enable_iommu: bool = True


### PR DESCRIPTION
Add per-node controls for virtio network and disk queue counts and for virtio IOMMU exposure in Cloud Hypervisor domain definitions.

Read these controls from the node capability typed Cloud Hypervisor extended runbook while generating domain XML. This keeps resolved platform-specific settings available during guest creation instead of relying on the generic remote-node runbook.

Apply the network queue and IOMMU settings to the virtio NIC and the disk queue setting to both the OS and cloud-init disks. Preserve existing behavior when controls are omitted by defaulting queue counts to the guest vCPU count and leaving NIC IOMMU enabled.

Allow omitted optional queue values to round-trip through Marshmallow as null while continuing to reject queue counts below one.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
