### PR TITLE
Lspci: only refresh the pciids database once per node

### DIFF
--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -296,11 +296,15 @@ class Lspci(Tool):
         if (not self._pci_devices) or force_run:
             if not self._pciids_initialized:
                 # Ensure pci device ids and name mappings are updated.
-                exit_code = self.node.execute("update-pciids", sudo=True, shell=True).exit_code
+                exit_code = self.node.execute(
+                    "update-pciids", sudo=True, shell=True
+                ).exit_code
                 if exit_code == 0:
                     self._pciids_initialized = True
                 else:
-                    self.node.log.debug(f"update-pciids failed, returned code {exit_code}")
+                    self.node.log.debug(
+                        f"update-pciids failed, returned code {exit_code}"
+                    )
             self._pci_devices = []
             self._pci_ids = {}
 

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -196,6 +196,7 @@ class Lspci(Tool):
     def _initialize(self, *args: Any, **kwargs: Any) -> None:
         self._command = "lspci"
         self._pci_devices: List[PciDevice] = []
+        self._pciids_initialized: bool = False
 
     def _install(self) -> bool:
         if isinstance(self.node.os, Posix):
@@ -293,10 +294,12 @@ class Lspci(Tool):
     @retry(KeyError, tries=30, delay=2)  # type: ignore
     def get_devices(self, force_run: bool = False) -> List[PciDevice]:
         if (not self._pci_devices) or force_run:
+            if not self._pciids_initialized:
+                # Ensure pci device ids and name mappings are updated.
+                self.node.execute("update-pciids", sudo=True, shell=True)
+                self._pciids_initialized = True
             self._pci_devices = []
             self._pci_ids = {}
-            # Ensure pci device ids and name mappings are updated.
-            self.node.execute("update-pciids", sudo=True, shell=True)
 
             # Fetching the id information using 'lspci -nnm' is not reliable
             # due to inconsistencies in device id patterns.

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -296,8 +296,11 @@ class Lspci(Tool):
         if (not self._pci_devices) or force_run:
             if not self._pciids_initialized:
                 # Ensure pci device ids and name mappings are updated.
-                self.node.execute("update-pciids", sudo=True, shell=True)
-                self._pciids_initialized = True
+                exit_code = self.node.execute("update-pciids", sudo=True, shell=True).exit_code
+                if exit_code == 0:
+                    self._pciids_initialized = True
+                else:
+                    self.node.log.debug(f"update-pciids failed, returned code {exit_code}")
             self._pci_devices = []
             self._pci_ids = {}
 


### PR DESCRIPTION
Part 3 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4655, review only the last commit.

`get_devices` ran `update-pciids` on every forced refresh, which adds a network download and a noticeable delay to hot plug tests that rescan the pci bus repeatedly. The database is now refreshed once per tool instance.

**Key Test Cases:**
verify_dpdk_sriov_rescind_failover_send_only|verify_device_reports_correct_pci_slot

**Impacted LISA Features:**
Sriov, NetworkInterface, Nvme, Gpu

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`
- `microsoftcblmariner azure-linux-3 azure-linux-3 latest`