### PR TITLE
Fix inactive SSH session retry for remote commands

### DIFF
--- a/lisa/util/__init__.py
+++ b/lisa/util/__init__.py
@@ -445,6 +445,13 @@ class SshSpawnTimeoutException(LisaException):
     """
 
 
+class SshSessionNotActiveException(LisaException):
+    """
+    This exception indicates that an SSH transport became inactive while
+    opening a command channel.
+    """
+
+
 class ContextMixin:
     def get_context(self, context_type: Type[T]) -> T:
         if not hasattr(self, "_context"):

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -27,7 +27,7 @@ from lisa.util import (
     create_timer,
     filter_ansi_escape,
 )
-from lisa.util.logger import Logger, LogWriter, add_handler, get_logger
+from lisa.util.logger import Logger, LogWriter, add_handler, get_logger, remove_handler
 from lisa.util.shell import Shell, SshShell
 
 # Prompt strings that sudo writes when it requires a password.
@@ -353,6 +353,11 @@ class Process:
             self._log.log(stderr_level, f"not found command: {e}")
         except (SshSpawnTimeoutException, SshSessionNotActiveException):
             # close the shell and try again, see if the ssh connection is interrupted.
+            self._stdout_writer.close()
+            self._stderr_writer.close()
+            remove_handler(self._log_handler, self.stdout_logger)
+            remove_handler(self._log_handler, self.stderr_logger)
+            self._log_handler.close()
             self._shell.close()
             raise
 

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -22,6 +22,7 @@ from spur.errors import NoSuchCommandError
 from lisa.util import (
     LisaException,
     RequireUserPasswordException,
+    SshSessionNotActiveException,
     SshSpawnTimeoutException,
     create_timer,
     filter_ansi_escape,
@@ -121,7 +122,7 @@ def _retry_spawn(func: Callable[..., Any]) -> Any:
     # wrap to pass in the logger object of the current process.
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         return retry(
-            exceptions=SshSpawnTimeoutException,
+            exceptions=(SshSpawnTimeoutException, SshSessionNotActiveException),
             tries=3,
             delay=1,
             backoff=3,
@@ -350,7 +351,7 @@ class Process:
                 "", e.strerror, 1, split_command, self._id_, self._timer.elapsed()
             )
             self._log.log(stderr_level, f"not found command: {e}")
-        except SshSpawnTimeoutException:
+        except (SshSpawnTimeoutException, SshSessionNotActiveException):
             # close the shell and try again, see if the ssh connection is interrupted.
             self._shell.close()
             raise

--- a/lisa/util/process.py
+++ b/lisa/util/process.py
@@ -357,7 +357,6 @@ class Process:
             self._stderr_writer.close()
             remove_handler(self._log_handler, self.stdout_logger)
             remove_handler(self._log_handler, self.stderr_logger)
-            self._log_handler.close()
             self._shell.close()
             raise
 

--- a/lisa/util/shell.py
+++ b/lisa/util/shell.py
@@ -34,6 +34,7 @@ from lisa import development, schema
 from lisa.util import (
     InitializableMixin,
     LisaException,
+    SshSessionNotActiveException,
     SshSpawnTimeoutException,
     TcpConnectionException,
     filter_ansi_escape,
@@ -458,6 +459,14 @@ class SshShell(InitializableMixin):
                     "the process wait for inputs, "
                     "the paramiko/spur not support the shell of node."
                 )
+            except SSHException as e:
+                if str(e) != "SSH session not active":
+                    raise
+                raise SshSessionNotActiveException(
+                    "SSH session became inactive while opening a command channel. "
+                    "Close the stale connection and reconnect before retrying the "
+                    "command."
+                ) from e
             except spur.errors.CommandInitializationError as e:
                 # *Second* chance in getting a clue about no POSIX shell
                 # support (still not Windows). Set minimal shell type if

--- a/selftests/test_process.py
+++ b/selftests/test_process.py
@@ -2,18 +2,79 @@
 # Licensed under the MIT license.
 
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, patch
 
 from assertpy import assert_that
+from paramiko.ssh_exception import SSHException
 
-from lisa.util import LisaException
+from lisa.util import LisaException, SshSessionNotActiveException
 from lisa.util.process import Process
+from lisa.util.shell import SshShell
 
 
 class ProcessTestCase(TestCase):
-    def test_wait_result_caching_prevents_reprocessing(self) -> None:
-        from unittest.mock import MagicMock, patch
+    def test_start_reconnects_after_inactive_ssh_session(self) -> None:
+        shell = Mock(spec=SshShell)
+        shell.is_posix = True
+        shell.is_remote = True
+        ssh_process = MagicMock()
+        shell.spawn.side_effect = [
+            SshSessionNotActiveException("SSH session became inactive"),
+            ssh_process,
+        ]
+        process = Process("test", shell)
 
+        with patch("retry.api.time.sleep"):
+            process.start("echo test")
+
+        assert_that(shell.close.call_count).is_equal_to(1)
+        assert_that(shell.spawn.call_count).is_equal_to(2)
+        assert_that(process._process).is_same_as(ssh_process)
+
+    def test_start_stops_after_inactive_ssh_retry_limit(self) -> None:
+        shell = Mock(spec=SshShell)
+        shell.is_posix = True
+        shell.is_remote = True
+        shell.spawn.side_effect = SshSessionNotActiveException(
+            "SSH session became inactive"
+        )
+        process = Process("test", shell)
+
+        with patch("retry.api.time.sleep"), self.assertRaises(
+            SshSessionNotActiveException
+        ):
+            process.start("echo test")
+
+        assert_that(shell.close.call_count).is_equal_to(3)
+        assert_that(shell.spawn.call_count).is_equal_to(3)
+
+    def test_shell_converts_inactive_ssh_exception(self) -> None:
+        shell = self._create_initialized_ssh_shell()
+
+        with patch(
+            "lisa.util.shell._spawn_ssh_process",
+            side_effect=SSHException("SSH session not active"),
+        ), self.assertRaises(SshSessionNotActiveException):
+            shell.spawn(["echo", "test"])
+
+    def test_shell_does_not_convert_unrelated_ssh_exception(self) -> None:
+        shell = self._create_initialized_ssh_shell()
+
+        with patch(
+            "lisa.util.shell._spawn_ssh_process",
+            side_effect=SSHException("authentication failed"),
+        ), self.assertRaises(SSHException):
+            shell.spawn(["echo", "test"])
+
+    def _create_initialized_ssh_shell(self) -> SshShell:
+        shell = SshShell.__new__(SshShell)
+        shell._is_initialized = True
+        shell._inner_shell = MagicMock()
+        shell._inner_shell._spur._shell_type = MagicMock()
+        shell.spawn_timeout = 20
+        return shell
+
+    def test_wait_result_caching_prevents_reprocessing(self) -> None:
         shell = Mock()
         shell.is_posix = True
         shell.is_remote = False
@@ -44,8 +105,6 @@ class ProcessTestCase(TestCase):
             assert_that(mock_process.wait_for_result.call_count).is_equal_to(1)
 
     def test_wait_result_timeout_with_raise_on_timeout_true(self) -> None:
-        from unittest.mock import MagicMock, patch
-
         shell = Mock()
         shell.is_posix = True
         shell.is_remote = False
@@ -77,8 +136,6 @@ class ProcessTestCase(TestCase):
             assert_that(str(context.exception)).contains("timeout after 10 seconds")
 
     def test_wait_result_timeout_with_raise_on_timeout_false(self) -> None:
-        from unittest.mock import MagicMock, patch
-
         shell = Mock()
         shell.is_posix = True
         shell.is_remote = False

--- a/selftests/test_process.py
+++ b/selftests/test_process.py
@@ -4,6 +4,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
+import spur
 from assertpy import assert_that
 from paramiko.ssh_exception import SSHException
 
@@ -24,11 +25,14 @@ class ProcessTestCase(TestCase):
         ]
         process = Process("test", shell)
 
-        with patch("retry.api.time.sleep"):
+        with patch("retry.api.time.sleep"), patch(
+            "lisa.util.process.remove_handler"
+        ) as remove_handler:
             process.start("echo test")
 
         assert_that(shell.close.call_count).is_equal_to(1)
         assert_that(shell.spawn.call_count).is_equal_to(2)
+        assert_that(remove_handler.call_count).is_equal_to(2)
         assert_that(process._process).is_same_as(ssh_process)
 
     def test_start_stops_after_inactive_ssh_retry_limit(self) -> None:
@@ -40,13 +44,14 @@ class ProcessTestCase(TestCase):
         )
         process = Process("test", shell)
 
-        with patch("retry.api.time.sleep"), self.assertRaises(
-            SshSessionNotActiveException
-        ):
+        with patch("retry.api.time.sleep"), patch(
+            "lisa.util.process.remove_handler"
+        ) as remove_handler, self.assertRaises(SshSessionNotActiveException):
             process.start("echo test")
 
         assert_that(shell.close.call_count).is_equal_to(3)
         assert_that(shell.spawn.call_count).is_equal_to(3)
+        assert_that(remove_handler.call_count).is_equal_to(6)
 
     def test_shell_converts_inactive_ssh_exception(self) -> None:
         shell = self._create_initialized_ssh_shell()
@@ -70,7 +75,7 @@ class ProcessTestCase(TestCase):
         shell = SshShell.__new__(SshShell)
         shell._is_initialized = True
         shell._inner_shell = MagicMock()
-        shell._inner_shell._spur._shell_type = MagicMock()
+        shell._inner_shell._spur._shell_type = spur.ssh.ShellTypes.sh
         shell.spawn_timeout = 20
         return shell
 


### PR DESCRIPTION
## Description

Long-running test runs can retain an SSH transport after it becomes inactive. Opening a command channel then raises `SSH session not active`, and the command currently fails without rebuilding the connection.

This change:

- Converts the inactive Paramiko transport error into a dedicated retryable exception.
- Closes the stale shell and reuses the existing bounded three-attempt spawn retry.
- Leaves unrelated SSH errors unchanged.
- Adds regression coverage for successful reconnection, retry exhaustion, and error classification.

## Test Validation

- `python -m unittest selftests.test_process selftests.test_reboot -v`
- `python -m black --check lisa/util/__init__.py lisa/util/shell.py lisa/util/process.py selftests/test_process.py`
- `python -m isort --check-only lisa/util/__init__.py lisa/util/shell.py lisa/util/process.py selftests/test_process.py`
- `python -m flake8 lisa/util/__init__.py lisa/util/shell.py lisa/util/process.py selftests/test_process.py`
- `git diff --check`