### PR TITLE
fix reboot inactive ssh session

### DIFF
--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -18,7 +18,7 @@ from lisa.util import (
     TcpConnectionException,
     constants,
 )
-from lisa.util.perf_timer import Timer, create_timer
+from lisa.util.perf_timer import create_timer
 from lisa.util.shell import wait_tcp_port_ready
 
 from .date import Date
@@ -106,32 +106,6 @@ class Reboot(Tool):
             self._command = command_result.stdout.strip()
         self.run(force_run=True, sudo=True, timeout=10)
 
-    def _wait_for_minimum_uptime(
-        self, last_boot_time: datetime, time_out: int, timer: Timer
-    ) -> bool:
-        current_boot_time = last_boot_time
-        date = self.node.tools[Date]
-        # Boot time has no tzinfo, so remove it from the date result to avoid
-        # TypeError when subtracting offset-naive and offset-aware datetimes.
-        current_delta = date.current().replace(tzinfo=None) - current_boot_time
-        self._log.debug(f"delta time since last boot: {current_delta}")
-        while current_delta < timedelta(minutes=1):
-            wait_seconds = 60 - current_delta.seconds + 1
-            self._log.debug(f"waiting {wait_seconds} seconds before rebooting")
-            sleep(wait_seconds)
-
-            self.node.close()
-            current_boot_time = self._get_last_boot_time()
-            if last_boot_time < current_boot_time:
-                remaining_stability_wait = max(0, time_out - int(timer.elapsed(False)))
-                if remaining_stability_wait > 0:
-                    self._wait_ssh_session_stable(remaining_stability_wait)
-                return True
-
-            current_delta = date.current().replace(tzinfo=None) - current_boot_time
-
-        return False
-
     def reboot_and_check_panic(self, log_path: Path) -> None:
         try:
             self.reboot()
@@ -158,8 +132,19 @@ class Reboot(Tool):
         # so if the node rebooted in one minute, the who -b is not changed.
         # The reboot will wait forever.
         # in this case, verify the time is wait enough to prevent this problem.
-        if self._wait_for_minimum_uptime(last_boot_time, time_out, timer):
-            return
+        date = self.node.tools[Date]
+        # boot time has no tzinfo, so remove from date result to avoid below error.
+        # TypeError: can't subtract offset-naive and offset-aware datetimes
+        current_delta = date.current().replace(tzinfo=None) - current_boot_time
+        self._log.debug(f"delta time since last boot: {current_delta}")
+        while current_delta < timedelta(minutes=1):
+            # wait until one minute
+            wait_seconds = 60 - current_delta.seconds + 1
+            self._log.debug(f"waiting {wait_seconds} seconds before rebooting")
+            sleep(wait_seconds)
+            # Reconnect because the SSH session may become inactive during the wait.
+            self.node.close()
+            current_delta = date.current().replace(tzinfo=None) - current_boot_time
 
         self._log.debug(f"rebooting with boot time: {last_boot_time}")
         try:

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -18,7 +18,7 @@ from lisa.util import (
     TcpConnectionException,
     constants,
 )
-from lisa.util.perf_timer import create_timer
+from lisa.util.perf_timer import Timer, create_timer
 from lisa.util.shell import wait_tcp_port_ready
 
 from .date import Date
@@ -106,6 +106,32 @@ class Reboot(Tool):
             self._command = command_result.stdout.strip()
         self.run(force_run=True, sudo=True, timeout=10)
 
+    def _wait_for_minimum_uptime(
+        self, last_boot_time: datetime, time_out: int, timer: Timer
+    ) -> bool:
+        current_boot_time = last_boot_time
+        date = self.node.tools[Date]
+        # Boot time has no tzinfo, so remove it from the date result to avoid
+        # TypeError when subtracting offset-naive and offset-aware datetimes.
+        current_delta = date.current().replace(tzinfo=None) - current_boot_time
+        self._log.debug(f"delta time since last boot: {current_delta}")
+        while current_delta < timedelta(minutes=1):
+            wait_seconds = 60 - current_delta.seconds + 1
+            self._log.debug(f"waiting {wait_seconds} seconds before rebooting")
+            sleep(wait_seconds)
+
+            self.node.close()
+            current_boot_time = self._get_last_boot_time()
+            if last_boot_time < current_boot_time:
+                remaining_stability_wait = max(0, time_out - int(timer.elapsed(False)))
+                if remaining_stability_wait > 0:
+                    self._wait_ssh_session_stable(remaining_stability_wait)
+                return True
+
+            current_delta = date.current().replace(tzinfo=None) - current_boot_time
+
+        return False
+
     def reboot_and_check_panic(self, log_path: Path) -> None:
         try:
             self.reboot()
@@ -132,28 +158,8 @@ class Reboot(Tool):
         # so if the node rebooted in one minute, the who -b is not changed.
         # The reboot will wait forever.
         # in this case, verify the time is wait enough to prevent this problem.
