### PR TITLE
hyperv: add safe PCI NVMe passthrough support

### DIFF
--- a/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
+++ b/lisa/sut_orchestrator/hyperv/hyperv_device_pool.py
@@ -36,6 +36,7 @@ class HyperVDevicePool(BaseDevicePool):
         self.supported_pool_type = [
             HostDevicePoolType.PCI_NIC,
             HostDevicePoolType.PCI_GPU,
+            HostDevicePoolType.PCI_NVME,
         ]
         self._server = node
         self._hyperv_runbook = runbook
@@ -55,6 +56,14 @@ class HyperVDevicePool(BaseDevicePool):
             vendor_id=vendor_id,
             device_id=device_id,
         )
+        if pool_type == HostDevicePoolType.PCI_NVME:
+            if len(devices) != 1:
+                raise LisaException(
+                    "Hyper-V PCI NVMe vendor/device selection must resolve "
+                    f"exactly one DDA-assignable device, found {len(devices)}. "
+                    "Use 'location_path' to select a specific device."
+                )
+            self._validate_nvme_devices(devices)
         self._append_devices_to_pool(pool_type=pool_type, devices=devices)
 
     def create_device_pool_from_pci_addresses(
@@ -78,7 +87,123 @@ class HyperVDevicePool(BaseDevicePool):
             log=self.log,
         )
         devices = hv_dev.get_assignable_devices_by_location_paths(location_paths)
+        if pool_type == HostDevicePoolType.PCI_NVME:
+            self._validate_nvme_devices(devices)
         self._append_devices_to_pool(pool_type=pool_type, devices=devices)
+
+    def _validate_nvme_devices(self, devices: List[DeviceAddressSchema]) -> None:
+        powershell = self._server.tools[PowerShell]
+        for device in devices:
+            escaped_instance_id = device.instance_id.replace("'", "''")
+            disk_records = powershell.run_cmdlet(
+                cmdlet=f"""
+$controllerId = '{escaped_instance_id}'
+$pending = [System.Collections.Generic.Queue[string]]::new()
+$seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+$pending.Enqueue($controllerId)
+while ($pending.Count -gt 0) {{
+    $currentId = $pending.Dequeue()
+    if (-not $seen.Add($currentId)) {{
+        continue
+    }}
+
+    $childrenProperty = Get-PnpDeviceProperty `
+        -InstanceId $currentId `
+        -KeyName 'DEVPKEY_Device_Children' `
+        -ErrorAction SilentlyContinue
+    if ($currentId -eq $controllerId -and $null -eq $childrenProperty) {{
+        throw "Could not query PnP children for NVMe controller '$controllerId'"
+    }}
+    foreach ($childId in @($childrenProperty.Data)) {{
+        if ($childId) {{
+            $pending.Enqueue([string]$childId)
+        }}
+    }}
+}}
+
+$diskDrives = @(
+    Get-CimInstance Win32_DiskDrive |
+    Where-Object {{ $seen.Contains([string]$_.PNPDeviceID) }}
+)
+$diskRecords = foreach ($diskDrive in $diskDrives) {{
+    $disk = Get-Disk -Number ([int]$diskDrive.Index) -ErrorAction Stop
+    $mountedPartitions = @(
+        Get-CimInstance `
+            -Namespace ROOT/Microsoft/Windows/Storage `
+            -ClassName MSFT_Partition `
+            -Filter "DiskNumber = $($disk.Number)" `
+            -ErrorAction Stop |
+        Where-Object {{ @($_.AccessPaths).Count -gt 0 }}
+    )
+    [PSCustomObject]@{{
+        Number = [int]$disk.Number
+        FriendlyName = [string]$disk.FriendlyName
+        BusType = [string]$disk.BusType
+        IsBoot = [bool]$disk.IsBoot
+        IsSystem = [bool]$disk.IsSystem
+        IsMounted = ($mountedPartitions.Count -gt 0)
+    }}
+}}
+$diskRecords
+""",
+                output_json=True,
+                force_run=True,
+            )
+            if disk_records is None or disk_records == "":
+                normalized_records: List[Dict[str, Any]] = []
+            elif isinstance(disk_records, list):
+                normalized_records = disk_records
+            else:
+                normalized_records = [disk_records]
+
+            if len(normalized_records) != 1 or not isinstance(
+                normalized_records[0], dict
+            ):
+                raise LisaException(
+                    f"Hyper-V PCI NVMe device '{device.instance_id}' must map "
+                    "to exactly one Windows disk, found "
+                    f"{len(normalized_records)}"
+                )
+
+            disk = normalized_records[0]
+            required_properties = {
+                "Number",
+                "BusType",
+                "IsBoot",
+                "IsSystem",
+                "IsMounted",
+            }
+            missing_properties = required_properties.difference(disk)
+            if missing_properties:
+                raise LisaException(
+                    f"Hyper-V PCI NVMe device '{device.instance_id}' returned "
+                    "an incomplete Windows disk safety record. Missing: "
+                    f"{', '.join(sorted(missing_properties))}"
+                )
+
+            bus_type = str(disk["BusType"]).strip()
+            if bus_type.lower() != "nvme":
+                raise LisaException(
+                    f"Hyper-V PCI NVMe device '{device.instance_id}' maps to "
+                    f"Windows disk bus type '{bus_type or 'unknown'}', not NVMe"
+                )
+
+            unsafe_reasons = []
+            if disk.get("IsBoot"):
+                unsafe_reasons.append("boot")
+            if disk.get("IsSystem"):
+                unsafe_reasons.append("system")
+            if disk.get("IsMounted"):
+                unsafe_reasons.append("mounted")
+            if unsafe_reasons:
+                disk_number = disk.get("Number", "unknown")
+                raise LisaException(
+                    f"Hyper-V PCI NVMe device '{device.instance_id}' maps to "
+                    f"unsafe Windows disk {disk_number}: "
+                    f"{', '.join(unsafe_reasons)}"
+                )
 
     def _prepare_devices_on_host(self, location_paths: List[str]) -> None:
         normalized_paths = [path.strip() for path in location_paths if path.strip()]
