### PR TITLE
test(vm_extensions): normalize AzCertify extension tags

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/aks_linux_aksnode.py
+++ b/lisa/microsoft/testsuites/vm_extensions/aks_linux_aksnode.py
@@ -17,7 +17,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     description="""
     This test suite validates the Microsoft AKS Linux AKSNode VM extension.
     """,
-    tags=["VM_Extension", "microsoft.aks.compute.aks.linux.aksnode"],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -45,6 +45,7 @@ class AksLinuxAksNodeTests(VmExtensionTestBase):  # type: ignore[misc]
         'aks_linux_aksnode_version' runbook variable.
         """,
         priority=5,
+        tags=["microsoft.aks.compute.aks.linux.aksnode"],
         maturity="preview",
     )
     def microsoft_aks_compute_aks_linux_aksnode_boot_validation_test(

--- a/lisa/microsoft/testsuites/vm_extensions/aks_linux_aksnode.py
+++ b/lisa/microsoft/testsuites/vm_extensions/aks_linux_aksnode.py
@@ -17,7 +17,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     description="""
     This test suite validates the Microsoft AKS Linux AKSNode VM extension.
     """,
-    tags=["VM_Extension", "Microsoft.AKS.Compute.AKS.Linux.AKSNode"],
+    tags=["VM_Extension", "microsoft.aks.compute.aks.linux.aksnode"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/aks_linux_billing.py
+++ b/lisa/microsoft/testsuites/vm_extensions/aks_linux_billing.py
@@ -17,7 +17,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     description="""
     This test suite validates the Microsoft AKS Linux Billing VM extension.
     """,
-    tags=["VM_Extension", "Microsoft.AKS.Compute.AKS.Linux.Billing"],
+    tags=["VM_Extension", "microsoft.aks.compute.aks.linux.billing"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/aks_linux_billing.py
+++ b/lisa/microsoft/testsuites/vm_extensions/aks_linux_billing.py
@@ -17,7 +17,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     description="""
     This test suite validates the Microsoft AKS Linux Billing VM extension.
     """,
-    tags=["VM_Extension", "microsoft.aks.compute.aks.linux.billing"],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -42,6 +42,7 @@ class AksLinuxBillingTests(VmExtensionTestBase):  # type: ignore[misc]
         'aks_linux_billing_version' runbook variable.
         """,
         priority=5,
