### PR TITLE
[AI Generated] hpc: mark selected tests as preview

### DIFF
--- a/lisa/microsoft/testsuites/hpc/infinibandsuite.py
+++ b/lisa/microsoft/testsuites/hpc/infinibandsuite.py
@@ -175,6 +175,7 @@ class InfinibandSuite(TestSuite):
         2. Run several ping-pong tests to check RDMA / Infiniband functionality
         """,
         priority=1,
+        maturity="preview",
         requirement=simple_requirement(
             supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
@@ -244,6 +245,7 @@ class InfinibandSuite(TestSuite):
             5. Run other MPI tests
             """,
         priority=4,
+        maturity="preview",
         requirement=simple_requirement(
             supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
@@ -338,6 +340,7 @@ class InfinibandSuite(TestSuite):
             5. Run other MPI tests
             """,
         priority=4,
+        maturity="preview",
         requirement=simple_requirement(
             supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,
@@ -550,6 +553,7 @@ class InfinibandSuite(TestSuite):
             5. Run other MPI tests
             """,
         priority=4,
+        maturity="preview",
         requirement=simple_requirement(
             supported_features=[Infiniband, AvailabilitySetEnabled()],
             min_count=2,

--- a/lisa/microsoft/testsuites/osu/osusuite.py
+++ b/lisa/microsoft/testsuites/osu/osusuite.py
@@ -51,6 +51,7 @@ class OSUTestSuite(TestSuite):
 
         """,
         timeout=TIMEOUT,
+        maturity="preview",
         requirement=simple_requirement(
             supported_features=[GpuEnabled(), SerialConsole],
         ),


### PR DESCRIPTION
> **AI Generated**: Generated with GitHub Copilot. Reviewers: verify test metadata and maturity selection.

## Description

Mark five HPC functional and performance tests as preview to align their maturity with their current validation status. Stable test selection will exclude these cases by default, while runs that explicitly include preview maturity can continue to execute them.

## Related Issue

None.

## Type of Change

- [x] Test metadata

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_open_mpi|verify_ping_pong|verify_intel_mpi|verify_mvapich_mpi|perf_mpi_operations

**Impacted LISA Features:**
None (test selection metadata only)

**Tested Azure Marketplace Images:**
- Not run (metadata-only change)

## Test Results

| Validation | Result |
|------------|--------|
| `pytest selftests/test_testselector.py -k maturity` | PASSED (14 tests) |
| Exact metadata audit | PASSED (5 expected preview cases, no unexpected cases) |
| Black | PASSED |
| flake8 | PASSED |
| pylint | PASSED (10.00/10) |
| `git diff --check` | PASSED |

Mypy reports existing errors in unchanged framework and Azure modules; no errors point to the two changed test-suite files.
