### PR TITLE
fix(nvme): wait for deferred space reclaim in verify_nvme_fstrim

### DIFF
--- a/lisa/microsoft/testsuites/nvme/nvme.py
+++ b/lisa/microsoft/testsuites/nvme/nvme.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import re
+
 from assertpy import assert_that
 
 from lisa import (
@@ -17,7 +19,57 @@ from lisa.search_space import IntRange
 from lisa.sut_orchestrator.azure.platform_ import AzurePlatform
 from lisa.tools import Cat, Df, Echo, Fdisk, Lspci, Mkfs, Mount, Nvmecli
 from lisa.tools.fdisk import FileSystem
+from lisa.util import LisaException, LisaTimeoutException, check_till_timeout
 from lisa.util.constants import DEVICE_TYPE_NVME, DEVICE_TYPE_SRIOV
+
+_FSTRIM_TRIMMED_BYTES_PATTERN = re.compile(r"\((?P<bytes>\d+) bytes\) trimmed")
+
+
+def _get_fstrim_trimmed_bytes(node: Node, mount_point: str) -> int:
+    fstrim_result = node.execute(f"fstrim {mount_point} -v", shell=True, sudo=True)
+    fstrim_result.assert_exit_code(
+        message=f"fstrim failed on [{mount_point}]. Verify the mount point exists "
+        "and the underlying device supports discard."
+    )
+    matched = _FSTRIM_TRIMMED_BYTES_PATTERN.search(fstrim_result.stdout)
+    if not matched:
+        raise LisaException(
+            f"cannot parse trimmed bytes from fstrim output on [{mount_point}]: "
+            f"[{fstrim_result.stdout}]. Verify the util-linux version on this distro "
+            "supports the verbose output of 'fstrim -v'."
+        )
+    return int(matched.group("bytes"))
+
+
+def _wait_for_trimmable_space(
+    node: Node,
+    mount_point: str,
+    expected_trimmed_bytes: int,
+    timeout: int,
+    interval: int,
+) -> int:
+    observed_trimmed_bytes = 0
+
+    def _is_space_reclaimed() -> bool:
+        nonlocal observed_trimmed_bytes
+        observed_trimmed_bytes = _get_fstrim_trimmed_bytes(node, mount_point)
+        return observed_trimmed_bytes >= expected_trimmed_bytes
+
+    try:
+        check_till_timeout(
+            _is_space_reclaimed,
+            timeout_message=f"[{mount_point}] reclaimed only "
+            f"{observed_trimmed_bytes} trimmable bytes, expected at least "
+            f"{expected_trimmed_bytes}",
+            timeout=timeout,
+            interval=interval,
+        )
+    except LisaTimeoutException:
+        node.log.debug(
+            f"[{mount_point}] stopped at {observed_trimmed_bytes} trimmable bytes "
+            f"after waiting {timeout} seconds"
+        )
+    return observed_trimmed_bytes
 
 
 def _format_mount_disk(
@@ -51,6 +103,13 @@ def _format_mount_disk(
 )
 class NvmeTestSuite(TestSuite):
     TIME_OUT = 300
+    # Freeing the blocks of a large file is deferred to background workers on xfs,
+    # so the space is not trimmable the instant `rm` returns.
+    FSTRIM_RECLAIM_TIMEOUT = 300
+    FSTRIM_RECLAIM_INTERVAL = 5
+    # A deleted file leaves some metadata (inode chunks, btree blocks) allocated,
+    # so the reclaimed space never returns to exactly the initial value.
+    FSTRIM_RECLAIM_RATIO = 0.99
 
     @TestCaseMetadata(
         description="""
@@ -138,8 +197,9 @@ class NvmeTestSuite(TestSuite):
         3. Create a 300 gb file 'data' using dd command in the partition.
         4. Check how much the mountpoint is trimmed after creating the file.
         5. Delete the file 'data'.
-        6. Check how much the mountpoint is trimmed after deleting the file,
-         and compare the final fstrim status with initial fstrim status.
+        6. Wait until the mountpoint reports the same trimmable space as the
+         initial fstrim status, since freeing the blocks of a large file is
+         deferred by the file system.
         """,
         priority=3,
         requirement=simple_requirement(
@@ -162,13 +222,7 @@ class NvmeTestSuite(TestSuite):
             _format_mount_disk(node, namespace, FileSystem.xfs)
 
             # 2. Check how much the mountpoint is trimmed before operations.
-            initial_fstrim = node.execute(
-                f"fstrim {mount_point} -v", shell=True, sudo=True
-            )
-            initial_fstrim.assert_exit_code(
-                message=f"{mount_point} not exist or fstrim command enounter "
-                "unexpected error."
-            )
+            initial_trimmed_bytes = _get_fstrim_trimmed_bytes(node, mount_point)
             # Use 80% of free space to create a test file.
             free_space_gb = int(df.get_filesystem_available_space(mount_point) * 0.8)
             # limit the free space to 300GB to avoid long time operation.
@@ -186,31 +240,39 @@ class NvmeTestSuite(TestSuite):
             )
 
             # 4. Check how much the mountpoint is trimmed after creating the file.
-            intermediate_fstrim = node.execute(
-                f"fstrim {mount_point} -v", shell=True, sudo=True
-            )
-            intermediate_fstrim.assert_exit_code(
-                message=f"{mount_point} not exist or fstrim command enounter "
-                "unexpected error."
-            )
+            _get_fstrim_trimmed_bytes(node, mount_point)
 
             # 5. Delete the file 'data'.
             node.execute(f"rm {mount_point}/data", shell=True, sudo=True)
-
-            # 6. Check how much the mountpoint is trimmed after deleting the file,
-            #  and compare the final fstrim status with initial fstrim status.
+            node.execute("sync", shell=True, sudo=True)
             node.tools[Echo].write_to_file(
                 "2", node.get_pure_path("/proc/sys/vm/drop_caches"), sudo=True
             )
-            final_fstrim = node.execute(
-                f"fstrim {mount_point} -v", shell=True, sudo=True
+
+            # 6. Wait until the deleted blocks are back in the trimmable pool.
+            expected_trimmed_bytes = int(
+                initial_trimmed_bytes * self.FSTRIM_RECLAIM_RATIO
             )
-            mount.umount(disk_name=namespace, point=mount_point)
+            node.log.info(
+                f"waiting for [{mount_point}] to reclaim the space of the deleted "
+                f"file, expecting at least {expected_trimmed_bytes} trimmable bytes"
+            )
+            try:
+                final_trimmed_bytes = _wait_for_trimmable_space(
+                    node,
+                    mount_point,
+                    expected_trimmed_bytes,
+                    self.FSTRIM_RECLAIM_TIMEOUT,
+                    self.FSTRIM_RECLAIM_INTERVAL,
+                )
+            finally:
+                mount.umount(disk_name=namespace, point=mount_point)
             assert_that(
-                final_fstrim.stdout,
-                "initial_fstrim should equal to final_fstrim after operations "
-                "after umount and re-mount.",
-            ).is_equal_to(initial_fstrim.stdout)
+                final_trimmed_bytes,
+                "trimmable space after deleting the test file should return to the "
+                "initial level, otherwise the freed blocks were not discarded on the "
+                "nvme device.",
+            ).is_greater_than_or_equal_to(expected_trimmed_bytes)
 
     @TestCaseMetadata(
         description="""


### PR DESCRIPTION

## Description

Nvme.verify_nvme_fstrim fills the local NVMe disk with dd (no fsync), deletes the file, and immediately re-runs fstrim, asserting the trimmed byte count exactly matches the pre-write value. There is no sync and no retry between the rm and the final fstrim — about 0.6 s.

On the non-L series SKUs that window is far too short. Average passing-run duration shows the throughput gap directly:

VMSize	Avg duration	Bytes written	Effective rate
Standard_L8as_v3	230 s	300 GiB	~1.4 GB/s
Standard_E2ds_v6	663 s	87 GiB	~140 MB/s
Standard_D2ads_v6	829 s	87 GiB	~110 MB/s
L8as_v3 writes 3.4× more data in roughly one third of the time — a ~10× gap. On E2ds_v6/D2ads_v6 the dd is still draining dirty pages when rm runs, so rm returns in 0.114 s without evicting the inode and XFS's deferred extent-free work queues behind that writeback; it actually completed during the observed 37 s umount, long after the assertion had already fired. Compounding it, the test's min(0.8 × free, 300 GiB) sizing fills the 110 GiB v6 disk to 79% versus ~17% on Lsv3's 1.92 TB disk, so the file is fragmented into far more extents to free.

Result: trim-mismatch failure rate of 77% on E2ds_v6 and 30% on D2ads_v6 (86 failures over 3 months), versus 0.3% on L8as_v3 and 0% on L80s_v3. Lsv3 isn't immune — it just finishes the deferred work inside the 0.6 s window. Kernel- and distro-independent (4.15 through 6.8, Ubuntu/RHEL/SLES/Debian/Azure Linux/Oracle), so this is a test-code race, not a kernel regression.

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_nvme_fstrim

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts latest|verify_nvme_fstrim|Standard_E8ds_v6| PASSED|
