### PR TITLE
fix upstream kernel grub writing bug

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT license.
 import os
 import re
+import shlex
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -2369,6 +2370,7 @@ class CBLMariner(RPMDistro):
 
     def _replace_default_entry(self, entry: str) -> None:
         self._log.debug(f"set boot entry to: {entry}")
+        grub_default_line = f"GRUB_DEFAULT={shlex.quote(entry)}"
 
         # Check if GRUB_DEFAULT already exists in the file
         grep_result = self._node.execute(
@@ -2382,14 +2384,14 @@ class CBLMariner(RPMDistro):
             sed = self._node.tools[Sed]
             sed.substitute(
                 regexp="GRUB_DEFAULT=.*",
-                replacement=f"GRUB_DEFAULT='{entry}'",
+                replacement=grub_default_line,
                 file="/etc/default/grub",
                 sudo=True,
             )
         else:
+            quoted_line = shlex.quote(grub_default_line)
             self._node.execute(
-                f"echo \"GRUB_DEFAULT='{entry}'\" >> /etc/default/grub",
-                sudo=True,
+                f"printf '\n%s\n' {quoted_line} | sudo tee -a /etc/default/grub",
                 shell=True,
                 expected_exit_code=0,
                 expected_exit_code_failure_message="Failed to append GRUB_DEFAULT",
@@ -2397,7 +2399,7 @@ class CBLMariner(RPMDistro):
 
         # output to log for troubleshooting
         cat = self._node.tools[Cat]
-        cat.run("/etc/default/grub")
+        cat.run("/etc/default/grub", sudo=True)
 
     @staticmethod
     def _get_kernel_version_candidates(kernel_version: str) -> List[str]:

--- a/selftests/test_operating_system.py
+++ b/selftests/test_operating_system.py
@@ -1,11 +1,54 @@
+import shlex
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
+from lisa.base_tools import Cat, Sed
 from lisa.operating_system import CBLMariner
 
 
 class OperatingSystemTestCase(TestCase):
+    def _create_mariner(
+        self, grub_default_exists: bool
+    ) -> tuple[CBLMariner, MagicMock]:
+        node = MagicMock()
+        node.execute.return_value.exit_code = 0 if grub_default_exists else 1
+        mariner = CBLMariner.__new__(CBLMariner)
+        mariner._node = node
+        mariner._log = MagicMock()
+        return mariner, node
+
+    def test_append_grub_default_on_new_line(self) -> None:
+        mariner, node = self._create_mariner(grub_default_exists=False)
+        entry = "AzureLinux GNU/Linux, with Linux 6.6.153.rc2-1.azl3"
+
+        mariner._replace_default_entry(entry)
+
+        grub_default_line = f"GRUB_DEFAULT={shlex.quote(entry)}"
+        node.execute.assert_any_call(
+            f"printf '\n%s\n' {shlex.quote(grub_default_line)} "
+            "| sudo tee -a /etc/default/grub",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message="Failed to append GRUB_DEFAULT",
+        )
+        node.tools[Cat].run.assert_called_once_with("/etc/default/grub", sudo=True)
+
+    def test_replace_existing_grub_default(self) -> None:
+        mariner, node = self._create_mariner(grub_default_exists=True)
+        entry = "AzureLinux GNU/Linux, with Linux 6.6.153.rc2-1.azl3"
+
+        mariner._replace_default_entry(entry)
+
+        node.tools[Sed].substitute.assert_called_once_with(
+            regexp="GRUB_DEFAULT=.*",
+            replacement=f"GRUB_DEFAULT={shlex.quote(entry)}",
+            file="/etc/default/grub",
+            sudo=True,
+        )
+        node.tools[Cat].run.assert_called_once_with("/etc/default/grub", sudo=True)
+
     def test_get_kernel_version_candidates_for_standard_kernel(self) -> None:
         candidates = CBLMariner._get_kernel_version_candidates(
             "kernel-6.6.135-1.azl3.x86_64"

--- a/selftests/test_operating_system.py
+++ b/selftests/test_operating_system.py
@@ -1,4 +1,5 @@
 import shlex
+from typing import Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -11,7 +12,7 @@ from lisa.operating_system import CBLMariner
 class OperatingSystemTestCase(TestCase):
     def _create_mariner(
         self, grub_default_exists: bool
-    ) -> tuple[CBLMariner, MagicMock]:
+    ) -> Tuple[CBLMariner, MagicMock]:
         node = MagicMock()
         node.execute.return_value.exit_code = 0 if grub_default_exists else 1
         mariner = CBLMariner.__new__(CBLMariner)


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue
Fix the Grub writing bug for kernel config.
The original logic: 
    echo "GRUB_DEFAULT='AzureLinux GNU/Linux, with Linux 6.6.153.rc2-1.azl3'" >> /etc/default/grub
If  /etc/default/grub doesn't have a newline in the end, then "GRUB_DEFAULT..." will be added at the end of the grub file.
Then grub2-mkconfig will report error:
   /etc/default/grub: line 23: syntax error: unexpected end of file

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
