### PR TITLE
fix: Add Azurelinx 4.0 Package Dependencies

### DIFF
--- a/lisa/features/infiniband.py
+++ b/lisa/features/infiniband.py
@@ -288,7 +288,6 @@ class Infiniband(Feature):
             "rdma-core-devel",
             "libibverbs",
             "libibverbs-utils",
-            "build-essential",
             "ucx",
             "ucx-ib",
             "ucx-rdmacm",
@@ -341,6 +340,13 @@ class Infiniband(Feature):
                     ubuntu_required_packages.append(package)
             node.os.install_packages(ubuntu_required_packages)
         elif isinstance(node.os, CBLMariner):
+            if node.os.information.version >= "4.0.0":
+                # build-essential not available on Azure Linux 4.0
+                cblmariner_required_packages.extend(
+                    ["kernel-headers", "binutils", "glibc-devel", "gcc", "make"]
+                )
+            else:
+                cblmariner_required_packages.append("build-essential")
             node.os.install_packages(cblmariner_required_packages)
         else:
             raise UnsupportedDistroException(

--- a/lisa/microsoft/testsuites/kselftest/kselftest.py
+++ b/lisa/microsoft/testsuites/kselftest/kselftest.py
@@ -34,7 +34,6 @@ _UBUNTU_OS_PACKAGES = [
 _MARINER_OS_PACKAGES = [
     "bison",
     "flex",
-    "build-essential",
     "openssl-devel",
     "bc",
     "dwarves",
@@ -162,7 +161,13 @@ class Kselftest(Tool):
                 self.node.os.install_packages(_UBUNTU_OS_PACKAGES)
             elif isinstance(self.node.os, CBLMariner):
                 # clone kernel, build kernel, then build kselftests
-                self.node.os.install_packages(_MARINER_OS_PACKAGES)
+                packages = list(_MARINER_OS_PACKAGES)
+                if self.node.os.information.version >= "4.0.0":
+                    # build-essential not available on Azure Linux 4.0
+                    packages.extend(["gcc", "make"])
+                else:
+                    packages.append("build-essential")
+                self.node.os.install_packages(packages)
 
             uname = self.node.tools[Uname]
             uname_result = uname.get_linux_information(force_run=False)

--- a/lisa/microsoft/testsuites/ltp/ltp.py
+++ b/lisa/microsoft/testsuites/ltp/ltp.py
@@ -439,15 +439,25 @@ class Ltp(Tool):
                 ]
             )
         elif isinstance(self.node.os, CBLMariner):
-            self.node.os.install_packages(
-                [
-                    "kernel-headers",
-                    "binutils",
-                    "diffutils",
-                    "glibc-devel",
-                    "zlib-devel",
-                ]
-            )
+            packages = [
+                "kernel-headers",
+                "binutils",
+                "diffutils",
+                "glibc-devel",
+            ]
+            if self.node.os.information.version >= "4.0.0":
+                packages.extend(
+                    [
+                        "libaio-devel",
+                        "libattr",
+                        "libcap-devel",
+                        "pkgconf-pkg-config",
+                        "zlib-ng-compat-devel",
+                    ]
+                )
+            else:
+                packages.append("zlib-devel")
+            self.node.os.install_packages(packages)
         else:
             raise LisaException(f"{self.node.os} is not supported")
 

--- a/lisa/microsoft/testsuites/xfstests/xfstests.py
+++ b/lisa/microsoft/testsuites/xfstests/xfstests.py
@@ -707,6 +707,19 @@ class Xfstests(Tool):
         "psmisc",
         "perl-CPAN",
     ]
+    # CBL Mariner >= 4.0.0 Dependencies
+    mariner_4_dep = [
+        "libattr-devel",
+        "binutils",
+        "kernel-headers",
+        "perl-CPAN",
+        "diffutils",
+        "btrfs-progs-devel",
+        "zlib-ng-compat-devel",
+        "libblkid-devel",
+        "libmount-devel",
+        "pkgconf-pkg-config",
+    ]
     # Regular expression for parsing xfstests output
     # Example:
     # Passed all 35 tests
@@ -921,7 +934,11 @@ class Xfstests(Tool):
         elif isinstance(self.node.os, Suse):
             package_list.extend(self.suse_dep)
         elif isinstance(self.node.os, CBLMariner):
