### PR TITLE
Pass custom workload paths to Cloud Hypervisor

### DIFF
--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1438,6 +1438,77 @@ exit $ec
         if "MIGRATABLE_VERSION" in os.environ:
             self.env_vars["MIGRATABLE_VERSION"] = os.environ["MIGRATABLE_VERSION"]
 
+    def _log_custom_kernel_metadata(self, kernel_path: str) -> None:
+        metadata_command = (
+            "kernel_path="
+            + shlex.quote(kernel_path)
+            + r"""
+echo "[uvm-kernel] path=$kernel_path"
+if [ ! -r "$kernel_path" ]; then
+    echo "[uvm-kernel] readable=false"
+    exit 0
+fi
+
+embedded_pattern='(Linux version )?[0-9]+\.[0-9]+\.[0-9]+'
+embedded_pattern="${embedded_pattern}[^[:space:][:cntrl:]]* \([^[:cntrl:]]+\)"
+embedded_build=$(
+    LC_ALL=C grep -a -o -E -m1 "$embedded_pattern" "$kernel_path" \
+        2>/dev/null | head -n 1 || true
+)
+if [ -z "$embedded_build" ] && command -v strings >/dev/null 2>&1; then
+    embedded_build=$(
+        strings -a "$kernel_path" 2>/dev/null \
+            | grep -a -E -m1 \
+                '^(Linux version )?[0-9]+\.[0-9]+\.[0-9]+[^[:space:]]* \(' \
+            || true
+    )
+fi
+if [ -n "$embedded_build" ]; then
+    echo "[uvm-kernel] embedded-build=$embedded_build"
+else
+    echo "[uvm-kernel] embedded-build=unavailable"
+fi
+
+kernel_sha=""
+if command -v sha256sum >/dev/null 2>&1; then
+    kernel_sha=$(sha256sum "$kernel_path" | cut -d ' ' -f 1)
+    echo "[uvm-kernel] sha256=$kernel_sha"
+fi
+
+if command -v file >/dev/null 2>&1; then
+    echo "[uvm-kernel] file=$(file -b "$kernel_path" 2>&1)"
+fi
+
+if command -v rpm >/dev/null 2>&1; then
+    package=$(
+        rpm -qf --qf '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n' \
+            "$kernel_path" 2>/dev/null || true
+    )
+    if [ -n "$package" ]; then
+        echo "[uvm-kernel] package=$package"
+    fi
+elif command -v dpkg-query >/dev/null 2>&1; then
+    package=$(dpkg-query -S "$kernel_path" 2>/dev/null | head -n 1 || true)
+    if [ -n "$package" ]; then
+        echo "[uvm-kernel] package=$package"
+    fi
+fi
+exit 0
+"""
+        )
+        result = self.node.execute(metadata_command, shell=True)
+        metadata = "\n".join(
+            output
+            for output in (result.stdout.strip(), result.stderr.strip())
+            if output
+        )
+        if result.exit_code != 0:
+            self._log.debug(
+                f"Failed to inspect selected UVM kernel '{kernel_path}': {metadata}"
+            )
+        elif metadata:
+            self._log.info(f"Selected UVM kernel metadata:\n{metadata}")
+
     def _install(self) -> bool:
         git = self.node.tools[Git]
         clone_path = self.get_tool_path(use_global=True)
@@ -1455,9 +1526,9 @@ exit $ec
                     kernel_name = "Image"
                 else:
                     kernel_name = "vmlinux.bin"
-                self.env_vars[
-                    "CH_CUSTOM_KERNEL"
-                ] = f"/usr/share/cloud-hypervisor/{kernel_name}"
+                kernel_path = f"/usr/share/cloud-hypervisor/{kernel_name}"
+                self.env_vars["CH_CUSTOM_KERNEL"] = kernel_path
+                self._log_custom_kernel_metadata(kernel_path)
             if self.use_ms_hypervisor_fw:
                 self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
                 self.env_vars[

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -1509,6 +1509,30 @@ exit 0
         elif metadata:
             self._log.info(f"Selected UVM kernel metadata:\n{metadata}")
 
+    def _set_ms_kernel_environment(self) -> None:
+        if self.use_ms_guest_kernel:
+            self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
+        if self.use_ms_bz_image:
+            self.env_vars["USE_MS_BZ_IMAGE"] = self.use_ms_bz_image
+
+        architecture = self.node.tools[Uname].get_machine_architecture()
+        kernel_path = ""
+        if architecture == CpuArchitecture.ARM64:
+            if self.use_ms_guest_kernel:
+                kernel_path = "/usr/share/cloud-hypervisor/Image"
+                self.env_vars["CH_CUSTOM_KERNEL"] = kernel_path
+            if self.use_ms_bz_image:
+                self.env_vars[
+                    "CH_CUSTOM_BZIMAGE"
+                ] = "/usr/share/cloud-hypervisor/bzImage"
+        else:
+            kernel_path = "/usr/share/cloud-hypervisor/vmlinux.bin"
+            self.env_vars["CH_CUSTOM_KERNEL"] = kernel_path
+            self.env_vars["CH_CUSTOM_BZIMAGE"] = "/usr/share/cloud-hypervisor/bzImage"
+
+        if kernel_path:
+            self._log_custom_kernel_metadata(kernel_path)
+
     def _install(self) -> bool:
         git = self.node.tools[Git]
         clone_path = self.get_tool_path(use_global=True)
@@ -1519,16 +1543,8 @@ exit 0
                 auth_token=self.ms_access_token,
             )
             self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
