### PR TITLE
Gate SR-IOV tests by expected VF driver

### DIFF
--- a/docs/run_test/runbook.rst
+++ b/docs/run_test/runbook.rst
@@ -570,6 +570,31 @@ When set to True, the value of this variable will be passed to the testcases,
 such as ``perf_nested_kvm_storage_singledisk`` which requires information
 about nested image.
 
+expected_vf_driver
+^^^^^^^^^^^^^^^^^^
+
+type: str, optional, default is empty
+
+Requires a specific SR-IOV virtual function (VF) driver to be present on the
+created Linux VM. Supported values are ``mlx`` and ``mana``. An empty value
+disables the check.
+
+The check applies only to test cases with ``sriov`` or ``vf`` in their names,
+matched case-insensitively. The variable must set ``is_case_visible`` to True
+so the test case can access it.
+
+.. code:: yaml
+
+   variable:
+     - name: expected_vf_driver
+       value: mana
+       is_case_visible: true
+
+Before an applicable test case runs, LISA refreshes the VM's network interface
+information and verifies that the requested VF driver is loaded. The test case
+fails if the driver is missing or the NIC state cannot be inspected. The check
+is skipped when no node is available or the node runs Windows.
+
 is_secret
 ^^^^^^^^^
 

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -8,7 +8,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from assertpy import assert_that
 from retry import retry
@@ -18,6 +18,20 @@ from lisa.util import InitializableMixin, LisaException, constants, find_groups_
 
 if TYPE_CHECKING:
     from lisa import Node
+
+# Normalized VF (Virtual Function) driver type -> kernel module name prefixes.
+# Used to gate test cases on the presence of a specific VF driver on the VM.
+# - "mlx": Mellanox ConnectX (mlx4_core / mlx5_core)
+# - "mana": Microsoft Azure Network Adapter (mana / mana_en / mana_ib)
+_VF_DRIVER_TYPE_PREFIXES: Dict[str, Tuple[str, ...]] = {
+    "mlx": ("mlx4", "mlx5"),
+    "mana": ("mana",),
+}
+
+
+def get_supported_vf_driver_types() -> List[str]:
+    """Return the VF driver types supported by the expected_vf_driver gate."""
+    return sorted(_VF_DRIVER_TYPE_PREFIXES.keys())
 
 
 class NicInfo:
@@ -225,6 +239,24 @@ class Nics(InitializableMixin):
             if item in used_module_list:
                 used_module_list.remove(item)
         return used_module_list
