### PR TITLE
Add openEuler operating system support

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2245,6 +2245,20 @@ class AlmaLinux(Redhat):
         return re.compile("^AlmaLinux")
 
 
+class OpenEuler(RPMDistro):
+    """
+    openEuler is an open source, dnf-based RPM Linux distribution. It is detected
+    via NAME/ID "openEuler" in /etc/os-release. It extends RPMDistro to reuse the
+    dnf-based package and repository handling, and relies on the base
+    Linux._get_information to parse /etc/os-release, since openEuler does not
+    provide /etc/fedora-release.
+    """
+
+    @classmethod
+    def name_pattern(cls) -> Pattern[str]:
+        return re.compile("^openEuler|openeuler$")
+
+
 class CBLMariner(RPMDistro):
     @classmethod
     def name_pattern(cls) -> Pattern[str]:

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2256,7 +2256,7 @@ class OpenEuler(RPMDistro):
 
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
-        return re.compile("^openEuler|openeuler$")
+        return re.compile("^(openEuler|openeuler)")
 
 
 class CBLMariner(RPMDistro):

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -6,7 +6,16 @@ from retry import retry
 
 from lisa.base_tools import Service, Wget
 from lisa.executable import Tool
-from lisa.operating_system import BSD, CBLMariner, CentOs, Debian, Fedora, Redhat, Suse
+from lisa.operating_system import (
+    BSD,
+    CBLMariner,
+    CentOs,
+    Debian,
+    Fedora,
+    OpenEuler,
+    Redhat,
+    Suse,
+)
 from lisa.util import (
     LisaException,
     ReleaseEndOfLifeException,
@@ -224,6 +233,12 @@ class Docker(Tool):
                 )
         elif isinstance(self.node.os, CBLMariner):
             self.node.os.install_packages(["moby-engine", "moby-cli"])
+        elif isinstance(self.node.os, OpenEuler):
+            # openEuler ships a native moby-based "docker" package in its update
+            # repository that provides both the daemon and CLI along with a
+            # docker systemd service. OpenEuler is an RPMDistro (not a Redhat
+            # subclass), so it needs its own branch here.
+            self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, Suse) or isinstance(self.node.os, Fedora):
             self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, BSD):

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -220,22 +220,25 @@ class KdumpBase(Tool):
     @classmethod
     def create(cls, node: "Node", *args: Any, **kwargs: Any) -> Tool:
         # FreeBSD image doesn't support kdump since the kernel has no DDB option
+        kdump_type: Type[KdumpBase]
         if isinstance(node.os, Redhat):
-            return KdumpRedhat(node)
+            kdump_type = KdumpRedhat
         elif isinstance(node.os, Debian):
-            return KdumpDebian(node)
+            kdump_type = KdumpDebian
         elif isinstance(node.os, Suse):
-            return KdumpSuse(node)
+            kdump_type = KdumpSuse
         elif isinstance(node.os, CBLMariner):
             if node.os.information.version.major >= 4:
-                return KdumpFedora(node)
-            return KdumpCBLMariner(node)
+                kdump_type = KdumpFedora
+            else:
+                kdump_type = KdumpCBLMariner
         elif type(node.os) is Fedora:
-            return KdumpFedora(node)
+            kdump_type = KdumpFedora
         elif isinstance(node.os, OpenEuler):
-            return KdumpOpenEuler(node)
+            kdump_type = KdumpOpenEuler
         else:
             raise UnsupportedDistroException(os=node.os)
+        return kdump_type(node)
 
     @property
     def dependencies(self) -> List[Type[Tool]]:

--- a/lisa/tools/kdump.py
+++ b/lisa/tools/kdump.py
@@ -17,6 +17,7 @@ from lisa.operating_system import (
     CBLMariner,
     Debian,
     Fedora,
+    OpenEuler,
     Oracle,
     Posix,
     Redhat,
@@ -231,6 +232,8 @@ class KdumpBase(Tool):
             return KdumpCBLMariner(node)
         elif type(node.os) is Fedora:
             return KdumpFedora(node)
+        elif isinstance(node.os, OpenEuler):
+            return KdumpOpenEuler(node)
         else:
             raise UnsupportedDistroException(os=node.os)
 
@@ -587,6 +590,19 @@ class KdumpRedhat(KdumpBase):
             sudo=True,
         )
         sed.append(f"path {self.dump_path}", kdump_conf, sudo=True)
+
+
+class KdumpOpenEuler(KdumpRedhat):
+    # openEuler is an RPMDistro (not a Redhat subclass) but is RHEL-derived: it
+    # ships the kdump service via the "kexec-tools" package (providing kdumpctl)
+    # and uses grubby to manage the crashkernel boot argument, the same as
+    # Redhat 8+. Only the install step needs its own OS assertion; the
+    # crashkernel config is inherited from KdumpRedhat (openEuler version 24 >= 8
+    # selects the grubby path).
+    def _install(self) -> bool:
+        assert isinstance(self.node.os, OpenEuler)
+        self.node.os.install_packages("kexec-tools")
+        return self._check_exists()
 
 
 class KdumpFedora(KdumpBase):

