### PR TITLE
feat(vm_extensions): add boot validation tests for Azure Security Linux Agent and Azure Monitor Linux Agent

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any, Dict
+
+from microsoft.testsuites.vm_extensions.vm_extension_base import VmExtensionTestBase
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuiteMetadata, simple_requirement
+from lisa.operating_system import BSD
+from lisa.sut_orchestrator import AZURE
+from lisa.sut_orchestrator.azure.features import AzureExtension
+
+
+@TestSuiteMetadata(
+    area="vm_extension",
+    category="functional",
+    description="""
+    This test suite validates the Azure Monitor Agent Linux VM extension
+    (Microsoft.Azure.Monitor.AzureMonitorLinuxAgent).
+
+    Coverage starts with boot validation: install the extension with empty
+    settings, confirm provisioning succeeds, confirm the requested version was
+    installed, confirm the VM is still reachable over SSH, then remove the
+    extension.
+    """,
+    tags=["VM_Extension", "AzureMonitorLinuxAgent"],
+    requirement=simple_requirement(
+        supported_features=[AzureExtension],
+        supported_platform_type=[AZURE],
+        unsupported_os=[BSD],
+    ),
+)
+class AzureMonitorLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
+    PUBLISHER = "Microsoft.Azure.Monitor"
+    EXTENSION_TYPE = "AzureMonitorLinuxAgent"
+    EXTENSION_KEY = "azure_monitor_linux_agent"
+
+    @TestCaseMetadata(
+        description="""
+        Basic boot validation for the Azure Monitor Agent Linux VM extension.
+
+        Installs the explicitly requested candidate version with empty public
+        settings and no protected settings. Verifies that extension provisioning
+        succeeds, the installed patch version matches when a full version is
+        supplied, and the VM remains reachable before removing the extension.
+
+        The candidate version is read from the 'extension_version' or
+        'azure_monitor_linux_agent_version' runbook variable.
+        """,
+        priority=5,
+        maturity="preview",
+    )
+    def microsoft_azure_monitor_azuremonitorlinuxagent_boot_validation_test(
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        self._boot_validation(
+            node=node,
+            log=log,
+            variables=variables,
+            settings={},
+        )

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from typing import Any, Dict
+
+from microsoft.testsuites.vm_extensions.vm_extension_base import VmExtensionTestBase
+
+from lisa import Logger, Node, TestCaseMetadata, TestSuiteMetadata, simple_requirement
+from lisa.operating_system import BSD
+from lisa.sut_orchestrator import AZURE
+from lisa.sut_orchestrator.azure.features import AzureExtension
+
+
+@TestSuiteMetadata(
+    area="vm_extension",
+    category="functional",
+    description="""
+    This test suite validates the Azure Security Linux Agent VM extension
+    (Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent).
+
+    Coverage starts with boot validation: install the extension with empty
+    settings, confirm provisioning succeeds, confirm the requested version was
+    installed, confirm the VM is still reachable over SSH, then remove the
+    extension.
+    """,
+    tags=["VM_Extension", "AzureSecurityLinuxAgent"],
+    requirement=simple_requirement(
+        supported_features=[AzureExtension],
+        supported_platform_type=[AZURE],
+        unsupported_os=[BSD],
+    ),
+)
+class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
+    PUBLISHER = "Microsoft.Azure.Security.Monitoring"
+    EXTENSION_TYPE = "AzureSecurityLinuxAgent"
+    EXTENSION_KEY = "azure_security_linux_agent"
+
+    @TestCaseMetadata(
+        description="""
+        Basic boot validation for the Azure Security Linux Agent VM extension.
+
+        Installs the explicitly requested candidate version with empty public
+        settings and no protected settings. Verifies that extension provisioning
+        succeeds, the installed patch version matches when a full version is
+        supplied, and the VM remains reachable before removing the extension.
+
+        The candidate version is read from the 'extension_version' or
+        'azure_security_linux_agent_version' runbook variable.
+        """,
+        priority=5,
+        maturity="preview",
+    )
+    def microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test(  # noqa: E501
+        self, log: Logger, node: Node, variables: Dict[str, Any]
+    ) -> None:
+        self._boot_validation(
+            node=node,
+            log=log,
+            variables=variables,
+            settings={},
+        )


### PR DESCRIPTION
## Summary

Adds dedicated **boot-validation** test suites for two VM extensions, following the existing `VmExtensionTestBase` onboarding pattern (same as CustomScript / AKS Linux Billing):

- **Azure Security Linux Agent** — `Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent`
- **Azure Monitor Linux Agent** — `Microsoft.Azure.Monitor.AzureMonitorLinuxAgent`

Each suite installs the extension with empty settings, asserts provisioning succeeds, verifies the installed version (when a full `Major.Minor.Patch` is requested), confirms the VM stays reachable over SSH, then removes the extension. All logic is delegated to the shared `_boot_validation` helper — no duplicated flow.

No boot-validation coverage existed for either extension. The existing `AzureMonitorAgentLinux` suite only provides a separate functional `verify_azuremonitoragent_linux` test and is left untouched.

## Validation

Both files pass: `py_compile`, `flake8`, `isort`, `black`, and strict `mypy`, and register correctly with the LISA test selector (`area=vm_extension`, `category=functional`, `priority=5`, `maturity=preview`).

Version is read from the `extension_version` (or the per-suite `{key}_version`) runbook variable; it is required (no default fallback), matching the boot-validation contract.

## Test guidance

**Key Test Cases:**
microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test|microsoft_azure_monitor_azuremonitorlinuxagent_boot_validation_test

**Impacted LISA Features:**
AzureExtension

**Tested Azure Marketplace Images:**
- canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest
