### PR TITLE
storage passthrough: support OpenVMM NVMe tests

### DIFF
--- a/lisa/microsoft/testsuites/device_passthrough/storage_tests.py
+++ b/lisa/microsoft/testsuites/device_passthrough/storage_tests.py
@@ -19,7 +19,7 @@ from lisa import (
 from lisa.messages import DiskSetupType, DiskType
 from lisa.microsoft.testsuites.performance.common import perf_disk
 from lisa.operating_system import Windows
-from lisa.sut_orchestrator import CLOUD_HYPERVISOR
+from lisa.sut_orchestrator import CLOUD_HYPERVISOR, OPENVMM
 from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 from lisa.testsuite import TestResult
 from lisa.tools import Cat, FileSystem, Kill, Ls, Lsblk, Lscpu, Lspci, Mkfs, Mount, Rm
@@ -159,11 +159,11 @@ def _get_disk_safety_issues(
     category="performance",
     description=(
         "Validates visibility and bounded FIO operation on an NVMe namespace "
-        "assigned to a Cloud Hypervisor guest through PCI passthrough."
+        "assigned to a Cloud Hypervisor or OpenVMM guest through PCI passthrough."
     ),
     owner="v-aratakonda",
     requirement=simple_requirement(
-        supported_platform_type=[CLOUD_HYPERVISOR],
+        supported_platform_type=[CLOUD_HYPERVISOR, OPENVMM],
         unsupported_os=[Windows],
     ),
 )
@@ -181,7 +181,7 @@ class StoragePassthroughPerfTests(TestSuite):
         priority=4,
         timeout=1800,
         requirement=simple_requirement(
-            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_platform_type=[CLOUD_HYPERVISOR, OPENVMM],
         ),
         tags=["ai-generated"],
     )
@@ -208,7 +208,7 @@ class StoragePassthroughPerfTests(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_platform_type=[CLOUD_HYPERVISOR, OPENVMM],
         ),
         tags=["ai-generated"],
     )
@@ -232,7 +232,7 @@ class StoragePassthroughPerfTests(TestSuite):
         priority=3,
         timeout=TIME_OUT,
         requirement=simple_requirement(
-            supported_platform_type=[CLOUD_HYPERVISOR],
+            supported_platform_type=[CLOUD_HYPERVISOR, OPENVMM],
         ),
         tags=["ai-generated"],
     )
@@ -328,9 +328,22 @@ class StoragePassthroughPerfTests(TestSuite):
         environment: Environment,
         log: Logger,
     ) -> Tuple[str, str, str]:
-        from lisa.sut_orchestrator.libvirt.context import get_node_context
+        if node.type_name() == OPENVMM:
+            from lisa.sut_orchestrator.openvmm.context import (
+                get_node_context as get_openvmm_node_context,
+            )
 
-        node_context = get_node_context(node)
+            node_context: Any = get_openvmm_node_context(node)
+            host_node = node_context.host
+        else:
+            from lisa.sut_orchestrator.libvirt.context import (
+                get_node_context as get_libvirt_node_context,
+            )
+
+            node_context = get_libvirt_node_context(node)
+            platform = environment.platform
+            host_node = getattr(platform, "host_node", None) if platform else None
+
         nvme_contexts = [
             context
             for context in node_context.passthrough_devices
@@ -346,15 +359,13 @@ class StoragePassthroughPerfTests(TestSuite):
                 f"PCI_NVME device; requested={requested_count}"
             )
 
-        platform = environment.platform
-        host_node = getattr(platform, "host_node", None) if platform else None
         if host_node is None:
