### PR TITLE
Make zstd dependency installable

### DIFF
--- a/lisa/microsoft/testsuites/network/networksettings.py
+++ b/lisa/microsoft/testsuites/network/networksettings.py
@@ -3,6 +3,7 @@
 
 import re
 import time
+from shlex import quote
 from typing import Any, Dict, List, Tuple, Union, cast
 
 from assertpy import assert_that
@@ -752,11 +753,14 @@ class NetworkSettings(TestSuite):
             # remove any escape character at the end of string
             netvsc_module = netvsc_module.strip()
             if netvsc_module.endswith((".xz", ".zst")):
-                module_file_name = netvsc_module.rsplit("/", 1)[-1]
-                copied_module = f"{node.working_path}/{module_file_name}"
-                decompressed_module = copied_module.rsplit(".", 1)[0]
+                module_path = node.get_pure_path(netvsc_module)
+                copied_module_path = node.working_path / module_path.name
+                decompressed_module_path = copied_module_path.with_suffix("")
+                copied_module = node.get_str_path(copied_module_path)
+                decompressed_module = node.get_str_path(decompressed_module_path)
                 node.execute(
-                    f"cp {netvsc_module} {node.working_path}/",
+                    f"cp {quote(netvsc_module)} "
+                    f"{quote(node.get_str_path(node.working_path))}",
                     cwd=node.working_path,
                     expected_exit_code=0,
                     expected_exit_code_failure_message=(
@@ -765,7 +769,7 @@ class NetworkSettings(TestSuite):
                 )
                 if netvsc_module.endswith(".xz"):
                     node.execute(
-                        f"xz -d -f {copied_module}",
+                        f"xz -d -f {quote(copied_module)}",
                         cwd=node.working_path,
                         expected_exit_code=0,
                         expected_exit_code_failure_message=(

--- a/lisa/microsoft/testsuites/network/networksettings.py
+++ b/lisa/microsoft/testsuites/network/networksettings.py
@@ -27,7 +27,7 @@ from lisa import (
 )
 from lisa.base_tools import Uname
 from lisa.operating_system import BSD, Debian, Redhat, Suse, Ubuntu, Windows
-from lisa.tools import Ethtool, Iperf3, KernelConfig, Ls, Modinfo, Nm
+from lisa.tools import Ethtool, Iperf3, KernelConfig, Ls, Modinfo, Nm, Zstd
 from lisa.util import parse_version
 
 # section sizes for netvsc buffers in bytes (from netvsc driver)
@@ -751,29 +751,30 @@ class NetworkSettings(TestSuite):
             netvsc_module = modinfo.get_filename("hv_netvsc")
             # remove any escape character at the end of string
             netvsc_module = netvsc_module.strip()
-            decompress_tool = ""
-            # if the module is archived as xz, extract it to check symbols
-            if netvsc_module.endswith(".xz"):
-                decompress_tool = "xz"
-            # if the module is archived as zst, extract it to check symbols
-            if netvsc_module.endswith(".zst"):
-                decompress_tool = "zstd"
-            if decompress_tool:
+            if netvsc_module.endswith((".xz", ".zst")):
+                module_file_name = netvsc_module.rsplit("/", 1)[-1]
+                copied_module = f"{node.working_path}/{module_file_name}"
+                decompressed_module = copied_module.rsplit(".", 1)[0]
                 node.execute(
-                    f"cp {netvsc_module} {node.working_path}/", cwd=node.working_path
-                )
-                node.execute(
-                    (
-                        f"{decompress_tool} -d {node.working_path}/"
-                        f"{netvsc_module.rsplit('/', 1)[-1]}"
+                    f"cp {netvsc_module} {node.working_path}/",
+                    cwd=node.working_path,
+                    expected_exit_code=0,
+                    expected_exit_code_failure_message=(
+                        f"Failed to copy kernel module {netvsc_module}."
                     ),
-                    cwd=node.working_path,
                 )
-                netvsc_module = node.execute(
-                    f"ls {node.working_path}/hv_netvsc.ko",
-                    shell=True,
-                    cwd=node.working_path,
-                ).stdout
+                if netvsc_module.endswith(".xz"):
+                    node.execute(
+                        f"xz -d -f {copied_module}",
+                        cwd=node.working_path,
+                        expected_exit_code=0,
+                        expected_exit_code_failure_message=(
+                            f"Failed to decompress kernel module {copied_module}."
+                        ),
+                    )
+                else:
+                    node.tools[Zstd].decompress(copied_module, decompressed_module)
+                netvsc_module = decompressed_module
 
             ls = node.tools[Ls]
             assert ls.path_exists(

--- a/lisa/tools/__init__.py
+++ b/lisa/tools/__init__.py
@@ -158,6 +158,7 @@ from .who import Who
 from .whoami import Whoami
 from .windows_feature import WindowsFeatureManagement
 from .wsl import Wsl
+from .zstd import Zstd
 
 __all__ = [
     "AptAddRepository",
@@ -333,6 +334,7 @@ __all__ = [
     "WindowsFeatureManagement",
     "Wsl",
     "YumConfigManager",
+    "Zstd",
     "Conntrack",
     "Ipset",
 ]

--- a/lisa/tools/zstd.py
+++ b/lisa/tools/zstd.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from shlex import quote
 from typing import cast
 
 from lisa.executable import Tool
@@ -31,8 +32,8 @@ class Zstd(Tool):
             output_file = file[:-4]
 
         self.run(
-            f"-d -f -o {output_file} {file}",
-            shell=True,
+            f"-d -f -o {quote(output_file)} {quote(file)}",
+            shell=False,
             force_run=True,
             sudo=sudo,
             expected_exit_code=0,

--- a/lisa/tools/zstd.py
+++ b/lisa/tools/zstd.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import cast
+
+from lisa.executable import Tool
+from lisa.operating_system import Posix
+from lisa.util import LisaException
+
+
+class Zstd(Tool):
+    @property
+    def command(self) -> str:
+        return "zstd"
+
+    @property
+    def can_install(self) -> bool:
+        return True
+
+    def _install(self) -> bool:
+        posix_os = cast(Posix, self.node.os)
+        posix_os.install_packages(self.command)
+        return self._check_exists()
+
+    def decompress(self, file: str, output_file: str = "", sudo: bool = False) -> str:
+        if not output_file:
+            if not file.endswith(".zst"):
+                raise LisaException(
+                    f"An output file is required to decompress non-.zst file {file}."
+                )
+            output_file = file[:-4]
+
+        self.run(
+            f"-d -f -o {output_file} {file}",
+            shell=True,
+            force_run=True,
+            sudo=sudo,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"Failed to decompress {file} to {output_file}."
+            ),
+        )
+        return output_file

--- a/selftests/test_zstd.py
+++ b/selftests/test_zstd.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from lisa.tools import Zstd
+
+
+class ZstdTestCase(TestCase):
+    def test_install_uses_zstd_package(self) -> None:
+        zstd = Zstd.__new__(Zstd)
+        zstd.node = MagicMock()
+        zstd._check_exists = MagicMock(return_value=True)
+
+        self.assertTrue(zstd._install())
+
+        zstd.node.os.install_packages.assert_called_once_with("zstd")
+
+    def test_decompress_checks_command_and_returns_output_path(self) -> None:
+        zstd = Zstd.__new__(Zstd)
+        zstd.run = MagicMock()
+
+        output_file = zstd.decompress("/tmp/hv_netvsc.ko.zst")
+
+        self.assertEqual("/tmp/hv_netvsc.ko", output_file)
+        zstd.run.assert_called_once_with(
+            "-d -f -o /tmp/hv_netvsc.ko /tmp/hv_netvsc.ko.zst",
+            shell=True,
+            force_run=True,
+            sudo=False,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "Failed to decompress /tmp/hv_netvsc.ko.zst to /tmp/hv_netvsc.ko."
+            ),
+        )

--- a/selftests/test_zstd.py
+++ b/selftests/test_zstd.py
@@ -17,20 +17,22 @@ class ZstdTestCase(TestCase):
 
         zstd.node.os.install_packages.assert_called_once_with("zstd")
 
-    def test_decompress_checks_command_and_returns_output_path(self) -> None:
+    def test_decompress_runs_expected_command_and_returns_output_path(self) -> None:
         zstd = Zstd.__new__(Zstd)
         zstd.run = MagicMock()
 
-        output_file = zstd.decompress("/tmp/hv_netvsc.ko.zst")
+        output_file = zstd.decompress("/tmp/lisa work/hv_netvsc.ko.zst")
 
-        self.assertEqual("/tmp/hv_netvsc.ko", output_file)
+        self.assertEqual("/tmp/lisa work/hv_netvsc.ko", output_file)
         zstd.run.assert_called_once_with(
-            "-d -f -o /tmp/hv_netvsc.ko /tmp/hv_netvsc.ko.zst",
-            shell=True,
+            "-d -f -o '/tmp/lisa work/hv_netvsc.ko' "
+            "'/tmp/lisa work/hv_netvsc.ko.zst'",
+            shell=False,
             force_run=True,
             sudo=False,
             expected_exit_code=0,
             expected_exit_code_failure_message=(
-                "Failed to decompress /tmp/hv_netvsc.ko.zst to /tmp/hv_netvsc.ko."
+                "Failed to decompress /tmp/lisa work/hv_netvsc.ko.zst "
+                "to /tmp/lisa work/hv_netvsc.ko."
             ),
         )


### PR DESCRIPTION
## Description

Fix `verify_device_msg_level_change` on Linux images that store kernel modules in Zstandard-compressed form without including the standalone `zstd` command.

Compressed kernel modules can be loaded through `kmod`/`libkmod` support or in-kernel module decompression, while the `zstd` CLI is distributed as a separate userspace package. Minimal and purpose-built images may therefore provide `.ko.zst` modules without installing the CLI.

The issue was observed on an Ubuntu 24.04 BOSH Linux stemcell, but it can affect any image with this package split. The test previously invoked `zstd` directly without declaring or installing it, ignored the failed decompression command, and later reported a misleading missing `hv_netvsc.ko` assertion.

## Related Issue

- Adds an install-aware `Zstd` tool that installs the distro package when the command is unavailable.
- Uses the tool to decompress `.zst` kernel modules before inspecting their symbols.
- Requires kernel-module copy and decompression commands to succeed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_device_msg_level_change

**Impacted LISA Features:**
NetworkInterface

**Tested Azure Marketplace Images:**
- canonical ubuntu-24_04-lts server latest

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| `canonical ubuntu-24_04-lts server 24.04.202608070` | Standard_D2ads_v5 | PASSED |
| [Ubuntu 24.04 BOSH Linux stemcell](https://storage.googleapis.com/bosh-core-stemcells/1.484/bosh-stemcell-1.484-azure-hyperv-ubuntu-noble.tgz) | Standard_D2ads_v5 | PASSED |