### PR TITLE
BugFix: install iperf3 source build dependencies

### DIFF
--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -17,7 +17,7 @@ from lisa.messages import (
     create_perf_message,
     send_unified_perf_message,
 )
-from lisa.operating_system import Posix
+from lisa.operating_system import CBLMariner, Posix
 from lisa.tools import Cat
 from lisa.util import (
     LisaException,
@@ -637,7 +637,12 @@ class Iperf3(Tool):
         firewall = self.node.tools[Firewall]
         firewall.stop()
 
+    def _install_dep_packages(self) -> None:
+        if isinstance(self.node.os, CBLMariner):
+            self.node.os.install_packages(["binutils", "glibc-devel"])
+
     def _install_from_src(self) -> None:
+        self._install_dep_packages()
         tool_path = self.get_tool_path()
         git = self.node.tools[Git]
         # Pin to a fixed upstream release so the built binary does not have the

--- a/lisa/tools/iperf3.py
+++ b/lisa/tools/iperf3.py
@@ -31,6 +31,7 @@ from lisa.util.perf_timer import create_timer
 from lisa.util.process import ExecutableResult, Process
 
 from .firewall import Firewall
+from .gcc import Gcc
 from .git import Git
 from .ls import Ls
 from .lsof import Lsof
@@ -115,7 +116,7 @@ class Iperf3(Tool):
 
     @property
     def dependencies(self) -> List[Type[Tool]]:
-        return [Git, Make]
+        return [Git, Make, Gcc]
 
     def help(self) -> ExecutableResult:
         return self.run("-h", force_run=True)
@@ -146,7 +147,7 @@ class Iperf3(Tool):
             < parse_version(self._first_fixed_version)
         )
 
-    def install(self) -> bool:
+    def _install(self) -> bool:
         posix_os: Posix = cast(Posix, self.node.os)
         try:
             posix_os.install_packages("iperf3")

--- a/selftests/test_iperf3.py
+++ b/selftests/test_iperf3.py
@@ -4,6 +4,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
+from lisa.operating_system import CBLMariner
 from lisa.tools import Gcc, Git, Make
 from lisa.tools.iperf3 import Iperf3
 
@@ -24,4 +25,15 @@ class Iperf3TestCase(TestCase):
 
         parent.assert_has_calls(
             [call.get(Git), call.get(Make), call.get(Gcc), call.install()]
+        )
+
+    def test_source_build_installs_cbl_mariner_linker_dependencies(self) -> None:
+        cbl_mariner = MagicMock(spec=CBLMariner)
+        iperf3 = Iperf3.__new__(Iperf3)
+        iperf3.node = MagicMock(os=cbl_mariner)
+
+        iperf3._install_dep_packages()
+
+        cbl_mariner.install_packages.assert_called_once_with(
+            ["binutils", "glibc-devel"]
         )

--- a/selftests/test_iperf3.py
+++ b/selftests/test_iperf3.py
@@ -22,4 +22,6 @@ class Iperf3TestCase(TestCase):
             parent.attach_mock(install, "install")
             self.assertTrue(iperf3.install())
 
-        parent.assert_has_calls([call.get(Git), call.get(Make), call.get(Gcc), call.install()])
+        parent.assert_has_calls(
+            [call.get(Git), call.get(Make), call.get(Gcc), call.install()]
+        )

--- a/selftests/test_iperf3.py
+++ b/selftests/test_iperf3.py
@@ -15,8 +15,11 @@ class Iperf3TestCase(TestCase):
         iperf3.node = MagicMock(tools=tools)
         iperf3._log = MagicMock()
 
+        parent = MagicMock()
+        parent.attach_mock(tools.get, "get")
+
         with patch.object(iperf3, "_install", return_value=True) as install:
+            parent.attach_mock(install, "install")
             self.assertTrue(iperf3.install())
 
-        tools.get.assert_has_calls([call(Git), call(Make), call(Gcc)])
-        install.assert_called_once_with()
+        parent.assert_has_calls([call.get(Git), call.get(Make), call.get(Gcc), call.install()])

--- a/selftests/test_iperf3.py
+++ b/selftests/test_iperf3.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+from lisa.tools import Gcc, Git, Make
+from lisa.tools.iperf3 import Iperf3
+
+
+class Iperf3TestCase(TestCase):
+    def test_install_loads_source_build_dependencies(self) -> None:
+        tools = MagicMock()
+        iperf3 = Iperf3.__new__(Iperf3)
+        iperf3.node = MagicMock(tools=tools)
+        iperf3._log = MagicMock()
+
+        with patch.object(iperf3, "_install", return_value=True) as install:
+            self.assertTrue(iperf3.install())
+
+        tools.get.assert_has_calls([call(Git), call(Make), call(Gcc)])
+        install.assert_called_once_with()


### PR DESCRIPTION
## Description

Fixes Iperf3 source installation failures when a C compiler is not already installed.

`Iperf3` declared `Git` and `Make` as dependencies, but it overrode the public `install()` method. This bypassed `Tool.install()`, which is responsible for loading declared tool dependencies before calling the tool-specific installation implementation.

When the package-manager installation was unavailable or an installed Iperf3 version needed to be replaced, LISA attempted to build Iperf3 from source. The build then failed during `./configure` because no C compiler was available.

This change:

- Renames `Iperf3.install()` to `Iperf3._install()` so installation runs through the inherited `Tool.install()` workflow.
- Adds `Gcc` as a direct Iperf3 dependency alongside `Git` and `Make`.
- Preserves the existing Iperf3 version detection and source-build behavior.
- Adds a regression test verifying that all three dependencies are requested before `Iperf3._install()` is called.

`Gcc` is declared directly rather than relying on `Make` to load it transitively. If `Make` is already installed or cached, its installation method may not run, so its dependencies are not guaranteed to be processed.

## Related Issue

<!-- The related issue is internal and is intentionally not linked in this public PR. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested
- [x] Tests executed and results posted below

## Test Validation

Completed locally:

- `python -m unittest selftests.test_iperf3 -v` — passed
- Runtime check that `Iperf3.install is Tool.install` — passed
- Runtime check that dependencies are `[Git, Make, Gcc]` — passed
- Black check on changed files — passed
- Flake8 check on changed files — passed
- Python compilation of changed files — passed
- `git diff --check` — passed