-            raise LisaException("No libvirt host node is available")
+            raise LisaException("No passthrough host node is available")
         host_nvme_bdfs = {
             _normalize_pci_bdf(device.slot)
-            for device in cast(Node, host_node)
-            .tools[Lspci]
-            .get_devices_by_type(DEVICE_TYPE_NVME, force_run=True)
+            for device in host_node.tools[Lspci].get_devices_by_type(
+                DEVICE_TYPE_NVME, force_run=True
+            )
         }
         assigned_bdfs = [
             self._device_address_to_bdf(device) for device in assigned_devices
@@ -370,25 +381,34 @@ class StoragePassthroughPerfTests(TestSuite):
             )
 
         host_bdf = assigned_nvme_bdfs[0]
-        domain = cast(Any, node_context.domain)
-        if domain is None:
-            raise LisaException("No libvirt domain is available for the guest node")
-        try:
-            domain_xml = cast(str, domain.XMLDesc(0))
-        except Exception as error:
-            raise LisaException("Failed to read live libvirt domain XML") from error
-        host_ids = self._get_pci_ids(cast(Node, host_node), host_bdf)
-        guest_bdf = _get_guest_pci_bdf_from_domain_xml(domain_xml, host_bdf)
-        if guest_bdf is None:
+        host_ids = self._get_pci_ids(host_node, host_bdf)
+        if node.type_name() == OPENVMM:
             guest_device = self._get_guest_nvme_device_by_pci_ids(node, host_ids)
             guest_bdf = _normalize_pci_bdf(guest_device.slot)
             log.debug(
-                f"Libvirt omitted the guest PCI address for host NVMe "
-                f"'{host_bdf}'; uniquely resolved guest '{guest_bdf}' by "
-                "matching its vendor/device IDs"
+                f"Uniquely resolved OpenVMM guest NVMe '{guest_bdf}' for host "
+                f"'{host_bdf}' by matching its vendor/device IDs"
             )
         else:
-            guest_device = self._get_guest_nvme_device(node, guest_bdf)
+            domain = cast(Any, node_context.domain)
+            if domain is None:
+                raise LisaException("No libvirt domain is available for the guest node")
+            try:
+                domain_xml = cast(str, domain.XMLDesc(0))
+            except Exception as error:
+                raise LisaException("Failed to read live libvirt domain XML") from error
+            libvirt_guest_bdf = _get_guest_pci_bdf_from_domain_xml(domain_xml, host_bdf)
+            if libvirt_guest_bdf is None:
+                guest_device = self._get_guest_nvme_device_by_pci_ids(node, host_ids)
+                guest_bdf = _normalize_pci_bdf(guest_device.slot)
+                log.debug(
+                    f"Libvirt omitted the guest PCI address for host NVMe "
+                    f"'{host_bdf}'; uniquely resolved guest '{guest_bdf}' by "
+                    "matching its vendor/device IDs"
+                )
+            else:
+                guest_bdf = libvirt_guest_bdf
+                guest_device = self._get_guest_nvme_device(node, guest_bdf)
         guest_ids = (guest_device.vendor_id.lower(), guest_device.device_id.lower())
         if guest_ids != host_ids:
             raise LisaException(

--- a/selftests/test_storage_passthrough.py
+++ b/selftests/test_storage_passthrough.py
@@ -15,6 +15,7 @@ from lisa.microsoft.testsuites.device_passthrough.storage_tests import (
     _get_num_jobs,
 )
 from lisa.microsoft.testsuites.performance.common import perf_disk
+from lisa.sut_orchestrator import OPENVMM
 from lisa.sut_orchestrator.util.schema import HostDevicePoolType
 from lisa.tools import Cat, Ls, Lspci
 from lisa.tools.lsblk import DiskInfo, PartitionInfo
@@ -247,6 +248,63 @@ class StoragePassthroughTestCase(TestCase):
         ):
             resolved = suite._resolve_passthrough_nvme_namespace(
                 node, environment, MagicMock()
+            )
+
+        self.assertEqual(("0000:3b:00.0", "0000:06:00.0", "/dev/nvme0n1"), resolved)
+
+    def test_resolves_openvmm_nvme_from_passthrough_context(self) -> None:
+        assigned_device = MagicMock(domain="0000", bus="3b", slot="00", function="0")
+        passthrough_context = MagicMock(
+            pool_type=HostDevicePoolType.PCI_NVME,
+            requested_count=1,
+            device_list=[assigned_device],
+        )
+
+        host_lspci = MagicMock()
+        host_lspci.get_devices_by_type.return_value = [MagicMock(slot="0000:3b:00.0")]
+        host_cat = MagicMock()
+        host_cat.read.side_effect = lambda path, **_: (
+            "0x144d" if path.endswith("/vendor") else "0xa821"
+        )
+        host_node = MagicMock()
+        host_node.tools.__getitem__.side_effect = {
+            Lspci: host_lspci,
+            Cat: host_cat,
+        }.__getitem__
+        node_context = MagicMock(
+            passthrough_devices=[passthrough_context],
+            host=host_node,
+        )
+
+        guest_lspci = MagicMock()
+        guest_lspci.get_devices_by_type.return_value = [
+            MagicMock(slot="0000:06:00.0", vendor_id="144d", device_id="a821")
+        ]
+        guest_ls = MagicMock()
+        guest_ls.list.side_effect = [
+            ["/sys/bus/pci/devices/0000:06:00.0/nvme/nvme0"],
+            ["/sys/class/nvme/nvme0/nvme0n1"],
+        ]
+        guest_ls.path_exists.return_value = True
+        node = MagicMock()
+        node.type_name.return_value = OPENVMM
+        node.tools.__getitem__.side_effect = {
+            Lspci: guest_lspci,
+            Ls: guest_ls,
+        }.__getitem__
+
+        suite_class = cast(Any, StoragePassthroughPerfTests).__wrapped__
+        suite = object.__new__(suite_class)
+        context_module = ModuleType("lisa.sut_orchestrator.openvmm.context")
+        context_module.__dict__["get_node_context"] = MagicMock(
+            return_value=node_context
+        )
+        with patch.dict(
+            sys.modules,
+            {"lisa.sut_orchestrator.openvmm.context": context_module},
+        ):
+            resolved = suite._resolve_passthrough_nvme_namespace(
+                node, MagicMock(), MagicMock()
             )
 
         self.assertEqual(("0000:3b:00.0", "0000:06:00.0", "/dev/nvme0n1"), resolved)


