### PR TITLE
Enhance VM naming, cleanup logic, and xfstests orchestration

### DIFF
--- a/lisa/messages.py
+++ b/lisa/messages.py
@@ -47,6 +47,8 @@ TestStatus = Enum(
         "SKIPPED",
         # A test result is failed with known issue.
         "ATTEMPTED",
+        # A test was explicitly excluded/skipped before runtime
+        "EXPUNGED",
     ],
 )
 
@@ -352,6 +354,7 @@ def _is_completed_status(status: TestStatus) -> bool:
         TestStatus.PASSED,
         TestStatus.SKIPPED,
         TestStatus.ATTEMPTED,
+        TestStatus.EXPUNGED,
     ]
 
 

--- a/lisa/microsoft/testsuites/xfstests/xfstesting.py
+++ b/lisa/microsoft/testsuites/xfstests/xfstesting.py
@@ -1,66 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 """
-Xfstesting Test Suite Module
-============================
+Xfstesting test suite: validates filesystems with the xfstests benchmark on
+data disks, NVMe disks, and Azure Files (SMB/CIFS and NFSv4.1).
 
-This module contains the Xfstesting test suite for validating filesystem
-functionality using the xfstests benchmark tool on various disk types.
-
-Test Categories:
-----------------
-1. **Standard Data Disk Tests**: Tests against Azure Standard HDD disks
-   - verify_generic_standard_datadisk (xfs)
-   - verify_generic_ext4_standard_datadisk (ext4)
-   - verify_xfs_standard_datadisk (xfs-specific)
-   - verify_ext4_standard_datadisk (ext4-specific)
-   - verify_btrfs_standard_datadisk (btrfs-specific)
-
-2. **NVMe Data Disk Tests**: Tests against NVMe disks
-   - verify_generic_nvme_datadisk (xfs)
-   - verify_generic_ext4_nvme_datadisk (ext4)
-   - verify_xfs_nvme_datadisk (xfs-specific)
-   - verify_ext4_nvme_datadisk (ext4-specific)
-   - verify_btrfs_nvme_datadisk (btrfs-specific)
-
-3. **Azure File Share Tests**: Tests against Azure Files (SMB/CIFS)
-   - verify_azure_file_share (parallel execution with multiple workers)
-
-Parallel Execution for Azure File Share (January 2026 Enhancement):
--------------------------------------------------------------------
-The verify_azure_file_share test uses parallel execution to reduce runtime.
-This is controlled by the `_default_worker_count` variable.
-
-**IMPORTANT: _default_worker_count ONLY affects verify_azure_file_share**
-
-Other tests (data disk, NVMe) continue to use sequential execution via
-the `_execute_xfstests()` method and are NOT affected by this variable.
-
-The `after_case()` method does reference `_default_worker_count` for cleanup,
-but this is defensive/best-effort cleanup wrapped in try/except blocks:
-- For non-parallel tests: cleanup attempts fail silently (resources don't exist)
-- For parallel tests: cleanup properly removes worker directories and mounts
-
-Benefits of Parallel Execution:
--------------------------------
-1. **Reduced Runtime**: ~45+ min → ~24 min (3 workers) or ~18 min (4 workers)
-2. **Better Resource Utilization**: Azure File Share tests are I/O bound,
-   not CPU bound, making parallelization effective
-3. **Isolated Workers**: Each worker has its own xfstests copy and file shares,
-   preventing race conditions and state conflicts
-
-Configuration:
---------------
-- `_default_worker_count`: Number of parallel workers (default: 4)
-- Each worker gets its own Azure File Share pair (test + scratch)
-- Tests are distributed round-robin across workers
-- Results are aggregated after all workers complete
-
-Known Limitations:
-------------------
-- Round-robin distribution doesn't account for test duration variability
-- Some tests (e.g., generic/007: 285s) are much slower than others (0-5s)
-- This can cause worker imbalance; future work: runtime-aware distribution
+The Azure Files tests (verify_azure_file_share, verify_azure_file_share_nfsv4)
+run in parallel across `_default_worker_count` workers, each with its own
+xfstests copy and test/scratch share pair. Data-disk and NVMe tests remain
+sequential via _execute_xfstests() and are unaffected by the worker count.
+Tests are distributed round-robin (by count, not runtime), so slow cases can
+imbalance workers; runtime-aware distribution is future work.
 """
 
 import string
@@ -300,80 +249,33 @@ _default_smb_testcases: str = (
     "generic/638 generic/639"
 )
 
-# =============================================================================
-# Section: Global Options
-# =============================================================================
-
 # Standard xfstests mount points (used by all tests)
 _scratch_folder = "/mnt/scratch"
 _test_folder = "/mnt/test"
 
-# -----------------------------------------------------------------------------
-# Parallel Worker Configuration
-# -----------------------------------------------------------------------------
-# Number of parallel workers for Azure File Share (verify_azure_file_share) test.
-#
-# SCOPE: This variable ONLY affects the verify_azure_file_share test case.
-#        All other test cases (data disk, NVMe) use sequential execution
-#        via _execute_xfstests() and are completely unaffected.
-#
-# The after_case() method references this for cleanup, but uses defensive
-# try/except blocks that fail silently for non-parallel tests.
-#
-# RECOMMENDED VALUES:
-#   - 3 workers: ~24 min runtime, good balance of speed vs resource usage
-#   - 4 workers: ~18-20 min runtime, better parallelization
-#   - Higher values: Diminishing returns, more Azure resources consumed
-#
-# RESOURCE IMPACT (per worker):
-#   - 1 xfstests directory copy (~500MB on remote VM)
-#   - 2 Azure File Shares (test + scratch)
-#   - 2 mount points on VM
-#
-# LOAD BALANCING NOTE:
-#   Tests are distributed round-robin by count, not by runtime.
-#   Some tests vary significantly in duration (0s to 285s), causing
-#   potential worker imbalance. Future enhancement: runtime-aware distribution.
+# Parallel workers for the Azure Files tests only (data-disk/NVMe are sequential).
+# 3 workers ~24 min, 4 workers ~18-20 min. Each worker adds an xfstests copy,
+# a test+scratch share pair, and two mount points.
+# Tests are distributed across workers round-robin by count, not runtime.
 _default_worker_count = 4
 
 
-# =============================================================================
-# Azure File Share Parallel Execution Context
-# =============================================================================
 @dataclass
 class AzureFileShareContext:
     """
-    Holds state for Azure File Share parallel test execution (SMB or NFS).
-
-    This unified dataclass encapsulates all the resources created during
-    parallel test setup for both SMB (CIFS) and NFS protocols. It makes
-    cleanup deterministic and self-documenting.
-
-    Works correctly with any worker_count (1 = single worker, N = N workers).
-
-    Usage:
-        context = AzureFileShareContext(runner=runner, protocol="cifs")
-        # ... setup populates context fields ...
-        # ... tests run ...
-        # ... cleanup uses context to know what to clean ...
+    State for a parallel Azure Files run (SMB or NFS); makes cleanup
+    deterministic. Works for any worker_count.
 
     Attributes:
         runner: XfstestsParallelRunner managing worker lifecycle
-        protocol: Protocol type - "cifs" for SMB or "nfs" for NFS
-        share_names: Mapping of worker share keys to Azure share names
-                     e.g., {"test_1": "lisaXXXw1fs", "scratch_1": "lisaXXXw1sc"}
-        all_share_names: Flat list of all created share names for bulk deletion
-        fs_url_dict: Mapping of share names to device paths
-                     SMB: //server/share URLs, NFS: server:/export paths
-        mount_opts: Mount options string
-                    SMB: full CIFS mount options with credentials
-                    NFS: raw options for LISA's NFSClient (without -o)
-        xfstests_mount_opts: Mount options for xfstests local.config
-                             NFS only: includes -o prefix
-                             SMB: same as mount_opts
-        nfs_server: NFS server hostname (NFS only, empty for SMB)
-                    e.g., account.file.core.windows.net
-        test_failed: Whether the test failed (affects cleanup behavior)
+        protocol: "cifs" for SMB or "nfs" for NFS
+        share_names: worker share keys -> Azure share names
+        all_share_names: flat list of all shares for bulk deletion
+        fs_url_dict: share name -> device path (SMB URL or NFS server:/export)
+        mount_opts: mount options (SMB includes credentials; NFS raw, no -o)
+        xfstests_mount_opts: options for local.config (NFS includes -o prefix)
+        nfs_server: NFS server host (NFS only, e.g. account.file.core.windows.net)
+        test_failed: whether the test failed (affects cleanup)
     """
 
     runner: XfstestsParallelRunner
