### PR TITLE
Force iptables forwarding commands to execute

### DIFF
--- a/lisa/sut_orchestrator/libvirt/platform.py
+++ b/lisa/sut_orchestrator/libvirt/platform.py
@@ -822,7 +822,9 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
         log.debug(f"Clearing port forwarding rules for environment {environment.name}")
         environment_context = get_environment_context(environment)
         for port, address in environment_context.port_forwarding_list:
-            self.host_node.tools[Iptables].stop_forwarding(port, address, 22)
+            self.host_node.tools[Iptables].stop_forwarding(
+                port, address, 22, force_run=True
+            )
 
     # Retrieve the VMs' dynamic properties (e.g. IP address).
     def _fill_nodes_metadata(self, environment: Environment, log: Logger) -> None:
@@ -862,7 +864,7 @@ class BaseLibvirtPlatform(Platform, IBaseLibvirtPlatform):
                         self._next_available_port += 1
 
                 self.host_node.tools[Iptables].start_forwarding(
-                    node_port, local_address, 22
+                    node_port, local_address, 22, force_run=True
                 )
 
                 environment_context.port_forwarding_list.append(

--- a/lisa/tools/firewall.py
+++ b/lisa/tools/firewall.py
@@ -90,12 +90,14 @@ class Iptables(Tool):
     def start_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
         self.run(
             f"-I FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
+            force_run=True,
             sudo=True,
             expected_exit_code=0,
         )
 
         self.run(
             f"-t nat -I PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
+            force_run=True,
             sudo=True,
             expected_exit_code=0,
         )
@@ -103,12 +105,14 @@ class Iptables(Tool):
     def stop_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
         self.run(
             f"-D FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
+            force_run=True,
             sudo=True,
             expected_exit_code=0,
         )
 
         self.run(
             f"-t nat -D PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
+            force_run=True,
             sudo=True,
             expected_exit_code=0,
         )

--- a/lisa/tools/firewall.py
+++ b/lisa/tools/firewall.py
@@ -87,32 +87,44 @@ class Iptables(Tool):
             ),
         )
 
-    def start_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
+    def start_forwarding(
+        self,
+        port: int,
+        dst_ip: str,
+        dst_port: int,
+        force_run: bool = False,
+    ) -> None:
         self.run(
             f"-I FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
-            force_run=True,
+            force_run=force_run,
             sudo=True,
             expected_exit_code=0,
         )
 
         self.run(
             f"-t nat -I PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
-            force_run=True,
+            force_run=force_run,
             sudo=True,
             expected_exit_code=0,
         )
 
-    def stop_forwarding(self, port: int, dst_ip: str, dst_port: int) -> None:
+    def stop_forwarding(
+        self,
+        port: int,
+        dst_ip: str,
+        dst_port: int,
+        force_run: bool = False,
+    ) -> None:
         self.run(
             f"-D FORWARD -o virbr0 -p tcp -d {dst_ip} --dport {dst_port} -j ACCEPT",
-            force_run=True,
+            force_run=force_run,
             sudo=True,
             expected_exit_code=0,
         )
 
         self.run(
             f"-t nat -D PREROUTING -p tcp --dport {port} -j DNAT --to {dst_ip}:{dst_port}",  # noqa: E501
-            force_run=True,
+            force_run=force_run,
             sudo=True,
             expected_exit_code=0,
         )

--- a/selftests/test_firewall.py
+++ b/selftests/test_firewall.py
@@ -13,9 +13,9 @@ class IptablesTestCase(TestCase):
         iptables.run = MagicMock()
         guest_address = "192.168.122.10"
 
-        iptables.start_forwarding(49152, guest_address, 22)
-        iptables.stop_forwarding(49152, guest_address, 22)
-        iptables.start_forwarding(49153, guest_address, 22)
+        iptables.start_forwarding(49152, guest_address, 22, force_run=True)
+        iptables.stop_forwarding(49152, guest_address, 22, force_run=True)
+        iptables.start_forwarding(49153, guest_address, 22, force_run=True)
 
         self.assertEqual(6, iptables.run.call_count)
         self.assertTrue(

--- a/selftests/test_firewall.py
+++ b/selftests/test_firewall.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from lisa.tools import Iptables
+
+
+class IptablesTestCase(TestCase):
+    def test_forwarding_rules_always_execute_when_dhcp_ip_is_reused(self) -> None:
+        iptables = Iptables.__new__(Iptables)
+        iptables.run = MagicMock()
+        guest_address = "192.168.122.10"
+
+        iptables.start_forwarding(49152, guest_address, 22)
+        iptables.stop_forwarding(49152, guest_address, 22)
+        iptables.start_forwarding(49153, guest_address, 22)
+
+        self.assertEqual(6, iptables.run.call_count)
+        self.assertTrue(
+            all(call.kwargs.get("force_run") for call in iptables.run.call_args_list)
+        )


### PR DESCRIPTION
## Description

Prevent cached command results from skipping iptables rules required for remote
libvirt guest SSH forwarding.

When DHCP assigns a new guest an IP address previously used by another guest,
LISA may return the cached successful result of an earlier FORWARD command.
Because the previous rule was removed during cleanup, the required rule is
missing and SSH to the new guest fails.

This change:

- Adds an optional `force_run` parameter to `Iptables.start_forwarding()` and
  `Iptables.stop_forwarding()`, defaulting to `False`.
- Passes `force_run=True` from the remote libvirt forwarding setup and cleanup
  paths.
- Adds a focused self-test covering forwarding cleanup and reuse of the same
  guest IP.

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
smoke_test|verify_cpu_count

**Impacted LISA Features:**
None 

**Tested Azure Marketplace Images:**


## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| Local focused self-test | N/A | PASSED |
| Full LISA self-test suite: 271 tests | N/A | PASSED |
| flake8 | N/A | PASSED |
