### PR TITLE
fix lvbs no memory reserved bug

### DIFF
--- a/lisa/operating_system.py
+++ b/lisa/operating_system.py
@@ -2260,6 +2260,12 @@ class OpenEuler(RPMDistro):
         return re.compile("^(openEuler|openeuler)")
 
 
+# Memory reservation required on the "securekernel" cmdline arg for LVBS
+# (VBS-enabled) kernels to boot their secure kernel (VTL1); without it the
+# secure kernel panics with "No memory reserved in cmdline for secure kernel".
+_LVBS_SECUREKERNEL_ARG = "128M@0x8000000"
+
+
 class CBLMariner(RPMDistro):
     @classmethod
     def name_pattern(cls) -> Pattern[str]:
@@ -2500,15 +2506,31 @@ class CBLMariner(RPMDistro):
         # Set the new kernel as default using the existing method
         self._replace_default_entry(menu_entry_name)
 
-        # Rebuild GRUB configuration to apply the changes
-        self._node.execute(
-            "grub2-mkconfig -o /boot/grub2/grub.cfg",
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=(
-                "Failed to rebuild GRUB configuration with new default"
-            ),
-        )
+        if "lvbs" in kernel_version.lower():
+            # LVBS kernels boot a secure kernel (VTL1) that panics with
+            # "No memory reserved in cmdline for secure kernel" unless
+            # memory is reserved for it via the "securekernel" cmdline arg.
+            # set_kernel_cmdline_arg() rebuilds the GRUB configuration, so
+            # the plain grub2-mkconfig rebuild below is skipped in this case.
+            from lisa.tools import GrubConfig
+
+            self._log.info(
+                "LVBS kernel detected, reserving memory for the secure "
+                f"kernel via '{_LVBS_SECUREKERNEL_ARG}'"
+            )
+            self._node.tools[GrubConfig].set_kernel_cmdline_arg(
+                "securekernel", _LVBS_SECUREKERNEL_ARG
+            )
+        else:
+            # Rebuild GRUB configuration to apply the changes
+            self._node.execute(
+                "grub2-mkconfig -o /boot/grub2/grub.cfg",
+                sudo=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    "Failed to rebuild GRUB configuration with new default"
+                ),
+            )
 
         self._log.info(
             f"Successfully configured GRUB to boot into kernel version "

--- a/selftests/test_operating_system.py
+++ b/selftests/test_operating_system.py
@@ -7,6 +7,7 @@ from assertpy import assert_that
 
 from lisa.base_tools import Cat, Sed
 from lisa.operating_system import CBLMariner
+from lisa.tools import GrubConfig
 
 
 class OperatingSystemTestCase(TestCase):
@@ -15,6 +16,15 @@ class OperatingSystemTestCase(TestCase):
     ) -> Tuple[CBLMariner, MagicMock]:
         node = MagicMock()
         node.execute.return_value.exit_code = 0 if grub_default_exists else 1
+        mariner = CBLMariner.__new__(CBLMariner)
+        mariner._node = node
+        mariner._log = MagicMock()
+        return mariner, node
+
+    def _create_mariner_for_replace_boot_kernel(
+        self,
+    ) -> Tuple[CBLMariner, MagicMock]:
+        node = MagicMock()
         mariner = CBLMariner.__new__(CBLMariner)
         mariner._node = node
         mariner._log = MagicMock()
@@ -49,6 +59,28 @@ class OperatingSystemTestCase(TestCase):
             sudo=True,
         )
         node.tools[Cat].run.assert_called_once_with("/etc/default/grub", sudo=True)
+
+    def test_replace_boot_kernel_sets_securekernel_arg_for_lvbs(self) -> None:
+        mariner, node = self._create_mariner_for_replace_boot_kernel()
+        entry = "AzureLinux GNU/Linux, with Linux 6.6.135-lvbs-1.azl3"
+        node.execute.return_value.stdout = f"menuentry '{entry}' {{"
+        mariner._replace_default_entry = MagicMock()
+
+        mariner.replace_boot_kernel("kernel-lvbs-6.6.135-1.azl3.x86_64")
+
+        node.tools[GrubConfig].set_kernel_cmdline_arg.assert_called_once_with(
+            "securekernel", "128M@0x8000000"
+        )
+
+    def test_replace_boot_kernel_skips_securekernel_arg_for_non_lvbs(self) -> None:
+        mariner, node = self._create_mariner_for_replace_boot_kernel()
+        entry = "AzureLinux GNU/Linux, with Linux 6.6.135-1.azl3"
+        node.execute.return_value.stdout = f"menuentry '{entry}' {{"
+        mariner._replace_default_entry = MagicMock()
+
+        mariner.replace_boot_kernel("kernel-6.6.135-1.azl3.x86_64")
+
+        node.tools[GrubConfig].set_kernel_cmdline_arg.assert_not_called()
 
     def test_get_kernel_version_candidates_for_standard_kernel(self) -> None:
         candidates = CBLMariner._get_kernel_version_candidates(


### PR DESCRIPTION
## Description
Fix lvbs no memory reserved bug
<!-- Briefly describe what this PR does and why. -->

## Related Issue
LVBS Memory reservation required on the "securekernel" cmdline arg for LVBS  (VBS-enabled) kernels to boot their secure kernel (VTL1); without it the secure kernel panics with "No memory reserved in cmdline for secure kernel".
<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] Description is filled in above
- [ ] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
