### PR TITLE
[AI Generated] BugFix: skip libvirt TCK suite on FIPS-enabled kernels

### DIFF
--- a/lisa/microsoft/testsuites/libvirt/libvirt_tck.py
+++ b/lisa/microsoft/testsuites/libvirt/libvirt_tck.py
@@ -48,7 +48,9 @@ class LibvirtTckSuite(TestSuite):
         )
         if fips_result.exit_code == 0 and (fips_result.stdout or "").strip() == "1":
             raise SkippedException(
-                "The libvirt TCK suite is not supported on FIPS-enabled kernels."
+                "FIPS mode is enabled (/proc/sys/crypto/fips_enabled=1); the libvirt "
+                "TCK community suite is not FIPS-aware. Use a non-FIPS image/kernel "
+                "to run this suite."
             )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:

--- a/lisa/microsoft/testsuites/libvirt/libvirt_tck.py
+++ b/lisa/microsoft/testsuites/libvirt/libvirt_tck.py
@@ -8,7 +8,7 @@ from microsoft.testsuites.libvirt.libvirt_tck_tool import LibvirtTck
 from lisa import Logger, Node, TestCaseMetadata, TestSuite, TestSuiteMetadata
 from lisa.operating_system import CBLMariner, Ubuntu
 from lisa.testsuite import TestResult, simple_requirement
-from lisa.tools import Dmesg, Journalctl, Lscpu
+from lisa.tools import Cat, Dmesg, Journalctl, Lscpu
 from lisa.util import SkippedException
 
 
@@ -37,6 +37,19 @@ class LibvirtTckSuite(TestSuite):
         virtualization_enabled = node.tools[Lscpu].is_virtualization_enabled()
         if not virtualization_enabled:
             raise SkippedException("Virtualization is not enabled in hardware")
+
+        # The libvirt TCK community suite is not FIPS-aware. On FIPS-enabled
+        # kernels the suite is unreliable (tests either time out or report
+        # spurious failures), so skip it rather than fail on FIPS images.
+        fips_result = node.tools[Cat].run(
+            "/proc/sys/crypto/fips_enabled",
+            force_run=True,
+            no_error_log=True,
+        )
+        if fips_result.exit_code == 0 and (fips_result.stdout or "").strip() == "1":
+            raise SkippedException(
+                "The libvirt TCK suite is not supported on FIPS-enabled kernels."
+            )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         node = kwargs["node"]


### PR DESCRIPTION
## Summary
The libvirt TCK community suite is not FIPS-aware and is unreliable on FIPS-enabled kernels: on FIPS-enabled images the tests either time out or report spurious failures. This change skips `verify_libvirt_tck` when the kernel reports FIPS mode (`/proc/sys/crypto/fips_enabled` == `1`), mirroring the existing FIPS-skip pattern already used by `verify_cifs_basic` in the core storage suite.

The check is added to `LibvirtTckSuite.before_case` so the suite is skipped cleanly (with an explanatory message) rather than failing on FIPS images.

## Validation Results
| Image | Result |
|-------|--------|
| microsoftcblmariner azure-linux-3 azure-linux-3-gen2-fips 3.20260501.01 | SKIPPED (FIPS detected) |
| microsoftcblmariner azure-linux-3 azure-linux-3-gen2 3.20260501.01 | Runs (not skipped; behavior unchanged by this PR) |