+        tags=["microsoft.aks.compute.aks.linux.billing"],
         maturity="preview",
     )
     def microsoft_aks_compute_aks_linux_billing_boot_validation_test(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
@@ -23,7 +23,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     installed, confirm the VM is still reachable over SSH, then remove the
     extension.
     """,
-    tags=["VM_Extension", "AzureMonitorLinuxAgent"],
+    tags=["VM_Extension", "microsoft.azure.monitor.azuremonitorlinuxagent"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_monitor_linux_agent.py
@@ -23,7 +23,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     installed, confirm the VM is still reachable over SSH, then remove the
     extension.
     """,
-    tags=["VM_Extension", "microsoft.azure.monitor.azuremonitorlinuxagent"],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -48,6 +48,7 @@ class AzureMonitorLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
         'azure_monitor_linux_agent_version' runbook variable.
         """,
         priority=5,
+        tags=["microsoft.azure.monitor.azuremonitorlinuxagent"],
         maturity="preview",
     )
     def microsoft_azure_monitor_azuremonitorlinuxagent_boot_validation_test(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -23,7 +23,10 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     installed, confirm the VM is still reachable over SSH, then remove the
     extension.
     """,
-    tags=["VM_Extension", "AzureSecurityLinuxAgent"],
+    tags=[
+        "VM_Extension",
+        "microsoft.azure.security.monitoring.azuresecuritylinuxagent",
+    ],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/azure_security_linux_agent.py
@@ -23,10 +23,7 @@ from lisa.sut_orchestrator.azure.features import AzureExtension
     installed, confirm the VM is still reachable over SSH, then remove the
     extension.
     """,
-    tags=[
-        "VM_Extension",
-        "microsoft.azure.security.monitoring.azuresecuritylinuxagent",
-    ],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -51,6 +48,7 @@ class AzureSecurityLinuxAgentTests(VmExtensionTestBase):  # type: ignore[misc]
         'azure_security_linux_agent_version' runbook variable.
         """,
         priority=5,
+        tags=["microsoft.azure.security.monitoring.azuresecuritylinuxagent"],
         maturity="preview",
     )
     def microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test(  # noqa: E501

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -45,7 +45,7 @@ from lisa.sut_orchestrator.azure.tools import Waagent
         11. Private sas file uri and command in public settings
         12. File uri (pointing to python script) and command in public settings
     """,
-    tags=["VM_Extension", "CustomScript"],
+    tags=["VM_Extension", "microsoft.azure.extensions.customscript"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/custom_script.py
@@ -45,7 +45,7 @@ from lisa.sut_orchestrator.azure.tools import Waagent
         11. Private sas file uri and command in public settings
         12. File uri (pointing to python script) and command in public settings
     """,
-    tags=["VM_Extension", "microsoft.azure.extensions.customscript"],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -74,6 +74,7 @@ class CustomScriptTests(VmExtensionTestBase):  # type: ignore[misc]
         'custom_script_version'.
         """,
         priority=5,
+        tags=["microsoft.azure.extensions.customscript"],
         maturity="preview",
     )
     def microsoft_azure_extensions_customscript_boot_validation_test(

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -44,7 +44,7 @@ from lisa.sut_orchestrator.azure.tools import Waagent
     12. File uri (pointing to python script) and command in public settings
 
     """,
-    tags=["VM_Extension", "RunCommandLinux"],
+    tags=["VM_Extension", "microsoft.cplat.core.runcommandlinux"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],

--- a/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
+++ b/lisa/microsoft/testsuites/vm_extensions/runtime_extensions/run_commandv1.py
@@ -44,7 +44,7 @@ from lisa.sut_orchestrator.azure.tools import Waagent
     12. File uri (pointing to python script) and command in public settings
 
     """,
-    tags=["VM_Extension", "microsoft.cplat.core.runcommandlinux"],
+    tags=["VM_Extension"],
     requirement=simple_requirement(
         supported_features=[AzureExtension],
         supported_platform_type=[AZURE],
@@ -72,6 +72,7 @@ class RunCommandV1Tests(VmExtensionTestBase):  # type: ignore[misc]
         '<publisher>_<extension_type>_boot_validation_test'.
         """,
         priority=5,
+        tags=["microsoft.cplat.core.runcommandlinux"],
         maturity="preview",
     )
     def microsoft_cplat_core_runcommandlinux_boot_validation_test(


### PR DESCRIPTION
## Description

Normalizes the AzCertify discovery tags for six Phase 1 VM extension boot-validation tests. Each lowercase `<publisher>.<extensionType>` tag is assigned directly to only its corresponding `<publisherName>_<extensionType>_boot_validation_test` testcase.

The extension-specific tags are intentionally not placed on `TestSuiteMetadata`. LISA propagates suite-level tags to every testcase, which would cause AzCertify to select unrelated functional cases in multi-case suites such as CustomScript and RunCommand v1. The existing `VM_Extension` tag remains at suite level.

Updated tags:

- `microsoft.azure.extensions.customscript`
- `microsoft.azure.security.monitoring.azuresecuritylinuxagent`
- `microsoft.azure.monitor.azuremonitorlinuxagent`
- `microsoft.aks.compute.aks.linux.billing`
- `microsoft.aks.compute.aks.linux.aksnode`
- `microsoft.cplat.core.runcommandlinux`

No testcase names, extension installation logic, requirements, or runtime behavior changed.

## Related Issue

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
microsoft_azure_extensions_customscript_boot_validation_test|microsoft_azure_security_monitoring_azuresecuritylinuxagent_boot_validation_test|microsoft_azure_monitor_azuremonitorlinuxagent_boot_validation_test|microsoft_aks_compute_aks_linux_billing_boot_validation_test|microsoft_aks_compute_aks_linux_aksnode_boot_validation_test|microsoft_cplat_core_runcommandlinux_boot_validation_test

**Impacted LISA Features:**
AzureExtension

**Tested Azure Marketplace Images:**
- Not applicable; metadata-only change

## Test Results

| Validation | Result |
|------------|--------|
| Black formatting check for all six suites | PASSED |
| Flake8 for all six suites | PASSED |
| Python compilation for all six suites | PASSED |
| LISA metadata discovery: each AzCertify tag selects exactly one boot-validation case | PASSED |
| Multi-case suite verification: non-boot CustomScript and RunCommand cases do not carry AzCertify tags | PASSED |