### PR TITLE
Fix/hibernation transient retry

### DIFF
--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import time
 from decimal import Decimal
 from typing import Any, List, cast
 
@@ -150,14 +151,33 @@ def _perform_hibernation_cycle(
 
     boot_time_before_hibernation = who.last_boot()
 
-    try:
-        startstop.stop(state=features.StopState.Hibernate)
-    except Exception as ex:
+    # Azure may return a transient "VMHibernateFailed" internal error; the
+    # platform guidance is to retry. Retry only that exact error, and only
+    # while the VM is still running.
+    max_hibernate_attempts = 3
+    hibernate_retry_delay = 30
+    for attempt in range(1, max_hibernate_attempts + 1):
         try:
-            dmesg.get_output(force_run=True)
-        except Exception as e:
-            log.debug(f"error on get dmesg output: {e}")
-        raise LisaException(f"fail to hibernate: {ex}")
+            startstop.stop(state=features.StopState.Hibernate)
+            break
+        except Exception as ex:
+            transient = "VMHibernateFailed" in str(ex)
+            if (
+                transient
+                and attempt < max_hibernate_attempts
+                and startstop.get_status() == VMStatus.Running
+            ):
+                log.info(
+                    f"transient VMHibernateFailed on attempt {attempt}; "
+                    f"retrying in {hibernate_retry_delay}s"
+                )
+                time.sleep(hibernate_retry_delay)
+                continue
+            try:
+                dmesg.get_output(force_run=True)
+            except Exception as e:
+                log.debug(f"error on get dmesg output: {e}")
+            raise LisaException(f"fail to hibernate: {ex}")
 
     is_ready = True
     timeout = 900

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 from decimal import Decimal
+from time import sleep
 from typing import Any, List, cast
 
 from assertpy import assert_that
@@ -28,6 +29,13 @@ from lisa.tools import (
 )
 from lisa.util import LisaException, SkippedException
 from lisa.util.perf_timer import create_timer
+
+# Azure returns VMHibernateFailed when a hibernate request is rejected, e.g. when
+# the guest is not yet ready shortly after boot (slow FIPS kernels can still be
+# completing crypto init). Azure guidance is to retry after ~5 minutes.
+# https://learn.microsoft.com/azure/virtual-machines/hibernate-resume-troubleshooting
+_HIBERNATE_FAILED_MARKER = "VMHibernateFailed"
+_HIBERNATE_RETRY_INTERVAL_SECONDS = 300
 
 
 def is_distro_supported(node: Node) -> None:
@@ -150,14 +158,29 @@ def _perform_hibernation_cycle(
 
     boot_time_before_hibernation = who.last_boot()
 
-    try:
-        startstop.stop(state=features.StopState.Hibernate)
-    except Exception as ex:
+    # Retry a VMHibernateFailed result once, spaced by the Azure-recommended
+    # interval. A rejected hibernate leaves the VM running, so the guest is
+    # reachable for diagnostics and the request can be re-issued. Any other
+    # failure is raised immediately.
+    max_attempts = 2
+    for attempt in range(1, max_attempts + 1):
         try:
-            dmesg.get_output(force_run=True)
-        except Exception as e:
-            log.debug(f"error on get dmesg output: {e}")
-        raise LisaException(f"fail to hibernate: {ex}")
+            startstop.stop(state=features.StopState.Hibernate)
+            break
+        except Exception as ex:
+            try:
+                dmesg.get_output(force_run=True)
+            except Exception as e:
+                log.debug(f"error on get dmesg output: {e}")
+            if attempt < max_attempts and _HIBERNATE_FAILED_MARKER in str(ex):
+                log.info(
+                    f"hibernation attempt {attempt}/{max_attempts} returned "
+                    f"{_HIBERNATE_FAILED_MARKER}; retrying in "
+                    f"{_HIBERNATE_RETRY_INTERVAL_SECONDS}s per Azure guidance"
+                )
+                sleep(_HIBERNATE_RETRY_INTERVAL_SECONDS)
+                continue
+            raise LisaException(f"fail to hibernate: {ex}")
 
     is_ready = True
     timeout = 900

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
-import time
 from decimal import Decimal
 from typing import Any, List, cast
 
@@ -151,33 +150,14 @@ def _perform_hibernation_cycle(
 
     boot_time_before_hibernation = who.last_boot()
 
-    # Azure may return a transient "VMHibernateFailed" internal error; the
-    # platform guidance is to retry. Retry only that exact error, and only
-    # while the VM is still running.
-    max_hibernate_attempts = 3
-    hibernate_retry_delay = 30
-    for attempt in range(1, max_hibernate_attempts + 1):
+    try:
+        startstop.stop(state=features.StopState.Hibernate)
+    except Exception as ex:
         try:
-            startstop.stop(state=features.StopState.Hibernate)
-            break
-        except Exception as ex:
-            transient = "VMHibernateFailed" in str(ex)
-            if (
-                transient
-                and attempt < max_hibernate_attempts
-                and startstop.get_status() == VMStatus.Running
-            ):
-                log.info(
-                    f"transient VMHibernateFailed on attempt {attempt}; "
-                    f"retrying in {hibernate_retry_delay}s"
-                )
-                time.sleep(hibernate_retry_delay)
-                continue
-            try:
-                dmesg.get_output(force_run=True)
-            except Exception as e:
-                log.debug(f"error on get dmesg output: {e}")
-            raise LisaException(f"fail to hibernate: {ex}")
+            dmesg.get_output(force_run=True)
+        except Exception as e:
+            log.debug(f"error on get dmesg output: {e}")
+        raise LisaException(f"fail to hibernate: {ex}")
 
     is_ready = True
     timeout = 900
@@ -402,16 +382,20 @@ def run_network_workload(environment: Environment) -> Decimal:
 
     iperf3_server = server_node.tools[Iperf3]
     iperf3_client = client_node.tools[Iperf3]
-    iperf3_server.run_as_server_async()
-    iperf3_client_result = iperf3_client.run_as_client_async(
-        server_ip=server_node.internal_address,
-        parallel_number=8,
-        run_time_seconds=120,
+    iperf3_server_process = iperf3_server.run_as_server_async(
+        port=5201, daemon=False
     )
-    result_before_hb = iperf3_client_result.wait_result()
-    kill = server_node.tools[Kill]
-    kill.by_name("iperf3")
-    return iperf3_client.get_sender_bandwidth(result_before_hb.stdout)
+    try:
+        iperf3_client_result = iperf3_client.run_as_client_async(
+            server_ip=server_node.internal_address,
+            parallel_number=8,
+            run_time_seconds=120,
+        )
+        result_before_hb = iperf3_client_result.wait_result()
+        return iperf3_client.get_sender_bandwidth(result_before_hb.stdout)
+    finally:
+        iperf3_server_process.kill()
+        server_node.tools[Kill].by_name("iperf3")
 
 
 def verify_hibernation(

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -40,9 +40,13 @@ def _is_fips_kernel(node: Node) -> bool:
     # Azure hibernation is unsupported on the certified FIPS kernel (e.g. Ubuntu
     # Pro *-azure-fips): it returns VMHibernateFailed on every attempt, so this
     # is an unmet precondition rather than a test failure.
-    fips_enabled = (
-        node.tools[Cat].read("/proc/sys/crypto/fips_enabled", force_run=True).strip()
-    )
+    fips_enabled = "0"
+    if node.tools[Ls].path_exists("/proc/sys/crypto/fips_enabled"):
+        fips_enabled = (
+            node.tools[Cat]
+            .read("/proc/sys/crypto/fips_enabled", force_run=True)
+            .strip()
+        )
     kernel_version = node.execute("uname -r", shell=True).stdout.strip()
     return fips_enabled == "1" or "fips" in kernel_version.lower()
 
@@ -161,7 +165,7 @@ def _perform_hibernation_cycle(
     """
 
     # The hibernation-setup tool writes resume=/resume_offset= to the
-    # bootloader, which only take effect after a reboot; without it the VM
+    # bootloader, which only takes effect after a reboot; without it the VM
     # accepts the hibernate uevent but never suspends (seen on Debian and
     # Ubuntu). A sleep(100) also works, but we are unsure of the exact time
     # required. So it is safer to reboot the VM.

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -382,20 +382,16 @@ def run_network_workload(environment: Environment) -> Decimal:
 
     iperf3_server = server_node.tools[Iperf3]
     iperf3_client = client_node.tools[Iperf3]
-    iperf3_server_process = iperf3_server.run_as_server_async(
-        port=5201, daemon=False
+    iperf3_server.run_as_server_async()
+    iperf3_client_result = iperf3_client.run_as_client_async(
+        server_ip=server_node.internal_address,
+        parallel_number=8,
+        run_time_seconds=120,
     )
-    try:
-        iperf3_client_result = iperf3_client.run_as_client_async(
-            server_ip=server_node.internal_address,
-            parallel_number=8,
-            run_time_seconds=120,
-        )
-        result_before_hb = iperf3_client_result.wait_result()
-        return iperf3_client.get_sender_bandwidth(result_before_hb.stdout)
-    finally:
-        iperf3_server_process.kill()
-        server_node.tools[Kill].by_name("iperf3")
+    result_before_hb = iperf3_client_result.wait_result()
+    kill = server_node.tools[Kill]
+    kill.by_name("iperf3")
+    return iperf3_client.get_sender_bandwidth(result_before_hb.stdout)
 
 
 def verify_hibernation(

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -139,10 +139,10 @@ def _perform_hibernation_cycle(
 
     # The hibernation-setup tool writes resume=/resume_offset= to the
     # bootloader, which only take effect after a reboot; without it the VM
-    # accepts the hibernate uevent but never suspends (seen on Debian 13).
-    # A sleep(100) also works, but we are unsure of the exact time required.
-    # So it is safer to reboot the VM.
-    if type(node.os) in (Redhat, AlmaLinux, SLES, Debian):
+    # accepts the hibernate uevent but never suspends (seen on Debian and
+    # Ubuntu). A sleep(100) also works, but we are unsure of the exact time
+    # required. So it is safer to reboot the VM.
+    if type(node.os) in (Redhat, AlmaLinux, SLES, Debian, Ubuntu):
         node.reboot()
 
     startstop = node.features[StartStop]

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -137,12 +137,12 @@ def _perform_hibernation_cycle(
     Returns (boot_time_before, boot_time_after) for verification.
     """
 
-    # This is a temporary workaround for a bug observed in Redhat Distros
-    # where the VM is not able to hibernate immediately after installing
-    # the hibernation-setup tool.
+    # The hibernation-setup tool writes resume=/resume_offset= to the
+    # bootloader, which only take effect after a reboot; without it the VM
+    # accepts the hibernate uevent but never suspends (seen on Debian 13).
     # A sleep(100) also works, but we are unsure of the exact time required.
     # So it is safer to reboot the VM.
-    if type(node.os) in (Redhat, AlmaLinux, SLES):
+    if type(node.os) in (Redhat, AlmaLinux, SLES, Debian):
         node.reboot()
 
     startstop = node.features[StartStop]

--- a/lisa/microsoft/testsuites/power/common.py
+++ b/lisa/microsoft/testsuites/power/common.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 from decimal import Decimal
-from time import sleep
 from typing import Any, List, cast
 
 from assertpy import assert_that
@@ -30,15 +29,32 @@ from lisa.tools import (
 from lisa.util import LisaException, SkippedException
 from lisa.util.perf_timer import create_timer
 
-# Azure returns VMHibernateFailed when a hibernate request is rejected, e.g. when
-# the guest is not yet ready shortly after boot (slow FIPS kernels can still be
-# completing crypto init). Azure guidance is to retry after ~5 minutes.
-# https://learn.microsoft.com/azure/virtual-machines/hibernate-resume-troubleshooting
+# Some Azure guest/kernel combinations, including certified FIPS kernels,
+# do not support hibernation at all. In those cases the platform returns
+# VMHibernateFailed on every attempt, so we treat it as an unmet precondition
+# rather than a transient failure that can be recovered with retry delay.
 _HIBERNATE_FAILED_MARKER = "VMHibernateFailed"
-_HIBERNATE_RETRY_INTERVAL_SECONDS = 300
+
+
+def _is_fips_kernel(node: Node) -> bool:
+    # Azure hibernation is unsupported on the certified FIPS kernel (e.g. Ubuntu
+    # Pro *-azure-fips): it returns VMHibernateFailed on every attempt, so this
+    # is an unmet precondition rather than a test failure.
+    fips_enabled = (
+        node.tools[Cat].read("/proc/sys/crypto/fips_enabled", force_run=True).strip()
+    )
+    kernel_version = node.execute("uname -r", shell=True).stdout.strip()
+    return fips_enabled == "1" or "fips" in kernel_version.lower()
 
 
 def is_distro_supported(node: Node) -> None:
+    if _is_fips_kernel(node):
+        raise SkippedException(
+            "Azure hibernation is not supported on FIPS-enabled kernels; "
+            f"the platform returns {_HIBERNATE_FAILED_MARKER} on every attempt. "
+            f"Kernel: {node.execute('uname -r', shell=True).stdout.strip()}"
+        )
+
     if not node.tools[KernelConfig].is_enabled("CONFIG_HIBERNATION"):
         raise SkippedException(
             f"CONFIG_HIBERNATION is not enabled in current distro {node.os.name}, "
@@ -158,29 +174,14 @@ def _perform_hibernation_cycle(
 
     boot_time_before_hibernation = who.last_boot()
 
-    # Retry a VMHibernateFailed result once, spaced by the Azure-recommended
-    # interval. A rejected hibernate leaves the VM running, so the guest is
-    # reachable for diagnostics and the request can be re-issued. Any other
-    # failure is raised immediately.
-    max_attempts = 2
-    for attempt in range(1, max_attempts + 1):
+    try:
+        startstop.stop(state=features.StopState.Hibernate)
+    except Exception as ex:
         try:
-            startstop.stop(state=features.StopState.Hibernate)
-            break
-        except Exception as ex:
-            try:
-                dmesg.get_output(force_run=True)
-            except Exception as e:
-                log.debug(f"error on get dmesg output: {e}")
-            if attempt < max_attempts and _HIBERNATE_FAILED_MARKER in str(ex):
-                log.info(
-                    f"hibernation attempt {attempt}/{max_attempts} returned "
-                    f"{_HIBERNATE_FAILED_MARKER}; retrying in "
-                    f"{_HIBERNATE_RETRY_INTERVAL_SECONDS}s per Azure guidance"
-                )
-                sleep(_HIBERNATE_RETRY_INTERVAL_SECONDS)
-                continue
-            raise LisaException(f"fail to hibernate: {ex}")
+            dmesg.get_output(force_run=True)
+        except Exception as e:
+            log.debug(f"error on get dmesg output: {e}")
+        raise LisaException(f"fail to hibernate: {ex}")
 
     is_ready = True
     timeout = 900


### PR DESCRIPTION
## Description

Skip hibernation tests on FIPS-enabled kernels (Azure returns `VMHibernateFailed` on every attempt, so it is an unmet precondition rather than a failure), and treat a missing `/proc/sys/crypto/fips_enabled` as FIPS-disabled instead of erroring. Also reboot after hibernation setup so the bootloader `resume=`/`resume_offset=` parameters take effect before hibernating.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_hibernation

**Impacted LISA Features:**
StartStop

**Tested Azure Marketplace Images:**
- redhat rhel 9_5 latest
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
- debian debian-12 12-gen2 latest

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
