### PR TITLE
Wget: make overwrite skip re-download

### DIFF
--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -48,7 +48,6 @@ class Wget(Tool):
         sudo: bool = False,
         force_run: bool = False,
         timeout: int = 600,
-        skip_exists: bool = False,
     ) -> str:
         cached_filename = self._url_file_cache.get(url, None)
         if cached_filename:
@@ -68,11 +67,12 @@ class Wget(Tool):
         # remove existing file and dir to download again.
         download_pure_path = self.node.get_pure_path(download_path)
         if self.node.shell.exists(download_pure_path):
-            if skip_exists or not overwrite:
+            if overwrite:
+                self.node.shell.remove(download_pure_path, recursive=True)
+            else:
                 self._url_file_cache[url] = download_path
                 return download_path
-            else:
-                self.node.shell.remove(download_pure_path, recursive=True)
+                
 
         command = f"'{url}' --no-check-certificate"
         if filename:
@@ -177,7 +177,6 @@ class WindowsWget(Wget):
         sudo: bool = False,
         force_run: bool = False,
         timeout: int = 600,
-        skip_exists: bool = False,
     ) -> str:
         cached_filename = self._url_file_cache.get(url, None)
         if cached_filename:
@@ -195,7 +194,7 @@ class WindowsWget(Wget):
         file_path, download_path = self._ensure_download_path(file_path, filename)
 
         # return early if file exists and caller doesn't want to overwrite
-        if ls.path_exists(download_path, sudo=sudo) and (skip_exists or not overwrite):
+        if ls.path_exists(download_path, sudo=sudo) and not overwrite:
             self._url_file_cache[url] = download_path
             return download_path
 

--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -48,6 +48,7 @@ class Wget(Tool):
         sudo: bool = False,
         force_run: bool = False,
         timeout: int = 600,
+        skip_exists: bool = False,
     ) -> str:
         cached_filename = self._url_file_cache.get(url, None)
         if cached_filename:
@@ -66,8 +67,12 @@ class Wget(Tool):
 
         # remove existing file and dir to download again.
         download_pure_path = self.node.get_pure_path(download_path)
-        if overwrite and self.node.shell.exists(download_pure_path):
-            self.node.shell.remove(download_pure_path, recursive=True)
+        if self.node.shell.exists(download_pure_path):
+            if skip_exists:
+                return download_path
+            elif overwrite:
+                self.node.shell.remove(download_pure_path, recursive=True)
+
         command = f"'{url}' --no-check-certificate"
         if filename:
             command = f"{command} -O {download_path}"
@@ -171,6 +176,7 @@ class WindowsWget(Wget):
         sudo: bool = False,
         force_run: bool = False,
         timeout: int = 600,
+        skip_exists: bool = False,
     ) -> str:
         cached_filename = self._url_file_cache.get(url, None)
         if cached_filename:

--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -72,7 +72,6 @@ class Wget(Tool):
             else:
                 self._url_file_cache[url] = download_path
                 return download_path
-                
 
         command = f"'{url}' --no-check-certificate"
         if filename:

--- a/lisa/base_tools/wget.py
+++ b/lisa/base_tools/wget.py
@@ -68,9 +68,10 @@ class Wget(Tool):
         # remove existing file and dir to download again.
         download_pure_path = self.node.get_pure_path(download_path)
         if self.node.shell.exists(download_pure_path):
-            if skip_exists:
+            if skip_exists or not overwrite:
+                self._url_file_cache[url] = download_path
                 return download_path
-            elif overwrite:
+            else:
                 self.node.shell.remove(download_pure_path, recursive=True)
 
         command = f"'{url}' --no-check-certificate"
@@ -193,11 +194,10 @@ class WindowsWget(Wget):
 
         file_path, download_path = self._ensure_download_path(file_path, filename)
 
-        # return if file exists and not overwrite
-        if ls.path_exists(file_path, sudo=sudo) and not overwrite:
-            self._log.debug(
-                f"File {download_path} already exists and rewrite is set to False"
-            )
+        # return early if file exists and caller doesn't want to overwrite
+        if ls.path_exists(download_path, sudo=sudo) and (skip_exists or not overwrite):
+            self._url_file_cache[url] = download_path
+            return download_path
 
         # create directory if it doesn't exist
         self.node.tools[Mkdir].create_directory(file_path, sudo=sudo)


### PR DESCRIPTION
Part 5 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4657, review only the last commit.

Downloading large source tarballs again on every run is slow and can fail on flaky mirrors. `Wget.get` gains `skip_exists` so callers can reuse a file that is already present on the node instead of removing and redownloading it. `WindowsWget.get` takes the same argument so the override keeps matching the base class.

**Key Test Cases:**
verify_dpdk_build_netvsc|verify_dpdk_build_failsafe

**Impacted LISA Features:**
Sriov, NetworkInterface

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`
- `microsoftcblmariner azure-linux-3 azure-linux-3 latest`