### PR TITLE
Fix verify_sriov_ethtool_offload_setting timing out on MANA-based Azure VMs

### DIFF
--- a/lisa/microsoft/testsuites/network/sriov.py
+++ b/lisa/microsoft/testsuites/network/sriov.py
@@ -539,8 +539,8 @@ class Sriov(TestSuite):
         Steps,
         1. Change scatter-gather feature on synthetic nic,
          verify the the feature status sync to the VF dynamically.
-        2. Disable and enable sriov,
-         check the scatter-gather feature status keep consistent in VF.
+        2. Rescind and re-add the VFs through PCI sysfs,
+         check the scatter-gather feature status keeps consistent in VF.
         """,
         priority=2,
         requirement=simple_requirement(
@@ -650,8 +650,8 @@ class Sriov(TestSuite):
                 "sg setting is not sync into VF.",
             ).is_equal_to(False)
 
-        # disable and enable sriov in network interface level
-        sriov_disable_enable(environment, 3)
+        # Rescind and re-add the VFs through PCI sysfs
+        disable_enable_devices(environment)
         # check VF still paired with synthetic nic
         vm_nics = initialize_nic_info(environment)
 

--- a/lisa/tools/ethtool.py
+++ b/lisa/tools/ethtool.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Any, Dict, List, Optional, Set, Type, cast
 
 from lisa.executable import Tool
@@ -11,9 +12,10 @@ from lisa.util import (
     find_groups_in_lines,
 )
 
-from .find import Find
 from .ip import Ip
+from .ls import Ls
 from .lscpu import Lscpu
+from .readlink import Readlink
 
 # Few ethtool device settings follow similar pattern like -
 #   ethtool device channel info from "ethtool -l eth0"
@@ -525,23 +527,16 @@ class Ethtool(Tool):
         if (not force_run) and self._device_set:
             return self._device_set
 
-        find_tool = self.node.tools[Find]
-        netdirs = find_tool.find_files(
-            self.node.get_pure_path("/sys/devices"),
-            name_pattern="net",
-            path_pattern=["*vmbus*", "*MSFT*"],
-            ignore_case=True,
-        )
-        for netdir in netdirs:
-            if not netdir:
-                continue
-            cmd_result = self.node.execute(f"ls {netdir}")
-            cmd_result.assert_exit_code(message="Could not find the network device.")
-            for result in cmd_result.stdout.split():
-                # add only the network devices with netvsc driver
-                driver = self.get_device_driver(result)
-                if "hv_netvsc" in driver:
-                    self._device_set.add(result)
+        self._device_set.clear()
+        readlink = self.node.tools[Readlink]
+        for interface_path in self.node.tools[Ls].list_dir("/sys/class/net"):
+            interface = PurePath(interface_path).name
+            driver_path = readlink.get_canonical_path(
+                f"/sys/class/net/{interface}/device/driver",
+                no_error_log=True,
+            )
+            if PurePath(driver_path).name == "hv_netvsc":
+                self._device_set.add(interface)
 
         if not self._device_set:
             raise LisaException("Did not find any synthetic network interface.")


### PR DESCRIPTION
## Description

`Ethtool.get_device_list()` previously searched recursively through `/sys/devices`. This traverses the complete dynamic device hierarchy and can block before returning the discovered interfaces. The implementation now enumerates the flat `/sys/class/net` interface registry and resolves each interface's driver symlink, selecting only `hv_netvsc` devices.

The test also previously changed Azure Accelerated Networking on a running VM to trigger VF removal. The control-plane setting can change without causing a live VF revocation. The test now uses PCI remove/rescan, directly exercising the guest VF removal, NetVSC fallback, MANA reprobe, and offload-setting recovery paths.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_sriov_ethtool_offload_setting

**Impacted LISA Features:**
NetworkInterface

**Tested Azure Marketplace Images:**
- canonical ubuntu-24_04-lts server latest

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| `canonical ubuntu-24_04-lts server 24.04.202608070` | Standard_D2ds_v7 | PASSED |
| [Ubuntu 24.04 BOSH Linux stemcell](https://storage.googleapis.com/bosh-core-stemcells/1.484/bosh-stemcell-1.484-azure-hyperv-ubuntu-noble.tgz) | Standard_D2ds_v7 | PASSED |
| [Ubuntu 24.04 BOSH Linux stemcell](https://storage.googleapis.com/bosh-core-stemcells/1.484/bosh-stemcell-1.484-azure-hyperv-ubuntu-noble.tgz) | Standard_D8as_v5 | PASSED |
