### PR TITLE
change kernel version match logic for LVBS kernel package

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2388,7 +2388,7 @@ class CBLMariner(RPMDistro):
     @staticmethod
     def _get_kernel_version_candidates(kernel_version: str) -> List[str]:
         rpm_version_pattern = re.compile(
-            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)" r"\.(x86_64|aarch64)$"
+            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)\.(x86_64|aarch64)$"
         )
         match_result = find_group_in_lines(
             kernel_version, rpm_version_pattern, single_line=True
@@ -2466,7 +2466,7 @@ class CBLMariner(RPMDistro):
             match_result = find_group_in_lines(
                 grub_cfg_result.stdout, menu_entry_pattern, single_line=True
             )
-            menu_entry_name = match_result.get("entry")
+            menu_entry_name = match_result.get("entry", "")
             if menu_entry_name:
                 matched_version = version_candidate
                 break

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2458,7 +2458,7 @@ class CBLMariner(RPMDistro):
         # => menuentry 'AzureLinux GNU/Linux, with Linux 6.6.96-3.cm2'
         menu_entry_name = ""
         matched_version = extracted_version
-        for version_candidate in version_candidates:
+        for version_candidate in sorted(version_candidates, key=len, reverse=True):
             menu_entry_pattern = re.compile(
                 rf"menuentry '(?P<entry>[^']*{re.escape(version_candidate)}\s*)'",
                 re.IGNORECASE,

--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2385,6 +2385,37 @@ class CBLMariner(RPMDistro):
         cat = self._node.tools[Cat]
         cat.run("/etc/default/grub")
 
+    @staticmethod
+    def _get_kernel_version_candidates(kernel_version: str) -> List[str]:
+        rpm_version_pattern = re.compile(
+            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)" r"\.(x86_64|aarch64)$"
+        )
+        match_result = find_group_in_lines(
+            kernel_version, rpm_version_pattern, single_line=True
+        )
+        extracted_version = match_result.get("version")
+        if not extracted_version:
+            return [kernel_version]
+
+        candidates = [extracted_version]
+        flavored_rpm_pattern = re.compile(
+            r"^kernel-(?P<flavor>[^-]+)-"
+            r"(?P<version>\d+(?:\.\d+)+)-(?P<release>.+)"
+            r"\.(x86_64|aarch64)$"
+        )
+        flavored_match = find_group_in_lines(
+            kernel_version, flavored_rpm_pattern, single_line=True
+        )
+        if all(flavored_match.get(group) for group in ("flavor", "version", "release")):
+            flavored_version = (
+                f"{flavored_match['version']}-{flavored_match['flavor']}-"
+                f"{flavored_match['release']}"
+            )
+            if flavored_version not in candidates:
+                candidates.append(flavored_version)
+
+        return candidates
+
     def replace_boot_kernel(self, kernel_version: str) -> None:
         self._log.info(
             f"Configuring Grub to boot into kernel version: {kernel_version}"
@@ -2395,15 +2426,9 @@ class CBLMariner(RPMDistro):
         # kernel-lvbs-6.6.89-9.cm2.x86_64 -> 6.6.89-9.cm2
         # kernel-6.6.89-9.azl3.x86_64 -> 6.6.89-9.azl3
         # kernel-6.6.89-9.azl3.aarch64 -> 6.6.89-9.azl3
-        extracted_version = kernel_version
-        rpm_version_pattern = re.compile(
-            r"^kernel-(?:[^-]+-)*(?P<version>\d+\.\d+\.\d+.*?)\.(x86_64|aarch64)$"
-        )
-        match_result = find_group_in_lines(
-            kernel_version, rpm_version_pattern, single_line=True
-        )
-        if match_result.get("version"):
-            extracted_version = match_result["version"]
+        version_candidates = self._get_kernel_version_candidates(kernel_version)
+        extracted_version = version_candidates[0]
+        if extracted_version != kernel_version:
             self._log.info(
                 f"Extracted kernel version '{extracted_version}' "
                 f"from RPM package '{kernel_version}'"
@@ -2431,19 +2456,25 @@ class CBLMariner(RPMDistro):
         # Examples of potential menu entries:
         # For kernel-6.6.96-3.cm2.x86_64 => 6.6.96-3.cm2
         # => menuentry 'AzureLinux GNU/Linux, with Linux 6.6.96-3.cm2'
-        menu_entry_pattern = re.compile(
-            rf"menuentry '(?P<entry>[^']*{re.escape(extracted_version)}\s*)'",
-            re.IGNORECASE,
-        )
-        match_result = find_group_in_lines(
-            grub_cfg_result.stdout, menu_entry_pattern, single_line=True
-        )
-        menu_entry_name = match_result.get("entry")
+        menu_entry_name = ""
+        matched_version = extracted_version
+        for version_candidate in version_candidates:
+            menu_entry_pattern = re.compile(
+                rf"menuentry '(?P<entry>[^']*{re.escape(version_candidate)}\s*)'",
+                re.IGNORECASE,
+            )
+            match_result = find_group_in_lines(
+                grub_cfg_result.stdout, menu_entry_pattern, single_line=True
+            )
+            menu_entry_name = match_result.get("entry")
+            if menu_entry_name:
+                matched_version = version_candidate
+                break
 
         if not menu_entry_name:
             self._log.warning(
                 f"Could not find GRUB menu entry for kernel version "
-                f"'{extracted_version}' (original: '{kernel_version}'). "
+                f"candidates {version_candidates} (original: '{kernel_version}'). "
                 f"GRUB configuration may not be updated properly."
             )
             return
@@ -2465,7 +2496,7 @@ class CBLMariner(RPMDistro):
 
         self._log.info(
             f"Successfully configured GRUB to boot into kernel version "
-            f"'{extracted_version}' (from RPM package '{kernel_version}')"
+            f"'{matched_version}' (from RPM package '{kernel_version}')"
         )
 
 

--- a/selftests/test_operating_system.py
+++ b/selftests/test_operating_system.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+from assertpy import assert_that
+
+from lisa.operating_system import CBLMariner
+
+
+class OperatingSystemTestCase(TestCase):
+    def test_get_kernel_version_candidates_for_standard_kernel(self) -> None:
+        candidates = CBLMariner._get_kernel_version_candidates(
+            "kernel-6.6.135-1.azl3.x86_64"
+        )
+
+        assert_that(candidates).is_equal_to(["6.6.135-1.azl3"])
+
+    def test_get_kernel_version_candidates_for_flavored_kernel(self) -> None:
+        candidates = CBLMariner._get_kernel_version_candidates(
+            "kernel-lvbs-6.6.135-1.azl3.x86_64"
+        )
+
+        assert_that(candidates).is_equal_to(["6.6.135-1.azl3", "6.6.135-lvbs-1.azl3"])
+
+    def test_get_kernel_version_candidates_for_unrecognized_name(self) -> None:
+        candidates = CBLMariner._get_kernel_version_candidates("custom-kernel")
+
+        assert_that(candidates).is_equal_to(["custom-kernel"])


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->
The logic for kernel match in Grub for CBL Mariner LVBS has some bug:
The RPM is e.g. "kernel-lvbs-6.6.89-9.cm2.x86_64", Grub MenuEntry is "6.6.135-lvbs-1.azl3".
grub.cfg content: 'AzureLinux GNU/Linux, with Linux 6.6.135-lvbs-1.azl3'
LISA logic for choosing kernel will ignore the "lvbs" and try to find "6.6.135-1.azl3" which doesn't exist.

Change this logic to extract the flavor like "lvbs" and match "6.6.135-lvbs-1.azl3"


## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
