### PR TITLE
[AI Generated] BugFix: add MANA dmesg diagnostics

### DIFF
--- a/lisa/microsoft/testsuites/network/common.py
+++ b/lisa/microsoft/testsuites/network/common.py
@@ -18,9 +18,7 @@ _NETWORK_DRIVER_ERROR_PATTERNS: Dict[str, List[Pattern[str]]] = {
         # Sample: mana 7870:00:00.0: gdma probe failed
         re.compile(r"\bmana\s+\S+:\s+gdma probe failed\b", re.IGNORECASE),
         # Sample: mana: probe of 7870:00:00.0 failed with error -71
-        re.compile(
-            r"\bmana:\s+probe of \S+ failed with error\b", re.IGNORECASE
-        ),
+        re.compile(r"\bmana:\s+probe of \S+ failed with error\b", re.IGNORECASE),
     ],
     "mlx4_core": [
         # Sample: mlx4_core 0001:00:00.0: probe with driver mlx4_core failed...

--- a/lisa/microsoft/testsuites/network/common.py
+++ b/lisa/microsoft/testsuites/network/common.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import re
-from typing import Dict, List, Tuple, cast
+from typing import Dict, List, Pattern, Tuple, cast
 
 from assertpy import assert_that
 from retry import retry
@@ -13,18 +13,46 @@ from lisa.operating_system import BSD
 from lisa.tools import Dhclient, Dmesg, Ip, IpInfo, Kill, Lspci, Ssh
 from lisa.util import find_patterns_in_lines
 
-_MANA_ERROR_PATTERNS = [
-    # Sample: mana 7870:00:00.0: gdma probe failed
-    re.compile(
-        r"\bmana\s+\S+:\s+gdma probe failed\b",
-        re.IGNORECASE,
-    ),
-    # Sample: mana: probe of 7870:00:00.0 failed with error -71
-    re.compile(
-        r"\bmana:\s+probe of \S+ failed with error\b",
-        re.IGNORECASE,
-    ),
-]
+_NETWORK_DRIVER_ERROR_PATTERNS: Dict[str, List[Pattern[str]]] = {
+    "mana": [
+        # Sample: mana 7870:00:00.0: gdma probe failed
+        re.compile(r"\bmana\s+\S+:\s+gdma probe failed\b", re.IGNORECASE),
+        # Sample: mana: probe of 7870:00:00.0 failed with error -71
+        re.compile(
+            r"\bmana:\s+probe of \S+ failed with error\b", re.IGNORECASE
+        ),
+    ],
+    "mlx4_core": [
+        # Sample: mlx4_core 0001:00:00.0: probe with driver mlx4_core failed...
+        re.compile(
+            r"\bmlx4_core\s+\S+:\s+probe with driver mlx4_core failed with error\b",
+            re.IGNORECASE,
+        ),
+    ],
+    "mlx5_core": [
+        # Sample: mlx5_core 0001:00:00.0: probe with driver mlx5_core failed...
+        re.compile(
+            r"\bmlx5_core\s+\S+:\s+probe with driver mlx5_core failed with error\b",
+            re.IGNORECASE,
+        ),
+    ],
+}
+
+
+def get_network_driver_error(node: Node) -> str:
+    """Return the first dmesg initialization error for an attached SR-IOV NIC."""
+    drivers = node.nics.get_sriov_network_drivers()
+    if not drivers:
+        return ""
+
+    dmesg_log = node.tools[Dmesg].get_output(force_run=True)
+    for driver in drivers:
+        patterns = _NETWORK_DRIVER_ERROR_PATTERNS.get(driver, [])
+        errors = find_patterns_in_lines(dmesg_log, patterns)
+        error = next((match for matches in errors for match in matches), "")
+        if error:
+            return f"{driver} error found in dmesg: {' '.join(error.split())}"
+    return ""
 
 
 @retry(exceptions=AssertionError, tries=30, delay=2)  # type:ignore
@@ -69,23 +97,15 @@ def initialize_nic_info(
             ).is_true()
         if is_sriov:
             pci_nic_count = len(nics_info.get_pci_nics(exclude_ib=True))
-            mana_error = ""
+            driver_error = ""
             if pci_nic_count != sriov_count:
-                dmesg_log = node.tools[Dmesg].get_output(force_run=True)
-                mana_errors = find_patterns_in_lines(dmesg_log, _MANA_ERROR_PATTERNS)
-                mana_error = next(
-                    (match for matches in mana_errors for match in matches), ""
-                )
-                if mana_error:
-                    mana_error = " ".join(mana_error.split())
-            mana_message = (
-                f" MANA error found in dmesg: {mana_error}" if mana_error else ""
-            )
+                driver_error = get_network_driver_error(node)
+            driver_error_message = f" {driver_error}" if driver_error else ""
             assert_that(pci_nic_count).described_as(
                 f"Ethernet VF count inside VM (without IB) is {pci_nic_count}, "
                 f"actual sriov nic count is {sriov_count}. "
                 f"Total PCI NICs: {nics_info.get_pci_nics()}."
-                f"{mana_message}"
+                f"{driver_error_message}"
             ).is_equal_to(sriov_count)
         vm_nics[node.name] = nics_info.nics
 

--- a/lisa/microsoft/testsuites/network/common.py
+++ b/lisa/microsoft/testsuites/network/common.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
+import re
 from typing import Dict, List, Tuple, cast
 
 from assertpy import assert_that
@@ -9,7 +10,21 @@ from lisa import Environment, Node, RemoteNode, SkippedException, constants
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import BSD
-from lisa.tools import Dhclient, Ip, IpInfo, Kill, Lspci, Ssh
+from lisa.tools import Dhclient, Dmesg, Ip, IpInfo, Kill, Lspci, Ssh
+from lisa.util import find_patterns_in_lines
+
+_MANA_ERROR_PATTERNS = [
+    # Sample: mana 7870:00:00.0: gdma probe failed
+    re.compile(
+        r"\bmana\s+\S+:\s+gdma probe failed\b",
+        re.IGNORECASE,
+    ),
+    # Sample: mana: probe of 7870:00:00.0 failed with error -71
+    re.compile(
+        r"\bmana:\s+probe of \S+ failed with error\b",
+        re.IGNORECASE,
+    ),
+]
 
 
 @retry(exceptions=AssertionError, tries=30, delay=2)  # type:ignore
@@ -54,10 +69,23 @@ def initialize_nic_info(
             ).is_true()
         if is_sriov:
             pci_nic_count = len(nics_info.get_pci_nics(exclude_ib=True))
+            mana_error = ""
+            if pci_nic_count != sriov_count:
+                dmesg_log = node.tools[Dmesg].get_output(force_run=True)
+                mana_errors = find_patterns_in_lines(dmesg_log, _MANA_ERROR_PATTERNS)
+                mana_error = next(
+                    (match for matches in mana_errors for match in matches), ""
+                )
+                if mana_error:
+                    mana_error = " ".join(mana_error.split())
+            mana_message = (
+                f" MANA error found in dmesg: {mana_error}" if mana_error else ""
+            )
             assert_that(pci_nic_count).described_as(
                 f"Ethernet VF count inside VM (without IB) is {pci_nic_count}, "
                 f"actual sriov nic count is {sriov_count}. "
-                f"Total PCI NICs: {nics_info.get_pci_nics()}"
+                f"Total PCI NICs: {nics_info.get_pci_nics()}."
+                f"{mana_message}"
             ).is_equal_to(sriov_count)
         vm_nics[node.name] = nics_info.nics
 

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -144,16 +144,6 @@ class Nics(InitializableMixin):
         ),
     }
 
