### PR TITLE
Nic: allow bind and unbind by device uuid and sysfs path

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -8,7 +8,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from assertpy import assert_that
 from retry import retry

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -8,7 +8,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from assertpy import assert_that
 from retry import retry
@@ -338,6 +338,9 @@ class Nics(InitializableMixin):
         # parses the subnet and mask string ex '10.0.1.0/24'
         network = ipaddress.ip_network(subnet)
         for nic in self.nics.values():
+            # Skip this check if the object does not have a subnet assigned.
+            if not nic.ip_addr:
+                continue
             # parse the ip address str for comparison
             ip_addr = ipaddress.ip_address(nic.ip_addr)
             # if the ip address resides within the subnet
@@ -348,29 +351,47 @@ class Nics(InitializableMixin):
                 return nic
         raise LisaException(f"Could not find a nic for requested subnet: {subnet}")
 
-    def unbind(self, nic: NicInfo) -> None:
-        # unbind nic from current driver and return the old sysfs path
+    def unbind(
+        self,
+        nic: "Union[NicInfo, str]",
+        driver_module_path: str = "",
+    ) -> None:
         tee = self._node.tools[Tee]
         ip = self._node.tools[Ip]
-        # if sysfs path is not set, fetch the current driver
-        if not nic.driver_sysfs_path:
-            self.get_nic_driver(nic.name)
-        # if the device is active, set to down before unbind
-        if ip.nic_exists(nic.name):
-            ip.down(nic.name)
-        unbind_path = nic.driver_sysfs_path.joinpath("unbind")
-        tee.write_to_file(nic.dev_uuid, unbind_path, sudo=True)
+        if isinstance(nic, str):
+            dev_uuid = nic
+            driver_sysfs_path = PurePosixPath(driver_module_path)
+        else:
+            # if sysfs path is not set, fetch the current driver
+            if not nic.driver_sysfs_path:
+                self.get_nic_driver(nic.name)
+            dev_uuid = nic.dev_uuid
+            driver_sysfs_path = nic.driver_sysfs_path
+            # if the device is active, set to down before unbind
+            if ip.nic_exists(nic.name):
+                ip.down(nic.name)
+        unbind_path = driver_sysfs_path.joinpath("unbind")
+        tee.write_to_file(dev_uuid, unbind_path, sudo=True)
 
-    def bind(self, nic: NicInfo, driver_module_path: str) -> None:
+    def bind(
+        self,
+        nic: "Union[NicInfo, str]",
+        driver_module_path: str,
+    ) -> None:
         tee = self._node.tools[Tee]
-        nic.driver_sysfs_path = PurePosixPath(driver_module_path)
-        bind_path = nic.driver_sysfs_path.joinpath("bind")
+        driver_sysfs_path = PurePosixPath(driver_module_path)
+        bind_path = driver_sysfs_path.joinpath("bind")
+        if isinstance(nic, str):
+            dev_uuid = nic
+        else:
+            dev_uuid = nic.dev_uuid
+            nic.driver_sysfs_path = driver_sysfs_path
+            nic.module_name = driver_sysfs_path.name
         tee.write_to_file(
-            nic.dev_uuid,
+            dev_uuid,
             self._node.get_pure_path(f"{str(bind_path)}"),
             sudo=True,
         )
-        nic.module_name = nic.driver_sysfs_path.name
 
     def load_nics_info(self, nic_name: Optional[str] = None) -> None:
         ip = self._node.tools[Ip]

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -351,45 +351,39 @@ class Nics(InitializableMixin):
                 return nic
         raise LisaException(f"Could not find a nic for requested subnet: {subnet}")
 
-    def unbind(
-        self,
-        nic: "Union[NicInfo, str]",
-        driver_module_path: str = "",
-    ) -> None:
-        tee = self._node.tools[Tee]
+    def unbind(self, nic: "NicInfo") -> None:
         ip = self._node.tools[Ip]
-        if isinstance(nic, str):
-            dev_uuid = nic
-            driver_sysfs_path = PurePosixPath(driver_module_path)
-        else:
-            # if sysfs path is not set, fetch the current driver
-            if not nic.driver_sysfs_path:
-                self.get_nic_driver(nic.name)
-            dev_uuid = nic.dev_uuid
-            driver_sysfs_path = nic.driver_sysfs_path
-            # if the device is active, set to down before unbind
-            if ip.nic_exists(nic.name):
-                ip.down(nic.name)
-        unbind_path = driver_sysfs_path.joinpath("unbind")
+        if not nic.driver_sysfs_path:
+            self.get_nic_driver(nic.name)
+        # if the device is active, set to down before unbind
+        if ip.nic_exists(nic.name):
+            ip.down(nic.name)
+        self.unbind_by_uuid(nic.dev_uuid, str(nic.driver_sysfs_path))
+
+    def unbind_by_uuid(self, dev_uuid: str, driver_module_path: str) -> None:
+        tee = self._node.tools[Tee]
+        ls = self._node.tools[Ls]
+        unbind_path = PurePosixPath(driver_module_path) / "unbind"
+        assert_that(ls.path_exists(str(unbind_path), sudo=True)).described_as(
+            f"Unbind path {unbind_path} does not exist."
+        ).is_true()
         tee.write_to_file(dev_uuid, unbind_path, sudo=True)
 
-    def bind(
-        self,
-        nic: "Union[NicInfo, str]",
-        driver_module_path: str,
-    ) -> None:
+    def bind(self, nic: "NicInfo", driver_module_path: str) -> None:
+        nic.driver_sysfs_path = PurePosixPath(driver_module_path)
+        nic.module_name = nic.driver_sysfs_path.name
+        self.bind_by_uuid(nic.dev_uuid, driver_module_path)
+
+    def bind_by_uuid(self, dev_uuid: str, driver_module_path: str) -> None:
         tee = self._node.tools[Tee]
-        driver_sysfs_path = PurePosixPath(driver_module_path)
-        bind_path = driver_sysfs_path.joinpath("bind")
-        if isinstance(nic, str):
-            dev_uuid = nic
-        else:
-            dev_uuid = nic.dev_uuid
-            nic.driver_sysfs_path = driver_sysfs_path
-            nic.module_name = driver_sysfs_path.name
+        ls = self._node.tools[Ls]
+        bind_path = PurePosixPath(driver_module_path) / "bind"
+        assert_that(ls.path_exists(str(bind_path), sudo=True)).described_as(
+            f"Bind path {bind_path} does not exist."
+        ).is_true()
         tee.write_to_file(
             dev_uuid,
-            self._node.get_pure_path(f"{str(bind_path)}"),
+            self._node.get_pure_path(str(bind_path)),
             sudo=True,
         )
 


### PR DESCRIPTION
Part 2 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4654, review only the last commit.

- `Nics.bind` and `Nics.unbind` required a `NicInfo`, so a device that is not represented in the node's nic list (for example a VF that has just been hot removed) could not be rebound. They now accept either a `NicInfo` or a raw device uuid string plus the driver sysfs path.
- `get_nic_by_subnet` skips nics without an assigned ip address instead of raising while parsing an empty address.

**Key Test Cases:**
verify_dpdk_sriov_rescind_failover_send_only|verify_dpdk_build_netvsc|verify_dpdk_build_failsafe

**Impacted LISA Features:**
Sriov, NetworkInterface

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`
- `redhat rhel 9_5 latest`