### PR TITLE
Ip: allow set_mtu to skip asserting the resulting mtu

### DIFF
--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -283,20 +283,20 @@ class Ip(Tool):
                     " skipping assertion since assert_success was False. "
                 )
                 return
-        
+
         self.run(f"link set dev {nic_name} mtu {mtu}", force_run=True, sudo=True)
-        
+
         new_mtu = self.get_mtu(nic_name=nic_name)
         if new_mtu != mtu:
             if assert_success:
                 raise LisaException(f"set mtu failed, wanted {mtu} and got {new_mtu}")
             else:
-                 # warn if assertion is turned off. 
+                 # warn if assertion is turned off.
                  # Weird enough situation to justify log.warning
-                 self.node.log.warning(
-                        f"set_mtu: expected new mtu {mtu}, got {new_mtu} instead. "
-                    )
-                
+                self.node.log.warning(
+                    f"set_mtu: expected new mtu {mtu}, got {new_mtu} instead. "
+                )
+
 
     def nic_exists(self, nic_name: str) -> bool:
         result = self.run(f"link show {nic_name}", force_run=True, sudo=True)

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -255,7 +255,11 @@ class Ip(Tool):
 
     def get_mtu(self, nic_name: str) -> int:
         cat = self.node.tools[Cat]
-        return int(cat.read(f"/sys/class/net/{nic_name}/mtu", force_run=True))
+        mtu_file=f"/sys/class/net/{nic_name}/mtu"
+        if self.node.shell.exists(self.node.get_pure_path(mtu_file)):
+            return int(cat.read(mtu_file, force_run=True))
+        else:
+            return int(self.get_detail(nic_name, "mtu"))
 
     def set_mtu(self, nic_name: str, mtu: int, assert_success: bool = True) -> None:
         # Check if mtu is integer

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -296,8 +296,7 @@ class Ip(Tool):
                 raise LisaException(f"set mtu failed, wanted {mtu} and got {new_mtu}")
             else:
                 # warn if assertion is turned off.