-            package_list.extend(self.mariner_dep)
+            if self.node.os.information.version >= "4.0.0":
+                package_list.extend(self.fedora_dep)
+                package_list.extend(self.mariner_4_dep)
+            else:
+                package_list.extend(self.mariner_dep)
         else:
             raise LisaException(
                 f"Current distro {self.node.os.name} doesn't support xfstests."

--- a/lisa/tools/cargo.py
+++ b/lisa/tools/cargo.py
@@ -163,7 +163,13 @@ class Cargo(Tool):
         node_os: Posix = cast(Posix, self.node.os)
 
         # install prerequisites
-        node_os.install_packages(["build-essential", "cmake"])
+        if isinstance(node_os, CBLMariner) and node_os.information.version >= "4.0.0":
+            # build-essential not available on Azure Linux 4.0
+            node_os.install_packages(
+                ["kernel-headers", "binutils", "glibc-devel", "gcc", "make", "cmake"]
+            )
+        else:
+            node_os.install_packages(["build-essential", "cmake"])
 
         gcc = self.node.tools[Gcc]
         gcc_version_info = gcc.get_version()

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -223,7 +223,11 @@ class Docker(Tool):
                     ["docker-ce", "docker-ce-cli", "containerd.io"]
                 )
         elif isinstance(self.node.os, CBLMariner):
-            self.node.os.install_packages(["moby-engine", "moby-cli"])
+            if self.node.os.information.version >= "4.0.0":
+                # moby-engine automatically installs docker-cli on Azure Linux 4.0
+                self.node.os.install_packages(["moby-engine"])
+            else:
+                self.node.os.install_packages(["moby-engine", "moby-cli"])
         elif isinstance(self.node.os, Suse) or isinstance(self.node.os, Fedora):
             self.node.os.install_packages(["docker"])
         elif isinstance(self.node.os, BSD):

--- a/lisa/tools/docker.py
+++ b/lisa/tools/docker.py
@@ -232,7 +232,11 @@ class Docker(Tool):
                     ["docker-ce", "docker-ce-cli", "containerd.io"]
                 )
         elif isinstance(self.node.os, CBLMariner):
-            self.node.os.install_packages(["moby-engine", "moby-cli"])
+            if self.node.os.information.version >= "4.0.0":
+                # moby-engine automatically installs docker-cli on Azure Linux 4.0
+                self.node.os.install_packages(["moby-engine"])
+            else:
+                self.node.os.install_packages(["moby-engine", "moby-cli"])
         elif isinstance(self.node.os, OpenEuler):
             # openEuler ships a native moby-based "docker" package in its update
             # repository that provides both the daemon and CLI along with a

--- a/lisa/tools/fio.py
+++ b/lisa/tools/fio.py
@@ -420,7 +420,6 @@ class Fio(Tool):
         elif isinstance(self.node.os, CBLMariner):
             package_list = [
                 "wget",
-                "build-essential",
                 "sysstat",
                 "blktrace",
                 "libaio",
@@ -431,8 +430,11 @@ class Fio(Tool):
                 "kernel-headers",
                 "binutils",
                 "glibc-devel",
-                "zlib-devel",
             ]
+            if self.node.os.information.version >= "4.0.0":
+                package_list.extend(["zlib-ng-compat-devel", "make"])
+            else:
+                package_list.extend(["build-essential", "zlib-devel"])
         else:
             raise LisaException(
                 f"tool {self.command} can't be installed in distro {self.node.os.name}."

--- a/lisa/tools/gpu_drivers.py
+++ b/lisa/tools/gpu_drivers.py
@@ -379,7 +379,18 @@ class NvidiaCudaDriver(GpuDriver):
             ]
         # CBL-Mariner dependencies
         elif isinstance(self.node.os, CBLMariner):
-            dependencies = ["build-essential", "binutils", "kernel-devel"]
+            if self.node.os.information.version >= "4.0.0":
+                # build-essential not available on Azure Linux 4.0
+                dependencies = [
+                    "kernel-headers",
+                    "binutils",
+                    "glibc-devel",
+                    "gcc",
+                    "make",
+                    "kernel-devel",
+                ]
+            else:
+                dependencies = ["build-essential", "binutils", "kernel-devel"]
 
         if not dependencies:
             return

