### PR TITLE
[AI Generated] BugFix: add SecureBoot to TrustedLaunchAndConfidentialVmSupported Linux image capabilities

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -394,8 +394,16 @@ class AzureImageSchema(schema.ImageSchema):
                 ]
             )
             encrypt_capability.append(True)
+        elif security_profile == "TrustedLaunchAndConfidentialVmSupported":
+            security_profile_capabilities.extend(
+                [
+                    SecurityProfileType.SecureBoot,
+                    SecurityProfileType.CVM,
+                    SecurityProfileType.Stateless,
+                ]
+            )
+            encrypt_capability.append(True)
         elif security_profile in (
-            "TrustedLaunchAndConfidentialVmSupported",
             "ConfidentialVmSupported",
             "ConfidentialVM",
         ):


### PR DESCRIPTION
## Summary

Linux images with `SecurityType=TrustedLaunchAndConfidentialVmSupported` were missing `SecureBoot` from their parsed security profile capabilities. This caused test cases requiring `security_profile: secureboot` to be skipped with:

```
capability doesn't support requirement: security_profile: requires [secureboot] but VM supports [cvm, stateless]
```

The Windows code path correctly included `SecureBoot` for the same SecurityType, but the Linux/generic path only set `[CVM, Stateless]`. This fix adds `SecurityProfileType.SecureBoot` to align with the Windows behavior and Azure documentation.

## Validation Results
| Image | Result |
|-------|--------|
| almalinux almalinux-x86_64 9-gen2 latest | PASSED |
| canonical 0001-com-ubuntu-server-jammy 22_04-lts-gen2 latest | PASSED |