### PR TITLE
Dpdk: roll back broken installs and reuse downloaded assets

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -150,7 +150,6 @@ class TarDownloader(Downloader):
                 self._tar_url,
                 overwrite=False,
                 file_path=str(work_path),
-                skip_exists=True,
             )
             remote_path = node.get_pure_path(tarfile)
             self.tar_filename = remote_path.name
@@ -188,7 +187,7 @@ class Installer:
     # First we download the assets to ensure asset_path is set
     # even if we end up skipping re-installation
     def _setup_node(self) -> None:
-        if not hasattr(self, "asset_path"):
+        if not self._asset_path_exists():
             self._download_assets()
 
     # check if the package is already installed:
@@ -219,7 +218,6 @@ class Installer:
         if not self._asset_path_exists():
             return
         asset_path = self.asset_path
-        delattr(self, "asset_path")
         working_path = str(self._node.get_working_path())
         assert_that(str(asset_path)).described_as(
             "Test bug: Installer source path was empty during attempted cleanup!"
@@ -233,6 +231,7 @@ class Installer:
             f"'{working_path}' during attempted cleanup!"
         ).is_not_equal_to(working_path)
         self._node.shell.remove(asset_path, recursive=True)
+        delattr(self, "asset_path")
 
     def _rollback_installation(self) -> None:
         try:
@@ -244,8 +243,7 @@ class Installer:
                 f"Installer cleanup failed; marking node dirty. {str(err)}"
             )
             self._node.mark_dirty()
-            self._node.log.debug("")
-            raise AssertionError(err, "Test bug: rollback of installation failed")
+            raise AssertionError(f"Test bug: rollback of installation failed: {str(err)}")
 
     # install the dependencies
     def _install_dependencies(self) -> None:
@@ -267,7 +265,7 @@ class Installer:
     # run the defined setup and installation steps.
     def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
         self._setup_node()
-        if self._should_install():
+        if self._should_install(required_version=required_version):
             # any issues here could result in a broken installation.
             # If the node is still usable, we don't want to discard it.
             # So attempt to roll back a broken installation and re-raise the problem.
@@ -281,7 +279,7 @@ class Installer:
                 self._install()
             except Exception as e:
                 self._rollback_installation()
-                raise e
+                raise
 
     def __init__(
         self,

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -232,7 +232,7 @@ class Installer:
             f"Test bug: Installer source path {asset_path} was set to working path "
             f"'{working_path}' during attempted cleanup!"
         ).is_not_equal_to(working_path)
-        self._node.execute(f"rm -rf {str(asset_path)}", shell=True)
+        self._node.shell.remove(asset_path, recursive=True)
 
     def _rollback_installation(self) -> None:
         try:
@@ -244,7 +244,8 @@ class Installer:
                 f"Installer cleanup failed; marking node dirty. {str(err)}"
             )
             self._node.mark_dirty()
-            raise err
+            self._node.log.debug("")
+            raise AssertionError(err, "Test bug: rollback of installation failed")
 
     # install the dependencies
     def _install_dependencies(self) -> None:

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -17,7 +17,7 @@ from lisa.tools import Git, Lscpu, Tar, Wget
 from lisa.tools.lscpu import CpuArchitecture
 from lisa.util import UnsupportedDistroException
 
-DPDK_STABLE_GIT_REPO = "https://dpdk.org/git/dpdk-stable"
+DPDK_STABLE_GIT_REPO = "https://github.com/dpdk/dpdk-stable.git"
 
 # azure routing table magic subnet prefix
 # signals 'route all traffic on this subnet'
@@ -150,6 +150,7 @@ class TarDownloader(Downloader):
                 self._tar_url,
                 overwrite=False,
                 file_path=str(work_path),
+                skip_exists=True,
             )
             remote_path = node.get_pure_path(tarfile)
             self.tar_filename = remote_path.name
@@ -167,12 +168,13 @@ class TarDownloader(Downloader):
         # force name as tarfile name
         # add option to skip files which already exist on disk
         # in the event we have already extracted this specific tar