--- a/lisa/tools/kernel_config.py
+++ b/lisa/tools/kernel_config.py
@@ -36,33 +36,25 @@ class KernelConfig(Tool):
     def can_install(self) -> bool:
         return False
 
+    def _grep_config(self, pattern: str) -> bool:
+        # /proc/config.gz is gzip-compressed and must be read with zcat, while
+        # the /boot/config-* files are plain text and can be grepped directly.
+        if self.config_path.endswith(".gz"):
+            command = f"zcat {self.config_path} | grep {pattern}"
+        else:
+            command = f"grep {pattern} {self.config_path}"
+        return self.node.execute(command, sudo=True, shell=True).exit_code == 0
+
     def is_kernel_config_set_to(
         self, config_name: str, config_value: ModulesType
     ) -> bool:
-        return (
-            self.node.execute(
-                f"grep ^{config_name}={config_value.value} {self.config_path}",
-                sudo=True,
-                shell=True,
-            ).exit_code
-            == 0
-        )
+        return self._grep_config(f"^{config_name}={config_value.value}")
 
     def is_built_in(self, config_name: str) -> bool:
-        return (
-            self.node.execute(
-                f"grep ^{config_name}=y {self.config_path}", sudo=True, shell=True
-            ).exit_code
-            == 0
-        )
+        return self._grep_config(f"^{config_name}=y")
 
     def is_built_as_module(self, config_name: str) -> bool:
-        return (
-            self.node.execute(
-                f"grep ^{config_name}=m {self.config_path}", sudo=True, shell=True
-            ).exit_code
-            == 0
-        )
+        return self._grep_config(f"^{config_name}=m")
 
     def is_enabled(self, config_name: str) -> bool:
         return self.is_built_as_module(config_name) or self.is_built_in(config_name)
@@ -77,9 +69,17 @@ class KernelConfig(Tool):
         uname_tool = self.node.tools[Uname]
         kernel_ver = uname_tool.get_linux_information().kernel_version_raw
         if isinstance(self.node.os, CoreOs):
-            self.config_path = f"/usr/boot/config-{kernel_ver}"
+            boot_config_path = f"/usr/boot/config-{kernel_ver}"
         else:
-            self.config_path = f"/boot/config-{kernel_ver}"
+            boot_config_path = f"/boot/config-{kernel_ver}"
+        # Some kernels (e.g. locally built ones with a version suffix like
+        # "6.6.0+") don't ship a matching /boot/config-<kernel_ver> file. Fall
+        # back to /proc/config.gz, which is exposed when CONFIG_IKCONFIG_PROC is
+        # enabled, so kernel config lookups still work.
+        if self.node.execute(f"ls -lt {boot_config_path}", sudo=True).exit_code == 0:
+            self.config_path = boot_config_path
+        else:
+            self.config_path = "/proc/config.gz"
 
 
 class KernelConfigFreeBSD(KernelConfig):

--- a/lisa/tools/lagscope.py
+++ b/lisa/tools/lagscope.py
@@ -13,7 +13,7 @@ from lisa.messages import (
     create_perf_message,
     send_unified_perf_message,
 )
-from lisa.operating_system import CBLMariner, Debian, Posix, Redhat, Suse
+from lisa.operating_system import CBLMariner, Debian, OpenEuler, Posix, Redhat, Suse
 from lisa.util import LisaException, constants, find_groups_in_lines, get_datetime_path
 from lisa.util.process import ExecutableResult, Process
 
@@ -505,6 +505,15 @@ class Lagscope(Tool, KillableMixin):
                 "glibc-devel",
                 "zlib-devel",
                 "cmake",
+            ]
+        elif isinstance(self.node.os, OpenEuler):
+            package_list = [
+                "libaio",
+                "sysstat",
+                "bc",
+                "wget",
+                "cmake",
+                "libarchive",
             ]
         else:
             raise LisaException(


### PR DESCRIPTION
openEuler images (e.g. openeuler-2403-lts) were detected as the generic Linux class, which does not implement _is_package_in_repo. This caused NotImplementedError during tool/package installation (e.g. installing git as a dependency of ntttcp), failing tests such as perf_tcp_ntttcp_sriov.

Add an OpenEuler class deriving from RPMDistro so it reuses the dnf-based package and repository handling, and inherits Linux._get_information which parses /etc/os-release (openEuler has no /etc/fedora-release).

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- eisoftwaretechnologyhongkongcolimited1722223098317 openeuler-2403-lts oe2403-free-gen2 24.03.0

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|eisoftwaretechnologyhongkongcolimited1722223098317 openeuler-2403-lts oe2403-free-gen2 24.03.0 |Standard_D48_v5| PASSED |
