### PR TITLE
Fix CVM Azure host SNP detection

### DIFF
--- a/lisa/microsoft/testsuites/cvm/cvm_azure_host.py
+++ b/lisa/microsoft/testsuites/cvm/cvm_azure_host.py
@@ -17,7 +17,7 @@ from lisa import (
 from lisa.operating_system import CBLMariner
 from lisa.sut_orchestrator.azure import features
 from lisa.testsuite import TestResult, simple_requirement
-from lisa.tools import Cat, Dmesg
+from lisa.tools import Dmesg, Ls
 from lisa.util import LisaException, SkippedException, get_matched_str
 
 
@@ -31,7 +31,9 @@ from lisa.util import LisaException, SkippedException, get_matched_str
     requirement=simple_requirement(supported_os=[CBLMariner]),
 )
 class CVMAzureHostTestSuite(TestSuite):
-    __sev_enabled_pattern = re.compile(r"mshv: SEV-SNP is supported")
+    __sev_enabled_pattern = re.compile(
+        r"mshv: (?:SEV-SNP is supported|SEV-SNP support status: available \(1\))"
+    )
     __sev_partition_pattern = re.compile(
         r"mshv: Maximum supported SEV-SNP partitions are: (\d+)"
     )
@@ -93,10 +95,4 @@ class CVMAzureHostTestSuite(TestSuite):
 
 
 def is_mariner_dom0(node: Node) -> bool:
-    cat = node.tools[Cat]
-    hosts = cat.read("/etc/hosts")
-    pattern = r"dom0-\d+-\d+-\d+-\w+-\d+"
-    matches = re.findall(pattern, hosts)
-    if matches:
-        return True
-    return False
+    return node.tools[Ls].path_exists("/dev/mshv", sudo=True)


### PR DESCRIPTION
Identify Azure Linux Dom0 hosts through the MSHV device instead of relying on the legacy dom0 hostname format in /etc/hosts. This allows current root-partition images to reach the SNP validation.

Accept both the legacy SEV-SNP support message and the current available status message while preserving the positive partition-count assertion.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