-        date = self.node.tools[Date]
-        # boot time has no tzinfo, so remove from date result to avoid below error.
-        # TypeError: can't subtract offset-naive and offset-aware datetimes
-        current_delta = date.current().replace(tzinfo=None) - current_boot_time
-        self._log.debug(f"delta time since last boot: {current_delta}")
-        while current_delta < timedelta(minutes=1):
-            # wait until one minute
-            wait_seconds = 60 - current_delta.seconds + 1
-            self._log.debug(f"waiting {wait_seconds} seconds before rebooting")
-            sleep(wait_seconds)
-
-            self.node.close()
-            current_boot_time = self._get_last_boot_time()
-            if last_boot_time < current_boot_time:
-                remaining_stability_wait = max(
-                    0, time_out - int(timer.elapsed(False))
-                )
-                if remaining_stability_wait > 0:
-                    self._wait_ssh_session_stable(remaining_stability_wait)
-                return
-
-            current_delta = date.current().replace(tzinfo=None) - current_boot_time
+        if self._wait_for_minimum_uptime(last_boot_time, time_out, timer):
+            return
 
         self._log.debug(f"rebooting with boot time: {last_boot_time}")
         try:

--- a/lisa/tools/reboot.py
+++ b/lisa/tools/reboot.py
@@ -142,6 +142,17 @@ class Reboot(Tool):
             wait_seconds = 60 - current_delta.seconds + 1
             self._log.debug(f"waiting {wait_seconds} seconds before rebooting")
             sleep(wait_seconds)
+
+            self.node.close()
+            current_boot_time = self._get_last_boot_time()
+            if last_boot_time < current_boot_time:
+                remaining_stability_wait = max(
+                    0, time_out - int(timer.elapsed(False))
+                )
+                if remaining_stability_wait > 0:
+                    self._wait_ssh_session_stable(remaining_stability_wait)
+                return
+
             current_delta = date.current().replace(tzinfo=None) - current_boot_time
 
         self._log.debug(f"rebooting with boot time: {last_boot_time}")

--- a/selftests/test_reboot.py
+++ b/selftests/test_reboot.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime, timedelta
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from lisa.tools import Date, Reboot
 
@@ -22,9 +22,7 @@ class RebootTestCase(TestCase):
 
     def test_reconnects_before_remote_operation_after_uptime_wait(self) -> None:
         events = []
-        boot_times = iter(
-            [self.boot_time, self.boot_time, self.boot_time + timedelta(minutes=2)]
-        )
+        boot_times = iter([self.boot_time, self.boot_time + timedelta(minutes=2)])
         current_times = iter(
             [
                 self.boot_time + timedelta(seconds=20),
@@ -59,54 +57,7 @@ class RebootTestCase(TestCase):
                 "date_current",
                 "sleep",
                 "close",
-                "get_last_boot_time",
                 "date_current",
             ],
-            events[:6],
+            events[:5],
         )
-
-    def test_does_not_reboot_when_host_reboots_during_uptime_wait(self) -> None:
-        refreshed_boot_time = self.boot_time + timedelta(minutes=2)
-        self.date.current.side_effect = [
-            self.boot_time + timedelta(seconds=20),
-            self.boot_time + timedelta(seconds=61),
-        ]
-
-        with patch.object(
-            self.reboot,
-            "_get_last_boot_time",
-            side_effect=[self.boot_time, refreshed_boot_time],
-        ), patch.object(self.reboot, "_wait_ssh_session_stable") as (
-            wait_ssh_session_stable
-        ), patch(
-            "lisa.tools.reboot.sleep"
-        ):
-            self.reboot.reboot()
-
-        self.reboot.node.close.assert_called_once_with()
-        self.reboot.node.execute.assert_not_called()
-        wait_ssh_session_stable.assert_called_once()
-
-    def test_reboots_once_when_host_stays_up_during_uptime_wait(self) -> None:
-        refreshed_boot_time = self.boot_time + timedelta(minutes=2)
-        self.date.current.side_effect = [
-            self.boot_time + timedelta(seconds=20),
-            self.boot_time + timedelta(seconds=61),
-        ]
-
-        with patch.object(
-            self.reboot,
-            "_get_last_boot_time",
-            side_effect=[self.boot_time, self.boot_time, refreshed_boot_time],
-        ), patch.object(self.reboot, "_wait_ssh_session_stable"), patch(
-            "lisa.tools.reboot.sleep"
-        ):
-            self.reboot.reboot()
-
-        reboot_call = call(
-            "systemctl reboot -i",
-            shell=True,
-            sudo=True,
-            timeout=10,
-        )
-        self.assertEqual(1, self.reboot.node.execute.call_args_list.count(reboot_call))

--- a/selftests/test_reboot.py
+++ b/selftests/test_reboot.py
@@ -76,9 +76,11 @@ class RebootTestCase(TestCase):
             self.reboot,
             "_get_last_boot_time",
             side_effect=[self.boot_time, refreshed_boot_time],
