### PR TITLE
fedora: exclude benign aarch64/raid6 message from corruption scan

### DIFF
--- a/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
+++ b/lisa/microsoft/testsuites/fedora/fedora_cloud_validation.py
@@ -66,13 +66,19 @@ class FedoraCloudValidation(TestSuite):
             "recovering",
             "tree-log replay",
         ]
+        # Lines that contain a corruption keyword but are known-benign.
+        exclusion_patterns = [
+            "recovery algorithm",
+            # aarch64 CPU feature announcement, not a filesystem dirty-bit
+            "hardware dirty bit management",
+        ]
         journalctl = node.tools[Journalctl]
         boot_logs = journalctl.first_n_logs_from_boot(boot_id=boot_id, no_of_lines=0)
         matches = [
             line
             for line in boot_logs.splitlines()
             if any(kw in line.lower() for kw in corruption_keywords)
-            and "recovery algorithm" not in line.lower()
+            and not any(excl in line.lower() for excl in exclusion_patterns)
         ]
         assert_that(matches).described_as(
             "No filesystem corruption or recovery errors should appear in journalctl"


### PR DESCRIPTION
_check_journal_corruption matched `dirty bit` against the ARM64 CPU feature message 'Hardware dirty bit management', causing false failures on aarch64 VMs.

## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_system_logging|verify_reboot_and_mounts
**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
-  westus3/fedora-5e266ba4-2250-406d-adad-5d73860d958f/fedora-cloud-rawhide-arm64/46.20260905.0

## Test Results
FedoraCloudValidation.verify_reboot_and_mounts: PASSED 
FedoraCloudValidation.verify_system_logging: PASSED
<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
| westus3/fedora-5e266ba4-2250-406d-adad-5d73860d958f/fedora-cloud-rawhide-arm64/46.20260905.0      |  Standard_D2pds_v6       | PASSED  |