--- a/lisa/tools/ntttcp.py
+++ b/lisa/tools/ntttcp.py
@@ -827,14 +827,16 @@ class Ntttcp(Tool):
 
     def _install(self) -> bool:
         if isinstance(self.node.os, CBLMariner):
-            self.node.os.install_packages(
-                [
-                    "kernel-headers",
-                    "binutils",
-                    "glibc-devel",
-                    "zlib-devel",
-                ]
-            )
+            packages = [
+                "kernel-headers",
+                "binutils",
+                "glibc-devel",
+            ]
+            if self.node.os.information.version >= "4.0.0":
+                packages.append("zlib-ng-compat-devel")
+            else:
+                packages.append("zlib-devel")
+            self.node.os.install_packages(packages)
         elif (
             isinstance(self.node.os, Ubuntu)
             and self.node.os.information.version >= "25.10.0"

--- a/lisa/tools/perf.py
+++ b/lisa/tools/perf.py
@@ -32,7 +32,11 @@ class Perf(Tool):
                 self.node.tools[Uname].get_linux_information().kernel_version_raw
             )
             if isinstance(self.node.os, CBLMariner):
-                self.node.os.install_packages("kernel-tools")
+                if self.node.os.information.version >= "4.0.0":
+                    # Azure Linux 4.0 has perf in a separate package
+                    self.node.os.install_packages("perf")
+                else:
+                    self.node.os.install_packages("kernel-tools")
             elif isinstance(self.node.os, (Redhat, Suse)):
                 self.node.os.install_packages("perf")
             elif isinstance(

--- a/lisa/tools/sockperf.py
+++ b/lisa/tools/sockperf.py
@@ -114,7 +114,11 @@ class Sockperf(Tool):
 
             # mariner needs headers and -dev packages
             if isinstance(posix_os, CBLMariner):
-                packages.append("build-essential")
+                if posix_os.information.version >= "4.0.0":
+                    # build-essential not available on Azure Linux 4.0
+                    packages.extend(["kernel-headers", "binutils", "glibc-devel"])
+                else:
+                    packages.append("build-essential")
 
             # install and pick build dir
             posix_os.install_packages(packages)

--- a/lisa/transformers/kernel_source_installer.py
+++ b/lisa/transformers/kernel_source_installer.py
@@ -535,25 +535,31 @@ class SourceInstaller(BaseInstaller):
                 ]
             )
         elif isinstance(os, CBLMariner):
-            os.install_packages(
-                [
-                    "build-essential",
-                    "bison",
-                    "flex",
-                    "bc",
-                    "ccache",
-                    "elfutils-libelf",
-                    "elfutils-libelf-devel",
-                    "ncurses-libs",
-                    "ncurses-compat",
-                    "xz",
-                    "xz-devel",
-                    "xz-libs",
-                    "openssl-libs",
-                    "openssl-devel",
-                    "xxhash-devel",
-                ]
-            )
+            packages = [
+                "bison",
+                "flex",
+                "bc",
+                "ccache",
+                "elfutils-libelf",
+                "elfutils-libelf-devel",
+                "ncurses-libs",
+                "xz",
+                "xz-devel",
+                "xz-libs",
+                "openssl-libs",
+                "openssl-devel",
+                "xxhash-devel",
+            ]
+            if os.information.version >= "4.0.0":
+                # build-essential not available on Azure Linux 4.0
+                # ncurses-compat is renamed ncurses-compat-libs in 4.0,
+                # but is unused here (olddefconfig only).
+                packages.extend(
+                    ["kernel-headers", "binutils", "glibc-devel", "gcc", "make"]
+                )
+            else:
+                packages.extend(["build-essential", "ncurses-compat"])
+            os.install_packages(packages)
         else:
             raise LisaException(
                 f"os '{os.name}' doesn't support in {self.type_name()}. "


### PR DESCRIPTION
## Description

This PR adds support for installing AzureLinux 4.0 Package Dependencies in multiple files. There are some missing packages like build-essential, renamed packages like zlib-devel and some new packages like perf. This PR handles all these cases by installing the correct dependencies for 4.0 for each test suite.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