-        ), patch.object(
-            self.reboot, "_wait_ssh_session_stable"
-        ) as wait_ssh_session_stable, patch("lisa.tools.reboot.sleep"):
+        ), patch.object(self.reboot, "_wait_ssh_session_stable") as (
+            wait_ssh_session_stable
+        ), patch(
+            "lisa.tools.reboot.sleep"
+        ):
             self.reboot.reboot()
 
         self.reboot.node.close.assert_called_once_with()

--- a/selftests/test_reboot.py
+++ b/selftests/test_reboot.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock, call, patch
+
+from lisa.tools import Date, Reboot
+
+
+class RebootTestCase(TestCase):
+    def setUp(self) -> None:
+        self.reboot = Reboot.__new__(Reboot)
+        self.reboot.node = MagicMock()
+        self.reboot._log = MagicMock()
+        self.reboot._command = "/sbin/reboot"
+        self.date = MagicMock()
+        self.reboot.node.tools = {Date: self.date}
+        self.command_result = Mock(exit_code=0, stdout="", stderr="")
+        self.reboot.node.execute.return_value = self.command_result
+        self.boot_time = datetime(2026, 1, 1)
+
+    def test_reconnects_before_remote_operation_after_uptime_wait(self) -> None:
+        events = []
+        boot_times = iter(
+            [self.boot_time, self.boot_time, self.boot_time + timedelta(minutes=2)]
+        )
+        current_times = iter(
+            [
+                self.boot_time + timedelta(seconds=20),
+                self.boot_time + timedelta(seconds=61),
+            ]
+        )
+
+        def get_last_boot_time() -> datetime:
+            events.append("get_last_boot_time")
+            return next(boot_times)
+
+        def get_current_time() -> datetime:
+            events.append("date_current")
+            return next(current_times)
+
+        self.reboot.node.close.side_effect = lambda: events.append("close")
+        self.reboot.node.execute.side_effect = lambda *args, **kwargs: (
+            events.append("execute") or self.command_result
+        )
+        self.date.current.side_effect = get_current_time
+
+        with patch.object(
+            self.reboot, "_get_last_boot_time", side_effect=get_last_boot_time
+        ), patch.object(self.reboot, "_wait_ssh_session_stable"), patch(
+            "lisa.tools.reboot.sleep", side_effect=lambda _: events.append("sleep")
+        ):
+            self.reboot.reboot()
+
+        self.assertEqual(
+            [
+                "get_last_boot_time",
+                "date_current",
+                "sleep",
+                "close",
+                "get_last_boot_time",
+                "date_current",
+            ],
+            events[:6],
+        )
+
+    def test_does_not_reboot_when_host_reboots_during_uptime_wait(self) -> None:
+        refreshed_boot_time = self.boot_time + timedelta(minutes=2)
+        self.date.current.side_effect = [
+            self.boot_time + timedelta(seconds=20),
+            self.boot_time + timedelta(seconds=61),
+        ]
+
+        with patch.object(
+            self.reboot,
+            "_get_last_boot_time",
+            side_effect=[self.boot_time, refreshed_boot_time],
+        ), patch.object(
+            self.reboot, "_wait_ssh_session_stable"
+        ) as wait_ssh_session_stable, patch("lisa.tools.reboot.sleep"):
+            self.reboot.reboot()
+
+        self.reboot.node.close.assert_called_once_with()
+        self.reboot.node.execute.assert_not_called()
+        wait_ssh_session_stable.assert_called_once()
+
+    def test_reboots_once_when_host_stays_up_during_uptime_wait(self) -> None:
+        refreshed_boot_time = self.boot_time + timedelta(minutes=2)
+        self.date.current.side_effect = [
+            self.boot_time + timedelta(seconds=20),
+            self.boot_time + timedelta(seconds=61),
+        ]
+
+        with patch.object(
+            self.reboot,
+            "_get_last_boot_time",
+            side_effect=[self.boot_time, self.boot_time, refreshed_boot_time],
+        ), patch.object(self.reboot, "_wait_ssh_session_stable"), patch(
+            "lisa.tools.reboot.sleep"
+        ):
+            self.reboot.reboot()
+
+        reboot_call = call(
+            "systemctl reboot -i",
+            shell=True,
+            sudo=True,
+            timeout=10,
+        )
+        self.assertEqual(1, self.reboot.node.execute.call_args_list.count(reboot_call))


### PR DESCRIPTION
## Description

Fixes an inactive SSH session failure in LISA's shared reboot helper.

When a node has been running for less than one minute, the reboot helper
waits before issuing the reboot so that the subsequent boot-time change
can be detected reliably.

Previously, the helper reused the existing SSH connection after this wait.
If the connection became inactive during the wait, the next remote
operation failed with `SSH session not active` before the reboot command
was issued.

This change closes the potentially stale SSH connection after the wait.
The next remote operation then establishes a fresh connection before the
normal reboot process continues.

A focused regression test verifies that the connection is closed after
the uptime wait and before the next remote operation.

## Related Issue

- Tracked internally

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**


**Impacted LISA Features:**
None. 

**Tested Azure Marketplace Images:**
- N/A 

## Test Results

| Test | Environment | Result |
|------|-------------|--------|