@@ -242,7 +367,11 @@ Get-VM | ForEach-Object {{
         pool_type: HostDevicePoolType,
         devices: List[DeviceAddressSchema],
     ) -> None:
-        primary_nic_id_list = self.get_primary_nic_id()
+        primary_nic_id_list = (
+            []
+            if pool_type == HostDevicePoolType.PCI_NVME
+            else self.get_primary_nic_id()
+        )
         pool = self.available_host_devices.get(pool_type, [])
         known_instance_ids = {device.instance_id for device in pool}
         for dev in devices:
@@ -274,6 +403,17 @@ Get-VM | ForEach-Object {{
         self.available_host_devices[pool_type] = pool
 
         return devices
+
+    def _return_devices_to_pool(
+        self,
+        pool_type: HostDevicePoolType,
+        devices: List[DeviceAddressSchema],
+    ) -> None:
+        pool = self.available_host_devices.get(pool_type, [])
+        for device in devices:
+            if device not in pool:
+                pool.append(device)
+        self.available_host_devices[pool_type] = pool
 
     def release_devices(
         self,
@@ -307,6 +447,10 @@ Get-VM | ForEach-Object {{
                     device.instance_id,
                     device.location_path,
                 )
+
+        for ctx in devices_ctx:
+            self._return_devices_to_pool(ctx.pool_type, ctx.device_list)
+        node_context.passthrough_devices.clear()
 
     def get_primary_nic_id(self) -> List[str]:
         powershell = self._server.tools[PowerShell]
@@ -404,6 +548,7 @@ Get-VM | ForEach-Object {{
     def _assign_devices_to_vm(
         self,
         vm_name: str,
+        pool_type: HostDevicePoolType,
         devices: List[DeviceAddressSchema],
     ) -> None:
         # Assign the devices to the VM
@@ -414,6 +559,9 @@ Get-VM | ForEach-Object {{
         powershell = self._server.tools[PowerShell]
 
         try:
+            if pool_type == HostDevicePoolType.PCI_NVME:
+                self._validate_nvme_devices(devices)
+
             for device in devices:
                 escaped_instance_id = device.instance_id.replace("'", "''")
                 escaped_location_path = device.location_path.replace("'", "''")
@@ -457,6 +605,7 @@ Get-VM | ForEach-Object {{
                     f"'{vm_name}': {err}. Rollback also failed: "
                     f"{'; '.join(rollback_errors)}"
                 ) from err
+            self._return_devices_to_pool(pool_type, devices)
             raise
 
     def _rollback_dda_assignment(
@@ -578,6 +727,7 @@ Get-VM | ForEach-Object {{
             )
             self._assign_devices_to_vm(
                 vm_name=vm_name,
+                pool_type=config.pool_type,
                 devices=devices,
             )
             device_context = DevicePassthroughContext()

--- a/selftests/test_hyperv_device_pool.py
+++ b/selftests/test_hyperv_device_pool.py
@@ -6,16 +6,315 @@ from typing import Any, List, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from lisa.sut_orchestrator.hyperv.context import DevicePassthroughContext, NodeContext
 from lisa.sut_orchestrator.hyperv.hyperv_device_pool import HyperVDevicePool
 from lisa.sut_orchestrator.hyperv.schema import (
     DeviceAddressSchema,
     HypervPlatformSchema,
+)
+from lisa.sut_orchestrator.util.schema import (
+    DeviceLocationPathIdentifier,
+    HostDevicePoolSchema,
+    HostDevicePoolType,
+    VendorDeviceIdIdentifier,
 )
 from lisa.tools import PowerShell
 from lisa.util import LisaException
 
 
 class HyperVDevicePoolTestCase(TestCase):
+    @patch("lisa.sut_orchestrator.hyperv.hyperv_device_pool.HypervAssignableDevices")
+    def test_configure_pci_nvme_pool_from_vendor_device_id(
+        self, assignable_devices_type: MagicMock
+    ) -> None:
+        nvme_device = DeviceAddressSchema(
+            instance_id="PCI\\VEN_144D&DEV_A80A",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+        get_assignable_devices = (
+            assignable_devices_type.return_value.get_assignable_devices
+        )
+        get_assignable_devices.return_value = [nvme_device]
+        powershell = MagicMock()
+        powershell.run_cmdlet.return_value = {
+            "Number": 1,
+            "FriendlyName": "NVMe data disk",
+            "BusType": "NVMe",
+            "IsBoot": False,
+            "IsSystem": False,
+            "IsMounted": False,
+        }
+        node = SimpleNamespace(tools={PowerShell: powershell})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+
+        pool.configure_device_passthrough_pool(
+            [
+                HostDevicePoolSchema(
+                    type=HostDevicePoolType.PCI_NVME,
+                    devices=[
+                        VendorDeviceIdIdentifier(vendor_id="144D", device_id="A80A")
+                    ],
+                )
+            ]
+        )
+
+        get_assignable_devices.assert_called_once_with(
+            vendor_id="144D",
+            device_id="A80A",
+        )
+        self.assertEqual(
+            [nvme_device],
+            pool.available_host_devices[HostDevicePoolType.PCI_NVME],
+        )
+
+    @patch("lisa.sut_orchestrator.hyperv.hyperv_device_pool.HypervAssignableDevices")
+    def test_configure_pci_nvme_pool_from_location_path(
+        self, assignable_devices_type: MagicMock
+    ) -> None:
+        location_path = "PCIROOT(1)#PCI(0000)"
+        nvme_device = DeviceAddressSchema(
+            instance_id="PCI\\VEN_144D&DEV_A80A",
+            location_path=location_path,
+        )
+        assignable_devices = assignable_devices_type.return_value
+        get_by_location_path = (
+            assignable_devices.get_assignable_devices_by_location_paths
+        )
+        get_by_location_path.return_value = [nvme_device]
+        powershell = MagicMock()
+        powershell.run_cmdlet.return_value = {
+            "Number": 1,
+            "FriendlyName": "NVMe data disk",
+            "BusType": "NVMe",
+            "IsBoot": False,
+            "IsSystem": False,
+            "IsMounted": False,
+        }
+        node = SimpleNamespace(tools={PowerShell: powershell})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+
+        with patch.object(pool, "_prepare_devices_on_host") as prepare_devices:
+            pool.configure_device_passthrough_pool(
+                [
+                    HostDevicePoolSchema(
+                        type=HostDevicePoolType.PCI_NVME,
+                        devices=DeviceLocationPathIdentifier(
+                            location_path=[location_path]
+                        ),
+                    )
+                ]
+            )
+
+        prepare_devices.assert_called_once_with([location_path])
+        get_by_location_path.assert_called_once_with([location_path])
+        self.assertEqual(
+            [nvme_device],
+            pool.available_host_devices[HostDevicePoolType.PCI_NVME],
+        )
+
+    @patch("lisa.sut_orchestrator.hyperv.hyperv_device_pool.HypervAssignableDevices")
+    def test_rejects_missing_or_ambiguous_pci_nvme_vendor_device_selection(
+        self, assignable_devices_type: MagicMock
+    ) -> None:
+        node = SimpleNamespace(tools={PowerShell: MagicMock()})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+        get_assignable_devices = (
+            assignable_devices_type.return_value.get_assignable_devices
+        )
+
+        for device_count in (0, 2):
+            with self.subTest(device_count=device_count):
+                devices = [
+                    DeviceAddressSchema(instance_id=f"PCI\\DEVICE_{device_index}")
+                    for device_index in range(device_count)
+                ]
+                get_assignable_devices.return_value = devices
+
+                with self.assertRaisesRegex(LisaException, "exactly one"):
+                    pool.create_device_pool_from_vendor_device_id(
+                        pool_type=HostDevicePoolType.PCI_NVME,
+                        vendor_id="144D",
+                        device_id="A80A",
+                    )
+
+    def test_rejects_unsafe_pci_nvme_disk(self) -> None:
+        device = DeviceAddressSchema(
+            instance_id="PCI\\VEN_144D&DEV_A80A",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+        safety_cases = {
+            "missing disk": ([], "exactly one Windows disk"),
+            "incomplete record": ({}, "incomplete Windows disk safety record"),
+            "multiple disks": (
+                [
+                    {"Number": 1, "IsBoot": False},
+                    {"Number": 2, "IsBoot": False},
+                ],
+                "exactly one Windows disk",
+            ),
+            "RAID disk": (
+                {
+                    "Number": 1,
+                    "BusType": "RAID",
+                    "IsBoot": False,
+                    "IsSystem": False,
+                    "IsMounted": False,
+                },
+                "not NVMe",
+            ),
+            "boot disk": (
+                {
+                    "Number": 0,
+                    "BusType": "NVMe",
+                    "IsBoot": True,
+                    "IsSystem": False,
+                    "IsMounted": False,
+                },
+                "boot",
+            ),
+            "system disk": (
+                {
+                    "Number": 0,
+                    "BusType": "NVMe",
+                    "IsBoot": False,
+                    "IsSystem": True,
+                    "IsMounted": False,
+                },
+                "system",
+            ),
+            "mounted disk": (
+                {
+                    "Number": 1,
+                    "BusType": "NVMe",
+                    "IsBoot": False,
+                    "IsSystem": False,
+                    "IsMounted": True,
+                },
+                "mounted",
+            ),
+        }
+
+        for case_name, (disk_records, expected_error) in safety_cases.items():
+            with self.subTest(case_name):
+                powershell = MagicMock()
+                powershell.run_cmdlet.return_value = disk_records
+                node = SimpleNamespace(tools={PowerShell: powershell})
+                pool = HyperVDevicePool(
+                    node=cast(Any, node),
+                    runbook=HypervPlatformSchema(),
+                    log=MagicMock(),
+                )
+
+                with self.assertRaisesRegex(LisaException, expected_error):
+                    pool._validate_nvme_devices([device])
+
+    def test_pci_gpu_still_excludes_primary_nic(self) -> None:
+        primary_nic = DeviceAddressSchema(
+            instance_id="PCI\\PRIMARY_NIC",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+        node = SimpleNamespace(tools={PowerShell: MagicMock()})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+
+        with patch.object(
+            pool, "get_primary_nic_id", return_value=[primary_nic.instance_id]
+        ) as get_primary_nic_id:
+            pool._append_devices_to_pool(HostDevicePoolType.PCI_GPU, [primary_nic])
+
+        get_primary_nic_id.assert_called_once_with()
+        self.assertEqual([], pool.available_host_devices[HostDevicePoolType.PCI_GPU])
+
+    def test_release_pci_nvme_restores_host_device(self) -> None:
+        device = DeviceAddressSchema(
+            instance_id="PCI\\VEN_144D&DEV_A80A",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+        powershell = MagicMock()
+        node = SimpleNamespace(tools={PowerShell: powershell})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+        node_context = NodeContext(
+            vm_name="vm1",
+            passthrough_devices=[
+                DevicePassthroughContext(
+                    pool_type=HostDevicePoolType.PCI_NVME,
+                    device_list=[device],
+                    requested_count=1,
+                )
+            ],
+        )
+
+        with patch.object(pool, "_wait_for_pnp_device_enabled") as wait_enabled:
+            pool.release_devices(node_context)
+
+        commands = [
+            call.kwargs.get("cmdlet", call.args[0] if call.args else "")
+            for call in powershell.run_cmdlet.call_args_list
+        ]
+        self.assertIn("Remove-VMAssignableDevice", commands[0])
+        self.assertIn("Mount-VMHostAssignableDevice", commands[1])
+        self.assertIn("Enable-PnpDevice", commands[2])
+        wait_enabled.assert_called_once_with(device.instance_id, device.location_path)
+        self.assertEqual(
+            [device], pool.available_host_devices[HostDevicePoolType.PCI_NVME]
+        )
+        self.assertEqual([], node_context.passthrough_devices)
+
+    def test_revalidates_pci_nvme_before_assignment(self) -> None:
+        device = DeviceAddressSchema(
+            instance_id="PCI\\VEN_144D&DEV_A80A",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+        powershell = MagicMock()
+        powershell.run_cmdlet.return_value = {
+            "Number": 0,
+            "BusType": "NVMe",
+            "IsBoot": True,
+            "IsSystem": True,
+            "IsMounted": True,
+        }
+        node = SimpleNamespace(tools={PowerShell: powershell})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+
+        with self.assertRaisesRegex(LisaException, "unsafe Windows disk"):
+            pool._assign_devices_to_vm(
+                vm_name="vm1",
+                pool_type=HostDevicePoolType.PCI_NVME,
+                devices=[device],
+            )
+
+        commands = [
+            call.kwargs.get("cmdlet", call.args[0] if call.args else "")
+            for call in powershell.run_cmdlet.call_args_list
+        ]
+        self.assertFalse(any("Disable-PnpDevice" in command for command in commands))
+        self.assertEqual(
+            [device], pool.available_host_devices[HostDevicePoolType.PCI_NVME]
+        )
+
     def test_assign_devices_rolls_back_on_dismount_failure(self) -> None:
         first_device = DeviceAddressSchema(
             instance_id="PCI\\FIRST",
@@ -48,6 +347,7 @@ class HyperVDevicePoolTestCase(TestCase):
             with self.assertRaises(LisaException):
                 pool._assign_devices_to_vm(
                     vm_name="vm1",
+                    pool_type=HostDevicePoolType.PCI_NIC,
                     devices=[first_device, second_device],
                 )
 
@@ -83,3 +383,37 @@ class HyperVDevicePoolTestCase(TestCase):
         wait_enabled.assert_any_call(
             first_device.instance_id, first_device.location_path
         )
+        self.assertEqual(
+            [first_device, second_device],
+            pool.available_host_devices[HostDevicePoolType.PCI_NIC],
+        )
+
+    def test_assignment_rollback_failure_keeps_device_out_of_pool(self) -> None:
+        device = DeviceAddressSchema(
+            instance_id="PCI\\DEVICE",
+            location_path="PCIROOT(1)#PCI(0000)",
+        )
+
+        def run_cmdlet(cmdlet: str, **_: Any) -> str:
+            if "Dismount-VMHostAssignableDevice" in cmdlet:
+                raise LisaException("dismount failed")
+            if "Enable-PnpDevice" in cmdlet:
+                raise LisaException("enable failed")
+            return ""
+
+        powershell = SimpleNamespace(run_cmdlet=MagicMock(side_effect=run_cmdlet))
+        node = SimpleNamespace(tools={PowerShell: powershell})
+        pool = HyperVDevicePool(
+            node=cast(Any, node),
+            runbook=HypervPlatformSchema(),
+            log=MagicMock(),
+        )
+
+        with self.assertRaisesRegex(LisaException, "Rollback also failed"):
+            pool._assign_devices_to_vm(
+                vm_name="vm1",
+                pool_type=HostDevicePoolType.PCI_NIC,
+                devices=[device],
+            )
+
+        self.assertNotIn(HostDevicePoolType.PCI_NIC, pool.available_host_devices)


### PR DESCRIPTION
## Description

Adds safe PCI NVMe passthrough support to the Hyper-V device pool for L1VH scenarios.

The change supports `PCI_NVME` pools using vendor/device IDs or explicit Hyper-V location paths. It resolves the selected PCI controller to exactly one Windows NVMe disk and rejects missing, ambiguous, RAID-backed, boot, system, or mounted disks before Hyper-V DDA assignment.

NVMe safety is revalidated immediately before destructive assignment operations. Existing DDA assignment, rollback, and release paths are reused. Successfully restored devices are returned to the pool, while devices with incomplete rollback remain unavailable to prevent unsafe reuse.

Existing PCI NIC and GPU behavior is preserved.

End-to-end Hyper-V DDA validation with a non-boot native PCI NVMe device is pending and will be completed with the follow-up L1VH pipeline integration.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**

`verify_storage_passthrough_nvme_visible|perf_storage_passthrough_fio_randread|perf_storage_passthrough_fio_randwrite`

**Impacted LISA Features:**

`Nvme`

**Tested Azure Marketplace Images:**

- None. This change updates Hyper-V host orchestration; L1VH marketplace-image validation is deferred to the follow-up end-to-end pipeline work.

## Test Results

| Image | VM Size | Result |
|---|---|---|
| N/A | Local selftests | PASSED - 9 Hyper-V device-pool tests |
| N/A | Full LISA selftest suite | PASSED - 302 tests |
| N/A | Static validation | PASSED - Black, Flake8, Mypy, Pylint, and Python 3.9 compilation |
| N/A | Windows host validation | PASSED - read-only NVMe controller-to-disk mapping and PowerShell syntax validation |
| L1VH Linux image | Physical Hyper-V host | PENDING - native PCI NVMe hardware availability |