### PR TITLE
nic: add Nics.get_subnets to enumerate the subnets a node is attached to

### DIFF
--- a/lisa/nic.py
+++ b/lisa/nic.py
@@ -8,7 +8,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from assertpy import assert_that
 from retry import retry
@@ -166,6 +166,23 @@ class Nics(InitializableMixin):
 
     def get_unpaired_devices(self) -> List[str]:
         return [x.name for x in self.nics.values() if not x.lower]
+
+    def get_subnets(self) -> List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]:
+        # Collect the distinct subnets the nics on this node are attached to.
+        # The guest is not told the real prefix length, and the test
+        # environments this is used with allocate a /24 per subnet, so a /24
+        # is assumed here. Returned in nic order so the subnet list is stable
+        # across nodes in the same environment.
+        subnets: List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]] = []
+        for nic in self.nics.values():
+            # skip nics which don't have an address assigned yet.
+            if not nic.ip_addr:
+                continue
+            subnet = ipaddress.ip_network((nic.ip_addr, 24), strict=False)
+            self._node.log.debug(f"Found subnet {subnet} for nic {nic.name}")
+            if subnet not in subnets:
+                subnets.append(subnet)
+        return subnets
 
     def get_synthetic_devices(self) -> List[str]:
         synthetic_devices = []


### PR DESCRIPTION


## Description

Multi-subnet tests need to discover which subnets a node has nics on rather than hard coding the list. Returns the distinct subnets in nic order so both sides of a test agree on the ordering, skipping nics which have no address assigned yet.

## Related Issue



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation


**Key Test Cases:**
n/a not called (needed for future PR)

**Impacted LISA Features:**
node.nic


**Tested Azure Marketplace Images:**
canonical ubuntu-24_04-lts server latest

## Test Results
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner               Dpdk.verify_dpdk_send_receive_netvsc: PASSED
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner test result summary
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     TOTAL    : 1
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     QUEUED   : 0
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     ASSIGNED : 0
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     RUNNING  : 0
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     FAILED   : 0
2026-09-08 20:50:14.991[8020][INFO] lisa.RootRunner     PASSED   : 1

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