-            if self.use_ms_guest_kernel:
-                self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
-                architecture = self.node.tools[Uname].get_machine_architecture()
-                if architecture == CpuArchitecture.ARM64:
-                    kernel_name = "Image"
-                else:
-                    kernel_name = "vmlinux.bin"
-                kernel_path = f"/usr/share/cloud-hypervisor/{kernel_name}"
-                self.env_vars["CH_CUSTOM_KERNEL"] = kernel_path
-                self._log_custom_kernel_metadata(kernel_path)
+            if self.use_ms_guest_kernel or self.use_ms_bz_image:
+                self._set_ms_kernel_environment()
             if self.use_ms_hypervisor_fw:
                 self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
                 self.env_vars[
@@ -1539,11 +1555,6 @@ exit 0
                 self.env_vars[
                     "CH_CUSTOM_OVMF"
                 ] = "/usr/share/cloud-hypervisor/CLOUDHV_EFI.fd"
-            if self.use_ms_bz_image:
-                self.env_vars["USE_MS_BZ_IMAGE"] = self.use_ms_bz_image
-                self.env_vars[
-                    "CH_CUSTOM_BZIMAGE"
-                ] = "/usr/share/cloud-hypervisor/bzImage"
 
             if self.use_pmem:
                 self.env_vars["USE_DATADISK"] = self.use_pmem

--- a/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
+++ b/lisa/microsoft/testsuites/cloud_hypervisor/ch_tests_tool.py
@@ -15,7 +15,7 @@ from lisa import Node
 from lisa.executable import ExecutableResult, Tool
 from lisa.features import SerialConsole
 from lisa.messages import TestStatus, send_sub_test_result_message
-from lisa.operating_system import CBLMariner, Posix, Ubuntu
+from lisa.operating_system import CBLMariner, CpuArchitecture, Posix, Ubuntu
 from lisa.testsuite import TestResult
 from lisa.tools import (
     Cat,
@@ -30,6 +30,7 @@ from lisa.tools import (
     Mkdir,
     Modprobe,
     Sed,
+    Uname,
     Whoami,
 )
 from lisa.util import (
@@ -1449,12 +1450,29 @@ exit $ec
             self.env_vars["GUEST_VM_TYPE"] = self.clh_guest_vm_type
             if self.use_ms_guest_kernel:
                 self.env_vars["USE_MS_GUEST_KERNEL"] = self.use_ms_guest_kernel
+                architecture = self.node.tools[Uname].get_machine_architecture()
+                if architecture == CpuArchitecture.ARM64:
+                    kernel_name = "Image"
+                else:
+                    kernel_name = "vmlinux.bin"
+                self.env_vars[
+                    "CH_CUSTOM_KERNEL"
+                ] = f"/usr/share/cloud-hypervisor/{kernel_name}"
             if self.use_ms_hypervisor_fw:
                 self.env_vars["USE_MS_HV_FW"] = self.use_ms_hypervisor_fw
+                self.env_vars[
+                    "CH_CUSTOM_FIRMWARE"
+                ] = "/usr/share/cloud-hypervisor/hypervisor-fw"
             if self.use_ms_ovmf_fw:
                 self.env_vars["USE_MS_OVMF_FW"] = self.use_ms_ovmf_fw
+                self.env_vars[
+                    "CH_CUSTOM_OVMF"
+                ] = "/usr/share/cloud-hypervisor/CLOUDHV_EFI.fd"
             if self.use_ms_bz_image:
                 self.env_vars["USE_MS_BZ_IMAGE"] = self.use_ms_bz_image
+                self.env_vars[
+                    "CH_CUSTOM_BZIMAGE"
+                ] = "/usr/share/cloud-hypervisor/bzImage"
 
             if self.use_pmem:
                 self.env_vars["USE_DATADISK"] = self.use_pmem


### PR DESCRIPTION
## Description

Pass the Microsoft Cloud Hypervisor workload paths through the `CH_CUSTOM_*` environment variables consumed by current Microsoft Cloud Hypervisor branches while retaining the legacy `USE_MS_*` selectors for older branches.

- Select `/usr/share/cloud-hypervisor/Image` for ARM64 guests and `/usr/share/cloud-hypervisor/vmlinux.bin` for other architectures.
- Map the hypervisor firmware, OVMF, and bzImage assets to their corresponding `CH_CUSTOM_*` variables.
- Log the selected UVM kernel's embedded build string, SHA-256, file type, and owning package when available to make workload-selection failures diagnosable.

## Related Issue


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_cloud_hypervisor_integration_tests

**Impacted LISA Features:**
None (CloudHypervisorTests tool setup only)

**Tested Azure Marketplace Images:**
- Not run; requires Microsoft Cloud Hypervisor artifacts and a virtualization-capable host

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| Local static validation | N/A | PASSED: Black, Flake8, targeted Pylint, py_compile, and git diff --check |

Full-file Pylint reports two pre-existing `implicit-str-concat` findings outside this branch's changed lines; targeted Pylint passes with that baseline rule disabled.