@@ -1037,6 +939,50 @@ class Xfstesting(TestSuite):
             except Exception as cleanup_error:
                 log.error(f"Failed to clean up file shares: {cleanup_error}")
 
+    def _prepare_worker_devices(
+        self,
+        node: RemoteNode,
+        ctx: AzureFileShareContext,
+        azure_file_share: AzureFileShare,
+        worker_id: int,
+        test_mount: str,
+        scratch_mount: str,
+        log: Logger,
+    ) -> Tuple[str, str]:
+        # Returns (test_dev, scratch_dev); mounts NFS shares as a side effect.
+        test_share_name = ctx.share_names[f"test_{worker_id}"]
+        scratch_share_name = ctx.share_names[f"scratch_{worker_id}"]
+
+        if ctx.protocol != "nfs":
+            log.debug(
+                f"Worker {worker_id}: Configuring CIFS local.config "
+                f"(test={test_share_name}, scratch={scratch_share_name})"
+            )
+            return (
+                ctx.fs_url_dict[test_share_name],
+                ctx.fs_url_dict[scratch_share_name],
+            )
+
+        # NFS export path format: /storageaccount/sharename
+        account = azure_file_share.storage_account_name
+        test_export = f"/{account}/{test_share_name}"
+        scratch_export = f"/{account}/{scratch_share_name}"
+        log.debug(
+            f"Worker {worker_id}: Mounting NFS shares "
+            f"(test={test_share_name}, scratch={scratch_share_name})"
+        )
+        node.tools[NFSClient].setup(
+            ctx.nfs_server, test_export, test_mount, options=ctx.mount_opts
+        )
+        node.tools[NFSClient].setup(
+            ctx.nfs_server, scratch_export, scratch_mount, options=ctx.mount_opts
+        )
+        # NFS device format for xfstests: server:/export
+        return (
+            f"{ctx.nfs_server}:{test_export}",
+            f"{ctx.nfs_server}:{scratch_export}",
+        )
+
     def _setup_azure_file_share_workers(
         self,
         log: Logger,
@@ -1046,28 +992,19 @@ class Xfstesting(TestSuite):
         azure_file_share: AzureFileShare,
         runner: XfstestsParallelRunner,
         random_str: str,
+        protocol: FileShareProtocol = FileShareProtocol.SMB,
     ) -> AzureFileShareContext:
         """
-        Set up Azure File Shares (SMB/CIFS) for parallel xfstests workers.
-
-        Creates separate file shares per worker and configures each worker's
-        local.config and exclude.txt. Worker directories must be created
-        by runner.create_workers() before calling this method.
-
-        Args:
-            log: Logger for status messages
-            node: Remote VM node to configure
-            xfstests: Xfstests tool instance
-            environment: LISA environment for Azure provisioning
-            azure_file_share: AzureFileShare feature for share creation
-            runner: XfstestsParallelRunner with workers already created
-            random_str: Random string for unique share naming
-
-        Returns:
-            AzureFileShareContext: Context object with all setup state
+        Provision per-worker Azure File Shares (SMB or NFS) and write each
+        worker's local.config and exclude.txt. Requires runner.create_workers()
+        to have run first. Only protocol-specific bits differ; the scaffolding
+        is shared. Returns a populated AzureFileShareContext for cleanup.
         """
+        is_nfs = protocol == FileShareProtocol.NFS
+        proto_label = "nfs" if is_nfs else "cifs"
+
         # Initialize context and create share mappings using helper