-                # Weird enough situation to justify log.warning
-                self.node.log.warning(
+                self.node.log.debug(
                     f"set_mtu: expected new mtu {mtu}, got {new_mtu} instead. "
                 )
 

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -257,15 +257,22 @@ class Ip(Tool):
         cat = self.node.tools[Cat]
         return int(cat.read(f"/sys/class/net/{nic_name}/mtu", force_run=True))
 
-    def set_mtu(self, nic_name: str, mtu: int) -> None:
+    def set_mtu(self, nic_name: str, mtu: int, assert_success: bool = True) -> None:
         # Check if mtu is integer
         try:
             mtu = int(mtu)
         except ValueError:
             raise LisaException(f"MTU value is not an integer: {mtu}")
         self.run(f"link set dev {nic_name} mtu {mtu}", force_run=True, sudo=True)
+        
         new_mtu = self.get_mtu(nic_name=nic_name)
-        assert_that(new_mtu).described_as("set mtu failed").is_equal_to(mtu)
+        if new_mtu != mtu:
+            if assert_success:
+                raise LisaException(f"set mtu failed, wanted {mtu} and got {new_mtu}")
+            else:
+                self.node.log.debug(
+                    "set_mtu: skipping result assertion since assert_success was False. "
+                )
 
     def nic_exists(self, nic_name: str) -> bool:
         result = self.run(f"link show {nic_name}", force_run=True, sudo=True)

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -259,7 +259,12 @@ class Ip(Tool):
         if self.node.shell.exists(self.node.get_pure_path(mtu_file)):
             return int(cat.read(mtu_file, force_run=True))
         else:
-            return int(self.get_detail(nic_name, "mtu"))
+            mtu = self.get_detail(nic_name, "mtu")
+            if mtu:
+                return int(mtu)
+            else:
+                self.node.log.debug(f"Could not find mtu information for interface {nic_name}")
+                return 0
 
     def set_mtu(self, nic_name: str, mtu: int, assert_success: bool = True) -> None:
         # Check if mtu is integer
@@ -268,14 +273,14 @@ class Ip(Tool):
         except ValueError:
             raise LisaException(f"MTU value is not an integer: {mtu}")
         # check if the device exists
-        exists = self.run(f"link show {nic_name}", force_run=True).exit_code
+        exists = self.run(f"link show {nic_name}", force_run=True).exit_code == 0
         if not exists:
             if assert_success:
                 raise LisaException(f"MTU set failed, could not find interface {nic_name}.")
             else:
                 self.node.log.debug(
-                    "set_mtu: skipping since device does not exist "
-                    "and assert_success was False."
+                    f"set_mtu: device {nic_name} not found,"
+                    " skipping assertion since assert_success was False. "
                 )
                 return
         
@@ -286,9 +291,12 @@ class Ip(Tool):
             if assert_success:
                 raise LisaException(f"set mtu failed, wanted {mtu} and got {new_mtu}")
             else:
-                self.node.log.debug(
-                    "set_mtu: skipping result assertion since assert_success was False. "
-                )
+                 # warn if assertion is turned off. 
+                 # Weird enough situation to justify log.warning
+                 self.node.log.warning(
+                        f"set_mtu: expected new mtu {mtu}, got {new_mtu} instead. "
+                    )
+                
 
     def nic_exists(self, nic_name: str) -> bool:
         result = self.run(f"link show {nic_name}", force_run=True, sudo=True)

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -267,6 +267,18 @@ class Ip(Tool):
             mtu = int(mtu)
         except ValueError:
             raise LisaException(f"MTU value is not an integer: {mtu}")
+        # check if the device exists
+        exists = self.run(f"link show {nic_name}", force_run=True).exit_code
+        if not exists:
+            if assert_success:
+                raise LisaException(f"MTU set failed, could not find interface {nic_name}.")
+            else:
+                self.node.log.debug(
+                    "set_mtu: skipping since device does not exist "
+                    "and assert_success was False."
+                )
+                return
+        
         self.run(f"link set dev {nic_name} mtu {mtu}", force_run=True, sudo=True)
         
         new_mtu = self.get_mtu(nic_name=nic_name)

--- a/lisa/tools/ip.py
+++ b/lisa/tools/ip.py
@@ -255,7 +255,7 @@ class Ip(Tool):
 
     def get_mtu(self, nic_name: str) -> int:
         cat = self.node.tools[Cat]
-        mtu_file=f"/sys/class/net/{nic_name}/mtu"
+        mtu_file = f"/sys/class/net/{nic_name}/mtu"
         if self.node.shell.exists(self.node.get_pure_path(mtu_file)):
             return int(cat.read(mtu_file, force_run=True))
         else:
@@ -263,7 +263,9 @@ class Ip(Tool):
             if mtu:
                 return int(mtu)
             else:
-                self.node.log.debug(f"Could not find mtu information for interface {nic_name}")
+                self.node.log.debug(
+                    f"Could not find mtu information for interface {nic_name}"
+                )
                 return 0
 
     def set_mtu(self, nic_name: str, mtu: int, assert_success: bool = True) -> None:
@@ -276,7 +278,9 @@ class Ip(Tool):
         exists = self.run(f"link show {nic_name}", force_run=True).exit_code == 0
         if not exists:
             if assert_success:
-                raise LisaException(f"MTU set failed, could not find interface {nic_name}.")
+                raise LisaException(
+                    f"MTU set failed, could not find interface {nic_name}."
+                )
             else:
                 self.node.log.debug(
                     f"set_mtu: device {nic_name} not found,"
@@ -291,12 +295,11 @@ class Ip(Tool):
             if assert_success:
                 raise LisaException(f"set mtu failed, wanted {mtu} and got {new_mtu}")
             else:
-                 # warn if assertion is turned off.
-                 # Weird enough situation to justify log.warning
+                # warn if assertion is turned off.
+                # Weird enough situation to justify log.warning
                 self.node.log.warning(
                     f"set_mtu: expected new mtu {mtu}, got {new_mtu} instead. "
                 )
-
 
     def nic_exists(self, nic_name: str) -> bool:
         result = self.run(f"link show {nic_name}", force_run=True, sudo=True)


### PR DESCRIPTION
Part 4 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4656, review only the last commit.

Some drivers silently clamp or ignore an mtu change, and callers that only wanted a best effort change had no way to avoid the assertion. `set_mtu` gains `assert_success`, defaulting to the existing behavior, and logs the mismatch instead of failing when it is disabled.

**Key Test Cases:**
verify_dpdk_send_receive_multi_txrx_queue_failsafe|verify_dpdk_send_receive_netvsc

**Impacted LISA Features:**
Sriov, NetworkInterface

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`