### PR TITLE
cvm: repair interrupted dpkg state before running cvm-attestation ins…

### DIFF
--- a/lisa/microsoft/testsuites/cvm/cvm_attestation_tool.py
+++ b/lisa/microsoft/testsuites/cvm/cvm_attestation_tool.py
@@ -102,6 +102,11 @@ class AzureCVMAttestationTests(Tool):
 
     def _install(self) -> bool:
         self._clone_repo()
+        # install.sh calls apt directly, bypassing LISA's package manager
+        # handling, so repair any interrupted dpkg state left by the image
+        # first, otherwise every apt call in the script fails.
+        if isinstance(self.node.os, Ubuntu):
+            self.node.os.wait_running_package_process()
         self.node.execute(
             "sudo ./install.sh",
             shell=True,


### PR DESCRIPTION
…tall.sh

The CVM attestation tool shells out to the upstream install.sh, which calls apt directly and bypasses LISA's package manager handling. On images that boot with dpkg in an interrupted state, every apt call in that script fails with 'E: dpkg was interrupted', install.sh exits 1, /usr/local/bin/attest is never built, and the test fails with the misleading 'install azurecvmattestationtests failed. After installed, it cannot be detected.'

Call Debian.wait_running_package_process() before install.sh so the existing 'dpkg --force-all --configure -a' repair runs first.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_azure_cvm_attestation_report

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- LSGSIG/proposedkernelgallery/jammy_linux-azure-fde_6.8.0-1065.72.22.04.1_x64_gen2/01.10.38

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|LSGSIG/proposedkernelgallery/jammy_linux-azure-fde_6.8.0-1065.72.22.04.1_x64_gen2/01.10.38|Standard_NCC40ads_H100_v5|PASSED|