### PR DESCRIPTION
## Description

Extends the safe NVMe passthrough tests introduced in #4686 to support OpenVMM guests.

For OpenVMM, the assigned host NVMe device is retrieved from the passthrough node context and mapped to the guest NVMe controller using PCI vendor and device IDs. The mapping must resolve to exactly one guest controller and namespace; otherwise, the tests stop safely.

This change enables the following tests on OpenVMM:

1. `verify_storage_passthrough_nvme_visible`
2. `perf_storage_passthrough_fio_randread`
3. `perf_storage_passthrough_fio_randwrite`

The existing Cloud Hypervisor and libvirt behavior remains unchanged. Device allocation, VFIO binding, cleanup, and host driver restoration remain managed by the OpenVMM platform lifecycle.

## Related Issue


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [ ] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_storage_passthrough_nvme_visible|perf_storage_passthrough_fio_randread|perf_storage_passthrough_fio_randwrite

**Impacted LISA Features:**
Nvme

**Tested Azure Marketplace Images:**
- N/A - OpenVMM BareMetal uses a configured Ubuntu guest image rather than an Azure Marketplace image.

## Test Results

| Image | VM Size | Result |
|-------|---------|--------|
| N/A - focused storage passthrough self-tests (20 tests) | N/A | PASSED |
| N/A - full LISA self-test suite (318 tests) | N/A | PASSED |

Additional validation:

- Black passed.
- Flake8 passed.
- Mypy passed.
- Pylint passed with a score of 10/10.
- Python compilation and `git diff --check` passed.
- OpenVMM BareMetal end-to-end validation passed. All three NVMe passthrough tests completed successfully, including unique device mapping, bounded random-read and random-write FIO, and host-driver restoration.