-    # The PCI device may be visible even when its driver fails to load. Keep this
-    # mapping here so callers can identify the expected driver in either state.
-    _sriov_device_driver_map = {
-        "1414:00ba": "mana",
-        "15b3:1004": "mlx4_core",
-        "15b3:1016": "mlx5_core",
-        "15b3:1018": "mlx5_core",
-        "15b3:101a": "mlx5_core",
-    }
-
     def __init__(self, node: "Node"):
         super().__init__()
         self._node = node
@@ -247,12 +237,12 @@ class Nics(InitializableMixin):
             if module_name in self._device_module_map and module_name not in drivers:
                 drivers.append(module_name)
 
-        pci_devices = self._node.tools[Lspci].get_devices_by_type(
+        lspci = self._node.tools[Lspci]
+        pci_devices = lspci.get_devices_by_type(
             constants.DEVICE_TYPE_SRIOV, force_run=True
         )
         for pci_device in pci_devices:
-            pci_id = f"{pci_device.vendor_id}:{pci_device.device_id}".lower()
-            driver = self._sriov_device_driver_map.get(pci_id)
+            driver = lspci.get_network_device_module(pci_device)
             if driver and driver not in drivers:
                 drivers.append(driver)
 

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -242,7 +242,7 @@ class Nics(InitializableMixin):
             constants.DEVICE_TYPE_SRIOV, force_run=True
         )
         for pci_device in pci_devices:
