### PR TITLE
fix(verify_repository_installed): accept Azure archive for Ubuntu ARM…

### DIFF
--- a/lisa/microsoft/testsuites/core/azure_image_standard.py
+++ b/lisa/microsoft/testsuites/core/azure_image_standard.py
@@ -817,12 +817,15 @@ class AzureImageStandard(TestSuite):
             # verify repository configuration
             if isinstance(node.os, Ubuntu):
                 repo_url_map = {
-                    CpuArchitecture.X64: "azure.archive.ubuntu.com",
-                    CpuArchitecture.ARM64: "ports.ubuntu.com",
+                    CpuArchitecture.X64: ["azure.archive.ubuntu.com"],
+                    CpuArchitecture.ARM64: [
+                        "ports.ubuntu.com",
+                        "azure.archive.ubuntu.com",
+                    ],
                 }
                 lscpu = node.tools[Lscpu]
                 arch = lscpu.get_architecture()
-                repo_url = repo_url_map.get(arch, None)
+                repo_urls = repo_url_map.get(arch, [])
                 contains_security_keyword = any(
                     [
                         "-security" in repository.name
@@ -831,7 +834,7 @@ class AzureImageStandard(TestSuite):
                 )
                 contains_repo_url = any(
                     [
-                        str(repo_url) in repository.uri
+                        any(repo_url in repository.uri for repo_url in repo_urls)
                         for repository in debian_repositories
                     ]
                 )
@@ -850,7 +853,7 @@ class AzureImageStandard(TestSuite):
 
                 assert_that(
                     is_repository_configured_correctly,
-                    f"`{repo_url}`, `security`, "
+                    f"one of `{repo_urls}`, `security`, "
                     "`updates` should be in `apt-get "
                     "update` output",
                 ).is_true()


### PR DESCRIPTION
…64 repos

verify_repository_installed hard-coded `ports.ubuntu.com` as the only valid repository host for every Ubuntu ARM64 image. Ubuntu 26.04 ARM64 (canonical ubuntu-26_04-lts server-arm64) serves packages from `azure.archive.ubuntu.com`, so the hostname check failed even though the image was healthy.

Observed on Standard_D2plds_v6 / westus2:
  AssertionError: [`ports.ubuntu.com`, `security`, `updates` should be in
  `apt-get update` output] Expected <True>, but was not.

Both `apt-get update` runs exited 0 and the resolute-updates and resolute-security pockets were present, so only the host predicate was false. This was a stale test expectation, not an image or network failure.

Change the per-architecture map to hold a list of accepted hosts and allow Ubuntu ARM64 to match either `ports.ubuntu.com` or `azure.archive.ubuntu.com`, keeping existing ports-based ARM64 images passing. x64 behavior is unchanged. The assertion message now lists the accepted hosts.

Canonical confirmed this change about repos in 2604+ arm64 images.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
- verify_repository_installed

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->


**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- canonical ubuntu-24_04-lts server-arm64 latest
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-arm64 latest
- canonical ubuntu-24_04-lts server latest
- Canonical ubuntu-26_04-lts server-arm64 latest

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|Canonical ubuntu-26_04-lts server-arm64 latest|Standard_D2plds_v6|PASSED|
