### PR TITLE
azure: add network client retry policy

### DIFF
--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -1741,7 +1741,7 @@ def get_network_client(platform: "AzurePlatform") -> NetworkManagementClient:
         base_url=platform.cloud.endpoints.resource_manager,
         credential_scopes=[platform.cloud.endpoints.resource_manager + "/.default"],
         retry_policy=RetryPolicy(
-            tries=10,
+            retry_total=10,
             retry_connect=10,
             retry_status=5,
             timeout=180,  # absolute retry timeout of 3 minutes

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -30,6 +30,7 @@ import requests
 from assertpy import assert_that
 from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
+from azure.core.pipeline.policies import RetryPolicy
 from azure.keyvault.certificates import (
     CertificateClient,
     CertificatePolicy,
@@ -1739,6 +1740,12 @@ def get_network_client(platform: "AzurePlatform") -> NetworkManagementClient:
         subscription_id=platform.subscription_id,
         base_url=platform.cloud.endpoints.resource_manager,
         credential_scopes=[platform.cloud.endpoints.resource_manager + "/.default"],
+        retry_policy=RetryPolicy(
+            tries=10,
+            retry_connect=10,
+            retry_status=5,
+            timeout=180,  # absolute retry timeout of 3 minutes
+        ),
     )
 
 


### PR DESCRIPTION
## Description


- Added a custom RetryPolicy to NetworkManagementClient.
- Increased connection retry attempts to better tolerate transient connectivity issues.
- Configured retry handling for HTTP status failures.
- Increased the overall retry timeout window to 3 minutes.


Network and ARM API operations can occasionally fail due to transient service, networking, or throttling conditions. The default retry behavior was not always sufficient for these scenarios, leading to avoidable operation failures. This change improves reliability by allowing additional retry attempts and extending the time available for successful completion before reporting failure.

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
