### PR TITLE
Azure: check SRIOV on all nics and retry switch_sriov

### DIFF
--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1045,7 +1045,9 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             nic_info = network_client.network_interfaces.get(
                 self._resource_group_name, nic_name
             )
-            sriov_enabled &= nic_info.enable_accelerated_networking
+            accelnet_setting = nic_info.enable_accelerated_networking
+            # check if all nics have accelnet enabled
+            sriov_enabled &= accelnet_setting if isinstance(accelnet_setting, bool) else False
         return sriov_enabled
 
     @retry(ResourceExistsError, tries=5, delay=2, backoff=1.5)  # type: ignore

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -988,6 +988,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
                     f"into status [{enable}]"
                 ).is_equal_to(enable)
 
+    @retry(HttpResponseError, tries=3, delay=30)  # type: ignore
     def switch_sriov(
         self, enable: bool, wait: bool = True, reset_connections: bool = True
     ) -> None:
@@ -1033,17 +1034,18 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             self._check_sriov_enabled(enable, reset_connections)
 
     def is_enabled_sriov(self) -> bool:
+        # check whether sriov is enabled on all nics
         azure_platform: AzurePlatform = self._platform  # type: ignore
         network_client = get_network_client(azure_platform)
-        sriov_enabled: bool = False
+        sriov_enabled: bool = True
         vm = get_vm(azure_platform, self._node)
-        nic = self._get_primary(vm.network_profile.network_interfaces)
-        assert nic.id, "'nic.id' must not be 'None'"
-        nic_name = nic.id.split("/")[-1]
-        primary_nic = network_client.network_interfaces.get(
-            self._resource_group_name, nic_name
-        )
-        sriov_enabled = primary_nic.enable_accelerated_networking
+        for nic in vm.network_profile.network_interfaces:
+            assert nic.id, "'nic.id' must not be 'None'"
+            nic_name = nic.id.split("/")[-1]
+            nic_info = network_client.network_interfaces.get(
+                self._resource_group_name, nic_name
+            )
+            sriov_enabled &= nic_info.enable_accelerated_networking
         return sriov_enabled
 
     @retry(ResourceExistsError, tries=5, delay=2, backoff=1.5)  # type: ignore

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1040,7 +1040,9 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         sriov_enabled: bool = True
         vm = get_vm(azure_platform, self._node)
         for nic in vm.network_profile.network_interfaces:
-            assert_that(nic.id).described_as("Azure NIC reference must include a resource ID").is_not_none()
+            assert_that(nic.id).described_as(
+                "Azure NIC reference must include a resource ID"
+            ).is_not_none()
             nic_name = nic.id.split("/")[-1]
             nic_info = network_client.network_interfaces.get(
                 self._resource_group_name, nic_name

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1040,7 +1040,7 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
         sriov_enabled: bool = True
         vm = get_vm(azure_platform, self._node)
         for nic in vm.network_profile.network_interfaces:
-            assert nic.id, "'nic.id' must not be 'None'"
+            assert_that(nic.id).described_as("Azure NIC reference must include a resource ID").is_not_none()
             nic_name = nic.id.split("/")[-1]
             nic_info = network_client.network_interfaces.get(
                 self._resource_group_name, nic_name

--- a/lisa/sut_orchestrator/azure/features.py
+++ b/lisa/sut_orchestrator/azure/features.py
@@ -1047,7 +1047,9 @@ class NetworkInterface(AzureFeatureMixin, features.NetworkInterface):
             )
             accelnet_setting = nic_info.enable_accelerated_networking
             # check if all nics have accelnet enabled
-            sriov_enabled &= accelnet_setting if isinstance(accelnet_setting, bool) else False
+            sriov_enabled &= (
+                accelnet_setting if isinstance(accelnet_setting, bool) else False
+            )
         return sriov_enabled
 
     @retry(ResourceExistsError, tries=5, delay=2, backoff=1.5)  # type: ignore


### PR DESCRIPTION
Part 6 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4658, review only the last commit.

- `is_enabled_sriov` only inspected the primary nic, so a multi nic VM reported accelerated networking as enabled while a secondary nic was still being updated. It now checks every nic on the VM.
- `switch_sriov` failed outright on transient `HttpResponseError` replies from the network resource provider, so it is retried a few times before giving up.

**Key Test Cases:**
verify_dpdk_sriov_rescind_failover_send_only|verify_sriov_disable_enable|verify_sriov_add_max_nics

**Impacted LISA Features:**
Sriov, NetworkInterface

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`
- `redhat rhel 9_5 latest`