-            driver = lspci.get_network_device_module(pci_device)
+            driver = lspci.get_device_module(constants.DEVICE_TYPE_SRIOV, pci_device)
             if driver and driver not in drivers:
                 drivers.append(driver)
 

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -147,11 +147,11 @@ class Nics(InitializableMixin):
     # The PCI device may be visible even when its driver fails to load. Keep this
     # mapping here so callers can identify the expected driver in either state.
     _sriov_device_driver_map = {
-        "00ba": "mana",
-        "1004": "mlx4_core",
-        "1016": "mlx5_core",
-        "1018": "mlx5_core",
-        "101a": "mlx5_core",
+        "1414:00ba": "mana",
+        "15b3:1004": "mlx4_core",
+        "15b3:1016": "mlx5_core",
+        "15b3:1018": "mlx5_core",
+        "15b3:101a": "mlx5_core",
     }
 
     def __init__(self, node: "Node"):
@@ -251,7 +251,8 @@ class Nics(InitializableMixin):
             constants.DEVICE_TYPE_SRIOV, force_run=True
         )
         for pci_device in pci_devices:
-            driver = self._sriov_device_driver_map.get(pci_device.device_id)
+            pci_id = f"{pci_device.vendor_id}:{pci_device.device_id}".lower()
+            driver = self._sriov_device_driver_map.get(pci_id)
             if driver and driver not in drivers:
                 drivers.append(driver)
 

--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -144,6 +144,16 @@ class Nics(InitializableMixin):
         ),
     }
 
+    # The PCI device may be visible even when its driver fails to load. Keep this
+    # mapping here so callers can identify the expected driver in either state.
+    _sriov_device_driver_map = {
+        "00ba": "mana",
+        "1004": "mlx4_core",
+        "1016": "mlx5_core",
+        "1018": "mlx5_core",
+        "101a": "mlx5_core",
+    }
+
     def __init__(self, node: "Node"):
         super().__init__()
         self._node = node
@@ -225,6 +235,27 @@ class Nics(InitializableMixin):
             if item in used_module_list:
                 used_module_list.remove(item)
         return used_module_list