+
+    def has_vf_driver(self, driver_type: str) -> bool:
+        """Return True if a VF driver of the given type is in use on the node.
+
+        ``driver_type`` is a normalized VF driver type (e.g. 'mlx' or 'mana').
+        Raises LisaException if the type is not supported.
+        """
+        normalized_type = driver_type.strip().lower()
+        prefixes = _VF_DRIVER_TYPE_PREFIXES.get(normalized_type)
+        if prefixes is None:
+            raise LisaException(
+                f"Unsupported VF driver type '{driver_type}'. Expected one of "
+                f"{get_supported_vf_driver_types()}."
+            )
+        # Exclude the synthetic hv_netvsc driver so only the VF (PCI passthrough)
+        # driver modules are considered.
+        used_modules = self.get_used_modules(["hv_netvsc"])
+        return any(module.startswith(prefixes) for module in used_modules)
 
     def get_device_slots(self, exclude_ib: bool = False) -> List[str]:
         """Get PCI slots for NICs.

--- a/lisa/testsuite.py
+++ b/lisa/testsuite.py
@@ -44,6 +44,7 @@ from lisa.util.perf_timer import Timer, create_timer
 
 _all_suites: Dict[str, TestSuiteMetadata] = {}
 _all_cases: Dict[str, TestCaseMetadata] = {}
+_EXPECTED_VF_DRIVER_CASE_NAME_MARKERS = ("sriov", "vf")
 
 
 def _call_with_timeout(
@@ -868,6 +869,12 @@ class TestSuite:
 
         timer = create_timer()
         try:
+            self._check_expected_vf_driver(
+                case_result.runtime_data.name,
+                case_result.runtime_data.metadata.suite.area,
+                test_kwargs,
+                log,
+            )
             _call_with_timeout(
                 self.before_case,
                 timeout=timeout,
@@ -879,6 +886,86 @@ class TestSuite:
 
         log.debug(f"before_case end in {timer}")
         return result
+
+    def _check_expected_vf_driver(
+        self,
+        case_name: str,
+        test_area: str,
+        test_kwargs: Dict[str, Any],
+        log: Logger,
+    ) -> None:
+        """Fail the case if the VM does not expose the required VF driver.
+
+        The requirement is opt-in through the case-visible runbook variable
+        ``expected_vf_driver`` (e.g. 'mlx' or 'mana'). When the variable is
+        absent or empty, no check is performed. When set, the created VM's NICs
+        are inspected and the case fails if the required VF driver is not
+        present.
+
+        The gate only applies to the ``sriov`` test area or test cases with
+        ``sriov`` or ``vf`` in their names; other cases are ignored.
+        """
+        normalized_case_name = case_name.lower()
+        is_vf_case = any(
+            marker in normalized_case_name
+            for marker in _EXPECTED_VF_DRIVER_CASE_NAME_MARKERS
+        )
+        if test_area.strip().lower() != "sriov" and not is_vf_case:
+            return
+
+        variables = test_kwargs.get("variables") or {}
+        expected_vf_driver = (
+            str(variables.get("expected_vf_driver", "")).strip().lower()
+        )
+        # No requirement configured, so the gate is a no-op.
+        if not expected_vf_driver:
+            return
+
+        # Import here to avoid a circular import at module load time.
+        from lisa.nic import get_supported_vf_driver_types
+
+        supported = get_supported_vf_driver_types()
+        if expected_vf_driver not in supported:
+            raise LisaException(
+                f"Invalid 'expected_vf_driver' value '{expected_vf_driver}'. "
+                f"Expected one of {supported}."
+            )
+
+        node = test_kwargs.get("node")
+        if node is None:
+            raise SkippedException(
+                "'expected_vf_driver' is set but no node is available to inspect "
+                "for a VF driver. Verify the environment has a deployed node."
+            )
+
+        if isinstance(node.os, Windows):
+            raise SkippedException(
+                f"'expected_vf_driver' check for '{expected_vf_driver}' is only "
+                f"supported on Linux nodes, but node '{node.name}' runs Windows."
+            )
+
+        try:
+            node.nics.reload()
+            has_vf = node.nics.has_vf_driver(expected_vf_driver)
+        except Exception as e:
+            # An unreadable NIC state is a real failure, not an unmet precondition.
+            raise LisaException(
+                f"Could not determine the VF driver on node '{node.name}' to verify "
+                f"the required '{expected_vf_driver}' VF driver. Investigate node "
+                f"connectivity or NIC state. Error: {e}"
+            ) from e
+
+        if not has_vf:
+            used_modules = node.nics.get_used_modules(["hv_netvsc"])
+            raise LisaException(
+                f"Required VF/VF driver '{expected_vf_driver}' was not found on node "
+                f"'{node.name}'. Detected VF driver modules: {used_modules or 'none'}."
+            )
+
+        log.info(
+            f"expected_vf_driver check passed: '{expected_vf_driver}' VF driver "
+            f"present on node '{node.name}'."
+        )
 
     def __after_case(
         self,


### PR DESCRIPTION
Add an optional case-visible expected_vf_driver variable that validates mlx or mana VF drivers before SR-IOV and VF test cases run. Refresh NIC data before validation, report actionable failures, and document the runbook configuration.

Example:
  variable:
    - name: expected_vf_driver
      value: mana
      is_case_visible: true

When expected_vf_driver is provided, all SRIOV area test cases and any tests with sriov or vf in their names will verify that the VF driver matches the specified value. Any mismatch will cause the test to fail.

As most VM sizes, including both older and newer generations, now support both MANA and MLX NICs, this feature helps ensure that test execution targets the correct NIC type.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_inet_diag_destroy|verify_inet_diag_enabled|validate_netvsc_reload|verify_network_interface_reload_via_ip_link|verify_ringbuffer_settings_change|verify_device_channels_change|verify_device_enabled_features|verify_device_gro_lro_settings_change|verify_device_rss_hash_key_change|verify_device_rx_hash_level_change|verify_device_msg_level_change|verify_device_statistics|verify_services_state|verify_sriov_basic|verify_sriov_single_vf_connection|verify_sriov_max_vf_connection|verify_sriov_disable_enable|verify_sriov_disable_enable_pci

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------| 
|Canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest|Standard_D32s_v5|PASSED|   