-        node.tools[Tar].extract(
-            file=str(remote_path),
-            dest_dir=str(work_path),
-            gzip=True,
-            skip_existing_files=True,
-        )
+        if not node.shell.exists(self.asset_path):
+            node.tools[Tar].extract(
+                file=str(remote_path),
+                dest_dir=str(work_path),
+                gzip=True,
+                skip_existing_files=True,
+            )
         return self.asset_path
 
 
@@ -186,7 +188,8 @@ class Installer:
     # First we download the assets to ensure asset_path is set
     # even if we end up skipping re-installation
     def _setup_node(self) -> None:
-        self._download_assets()
+        if not hasattr(self, "asset_path"):
+            self._download_assets()
 
     # check if the package is already installed:
     # Is the package installed from source? Or from the package manager?
@@ -209,6 +212,40 @@ class Installer:
     def _uninstall(self) -> None:
         raise NotImplementedError(f"_clean_previous_installation {self._err_msg}")
 
+    def _asset_path_exists(self) -> bool:
+        return hasattr(self, "asset_path") and self._node.shell.exists(self.asset_path)
+
+    def _delete_assets(self) -> None:
+        if not self._asset_path_exists():
+            return
+        asset_path = self.asset_path
+        delattr(self, "asset_path")
+        working_path = str(self._node.get_working_path())
+        assert_that(str(asset_path)).described_as(
+            "Test bug: Installer source path was empty during attempted cleanup!"
+        ).is_not_empty()
+        assert_that(str(asset_path)).described_as(
+            "Test bug: Installer source path was set to root dir '/' "
+            "during attempted cleanup!"
+        ).is_not_equal_to("/")
+        assert_that(str(asset_path)).described_as(
+            f"Test bug: Installer source path {asset_path} was set to working path "
+            f"'{working_path}' during attempted cleanup!"
+        ).is_not_equal_to(working_path)
+        self._node.execute(f"rm -rf {str(asset_path)}", shell=True)
+
+    def _rollback_installation(self) -> None:
+        try:
+            if self._check_if_installed():
+                self._uninstall()
+            self._delete_assets()
+        except Exception as err:
+            self._node.log.debug(
+                f"Installer cleanup failed; marking node dirty. {str(err)}"
+            )
+            self._node.mark_dirty()
+            raise err
+
     # install the dependencies
     def _install_dependencies(self) -> None:
         if self._os_dependencies is not None:
@@ -230,9 +267,20 @@ class Installer:
     def do_installation(self, required_version: Optional[VersionInfo] = None) -> None:
         self._setup_node()
         if self._should_install():
-            self._uninstall()
-            self._install_dependencies()
-            self._install()
+            # any issues here could result in a broken installation.
+            # If the node is still usable, we don't want to discard it.
+            # So attempt to roll back a broken installation and re-raise the problem.
+            # This avoids re-deployments and ensures a transient issue causing a broken
+            # installation doesn't propagate failures into future tests on
+            # that same node.
+            try:
+                self._download_assets()
+                self._uninstall()
+                self._install_dependencies()
+                self._install()
+            except Exception as e:
+                self._rollback_installation()
+                raise e
 
     def __init__(
         self,
@@ -289,7 +337,7 @@ def force_dpdk_default_source(variables: Dict[str, Any]) -> None:
         variables["dpdk_source"] = DPDK_STABLE_GIT_REPO
 
 
-_UBUNTU_LTS_VERSIONS = ["24.4.0", "22.4.0", "20.4.0", "18.4.0"]
+_UBUNTU_LTS_VERSIONS = ["26.4.0", "24.4.0", "22.4.0", "20.4.0", "18.4.0"]
 
 
 # see https://ubuntu.com/about/release-cycle

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -243,7 +243,9 @@ class Installer:
                 f"Installer cleanup failed; marking node dirty. {str(err)}"
             )
             self._node.mark_dirty()
-            raise AssertionError(f"Test bug: rollback of installation failed: {str(err)}")
+            raise AssertionError(
+                f"Test bug: rollback of installation failed: {str(err)}"
+            )
 
     # install the dependencies
     def _install_dependencies(self) -> None:

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -168,12 +168,23 @@ class TarDownloader(Downloader):
         # add option to skip files which already exist on disk
         # in the event we have already extracted this specific tar
         if not node.shell.exists(self.asset_path):
-            node.tools[Tar].extract(
-                file=str(remote_path),
-                dest_dir=str(work_path),
-                gzip=True,
-                skip_existing_files=True,
-            )
+            try:
+                node.tools[Tar].extract(
+                    file=str(remote_path),
+                    dest_dir=str(work_path),
+                    gzip=True,
+                    skip_existing_files=True,
+                )
+            except AssertionError:
+                # tar extraction failed,
+                # ensure potential broken dir and
+                # download are removed before reraising.
+                if node.shell.exists(self.asset_path):
+                    node.shell.remove(self.asset_path, recursive=True)
+                if node.shell.exists(remote_path):
+                    node.shell.remove(remote_path)
+                raise
+
         return self.asset_path
 
 

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -275,11 +275,10 @@ class Installer:
             # installation doesn't propagate failures into future tests on
             # that same node.
             try:
-                self._download_assets()
                 self._uninstall()
                 self._install_dependencies()
                 self._install()
-            except Exception as e:
+            except Exception:
                 self._rollback_installation()
                 raise
 

--- a/lisa/microsoft/testsuites/dpdk/rdmacore.py
+++ b/lisa/microsoft/testsuites/dpdk/rdmacore.py
@@ -1,4 +1,3 @@
-from assertpy import assert_that
 from microsoft.testsuites.dpdk.common import (
     DependencyInstaller,
     Installer,
@@ -14,7 +13,7 @@ from lisa.tools import Make, Pkgconfig
 
 RDMA_CORE_MANA_DEFAULT_SOURCE = (
     "https://github.com/linux-rdma/rdma-core/"
-    "releases/download/v50.1/rdma-core-50.1.tar.gz"
+    "releases/download/v59.0/rdma-core-59.0.tar.gz"
 )
 RDMA_CORE_SOURCE_DEPENDENCIES = DependencyInstaller(
     [
@@ -166,20 +165,6 @@ class RdmaCoreSourceInstaller(Installer):  # type: ignore[misc]
         self._node.tools[Make].run(
             parameters="uninstall", shell=True, sudo=True, cwd=self.asset_path
         )
-        working_path = str(self._node.get_working_path())
-        assert_that(str(self.asset_path)).described_as(
-            "RDMA Installer source path was empty during attempted cleanup!"
-        ).is_not_empty()
-        assert_that(str(self.asset_path)).described_as(
-            "RDMA Installer source path was set to root dir "
-            "'/' during attempted cleanup!"
-        ).is_not_equal_to("/")
-        assert_that(str(self.asset_path)).described_as(
-            f"RDMA Installer source path {self.asset_path} was set to "
-            f"working path '{working_path}' during attempted cleanup!"
-        ).is_not_equal_to(working_path)
-        # remove source code directory
-        self._node.execute(f"rm -rf {str(self.asset_path)}", shell=True)
 
     def get_installed_version(self) -> VersionInfo:
         version: VersionInfo = self._node.tools[Pkgconfig].get_package_version(


### PR DESCRIPTION
Part 7 of 9 of a stacked series that reworks the DPDK SRIOV hot plug tests. Stacked on #4659, review only the last commit.

- A failure part way through a source installation left the node with a half installed dpdk or rdma-core, and every later test on that node failed for an unrelated reason. The install steps are now wrapped so a failure uninstalls what was applied, removes the extracted source, marks the node dirty if even the cleanup fails, and re-raises the original error.
- The asset removal guards that were specific to the rdma-core installer now live on the base `Installer` as `_delete_assets`, so every installer is protected against deleting `/` or the working path.
- Downloads and extraction are skipped when the asset is already on the node, and dpdk-stable is fetched from the github mirror, which is far more reliable than dpdk.org from Azure.

**Key Test Cases:**
verify_dpdk_build_netvsc|verify_dpdk_build_failsafe|verify_dpdk_build_gb_hugepages_netvsc

**Impacted LISA Features:**
Sriov, NetworkInterface, Infiniband

**Tested Azure Marketplace Images:**
- `canonical 0001-com-ubuntu-server-jammy 22_04-lts latest`
- `microsoftcblmariner azure-linux-3 azure-linux-3 latest`
- `redhat rhel 9_5 latest`