+
+    def get_sriov_network_drivers(self) -> List[str]:
+        """Return the MANA or Mellanox drivers used by the SR-IOV NICs.
+
+        Fall back to the PCI device ID when a device has no bound driver, which
+        is the state where driver initialization diagnostics are most useful.
+        """
+        drivers: List[str] = []
+        for module_name in self.get_used_modules(["hv_netvsc"]):
+            if module_name in self._device_module_map and module_name not in drivers:
+                drivers.append(module_name)
+
+        pci_devices = self._node.tools[Lspci].get_devices_by_type(
+            constants.DEVICE_TYPE_SRIOV, force_run=True
+        )
+        for pci_device in pci_devices:
+            driver = self._sriov_device_driver_map.get(pci_device.device_id)
+            if driver and driver not in drivers:
+                drivers.append(driver)
+
+        return drivers
 
     def get_device_slots(self, exclude_ib: bool = False) -> List[str]:
         """Get PCI slots for NICs.

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -115,6 +115,14 @@ VENDOR_ID_DICT: Dict[str, List[str]] = {
     constants.DEVICE_TYPE_AMD_GPU: [VENDOR_ID_AMD],
 }
 
+NETWORK_DEVICE_MODULE_DICT: Dict[str, str] = {
+    f"{VENDOR_ID_MICROSOFT}:00ba": "mana",
+    f"{VENDOR_ID_MELLANOX}:1004": "mlx4_core",
+    f"{VENDOR_ID_MELLANOX}:1016": "mlx5_core",
+    f"{VENDOR_ID_MELLANOX}:1018": "mlx5_core",
+    f"{VENDOR_ID_MELLANOX}:101a": "mlx5_core",
+}
+
 CONTROLLER_ID_DICT: Dict[str, List[str]] = {
     constants.DEVICE_TYPE_SRIOV: [
         "0200",  # Ethernet controller
@@ -386,6 +394,10 @@ class Lspci(Tool):
         )
         matched = get_matched_str(result.stdout, PATTERN_MODULE_IN_USE)
         return matched
+
+    def get_network_device_module(self, device: PciDevice) -> str:
+        pci_id = f"{device.vendor_id}:{device.device_id}".lower()
+        return NETWORK_DEVICE_MODULE_DICT.get(pci_id, "")
 
     def get_gpu_devices(self, force_run: bool = False) -> List[PciDevice]:
         class_names = DEVICE_TYPE_DICT[constants.DEVICE_TYPE_GPU]

--- a/lisa/tools/lspci.py
+++ b/lisa/tools/lspci.py
@@ -115,12 +115,14 @@ VENDOR_ID_DICT: Dict[str, List[str]] = {
     constants.DEVICE_TYPE_AMD_GPU: [VENDOR_ID_AMD],
 }
 
-NETWORK_DEVICE_MODULE_DICT: Dict[str, str] = {
-    f"{VENDOR_ID_MICROSOFT}:00ba": "mana",
-    f"{VENDOR_ID_MELLANOX}:1004": "mlx4_core",
-    f"{VENDOR_ID_MELLANOX}:1016": "mlx5_core",
-    f"{VENDOR_ID_MELLANOX}:1018": "mlx5_core",
-    f"{VENDOR_ID_MELLANOX}:101a": "mlx5_core",
+DEVICE_MODULE_DICT: Dict[str, Dict[str, str]] = {
+    constants.DEVICE_TYPE_SRIOV: {
+        f"{VENDOR_ID_MICROSOFT}:00ba": "mana",
+        f"{VENDOR_ID_MELLANOX}:1004": "mlx4_core",
+        f"{VENDOR_ID_MELLANOX}:1016": "mlx5_core",
+        f"{VENDOR_ID_MELLANOX}:1018": "mlx5_core",
+        f"{VENDOR_ID_MELLANOX}:101a": "mlx5_core",
+    }
 }
 
 CONTROLLER_ID_DICT: Dict[str, List[str]] = {
@@ -395,9 +397,9 @@ class Lspci(Tool):
         matched = get_matched_str(result.stdout, PATTERN_MODULE_IN_USE)
         return matched
 
-    def get_network_device_module(self, device: PciDevice) -> str:
+    def get_device_module(self, device_type: str, device: PciDevice) -> str:
         pci_id = f"{device.vendor_id}:{device.device_id}".lower()
-        return NETWORK_DEVICE_MODULE_DICT.get(pci_id, "")
+        return DEVICE_MODULE_DICT.get(device_type.upper(), {}).get(pci_id, "")
 
     def get_gpu_devices(self, force_run: bool = False) -> List[PciDevice]:
         class_names = DEVICE_TYPE_DICT[constants.DEVICE_TYPE_GPU]


### PR DESCRIPTION
## Description

Add dmesg-based MANA probe failure detection to SR-IOV VF count mismatch errors, so failures can be classified as MANA driver related when applicable.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
verify_sriov_add_max_nics

**Impacted LISA Features:**
NA

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->


## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|   microsoftcblmariner cbl-mariner cbl-mariner-2-gen2 2.20241230.02    |   Standard_L16s_v4      |  FAILED |

```
Sriov.verify_sriov_add_max_nics: FAILED   failed. AssertionError: [Ethernet VF count inside VM (without IB) is 0, actual sriov nic count is 8. Total PCI NICs: [].  
MANA error found in dmesg: mana 7870:00:00.0: HWC: Failed hw_channel req: 0xc00000bb
 [ 6.737085] mana 7870:00:00.0: VfVerifyVersionOutput: -71, status=0xc00000bb 
 [ 6.740790] mana 7870:00:00.0: gdma probe failed] Expected <0> to be equal to <8>, but was not.
```