-        ctx = AzureFileShareContext(runner=runner, protocol="cifs")
+        ctx = AzureFileShareContext(runner=runner, protocol=proto_label)
         (
             share_names,
             all_share_names,
@@ -1077,40 +1014,62 @@ class Xfstesting(TestSuite):
         ctx.share_names = share_names
         ctx.all_share_names = all_share_names
 
-        log.info(f"Creating {len(ctx.all_share_names)} Azure file shares for workers")
-        ctx.fs_url_dict = _deploy_azure_file_share(
-            node=node,
-            environment=environment,
-            names=names_dict,
-            azure_file_share=azure_file_share,
-            file_share_quota_in_gb=per_share_quota,
-            provisioned_bandwidth_mibps=110,
-            provisioned_iops=3110,
-        )
+        share_desc = "NFS shares" if is_nfs else "file shares"
+        log.info(f"Creating {len(ctx.all_share_names)} Azure {share_desc} for workers")
 
-        ctx.mount_opts = (
-            f"-o {_default_smb_mount},"
-            f"credentials={azure_file_share.credential_file}"
-        )
-        ctx.xfstests_mount_opts = ctx.mount_opts  # Same for SMB
+        # NFS requires:
+        # - allow_shared_key_access=False (NFS uses network-based auth)
+        # - enable_https_traffic_only=False (NFS doesn't use HTTPS)
+        # - skip_mount=True (NFS mounting is done separately with NFSClient)
+        deploy_kwargs: Dict[str, Any] = {
+            "node": node,
+            "environment": environment,
+            "names": names_dict,
+            "azure_file_share": azure_file_share,
+            "file_share_quota_in_gb": per_share_quota,
+            "provisioned_bandwidth_mibps": 110,
+            "provisioned_iops": 3110,
+        }
+        if is_nfs:
+            deploy_kwargs.update(
+                protocol=FileShareProtocol.NFS,
+                allow_shared_key_access=False,
+                enable_private_endpoint=True,
+                enable_https_traffic_only=False,
+                skip_mount=True,
+            )
+        ctx.fs_url_dict = _deploy_azure_file_share(**deploy_kwargs)
+
+        # Configure protocol-specific mount options
+        if is_nfs:
+            ctx.nfs_server = (
+                f"{azure_file_share.storage_account_name}.file.core.windows.net"
+            )
+            ctx.mount_opts = _default_nfs_mount_opts
+            ctx.xfstests_mount_opts = _default_nfs_mount
+        else:
+            ctx.mount_opts = (
+                f"-o {_default_smb_mount},"
+                f"credentials={azure_file_share.credential_file}"
+            )
+            ctx.xfstests_mount_opts = ctx.mount_opts  # Same for SMB
 
         # Create worker mount points on the VM
         self._create_worker_mount_points(node, runner)
+
+        excluded_tests = (
+            _default_nfs_excluded_tests if is_nfs else _default_smb_excluded_tests
+        )
 
         # Configure each worker's local.config with worker-specific paths
         worker_paths = runner.worker_paths
         for worker_id in runner.worker_ids():
             test_mount = f"{_test_folder}_worker_{worker_id}"
             scratch_mount = f"{_scratch_folder}_worker_{worker_id}"
-            test_share_name = ctx.share_names[f"test_{worker_id}"]
-            scratch_share_name = ctx.share_names[f"scratch_{worker_id}"]
-            test_dev = ctx.fs_url_dict[test_share_name]
-            scratch_dev = ctx.fs_url_dict[scratch_share_name]
             worker_path = worker_paths[worker_id - 1]
 
-            log.debug(
-                f"Worker {worker_id}: Configuring local.config "
-                f"(test_dev={test_dev}, scratch_dev={scratch_dev})"
+            test_dev, scratch_dev = self._prepare_worker_devices(
+                node, ctx, azure_file_share, worker_id, test_mount, scratch_mount, log
             )
 
             xfstests.set_local_config(
@@ -1118,130 +1077,8 @@ class Xfstesting(TestSuite):
                 scratch_mnt=scratch_mount,
                 test_dev=test_dev,
                 test_folder=test_mount,
-                file_system="cifs",
-                test_section="cifs",
-                mount_opts=ctx.mount_opts,
-                testfs_mount_opts=ctx.mount_opts,
-                overwrite_config=True,
-                xfstests_path=worker_path,
-            )
-
-            xfstests.set_excluded_tests(
-                _default_smb_excluded_tests,
-                xfstests_path=worker_path,
-            )
-
-        return ctx
-
-    def _setup_azure_nfs_workers(
-        self,
-        log: Logger,
-        node: RemoteNode,
-        xfstests: Xfstests,
-        environment: Environment,
-        azure_file_share: AzureFileShare,
-        runner: XfstestsParallelRunner,
-        random_str: str,
-    ) -> AzureFileShareContext:
-        """
-        Set up Azure Files NFS shares for parallel xfstests workers.
-
-        Creates separate NFS shares per worker and configures each worker's
-        local.config. Uses shared helper methods for common operations.
-        Worker directories must be created by runner.create_workers() before
-        calling this method.
-
-        Args:
-            log: Logger for status messages
-            node: Remote VM node to configure
-            xfstests: Xfstests tool instance
-            environment: LISA environment for Azure provisioning
-            azure_file_share: AzureFileShare feature for share creation
-            runner: XfstestsParallelRunner with workers already created
-            random_str: Random string for unique share naming
-
-        Returns:
-            AzureFileShareContext: Context object with all setup state
-        """
-        # Initialize context and create share mappings using helper
-        ctx = AzureFileShareContext(runner=runner, protocol="nfs")
-        (
-            share_names,
-            all_share_names,
-            names_dict,
-            per_share_quota,
-        ) = self._create_worker_shares(runner, random_str)
-        ctx.share_names = share_names
-        ctx.all_share_names = all_share_names
-
-        log.info(f"Creating {len(ctx.all_share_names)} Azure NFS shares for workers")
-        # NFS requires:
-        # - allow_shared_key_access=False (NFS uses network-based auth, not shared keys)
-        # - enable_private_endpoint=True (NFS requires private network access)
-        # - enable_https_traffic_only=False (NFS doesn't use HTTPS)
-        # - skip_mount=True (NFS mounting is done separately with NFSClient)
-        ctx.fs_url_dict = _deploy_azure_file_share(
-            node=node,
-            environment=environment,
-            names=names_dict,
-            azure_file_share=azure_file_share,
-            protocol=FileShareProtocol.NFS,
-            allow_shared_key_access=False,
-            enable_private_endpoint=True,
-            enable_https_traffic_only=False,
-            file_share_quota_in_gb=per_share_quota,
-            provisioned_bandwidth_mibps=110,
-            provisioned_iops=3110,
-            skip_mount=True,
-        )
-
-        # Configure NFS-specific settings
-        storage_account_name = azure_file_share.storage_account_name
-        ctx.nfs_server = f"{storage_account_name}.file.core.windows.net"
-        ctx.mount_opts = _default_nfs_mount_opts
-        ctx.xfstests_mount_opts = _default_nfs_mount
-
-        # Create worker mount points on the VM
-        self._create_worker_mount_points(node, runner)
-
-        # Mount NFS shares and configure each worker's local.config
-        worker_paths = runner.worker_paths
-        for worker_id in runner.worker_ids():
-            test_mount = f"{_test_folder}_worker_{worker_id}"
-            scratch_mount = f"{_scratch_folder}_worker_{worker_id}"
-            test_share_name = ctx.share_names[f"test_{worker_id}"]
-            scratch_share_name = ctx.share_names[f"scratch_{worker_id}"]
-
-            # NFS export path format: /storageaccount/sharename
-            test_export = f"/{storage_account_name}/{test_share_name}"
-            scratch_export = f"/{storage_account_name}/{scratch_share_name}"
-
-            # NFS device format for xfstests: server:/export
-            test_dev = f"{ctx.nfs_server}:{test_export}"
-            scratch_dev = f"{ctx.nfs_server}:{scratch_export}"
-
-            worker_path = worker_paths[worker_id - 1]
-
-            log.debug(
-                f"Worker {worker_id}: Mounting NFS shares "
-                f"(test={test_share_name}, scratch={scratch_share_name})"
-            )
-
-            # Mount NFS shares
-            node.tools[NFSClient].setup(
-                ctx.nfs_server, test_export, test_mount, options=ctx.mount_opts
-            )
-            node.tools[NFSClient].setup(
-                ctx.nfs_server, scratch_export, scratch_mount, options=ctx.mount_opts
-            )
-
-            xfstests.set_local_config(
-                scratch_dev=scratch_dev,
-                scratch_mnt=scratch_mount,
-                test_dev=test_dev,
-                test_folder=test_mount,
-                file_system="nfs",
-                test_section="nfs",
+                file_system=proto_label,
+                test_section=proto_label,
                 mount_opts=ctx.xfstests_mount_opts,
                 testfs_mount_opts=ctx.xfstests_mount_opts,
                 overwrite_config=True,
@@ -1249,11 +1086,107 @@ class Xfstesting(TestSuite):
             )
 
             xfstests.set_excluded_tests(
-                _default_nfs_excluded_tests,
+                excluded_tests,
                 xfstests_path=worker_path,
             )
 
         return ctx
+
+    def _run_azure_file_share_xfstests(
+        self,
+        log: Logger,
+        log_path: Path,
+        result: TestResult,
+        protocol: FileShareProtocol,
+    ) -> None:
+        is_nfs = protocol == FileShareProtocol.NFS
+        proto_label = "nfs" if is_nfs else "cifs"
+        testcases = _default_nfs_testcases if is_nfs else _default_smb_testcases
+
+        environment = result.environment
+        assert environment, "fail to get environment from testresult"
+        assert isinstance(environment.platform, AzurePlatform)
+        node = cast(RemoteNode, environment.nodes[0])
+
+        # CIFS kernel module is required only for the SMB transport.
+        if not is_nfs and not node.tools[KernelConfig].is_enabled("CONFIG_CIFS"):
+            raise UnsupportedDistroException(
+                node.os, "current distro is not enabled with cifs module."
+            )
+
+        xfstests = self._install_xfstests(node)
+        azure_file_share = node.features[AzureFileShare]
+        random_str = generate_random_chars(string.ascii_lowercase + string.digits, 10)
+
+        runner = XfstestsParallelRunner(
+            xfstests=xfstests,
+            log=log,
+            worker_count=_default_worker_count,
+        )
+        log.info(
+            f"Using {runner.worker_count} parallel workers for {proto_label} xfstests"
+        )
+
+        ctx = AzureFileShareContext(runner=runner, protocol=proto_label)
+
+        try:
+            # set_max_session() closes the SSH connection; the echo forces a
+            # reconnect before parallel workers spawn, avoiding a shell race
+            # where workers see _is_initialized=True but _inner_shell is None.
+            log.debug(
+                f"Increasing SSH MaxSessions for {runner.worker_count} "
+                "parallel workers"
+            )
+            node.tools[Ssh].set_max_session()
+            node.execute("echo 'SSH reconnected'")
+
+            runner.create_workers()
+
+            ctx = self._setup_azure_file_share_workers(
+                log=log,
+                node=node,
+                xfstests=xfstests,
+                environment=environment,
+                azure_file_share=azure_file_share,
+                runner=runner,
+                random_str=random_str,
+                protocol=protocol,
+            )
+
+            all_tests = testcases.split()
+            test_batches = runner.split_tests(all_tests)
+            log.info(
+                f"Split {len(all_tests)} tests into {runner.worker_count} batches: "
+                f"{[len(b) for b in test_batches]} tests each"
+            )
+            log.info(
+                f"Running xfstests against Azure Files {proto_label} "
+                "with parallel workers"
+            )
+
+            # Execute tests in parallel using the runner
+            worker_results = runner.run_parallel(
+                test_batches=test_batches,
+                log_path=log_path,
+                result=result,
+                test_section=proto_label,
+                timeout=self.TIME_OUT,
+                run_id_prefix=f"{proto_label}_worker",
+            )
+
+            # Aggregate results (raises on failure)
+            _, _, ctx.test_failed = runner.aggregate_results(worker_results)
+        except Exception:
+            ctx.test_failed = True
+            raise
+        finally:
+            self._cleanup_azure_workers(
+                log=log,
+                node=node,
+                ctx=ctx,
+                azure_file_share=azure_file_share,
+                environment=environment,
+            )
 
     @TestCaseMetadata(
         description="""
@@ -1281,94 +1214,9 @@ class Xfstesting(TestSuite):
     def verify_azure_file_share(
         self, log: Logger, log_path: Path, result: TestResult
     ) -> None:
-        environment = result.environment
-        assert environment, "fail to get environment from testresult"
-        assert isinstance(environment.platform, AzurePlatform)
-        node = cast(RemoteNode, environment.nodes[0])
-        if not node.tools[KernelConfig].is_enabled("CONFIG_CIFS"):
-            raise UnsupportedDistroException(
-                node.os, "current distro is not enabled with cifs module."
-            )
-        xfstests = self._install_xfstests(node)
-        azure_file_share = node.features[AzureFileShare]
-        random_str = generate_random_chars(string.ascii_lowercase + string.digits, 10)
-
-        # Create parallel runner for worker management
-        runner = XfstestsParallelRunner(
-            xfstests=xfstests,
-            log=log,
-            worker_count=_default_worker_count,
+        self._run_azure_file_share_xfstests(
+            log, log_path, result, FileShareProtocol.SMB
         )
-        log.info(f"Using {runner.worker_count} parallel workers for xfstests")
-
-        # Initialize context - will be populated by setup, used by cleanup
-        ctx = AzureFileShareContext(runner=runner, protocol="cifs")
-
-        try:
-            # Increase SSH MaxSessions to handle parallel worker SSH commands.
-            # Default Ubuntu MaxSessions=10 is insufficient for 6 workers
-            # each running 4+ concurrent SSH commands during worker creation.
-            # This prevents: ChannelException(2, 'Connect failed')
-            log.debug(
-                f"Increasing SSH MaxSessions for {runner.worker_count} parallel workers"
-            )
-            node.tools[Ssh].set_max_session()
-
-            # Force SSH reconnection after set_max_session() closes the connection.
-            # This ensures the connection is re-established before parallel workers
-            # start, preventing race conditions where workers see _is_initialized=True
-            # but _inner_shell is still None (AssertionError in shell.spawn).
-            node.execute("echo 'SSH reconnected'")
-
-            # Create worker xfstests directory copies first
-            runner.create_workers()
-
-            # Set up Azure file shares and configure workers
-            # Returns populated context with all setup state
-            ctx = self._setup_azure_file_share_workers(
-                log=log,
-                node=node,
-                xfstests=xfstests,
-                environment=environment,
-                azure_file_share=azure_file_share,
-                runner=runner,
-                random_str=random_str,
-            )
-
-            # Get the list of tests and split into batches
-            all_tests = _default_smb_testcases.split()
-            test_batches = runner.split_tests(all_tests)
-            log.info(
-                f"Split {len(all_tests)} tests into {runner.worker_count} batches: "
-                f"{[len(b) for b in test_batches]} tests each"
-            )
-
-            log.info("Running xfstests against azure file share with parallel workers")
-
-            # Execute tests in parallel using the runner
-            worker_results = runner.run_parallel(
-                test_batches=test_batches,
-                log_path=log_path,
-                result=result,
-                test_section="cifs",
-                timeout=self.TIME_OUT,
-                run_id_prefix="cifs_worker",
-            )
-
-            # Aggregate results (raises on failure)
-            _, _, ctx.test_failed = runner.aggregate_results(worker_results)
-
-        except Exception:
-            ctx.test_failed = True
-            raise
-        finally:
-            self._cleanup_azure_workers(
-                log=log,
-                node=node,
-                ctx=ctx,
-                azure_file_share=azure_file_share,
-                environment=environment,
-            )
 
     @TestCaseMetadata(
         description="""
@@ -1402,123 +1250,18 @@ class Xfstesting(TestSuite):
     def verify_azure_file_share_nfsv4(
         self, log: Logger, log_path: Path, result: TestResult
     ) -> None:
-        environment = result.environment
-        assert environment, "fail to get environment from testresult"
-        assert isinstance(environment.platform, AzurePlatform)
-        node = cast(RemoteNode, environment.nodes[0])
-
-        # Install xfstests
-        xfstests = self._install_xfstests(node)
-
-        # Get Azure File Share feature
-        azure_file_share = node.features[AzureFileShare]
-        random_str = generate_random_chars(string.ascii_lowercase + string.digits, 10)
-
-        # Create parallel runner for worker management
-        runner = XfstestsParallelRunner(
-            xfstests=xfstests,
-            log=log,
-            worker_count=_default_worker_count,
+        self._run_azure_file_share_xfstests(
+            log, log_path, result, FileShareProtocol.NFS
         )
-        log.info(f"Using {runner.worker_count} parallel workers for NFS xfstests")
-
-        # Initialize context - will be populated by setup, used by cleanup
-        ctx = AzureFileShareContext(runner=runner, protocol="nfs")
-
-        try:
-            # Increase SSH MaxSessions to handle parallel worker SSH commands.
-            # Default Ubuntu MaxSessions=10 is insufficient for 6 workers
-            # each running 4+ concurrent SSH commands during worker creation.
-            # This prevents: ChannelException(2, 'Connect failed')
-            log.debug(
-                f"Increasing SSH MaxSessions for {runner.worker_count} parallel workers"
-            )
-            node.tools[Ssh].set_max_session()
-
-            # Force SSH reconnection after set_max_session() closes the connection.
-            # This ensures the connection is re-established before parallel workers
-            # start, preventing race conditions where workers see _is_initialized=True
-            # but _inner_shell is still None (AssertionError in shell.spawn).
-            node.execute("echo 'SSH reconnected'")
-
-            # Create worker xfstests directory copies first
-            runner.create_workers()
-
-            # Set up Azure Files NFS shares and configure workers
-            ctx = self._setup_azure_nfs_workers(
-                log=log,
-                node=node,
-                xfstests=xfstests,
-                environment=environment,
-                azure_file_share=azure_file_share,
-                runner=runner,
-                random_str=random_str,
-            )
-
-            # Get the list of tests and split into batches
-            all_tests = _default_nfs_testcases.split()
-            test_batches = runner.split_tests(all_tests)
-            log.info(
-                f"Split {len(all_tests)} tests into {runner.worker_count} batches: "
-                f"{[len(b) for b in test_batches]} tests each"
-            )
-
-            log.info("Running xfstests against Azure Files NFS with parallel workers")
-
-            # Execute tests in parallel using the runner
-            worker_results = runner.run_parallel(
-                test_batches=test_batches,
-                log_path=log_path,
-                result=result,
-                test_section="nfs",
-                timeout=self.TIME_OUT,
-                run_id_prefix="nfs_worker",
-            )
-
-            # Aggregate results (raises on failure)
-            _, _, ctx.test_failed = runner.aggregate_results(worker_results)
-
-        except Exception:
-            ctx.test_failed = True
-            raise
-        finally:
-            self._cleanup_azure_workers(
-                log=log,
-                node=node,
-                ctx=ctx,
-                azure_file_share=azure_file_share,
-                environment=environment,
-            )
 
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         """
-        Cleanup handler executed after each test case in this test suite.
-
-        This method handles cleanup for BOTH sequential tests (data disk, NVMe)
-        AND parallel tests (verify_azure_file_share). The design ensures backward
-        compatibility with existing tests while properly cleaning up parallel
-        execution resources.
-
-        Cleanup Operations:
-        -------------------
-        1. Device mapper cleanup: Removes delay-test, huge-test devices
-        2. Standard mount points: Unmounts /mnt/scratch, /mnt/test
-        3. Worker mount points: Unmounts /mnt/test_worker_N, /mnt/scratch_worker_N
-           (best-effort, wrapped in try/except for non-parallel tests)
-        4. Worker directories: Removes /tmp/xfs_worker_N directories
-           (best-effort, wrapped in try/except for non-parallel tests)
-        5. fstab cleanup: Removes entries for test/scratch mount points
-
-        Impact on Non-Parallel Tests:
-        -----------------------------
-        The worker cleanup loops (steps 3-4) reference _default_worker_count but
-        are completely safe for non-parallel tests because:
-        - umount on non-existent mount points is caught and ignored
-        - cleanup_worker_copy on non-existent directories is caught and ignored
-        - This is "defensive cleanup" - attempts that fail are not errors
-
-        This design allows a single after_case() to handle both sequential and
-        parallel test cleanup without conditional logic based on test type.
+        Cleanup after every case in this suite. Handles both sequential
+        (data-disk/NVMe) and parallel Azure Files tests: removes device-mapper
+        devices, unmounts standard and per-worker mount points, deletes worker
+        xfstests copies, and strips test/scratch entries from fstab. The
+        worker loops are best-effort (try/except) so they no-op for the
+        non-parallel tests where those resources never existed.
         """
         try:
             node: Node = kwargs.pop("node")
@@ -1534,23 +1277,7 @@ class Xfstesting(TestSuite):
             for mount_point in [_scratch_folder, _test_folder]:
                 node.tools[Mount].umount("", mount_point, erase=False)
 
-            # -------------------------------------------------------------------------
-            # Parallel Execution Cleanup (verify_azure_file_share only)
-            # -------------------------------------------------------------------------
-            # The following cleanup loops attempt to unmount worker-specific mount
-            # points and remove worker xfstests directory copies. These resources
-            # ONLY exist after running verify_azure_file_share.
-            #
-            # For all other tests (data disk, NVMe), these loops execute but:
-            # - umount fails silently (mount point doesn't exist)
-            # - cleanup_worker_copy fails silently (directory doesn't exist)
-            #
-            # This is intentional "best effort" cleanup that ensures resources are
-            # released without requiring test-specific cleanup logic.
-            # -------------------------------------------------------------------------
-
-            # Unmount worker-specific mount points (for parallel execution)
-            # Uses _default_worker_count to match the number of workers created
+            # Best-effort cleanup of per-worker mounts (parallel Azure Files only).
             for worker_id in range(1, _default_worker_count + 1):
                 for base_mount in [_test_folder, _scratch_folder]:
                     worker_mount = f"{base_mount}_worker_{worker_id}"
@@ -1559,8 +1286,7 @@ class Xfstesting(TestSuite):
                     except Exception:
                         pass  # Best effort - resource may not exist
 
-            # Clean up worker xfstests directory copies (for parallel execution)
-            # Uses DEFAULT_WORKER_BASE_DIR constant for consistent path generation
+            # Best-effort removal of per-worker xfstests copies.
             xfstests: Xfstests = node.tools[Xfstests]
             for worker_id in range(1, _default_worker_count + 1):
                 try:
@@ -1570,19 +1296,8 @@ class Xfstesting(TestSuite):
                 except Exception:
                     pass  # Best effort - resource may not exist
 
-            # -------------------------------------------------------------------------
-            # fstab Cleanup (CIFS/SMB mounts only)
-            # -------------------------------------------------------------------------
-            # NFS mounts use NFSClient.setup() which calls Mount.mount() directly
-            # without creating fstab entries, so this cleanup only affects CIFS.
-            #
-            # The sed patterns match mount point paths, which catches:
-            # - Standard mounts: /mnt/test, /mnt/scratch
-            # - Worker mounts: /mnt/test_worker_N, /mnt/scratch_worker_N
-            #
-            # This is more reliable than restoring a backup and doesn't risk
-            # losing other fstab changes made outside of LISA.
-            # -------------------------------------------------------------------------
+            # Strip test/scratch fstab entries (CIFS only; NFS never adds them).
+            # Pattern matches both standard and /mnt/*_worker_N mounts.
             for base_mount in [_test_folder, _scratch_folder]:
                 node.execute(
                     f"sed -i '\\#{base_mount}#d' /etc/fstab",

--- a/lisa/microsoft/testsuites/xfstests/xfstests.py
+++ b/lisa/microsoft/testsuites/xfstests/xfstests.py
@@ -472,12 +472,6 @@ class XfstestsParallelRunner:
                     run_id=exec_result.run_id,
                     xfstests_path=worker_path,
                 )
-                status = "PASSED" if final_result.success else "FAILED"
-                self.log.info(
-                    f"Worker {exec_result.run_id}: {status} - "
-                    f"{final_result.total_count} tests, "
-                    f"{final_result.fail_count} failed"
-                )
                 final_results.append(final_result)
             except Exception as e:
                 self.log.error(f"[{exec_result.run_id}] Result collection failed: {e}")

--- a/lisa/microsoft/testsuites/xfstests/xfstests.py
+++ b/lisa/microsoft/testsuites/xfstests/xfstests.py
@@ -149,6 +149,8 @@ class XfstestsRunResult:
     success: bool = True
     fail_count: int = 0
     total_count: int = 0
+    skipped_count: int = 0
+    expunged_count: int = 0
     fail_cases: List[str] = field(default_factory=list)
     fail_info: str = ""
     run_id: str = ""
@@ -502,28 +504,38 @@ class XfstestsParallelRunner:
         """
         total_passed = 0
         total_failed = 0
+        total_skipped = 0
+        total_expunged = 0
         any_failures = False
 
         for worker_result in worker_results:
+            skipped = worker_result.skipped_count + worker_result.expunged_count
+            total_skipped += worker_result.skipped_count
+            total_expunged += worker_result.expunged_count
             if worker_result.success:
                 self.log.info(
                     f"Worker {worker_result.run_id}: PASSED "
-                    f"({worker_result.total_count} tests)"
+                    f"({worker_result.total_count} tests, "
+                    f"{skipped} skipped "
+                    f"({worker_result.expunged_count} expunged))"
                 )
                 total_passed += worker_result.total_count
             else:
                 self.log.error(
                     f"Worker {worker_result.run_id}: FAILED "
                     f"({worker_result.fail_count}/{worker_result.total_count} "
-                    f"tests failed)"
+                    f"tests failed, {skipped} skipped "
+                    f"({worker_result.expunged_count} expunged))"
                 )
                 total_passed += worker_result.total_count - worker_result.fail_count
                 total_failed += worker_result.fail_count
                 any_failures = True
 
+        total_skipped_all = total_skipped + total_expunged
         self.log.info(
             f"Parallel xfstests summary: {total_passed} passed, "
-            f"{total_failed} failed across {len(worker_results)} workers"
+            f"{total_failed} failed, {total_skipped_all} skipped "
+            f"({total_expunged} expunged) across {len(worker_results)} workers"
         )
 
         # Raise if any worker failed and raise_on_failure is True
@@ -731,6 +743,9 @@ class Xfstests(Tool):
         r"([\w\W]*?)Not run: (?P<not_run_cases>.*)",
         re.MULTILINE,
     )
+    # Example:
+    # generic/001	[expunged]
+    __expunged_case_pattern = re.compile(r"(?P<case>[\w/]+)\s+\[expunged\]")
 
     @property
     def command(self) -> str:
@@ -1322,6 +1337,93 @@ class Xfstests(Tool):
             echo = self.node.tools[Echo]
             echo.write_to_file(content, exclude_file_path, append=False)
 
+    def _parse_xfstests_cases(
+        self, raw_message: str, test_section: str
+    ) -> Optional[tuple[List[str], List[str], List[str], List[str]]]:
+        """Parse the Ran/Not run/Failures lines from xfstests output.
+
+        Returns a (pass_cases, not_run_cases, fail_cases, expunged_cases)
+        tuple, or None if no recognizable test output was produced (setup
+        failure), in which case the caller should skip subtest notifications.
+        """
+        all_cases_match = self.__all_cases_pattern.match(raw_message)
+        if not all_cases_match:
+            # No "Ran:" line in the output. Either all selected tests were
+            # expunged/skipped (not a failure), or xfstests failed during
+            # setup (e.g., scratch device busy, mkfs failed).
+            all_pass_match = self.__all_pass_pattern.match(raw_message)
+            if all_pass_match and all_pass_match.group("pass_count") == "0":
+                # All selected tests were expunged (or none were selected to
+                # run). Report them as EXPUNGED rather than failing the run.
+                expunged_cases = self.__expunged_case_pattern.findall(raw_message)
+                if not expunged_cases:
+                    self._log.info("No cases were selected to run")
+                return [], [], [], expunged_cases
+
+            self._log.info(
+                f"No test cases found in xfstests output for '{test_section}'. "
+                f"This may indicate a setup failure (e.g., scratch device busy). "
+                f"Skipping subtest notifications."
+            )
+            return None
+
+        all_cases = (all_cases_match.group("all_cases")).split()
+        not_run_cases: List[str] = []
+        not_run_match = self.__not_run_cases_pattern.match(raw_message)
+        if not_run_match:
+            not_run_cases = (not_run_match.group("not_run_cases")).split()
+        fail_cases: List[str] = []
+        fail_match = self.__fail_cases_pattern.match(raw_message)
+        if fail_match:
+            fail_cases = (fail_match.group("fail_cases")).split()
+        not_run_cases_set = set(not_run_cases)
+        fail_cases_set = set(fail_cases)
+        pass_cases = [
+            x
+            for x in all_cases
+            if x not in not_run_cases_set and x not in fail_cases_set
+            # expunged cases aren't part of all_cases, so no need to filter
+        ]
+        return pass_cases, not_run_cases, fail_cases, []
+
+    def _send_case_result_message(
+        self,
+        test_result: "TestResult",
+        result: XfstestsResult,
+        test_section: str,
+        data_disk: str,
+        raw_message: str,
+        xfstests_path: Optional[PurePath],
+    ) -> None:
+        info: Dict[str, Any] = {"information": {}}
+        if test_section:
+            info["information"]["test_section"] = test_section
+        if data_disk:
+            info["information"]["data_disk"] = data_disk
+        info["information"]["test_details"] = str(
+            self.create_xfstest_stack_info(
+                result.name,
+                test_section,
+                str(result.status.name),
+                xfstests_path=xfstests_path,
+            )
+        )
+        # Only PASSED tests prefix their message with a duration (e.g. "39s");
+        # FAILED/SKIPPED messages carry no duration, so default to 0.0.
+        subtest_duration: float = 0.0
+        duration_match = re.match(r"^(\d+)s", result.message)
+        if duration_match:
+            subtest_duration = float(duration_match.group(1))
+
+        send_sub_test_result_message(
+            test_result=test_result,
+            test_case_name=result.name,
+            test_status=result.status,
+            test_message=result.message,
+            other_fields=info,
+            subtest_duration=subtest_duration,
+        )
+
     def create_send_subtest_msg(
         self,
         test_result: "TestResult",
@@ -1329,107 +1431,53 @@ class Xfstests(Tool):
         test_section: str,
         data_disk: str,
         xfstests_path: Optional[PurePath] = None,
+        run_result: Optional["XfstestsRunResult"] = None,
     ) -> None:
         """
         About:This method is internal to LISA and is not intended for direct calls.
         This method will create and send subtest results to the test result object.
-        Parmaeters:
+        Parameters:
         test_result: The test result object to which the subtest results will be sent
         raw_message: The raw message from the xfstests output
         test_section: The test group name used for testing
         data_disk: The data disk used for testing. ( method is partially implemented )
         xfstests_path: Optional custom xfstests directory path. Used for parallel
             worker execution. If not provided, uses get_xfstests_path().
+        run_result: Optional XfstestsRunResult to populate skipped/expunged counts.
         """
-        all_cases_match = self.__all_cases_pattern.match(raw_message)
-        if not all_cases_match:
-            # No tests were run (e.g., xfstests failed during setup).
-            # This can happen when scratch device is busy, mkfs fails, etc.
-            # Log a warning and skip sending notifications for this section.
-            self._log.warning(
-                f"No test cases found in xfstests output for '{test_section}'. "
-                f"This may indicate a setup failure (e.g., scratch device busy). "
-                f"Skipping subtest notifications."
-            )
+        parsed_cases = self._parse_xfstests_cases(raw_message, test_section)
+        if parsed_cases is None:
             return
-        all_cases = (all_cases_match.group("all_cases")).split()
-        not_run_cases: List[str] = []
-        fail_cases: List[str] = []
-        not_run_match = self.__not_run_cases_pattern.match(raw_message)
-        if not_run_match:
-            not_run_cases = (not_run_match.group("not_run_cases")).split()
-        fail_match = self.__fail_cases_pattern.match(raw_message)
-        if fail_match:
-            fail_cases = (fail_match.group("fail_cases")).split()
-        pass_cases = [
-            x for x in all_cases if x not in not_run_cases and x not in fail_cases
-        ]
-        results: List[XfstestsResult] = []
-        for case in fail_cases:
-            results.append(
-                XfstestsResult(
-                    name=case,
-                    status=TestStatus.FAILED,
-                    message=self.extract_case_content(case, raw_message),
-                )
-            )
-        for case in pass_cases:
-            results.append(
-                XfstestsResult(
-                    name=case,
-                    status=TestStatus.PASSED,
-                    message=self.extract_case_content(case, raw_message),
-                )
-            )
-        for case in not_run_cases:
-            results.append(
-                XfstestsResult(
-                    name=case,
-                    status=TestStatus.SKIPPED,
-                    message=self.extract_case_content(case, raw_message),
-                )
-            )
-        for result in results:
-            # create test result message
-            info: Dict[str, Any] = {}
-            info["information"] = {}
-            if test_section:
-                info["information"]["test_section"] = test_section
-            if data_disk:
-                info["information"]["data_disk"] = data_disk
-            info["information"]["test_details"] = str(
-                self.create_xfstest_stack_info(
-                    result.name,
-                    test_section,
-                    str(result.status.name),
-                    xfstests_path=xfstests_path,
-                )
-            )
-            # Parse actual test duration from xfstests output (e.g., "46s", "302s")
-            # The message format starts with duration for PASSED tests.
-            # For FAILED/SKIPPED tests, xfstests doesn't report duration, set to 0.0
-            #
-            # Example raw message format:
-            # Case: Parse actual test duration from xfstests output
-            # (e.g., "46s", "302s")
-            # Raw xfstests output format from check command:
-            #   PASSED:  "generic/001    39s"        → message="39s"
-            #   FAILED:  "generic/615    _check_dmesg: ..."  → message="_check_dmesg:"
-            #   SKIPPED: "generic/010    [not run] reason"   → message="reason"
-            # Only PASSED tests have duration in message; FAILED/SKIPPED set to 0.0
-            subtest_duration: float = 0.0
-            duration_match = re.match(r"^(\d+)s", result.message)
-            if duration_match:
-                subtest_duration = float(duration_match.group(1))
+        pass_cases, not_run_cases, fail_cases, expunged_cases = parsed_cases
 
-            send_sub_test_result_message(
-                test_result=test_result,
-                test_case_name=result.name,
-                test_status=result.status,
-                test_message=result.message,
-                other_fields=info,
-                subtest_duration=subtest_duration,
-            )
+        # Populate skipped/expunged counts on run_result if provided
+        if run_result is not None:
+            run_result.skipped_count = len(not_run_cases)
+            run_result.expunged_count = len(expunged_cases)
+
+        # Order matters: fail -> pass -> not_run -> expunged is the emission
+        # sequence consumers expect.
+        cases_by_status = [
+            (fail_cases, TestStatus.FAILED),
+            (pass_cases, TestStatus.PASSED),
+            (not_run_cases, TestStatus.SKIPPED),
+            (expunged_cases, TestStatus.EXPUNGED),
+        ]
+        for cases, status in cases_by_status:
+            for case in cases:
+                result = XfstestsResult(
+                    name=case,
+                    status=status,
+                    message=self.extract_case_content(case, raw_message),
+                )
+                self._send_case_result_message(
+                    test_result,
+                    result,
+                    test_section,
+                    data_disk,
+                    raw_message,
+                    xfstests_path,
+                )
 
     def _file_exists_with_timeout(self, path: PurePath, timeout: int = 60) -> bool:
         """
@@ -1523,6 +1571,7 @@ class Xfstests(Tool):
                     test_section=test_section,
                     data_disk=data_disk,
                     xfstests_path=working_path,
+                    run_result=run_result,
                 )
 
             # Use _file_exists_with_timeout instead of shell.exists() to avoid

--- a/lisa/notifiers/junit.py
+++ b/lisa/notifiers/junit.py
@@ -323,6 +323,7 @@ class JUnit(Notifier):
         elif (
             message.status == TestStatus.SKIPPED
             or message.status == TestStatus.ATTEMPTED
+            or message.status == TestStatus.EXPUNGED
         ):
             skipped = ET.SubElement(testcase, "skipped")
             skipped.attrib["message"] = message.message

--- a/lisa/runner.py
+++ b/lisa/runner.py
@@ -74,9 +74,9 @@ def print_results(
     output_with_ending(f"    TOTAL    : {len(test_results)}")
     for key in TestStatus:
         count = result_count_dict.get(key, 0)
-        if key == TestStatus.ATTEMPTED and count == 0:
-            # attempted is confusing if user don't know it.
-            # so hide it if there is no attempted cases.
+        if key in (TestStatus.ATTEMPTED, TestStatus.EXPUNGED) and count == 0:
+            # attempted/expunged are confusing if user doesn't know them.
+            # so hide them if there are no such cases.
             continue
         output_with_ending(f"    {key.name:<9}: {count}")
 

--- a/lisa/sut_orchestrator/azure/common.py
+++ b/lisa/sut_orchestrator/azure/common.py
@@ -70,7 +70,12 @@ from azure.mgmt.privatedns.models import (
 )
 from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
 from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.storage.models import Sku, StorageAccountCreateParameters
+from azure.mgmt.storage.models import (
+    DeleteRetentionPolicy,
+    FileServiceProperties,
+    Sku,
+    StorageAccountCreateParameters,
+)
 from azure.storage.blob import (
     BlobClient,
     BlobSasPermissions,
@@ -2293,6 +2298,40 @@ def list_file_shares(
         return []
 
 
+def _disable_share_soft_delete(
+    credential: Any,
+    subscription_id: str,
+    cloud: Cloud,
+    account_name: str,
+    resource_group_name: str,
+    log: Logger,
+) -> None:
+    try:
+        storage_client = get_storage_client(credential, subscription_id, cloud)
+        current_props = storage_client.file_services.get_service_properties(
+            resource_group_name=resource_group_name,
+            account_name=account_name,
+        )
+        retention_policy = current_props.share_delete_retention_policy
+        if retention_policy and retention_policy.enabled:
+            log.debug(
+                f"Disabling share soft-delete on storage account {account_name} "
+                f"to prevent provisioned capacity leaks from previous test runs"
+            )
+            storage_client.file_services.set_service_properties(
+                resource_group_name=resource_group_name,
+                account_name=account_name,
+                parameters=FileServiceProperties(
+                    share_delete_retention_policy=DeleteRetentionPolicy(
+                        enabled=False,
+                    )
+                ),
+            )
+            log.debug(f"Disabled share soft-delete on storage account {account_name}")
+    except Exception as e:
+        log.debug(f"Failed to disable share soft-delete on {account_name}: {e}")
+
+
 def get_or_create_file_share(
     credential: Any,
     subscription_id: str,
@@ -2365,6 +2404,17 @@ def get_or_create_file_share(
             cloud,
             account_name,
             resource_group_name,
+        )
+        # Disable share soft-delete to prevent soft-deleted shares from previous
+        # test runs consuming provisioned capacity, which causes
+        # TotalSharesProvisionedCapacityExceedsAccountLimit errors.
+        _disable_share_soft_delete(
+            credential=credential,
+            subscription_id=subscription_id,
+            cloud=cloud,
+            account_name=account_name,
+            resource_group_name=resource_group_name,
+            log=log,
         )
         all_shares = list(share_service_client.list_shares())
         if file_share_name not in (x.name for x in all_shares):

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -1566,6 +1566,23 @@ class AzurePlatform(Platform):
             },
         )
 
+    def _generate_node_name(self, index: int, name_prefix: str) -> str:
+        # the max length of vm name is 64 chars. Below logic takes last 45
+        # chars in resource group name and keep the leading 5 chars.
+        # name_prefix can contain any of customized (existing) or
+        # generated (starts with "lisa-") resource group name,
+        # so, pass the first 5 chars as prefix to truncate_keep_prefix
+        # to handle both cases.
+        # When a resource group is provided by the user, include a
+        # timestamp in the VM name to ensure uniqueness across
+        # multiple deployments into the same resource group.
+        if self._azure_runbook.resource_group_name:
+            time_stamp = get_datetime_path()
+            node_name = f"{name_prefix}-{time_stamp}-n{index}"
+        else:
+            node_name = f"{name_prefix}-n{index}"
+        return truncate_keep_prefix(node_name, 50, node_name[:5])
+
     def _create_node_runbook(
         self,
         index: int,
@@ -1583,14 +1600,7 @@ class AzurePlatform(Platform):
         #  if user gives the vm name, azure_node_runbook.name stores the given user name
         #  if user doesn't give the vm name, it will be filled in initialize_environment
         if self._azure_runbook.deploy and not azure_node_runbook.name:
-            # the max length of vm name is 64 chars. Below logic takes last 45
-            # chars in resource group name and keep the leading 5 chars.
-            # name_prefix can contain any of customized (existing) or
-            # generated (starts with "lisa-") resource group name,
-            # so, pass the first 5 chars as prefix to truncate_keep_prefix
-            # to handle both cases
-            node_name = f"{name_prefix}-n{index}"
-            azure_node_runbook.name = truncate_keep_prefix(node_name, 50, node_name[:5])
+            azure_node_runbook.name = self._generate_node_name(index, name_prefix)
         if azure_node_runbook.name:
             # It's used as computer name only. Windows doesn't support name more
             # than 15 chars

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -118,6 +118,8 @@ from .common import (
     AZURE_SHARED_RG_NAME,
     AZURE_SUBNET_PREFIX,
     AZURE_VIRTUAL_NETWORK_NAME,
+    NIC_NAME_PATTERN,
+    PATTERN_PUBLIC_IP_NAME,
     SAS_URL_PATTERN,
     AzureArmParameter,
     AzureCapability,
@@ -139,6 +141,7 @@ from .common import (
     get_deployable_storage_path,
     get_environment_context,
     get_marketplace_ordering_client,
+    get_network_client,
     get_node_context,
     get_or_create_storage_container,
     get_primary_ip_addresses,
@@ -737,10 +740,26 @@ class AzurePlatform(Platform):
         assert self._azure_runbook
 
         if not environment_context.resource_group_is_specified:
-            log.info(
-                f"skipped to delete resource group: {resource_group_name}, "
-                f"as it's specified in runbook."
-            )
+            if self._azure_runbook.deploy:
+                log.info(
+                    f"skipped to delete resource group: {resource_group_name}, "
+                    f"as it's specified in runbook. "
+                    f"Deleting individual LISA-created resources instead."
+                )
+                try:
+                    self._delete_nodes_resources(environment, log)
+                except Exception as e:
+                    log.warning(
+                        f"error during per-resource cleanup in "
+                        f"{resource_group_name}: {e}"
+                    )
+            else:
+                log.info(
+                    f"skipped to delete resource group: {resource_group_name}, "
+                    f"as it's specified in runbook. Skipped per-resource "
+                    f"cleanup because LISA reused pre-existing resources "
+                    f"(deploy is false)."
+                )
         elif self._azure_runbook.dry_run:
             log.info(
                 f"skipped to delete resource group: {resource_group_name}, "
@@ -770,6 +789,146 @@ class AzurePlatform(Platform):
                 )
             else:
                 log.debug("not wait deleting")
+
+    def _delete_nodes_resources(self, environment: Environment, log: Logger) -> None:
+        """Delete individual LISA-created resources (VM, NICs, Public IPs,
+        disks) when the resource group is user-specified and should not be
+        deleted as a whole."""
+        environment_context = get_environment_context(environment=environment)
+        resource_group_name = environment_context.resource_group_name
+        compute_client = get_compute_client(self)
+        network_client = get_network_client(self)
+
+        for node in environment.nodes.list():
+            node_context = get_node_context(node)
+            vm_name = node_context.vm_name
+            if not vm_name:
+                continue
+
+            try:
+                vm = compute_client.virtual_machines.get(resource_group_name, vm_name)
+            except ResourceNotFoundError:
+                log.debug(f"VM {vm_name} not found, skipping resource cleanup")
+                continue
+
+            nic_names, public_ip_names = self._collect_vm_network_resources(
+                vm, resource_group_name, network_client, log
+            )
+            os_disk_name, data_disk_names = self._collect_vm_disk_resources(vm)
+
+            # Delete VM first (must be gone before its NICs and disks)
+            log.info(f"deleting VM: {vm_name}")
+            try:
+                operation = compute_client.virtual_machines.begin_delete(
+                    resource_group_name, vm_name
+                )
+                wait_operation(operation, failure_identity=f"delete VM {vm_name}")
+            except Exception as e:
+                log.warning(f"error deleting VM {vm_name}: {e}")
+                # If VM deletion fails, skip dependent resource cleanup
+                continue
+
+            # Delete dependent resources in order: NICs -> Public IPs -> Disks
+            self._delete_resource_list(
+                network_client.network_interfaces,
+                resource_group_name,
+                nic_names,
+                "NIC",
+                log,
+            )
+            self._delete_resource_list(
+                network_client.public_ip_addresses,
+                resource_group_name,
+                public_ip_names,
+                "Public IP",
+                log,
+            )
+            all_disks = ([os_disk_name] if os_disk_name else []) + data_disk_names
+            self._delete_resource_list(
+                compute_client.disks,
+                resource_group_name,
+                all_disks,
+                "Disk",
+                log,
+            )
+
+            log.info(
+                f"finished cleaning up resources for VM {vm_name}: "
+                f"NICs={nic_names}, PublicIPs={public_ip_names}, "
+                f"OSDisk={os_disk_name}, DataDisks={data_disk_names}"
+            )
+
+    @staticmethod
+    def _collect_vm_network_resources(
+        vm: VirtualMachine,
+        resource_group_name: str,
+        network_client: Any,
+        log: Logger,
+    ) -> Tuple[List[str], List[str]]:
+        """Extract NIC names and public IP names from a VM's network
+        profile."""
+        nic_names: List[str] = []
+        public_ip_names: List[str] = []
+        if not (vm.network_profile and vm.network_profile.network_interfaces):
+            return nic_names, public_ip_names
+
+        for nic_ref in vm.network_profile.network_interfaces:
+            nic_name = get_matched_str(nic_ref.id, NIC_NAME_PATTERN)
+            if not nic_name:
+                continue
+            nic_names.append(nic_name)
+            try:
+                nic = network_client.network_interfaces.get(
+                    resource_group_name, nic_name
+                )
+                for ip_config in nic.ip_configurations:
+                    if ip_config.public_ip_address and ip_config.public_ip_address.id:
+                        pip_name = get_matched_str(
+                            ip_config.public_ip_address.id,
+                            PATTERN_PUBLIC_IP_NAME,
+                        )
+                        if pip_name:
+                            public_ip_names.append(pip_name)
+            except Exception as e:
+                log.debug(f"error getting NIC {nic_name} details: {e}")
+
+        return nic_names, public_ip_names
+
+    @staticmethod
+    def _collect_vm_disk_resources(
+        vm: VirtualMachine,
+    ) -> Tuple[str, List[str]]:
+        """Extract OS disk name and data disk names from a VM's storage
+        profile."""
+        os_disk_name = ""
+        data_disk_names: List[str] = []
+        if vm.storage_profile:
+            if vm.storage_profile.os_disk:
+                os_disk_name = vm.storage_profile.os_disk.name
+            if vm.storage_profile.data_disks:
+                data_disk_names = [d.name for d in vm.storage_profile.data_disks]
+        return os_disk_name, data_disk_names
+
+    @staticmethod
+    def _delete_resource_list(
+        client_operations: Any,
+        resource_group_name: str,
+        resource_names: List[str],
+        resource_type: str,
+        log: Logger,
+    ) -> None:
+        """Delete a list of Azure resources using the given client
+        operations (e.g. network_interfaces, public_ip_addresses, disks)."""
+        for name in resource_names:
+            log.info(f"deleting {resource_type}: {name}")
+            try:
+                operation = client_operations.begin_delete(resource_group_name, name)
+                wait_operation(
+                    operation,
+                    failure_identity=f"delete {resource_type} {name}",
+                )
+            except Exception as e:
+                log.debug(f"error deleting {resource_type} {name}: {e}")
 
     def _save_console_log_and_check_panic(
         self,

--- a/lisa/sut_orchestrator/azure/platform_.py
+++ b/lisa/sut_orchestrator/azure/platform_.py
@@ -749,13 +749,13 @@ class AzurePlatform(Platform):
                 try:
                     self._delete_nodes_resources(environment, log)
                 except Exception as e:
-                    log.warning(
+                    log.info(
                         f"error during per-resource cleanup in "
                         f"{resource_group_name}: {e}"
                     )
             else:
                 log.info(
-                    f"skipped to delete resource group: {resource_group_name}, "
+                    f"Skipped to delete resource group: {resource_group_name}, "
                     f"as it's specified in runbook. Skipped per-resource "
                     f"cleanup because LISA reused pre-existing resources "
                     f"(deploy is false)."
@@ -824,7 +824,7 @@ class AzurePlatform(Platform):
                 )
                 wait_operation(operation, failure_identity=f"delete VM {vm_name}")
             except Exception as e:
-                log.warning(f"error deleting VM {vm_name}: {e}")
+                log.info(f"error deleting VM {vm_name}: {e}")
                 # If VM deletion fails, skip dependent resource cleanup
                 continue
 
@@ -881,7 +881,7 @@ class AzurePlatform(Platform):
                 nic = network_client.network_interfaces.get(
                     resource_group_name, nic_name
                 )
-                for ip_config in nic.ip_configurations:
+                for ip_config in nic.ip_configurations or []:
                     if ip_config.public_ip_address and ip_config.public_ip_address.id:
                         pip_name = get_matched_str(
                             ip_config.public_ip_address.id,


### PR DESCRIPTION
This pull request introduces improvements in two main areas: (1) enhanced handling and reporting of "expunged" test cases in the xfstests suite, and (2) improved Azure resource cleanup logic to avoid storage leaks and better handle resource group deletion scenarios. The changes add a new test status (`EXPUNGED`), ensure accurate reporting and notification of such cases, and introduce logic to disable Azure file share soft-delete to prevent capacity leaks during repeated test runs.

**Xfstests "expunged" test case support and reporting:**

- Added a new `EXPUNGED` status to the `TestStatus` enum, updated logic to recognize, process, and report expunged xfstests cases throughout the test result pipeline, including result aggregation, JUnit output, and summary display. 
- Refactored xfstests result parsing and notification logic to accurately extract expunged cases from raw output, distinguish them from other skipped cases, and emit them with the correct status and counts.

**Azure resource cleanup and reliability improvements:**

- Added `_disable_share_soft_delete` to programmatically disable Azure file share soft-delete, preventing provisioned capacity leaks from previous test runs by ensuring deleted shares are actually removed. \
- Improved logic in environment deletion to perform per-resource cleanup when the resource group is specified and `deploy` is true, with clear logging and error handling.

**Dependency and import updates:**

- Updated Azure SDK imports to include new types required for file share property management and resource cleanup. 

These changes improve test reporting accuracy and Azure resource management, reducing the risk of resource leaks and making test results more informative and actionable.## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [ ] Tests executed and results posted below