### PR TITLE
DPDK: hotplug and MANA pmd fixes

### DIFF
--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -521,6 +521,8 @@ class Pmd(str, Enum):
     # librte_net_netvsc
     # https://doc.dpdk.org/guides/nics/netvsc.html
     NETVSC = "netvsc"
+    # direct use of MANA pmd.
+    MANA = "MANA"
 
 
 # set a threshold for an expected PPS minimum with DPDK.

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -522,7 +522,7 @@ class Pmd(str, Enum):
     # https://doc.dpdk.org/guides/nics/netvsc.html
     NETVSC = "netvsc"
     # direct use of MANA pmd.
-    MANA = "MANA"
+    MANA = "mana"
 
 
 # set a threshold for an expected PPS minimum with DPDK.

--- a/lisa/microsoft/testsuites/dpdk/common.py
+++ b/lisa/microsoft/testsuites/dpdk/common.py
@@ -289,8 +289,15 @@ class Installer:
                 self._uninstall()
                 self._install_dependencies()
                 self._install()
-            except Exception:
-                self._rollback_installation()
+            except Exception as install_error:
+                try:
+                    self._rollback_installation()
+                except Exception as rollback_error:
+                    self._node.log.debug(
+                        "Installation rollback also failed; preserving the original "
+                        f"{type(install_error).__name__}: {install_error!r}. "
+                        f"Rollback error: {rollback_error!r}"
+                    )
                 raise
 
     def __init__(

--- a/lisa/microsoft/testsuites/dpdk/devname/main.c
+++ b/lisa/microsoft/testsuites/dpdk/devname/main.c
@@ -91,6 +91,13 @@ int main(int argc, char **argv)
 		);
 	}
 
+	/* explicitly stop ports before cleanup */
+	for (uint16_t portid = 0; portid < RTE_MAX_ETHPORTS; portid++)
+	{
+			if (rte_eth_dev_is_valid_port(portid))
+					rte_eth_dev_stop(portid);
+	}
+	
 	/* clean up the EAL */
 	rte_eal_cleanup();
 

--- a/lisa/microsoft/testsuites/dpdk/dpdkovs.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkovs.py
@@ -4,8 +4,8 @@ import re
 from typing import Dict, List, Tuple, Type
 
 from assertpy import assert_that, fail
+from microsoft.testsuites.dpdk.common import Pmd
 from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
-from microsoft.testsuites.dpdk.dpdkutil import DpdkDevnameInfo
 from semver import VersionInfo
 
 from lisa.executable import Tool
@@ -251,7 +251,7 @@ class DpdkOvs(Tool):
         )
 
     def _get_eal_and_device_args(
-        self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd
+        self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd, pmd: Pmd
     ) -> Tuple[str, str]:
         assert_that(nics).described_as(
             "setup_ovs needs at least one test nic to attach to the bridge"
@@ -260,21 +260,23 @@ class DpdkOvs(Tool):
         # dpdk-devname enumerates the ports the EAL actually sees. Running it
         # both validates the netvsc PMD setup and gives us the EAL device
         # arguments needed to select those ports.
-        devname_info = DpdkDevnameInfo(testpmd=dpdk_tool)
-        devname_info.get_port_info(nics, expect_ports=len(nics))
-
+        eal_args_list = dpdk_tool.generate_testpmd_include(nics, 0, pmd)
+        eal_args = " ".join(eal_args_list)
         # the devname args are built for a shell invocation, but OVS hands the
         # value straight to the EAL, so the embedded quoting has to go.
-        eal_args = devname_info.nic_args.replace('"', "")
 
         # The netvsc PMD drives the synthetic vmbus device, so the PCI address
         # of the VF does not name the port. Select it by MAC instead, which is
         # bus agnostic. See netdev_dpdk_process_devargs in lib/netdev-dpdk.c.
-        device_args = f"class=eth,mac={nics[0].mac_addr}"
+        device_args = "class=eth," + ",".join([f"mac={nic.mac_addr}" for nic in nics])
         return eal_args, device_args
 
     def setup_ovs(
-        self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd, queues: int = 2
+        self,
+        nics: List[NicInfo],
+        dpdk_tool: DpdkTestpmd,
+        queues: int = 2,
+        pmd: Pmd = Pmd.NETVSC,
     ) -> None:
         # setup OVS and track which state we are in.
         # this will allow a try/except to catch a failure and hold it until
@@ -283,7 +285,7 @@ class DpdkOvs(Tool):
         node = self.node
         modprobe = node.tools[Modprobe]
         self.teardown_state = self.INIT
-        eal_args, device_args = self._get_eal_and_device_args(nics, dpdk_tool)
+        eal_args, device_args = self._get_eal_and_device_args(nics, dpdk_tool, pmd)
 
         # load ovs driver
         modprobe.load("openvswitch")

--- a/lisa/microsoft/testsuites/dpdk/dpdkovs.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkovs.py
@@ -1,15 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 import re
-from typing import List, Type
+from typing import Dict, List, Tuple, Type
 
-from assertpy import fail
+from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.dpdktestpmd import DpdkTestpmd
+from microsoft.testsuites.dpdk.dpdkutil import DpdkDevnameInfo
 from semver import VersionInfo
 
 from lisa.executable import Tool
+from lisa.nic import NicInfo
 from lisa.operating_system import Debian, Fedora
-from lisa.tools import Chown, Gcc, Git, Ip, Make, Modprobe, Uname, Whoami
+from lisa.tools import Cat, Chown, Gcc, Git, Ip, Make, Modprobe, Uname, Whoami
 from lisa.util import SkippedException, UnsupportedDistroException
 
 
@@ -19,6 +21,18 @@ class DpdkOvs(Tool):
         r"v(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)"
     )
     OVS_BRIDGE_NAME = "br-dpdk"  # name for the bridge, can be anything
+
+    # OVS records the DPDK release each OVS release builds against in its own
+    # source tree, so parse the pairing from the checkout instead of keeping a
+    # copy here that goes stale every release.
+    # rendered at https://docs.openvswitch.org/en/latest/faq/releases/
+    OVS_RELEASES_DOC = "Documentation/faq/releases.rst"
+
+    # matches the rows of the "Open vSwitch / DPDK" table, ex: "3.3.x  23.11.7"
+    _ovs_dpdk_pairing_regex = re.compile(
+        r"^\s*(?P<ovs>\d+\.\d+)\.x\s+(?P<dpdk>\d+(?:\.\d+)+)\s*$",
+        re.MULTILINE,
+    )
 
     # constants for tracking setup state
     INIT = 0
@@ -121,17 +135,43 @@ class DpdkOvs(Tool):
             )
             self.ovs_version = VersionInfo(major, minor, patch)
 
+    @staticmethod
+    def _as_version_tuple(version: str) -> Tuple[int, ...]:
+        return tuple(int(part) for part in version.split("."))
+
+    def _get_dpdk_to_ovs_version_map(self) -> Dict[int, str]:
+        # Parse the "Open vSwitch / DPDK" build compatibility table out of the
+        # OVS docs. _install checks out the newest OVS tag, so the table is as
+        # up to date as the OVS release we cloned.
+        releases_doc = self.node.tools[Cat].read(
+            str(self.repo_dir.joinpath(self.OVS_RELEASES_DOC)),
+            force_run=True,
+        )
+
+        version_map: Dict[int, str] = {}
+        for match in self._ovs_dpdk_pairing_regex.finditer(releases_doc):
+            ovs_version = match.group("ovs")
+            # DPDK uses YY.MM versioning, so the major identifies the release
+            # year. The table only pairs against the YY.11 LTS releases.
+            dpdk_major = int(match.group("dpdk").split(".")[0])
+            current = version_map.get(dpdk_major)
+            # Multiple OVS releases build against the same DPDK release. Keep
+            # the oldest, it is the minimum OVS version for that DPDK.
+            if current is None or self._as_version_tuple(
+                ovs_version
+            ) < self._as_version_tuple(current):
+                version_map[dpdk_major] = ovs_version
+
+        if not version_map:
+            fail(
+                "Could not parse the OVS/DPDK version table from "
+                f"{self.OVS_RELEASES_DOC}. The OVS doc format may have changed, "
+                "check https://docs.openvswitch.org/en/latest/faq/releases/"
+            )
+        return version_map
+
     def _force_ovs_dpdk_compatibility(self, dpdk_tool: DpdkTestpmd) -> None:
         dpdk_version = dpdk_tool.get_dpdk_version()
-        # confirm supported ovs:dpdk version pairing based on
-        # https://docs.openvswitch.org/en/latest/faq/releases/
-        # to account for minor releases check release is below a major version threshold
-        dpdk_to_ovs_minimum_version = {
-            19: "2.13.0",
-            20: "2.15.0",
-            21: "2.17.0",
-            22: "3.1.0",
-        }
 
         # check if dpdk version too low
         if dpdk_version < "19.11.0":
@@ -139,14 +179,19 @@ class DpdkOvs(Tool):
                 f"Dpdk version {dpdk_version} is not supported by this test."
             )
 
+        # confirm supported ovs:dpdk version pairing using the table published
+        # in the OVS source tree we checked out during _install.
+        dpdk_to_ovs_minimum_version = self._get_dpdk_to_ovs_version_map()
+
         # check if DPDK version is above the versions in the table.
         if int(dpdk_version.major) not in dpdk_to_ovs_minimum_version.keys():
             # we've already checked out latest OVS
-            # DPDK version is above 22, warn and proceed.
+            # DPDK version is newer than any release OVS documents, warn
+            # and proceed.
             self.node.log.info(
                 "DPDK version is above the maximum in the version match "
-                "table. Using latest OVS. If test fails, the dpdk_to_ovs_minimum "
-                "verison table may need an update. "
+                "table. Using latest OVS. If test fails, OVS may not support "
+                "this DPDK release yet. "
                 "check https://docs.openvswitch.org/en/latest/faq/releases/"
             )
             return
@@ -205,7 +250,30 @@ class DpdkOvs(Tool):
             cwd=self.repo_dir,
         )
 
-    def setup_ovs(self, device_address: str) -> None:
+    def _get_eal_and_device_args(
+        self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd
+    ) -> Tuple[str, str]:
+        assert_that(nics).described_as(
+            "setup_ovs needs at least one test nic to attach to the bridge"
+        ).is_not_empty()
+
+        # dpdk-devname enumerates the ports the EAL actually sees. Running it
+        # both validates the netvsc PMD setup and gives us the EAL device
+        # arguments needed to select those ports.
+        devname_info = DpdkDevnameInfo(testpmd=dpdk_tool)
+        devname_info.get_port_info(nics, expect_ports=len(nics))
+
+        # the devname args are built for a shell invocation, but OVS hands the
+        # value straight to the EAL, so the embedded quoting has to go.
+        eal_args = devname_info.nic_args.replace('"', "")
+
+        # The netvsc PMD drives the synthetic vmbus device, so the PCI address
+        # of the VF does not name the port. Select it by MAC instead, which is
+        # bus agnostic. See netdev_dpdk_process_devargs in lib/netdev-dpdk.c.
+        device_args = f"class=eth,mac={nics[0].mac_addr}"
+        return eal_args, device_args
+
+    def setup_ovs(self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd) -> None:
         # setup OVS and track which state we are in.
         # this will allow a try/except to catch a failure and hold it until
         # until after the teardown. It should also allow teardown
@@ -213,6 +281,8 @@ class DpdkOvs(Tool):
         node = self.node
         modprobe = node.tools[Modprobe]
         self.teardown_state = self.INIT
+
+        eal_args, device_args = self._get_eal_and_device_args(nics, dpdk_tool)
 
         # load ovs driver
         modprobe.load("openvswitch")
@@ -226,6 +296,35 @@ class DpdkOvs(Tool):
             expected_exit_code_failure_message="Could not start ovs-ctl",
         )
         self.teardown_state = self.SERVICE_START
+
+        # Pass the device selection to the EAL. This has to happen before
+        # dpdk-init flips to true, since that is when OVS runs rte_eal_init.
+        node.execute(
+            (
+                "ovs-vsctl --no-wait set Open_vSwitch . "
+                f'other_config:dpdk-extra="{eal_args}"'
+            ),
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "Could not set the EAL device arguments for OVS"
+            ),
+        )
+
+        # OVS 4.0 stopped probing devices during EAL init, which breaks the
+        # "class=eth,mac=" lookup because it only searches ports that are
+        # already probed. Older releases probe at init and ignore this key.
+        node.execute(
+            (
+                "ovs-vsctl --no-wait set Open_vSwitch . "
+                "other_config:dpdk-probe-at-init=true"
+            ),
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "Could not enable device probing at DPDK init for OVS"
+            ),
+        )
 
         # enable dpdk in ovs config
         node.execute(
@@ -254,7 +353,7 @@ class DpdkOvs(Tool):
         node.execute(
             (
                 f"ovs-vsctl add-port {self.OVS_BRIDGE_NAME} p1 -- "
-                f"set Interface p1 type=dpdk options:dpdk-devargs={device_address}"
+                f'set Interface p1 type=dpdk options:dpdk-devargs="{device_args}"'
             ),
             sudo=True,
             expected_exit_code=0,

--- a/lisa/microsoft/testsuites/dpdk/dpdkovs.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkovs.py
@@ -273,7 +273,9 @@ class DpdkOvs(Tool):
         device_args = f"class=eth,mac={nics[0].mac_addr}"
         return eal_args, device_args
 
-    def setup_ovs(self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd) -> None:
+    def setup_ovs(
+        self, nics: List[NicInfo], dpdk_tool: DpdkTestpmd, queues: int = 2
+    ) -> None:
         # setup OVS and track which state we are in.
         # this will allow a try/except to catch a failure and hold it until
         # until after the teardown. It should also allow teardown
@@ -281,7 +283,6 @@ class DpdkOvs(Tool):
         node = self.node
         modprobe = node.tools[Modprobe]
         self.teardown_state = self.INIT
-
         eal_args, device_args = self._get_eal_and_device_args(nics, dpdk_tool)
 
         # load ovs driver
@@ -354,7 +355,7 @@ class DpdkOvs(Tool):
             (
                 f"ovs-vsctl add-port {self.OVS_BRIDGE_NAME} p1 -- "
                 f'set Interface p1 type=dpdk options:dpdk-devargs="{device_args}" '
-                "options:n_rxq=2 options:n_txq=2"
+                f"options:n_rxq={queues} options:n_txq={queues}"
             ),
             sudo=True,
             expected_exit_code=0,

--- a/lisa/microsoft/testsuites/dpdk/dpdkovs.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkovs.py
@@ -353,7 +353,8 @@ class DpdkOvs(Tool):
         node.execute(
             (
                 f"ovs-vsctl add-port {self.OVS_BRIDGE_NAME} p1 -- "
-                f'set Interface p1 type=dpdk options:dpdk-devargs="{device_args}"'
+                f'set Interface p1 type=dpdk options:dpdk-devargs="{device_args}" '
+                "options:n_rxq=2 options:n_txq=2"
             ),
             sudo=True,
             expected_exit_code=0,

--- a/lisa/microsoft/testsuites/dpdk/dpdkperf.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkperf.py
@@ -218,7 +218,7 @@ class DpdkPerformance(TestSuite):
             result,
             log,
             variables,
-            use_queues=True,
+            queues=4,
         )
 
     @TestCaseMetadata(
@@ -246,7 +246,7 @@ class DpdkPerformance(TestSuite):
             result,
             log,
             variables,
-            use_queues=True,
+            queues=4,
         )
 
     @TestCaseMetadata(
@@ -290,7 +290,7 @@ class DpdkPerformance(TestSuite):
         test_result: TestResult,
         log: Logger,
         variables: Dict[str, Any],
-        use_queues: bool = False,
+        queues: int = 1,
     ) -> None:
         environment = test_result.environment
         assert environment, "fail to get environment from testresult"
@@ -298,12 +298,13 @@ class DpdkPerformance(TestSuite):
         # run build + validation to populate results
         self._validate_core_counts_are_equal(test_result)
         try:
-            if use_queues:
+            if queues > 1:
                 send_kit, receive_kit = verify_dpdk_send_receive_multi_txrx_queue(
                     environment,
                     log,
                     variables,
                     pmd,
+                    queues=queues,
                     result=test_result,
                 )
             else:

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -743,9 +743,26 @@ class Dpdk(TestSuite):
                 )
             )
 
+    def _verify_dpdk_send_receive_with_queues(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        pmd: Pmd,
+        queues: int,
+        result: TestResult,
+    ) -> None:
+        try:
+            verify_dpdk_send_receive_multi_txrx_queue(
+                environment, log, variables, pmd, queues=queues, result=result
+            )
+        except UnsupportedPackageVersionException as err:
+            raise SkippedException(err)
+
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for default failsafe driver setup.
+            Tests a basic sender/receiver setup for default failsafe driver setup
+            with 1 rx/tx queue, backed by 1 dedicated forwarding core.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the
             expected order-of-magnitude.
@@ -753,45 +770,154 @@ class Dpdk(TestSuite):
         priority=2,
         maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=3,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_failsafe(
+    def verify_dpdk_send_receive_1_queue_failsafe(
         self,
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        try:
-            verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, Pmd.FAILSAFE, result=result
-            )
-        except UnsupportedPackageVersionException as err:
-            raise SkippedException(err)
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.FAILSAFE, queues=1, result=result
+        )
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for dpdk netvsc pmd with jumbo frames.
-            Default is set to request an mtu of 9k, test will skip if it's not possible.
+            Tests a basic sender/receiver setup for default failsafe driver setup
+            with 2 rx/tx queues, backed by 2 dedicated forwarding cores.
             Sender sends the packets, receiver receives them.
-            Test checks that traffic flowed, and annotates the Gbps throughput.
-            """,
+            We check both to make sure the received traffic is within the
+            expected order-of-magnitude.
+        """,
         priority=2,
-        maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=4,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_max_mtu_netvsc(
+    def verify_dpdk_send_receive_2_queue_failsafe(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.FAILSAFE, queues=2, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for default failsafe driver setup
+            with 4 rx/tx queues, backed by 4 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the
+            expected order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=6,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+    )
+    def verify_dpdk_send_receive_4_queue_failsafe(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.FAILSAFE, queues=4, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for default failsafe driver setup
+            with 8 rx/tx queues, backed by 8 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the
+            expected order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=10,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+    )
+    def verify_dpdk_send_receive_8_queue_failsafe(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.FAILSAFE, queues=8, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for default failsafe driver setup
+            with 16 rx/tx queues, backed by 16 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the
+            expected order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=18,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+    )
+    def verify_dpdk_send_receive_16_queue_failsafe(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.FAILSAFE, queues=16, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with jumbo
+            frames, using 4 rx/tx queues backed by 4 dedicated forwarding cores.
+            Default is set to request an mtu of 9k, test will skip if it's not possible.
+            Sender sends the packets, receiver receives them.
+            Test checks that traffic flowed, and annotates the Gbps throughput.
+            """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=6,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+    )
+    def verify_dpdk_send_receive_4_queue_max_mtu_netvsc(
         self,
         environment: Environment,
         log: Logger,
@@ -806,6 +932,7 @@ class Dpdk(TestSuite):
                 log,
                 variables,
                 Pmd.NETVSC,
+                queues=4,
                 result=result,
                 set_mtu=mtu_size,
                 grading_metric=DpdkGradeMetric.BPS,
@@ -815,7 +942,8 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of 1500.
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of
+            1500, using 4 rx/tx queues backed by 4 dedicated forwarding cores.
             Sender sends the packets, receiver receives them.
             Test will fail if MTU set fails and/or DPDK crashes.
             Test Gbps throughput is annotated into the test result.
@@ -823,14 +951,14 @@ class Dpdk(TestSuite):
         priority=2,
         maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=6,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_1500_mtu_netvsc(
+    def verify_dpdk_send_receive_4_queue_1500_mtu_netvsc(
         self,
         environment: Environment,
         log: Logger,
@@ -845,6 +973,7 @@ class Dpdk(TestSuite):
                 log,
                 variables,
                 Pmd.NETVSC,
+                queues=4,
                 result=result,
                 set_mtu=mtu_size,
                 grading_metric=DpdkGradeMetric.BPS,
@@ -854,7 +983,8 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of 4k.
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of
+            4k, using 4 rx/tx queues backed by 4 dedicated forwarding cores.
             Sender sends the packets, receiver receives them.
             Test will fail if MTU set fails and/or DPDK crashes.
             Test Gbps throughput is annotated into the test result.
@@ -862,14 +992,14 @@ class Dpdk(TestSuite):
         priority=2,
         maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=6,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_4k_mtu_netvsc(
+    def verify_dpdk_send_receive_4_queue_4k_mtu_netvsc(
         self,
         environment: Environment,
         log: Logger,
@@ -879,11 +1009,12 @@ class Dpdk(TestSuite):
         # allow configuring for different platforms
         mtu_size = 4000
         try:
-            snd, rcv = verify_dpdk_send_receive_multi_txrx_queue(
+            verify_dpdk_send_receive_multi_txrx_queue(
                 environment,
                 log,
                 variables,
                 Pmd.NETVSC,
+                queues=4,
                 result=result,
                 set_mtu=mtu_size,
                 grading_metric=DpdkGradeMetric.BPS,
@@ -893,7 +1024,8 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of 8k.
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with MTU of
+            8k, using 4 rx/tx queues backed by 4 dedicated forwarding cores.
             Sender sends the packets, receiver receives them.
             Test will fail if MTU set fails and/or DPDK crashes.
             Test Gbps throughput is annotated into the test result.
@@ -901,14 +1033,14 @@ class Dpdk(TestSuite):
         priority=2,
         maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=6,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_8k_mtu_netvsc(
+    def verify_dpdk_send_receive_4_queue_8k_mtu_netvsc(
         self,
         environment: Environment,
         log: Logger,
@@ -923,6 +1055,7 @@ class Dpdk(TestSuite):
                 log,
                 variables,
                 Pmd.NETVSC,
+                queues=4,
                 result=result,
                 set_mtu=mtu_size,
                 grading_metric=DpdkGradeMetric.BPS,
@@ -932,7 +1065,8 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            Tests a basic sender/receiver setup for default failsafe driver setup.
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with 1
+            rx/tx queue, backed by 1 dedicated forwarding core.
             Sender sends the packets, receiver receives them.
             We check both to make sure the received traffic is within the expected
             order-of-magnitude.
@@ -940,26 +1074,140 @@ class Dpdk(TestSuite):
         priority=2,
         maturity="preview",
         requirement=simple_requirement(
-            min_core_count=8,
+            min_core_count=3,
             min_nic_count=2,
             network_interface=Sriov(),
             unsupported_features=[Gpu, Infiniband],
             min_count=2,
         ),
+        timeout=600,
     )
-    def verify_dpdk_send_receive_multi_txrx_queue_netvsc(
+    def verify_dpdk_send_receive_1_queue_netvsc(
         self,
         environment: Environment,
         log: Logger,
         variables: Dict[str, Any],
         result: TestResult,
     ) -> None:
-        try:
-            verify_dpdk_send_receive_multi_txrx_queue(
-                environment, log, variables, Pmd.NETVSC, result=result
-            )
-        except UnsupportedPackageVersionException as err:
-            raise SkippedException(err)
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.NETVSC, queues=1, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with 2
+            rx/tx queues, backed by 2 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the expected
+            order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=4,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+        timeout=600,
+    )
+    def verify_dpdk_send_receive_2_queue_netvsc(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.NETVSC, queues=2, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with 4
+            rx/tx queues, backed by 4 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the expected
+            order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=6,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+        timeout=600,
+    )
+    def verify_dpdk_send_receive_4_queue_netvsc(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.NETVSC, queues=4, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with 8
+            rx/tx queues, backed by 8 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the expected
+            order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=10,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+        timeout=600,
+    )
+    def verify_dpdk_send_receive_8_queue_netvsc(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.NETVSC, queues=8, result=result
+        )
+
+    @TestCaseMetadata(
+        description="""
+            Tests a basic sender/receiver setup for dpdk netvsc pmd with 16
+            rx/tx queues, backed by 16 dedicated forwarding cores.
+            Sender sends the packets, receiver receives them.
+            We check both to make sure the received traffic is within the expected
+            order-of-magnitude.
+        """,
+        priority=2,
+        requirement=simple_requirement(
+            min_core_count=18,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+        ),
+        timeout=600,
+    )
+    def verify_dpdk_send_receive_16_queue_netvsc(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+        result: TestResult,
+    ) -> None:
+        self._verify_dpdk_send_receive_with_queues(
+            environment, log, variables, Pmd.NETVSC, queues=16, result=result
+        )
 
     @TestCaseMetadata(
         description="""
@@ -1142,11 +1390,12 @@ class Dpdk(TestSuite):
             hugepage_size=HugePageSize.HUGE_2MB,
             pmd=pmd,
             result=result,
-            multiple_queues=True,
+            queues=4,
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1154,7 +1403,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1180,7 +1430,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1188,7 +1439,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -1146,7 +1146,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1154,7 +1155,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1180,7 +1182,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1188,7 +1191,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -28,7 +28,6 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     run_testpmd_hotplug,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
-    verify_dpdk_mutliple_ports,
     verify_dpdk_send_receive,
     verify_dpdk_send_receive_multi_txrx_queue,
 )
@@ -1354,44 +1353,6 @@ class Dpdk(TestSuite):
             )
         except UnsupportedPackageVersionException as err:
             raise SkippedException(err)
-
-    @TestCaseMetadata(
-        description="""
-                Run testpmd with multiple senders to a single receiver
-                using the netvsc pmd. This test checks how the receiver VM
-                handles a large volume of traffic on multiple ports.
-                Otherwise it is very similar to the
-                single sender / single receiver version of the tests.
-            """,
-        priority=3,
-        maturity="preview",
-        requirement=simple_requirement(
-            supported_os=[Ubuntu],
-            min_core_count=8,
-            min_count=3,
-            min_nic_count=3,
-            network_interface=Sriov(),
-            unsupported_features=[Gpu, Infiniband],
-        ),
-    )
-    def verify_dpdk_testpmd_multiple_port_receive_netvsc_pmd(
-        self,
-        environment: Environment,
-        log: Logger,
-        variables: Dict[str, Any],
-        result: TestResult,
-    ) -> None:
-        force_dpdk_default_source(variables)
-        pmd = Pmd.NETVSC
-        verify_dpdk_mutliple_ports(
-            environment,
-            log,
-            variables,
-            hugepage_size=HugePageSize.HUGE_2MB,
-            pmd=pmd,
-            result=result,
-            queues=4,
-        )
 
     @TestCaseMetadata(
         description=(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -248,9 +248,15 @@ class Dpdk(TestSuite):
             raise SkippedException("OVS test not supported on ARM64")
 
         force_dpdk_default_source(variables)
+        test_nics = [node.nics.get_secondary_nic()]
         try:
             test_kit = initialize_node_resources(
-                node, log, variables, Pmd.NETVSC, HugePageSize.HUGE_2MB
+                node,
+                log,
+                variables,
+                Pmd.NETVSC,
+                HugePageSize.HUGE_2MB,
+                test_nics=test_nics,
             )
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
@@ -272,7 +278,7 @@ class Dpdk(TestSuite):
 
         try:
             # run OVS tests, providing OVS with the NIC info needed for DPDK init
-            ovs.setup_ovs(node.nics.get_secondary_nic().pci_slot)
+            ovs.setup_ovs(test_nics, test_kit.testpmd)
 
             # validate if OVS was able to initialize DPDK
             node.execute(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -14,7 +14,6 @@ from microsoft.testsuites.dpdk.common import (
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
-from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
     UIO_HV_GENERIC_SYSFS_PATH,
     UnsupportedPackageVersionException,
@@ -25,6 +24,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     init_nodes_concurrent,
     initialize_node_resources,
     run_dpdk_symmetric_mp,
+    run_ovs_test,
     run_testpmd_hotplug,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
@@ -240,57 +240,36 @@ class Dpdk(TestSuite):
             ),
         ),
     )
-    def verify_dpdk_ovs(
+    def verify_dpdk_ovs_mana(
         self, node: Node, log: Logger, variables: Dict[str, Any]
     ) -> None:
         # initialize DPDK first, OVS requires it built from source before configuring.
-        if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
-            raise SkippedException("OVS test not supported on ARM64")
-
         force_dpdk_default_source(variables)
-        test_nics = [node.nics.get_secondary_nic()]
-        try:
-            test_kit = initialize_node_resources(
-                node,
-                log,
-                variables,
-                Pmd.NETVSC,
-                HugePageSize.HUGE_2MB,
-                test_nics=test_nics,
-            )
-        except (NotEnoughMemoryException, UnsupportedOperationException) as err:
-            raise SkippedException(err)
+        run_ovs_test(node, log, variables, Pmd.MANA)
 
-        # checkout OpenVirtualSwitch
-        ovs: DpdkOvs = node.tools[DpdkOvs]
-
-        # check for runbook variable to skip dpdk version check
-        use_latest_ovs = variables.get("use_latest_ovs", False)
-        # provide ovs build with DPDK tool info and build
-        ovs.build_with_dpdk(test_kit.testpmd, use_latest_ovs=use_latest_ovs)
-
-        # enable hugepages needed for dpdk EAL
-        hugepages = node.tools[Hugepages]
-        try:
-            hugepages.init_hugepages(HugePageSize.HUGE_2MB)
-        except (NotEnoughMemoryException, UnsupportedOperationException) as err:
-            raise SkippedException(err)
-
-        try:
-            # run OVS tests, providing OVS with the NIC info needed for DPDK init
-            ovs.setup_ovs(test_nics, test_kit.testpmd)
-
-            # validate if OVS was able to initialize DPDK
-            node.execute(
-                "ovs-vsctl get Open_vSwitch . dpdk_initialized",
-                sudo=True,
-                expected_exit_code=0,
-                expected_exit_code_failure_message=(
-                    "OVS repoted that DPDK EAL failed to initialize."
-                ),
-            )
-        finally:
-            ovs.stop_ovs()
+    @TestCaseMetadata(
+        description="""
+           Install and run OVS+DPDK functional tests
+        """,
+        priority=4,
+        maturity="preview",
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            disk=schema.DiskOptionSettings(
+                data_disk_count=search_space.IntRange(min=1),
+                data_disk_size=search_space.IntRange(min=64),
+            ),
+        ),
+    )
+    def verify_dpdk_ovs_netvsc(
+        self, node: Node, log: Logger, variables: Dict[str, Any]
+    ) -> None:
+        # initialize DPDK first, OVS requires it built from source before configuring.
+        force_dpdk_default_source(variables)
+        run_ovs_test(node, log, variables, Pmd.NETVSC)
 
     @TestCaseMetadata(
         description="""
@@ -1371,7 +1350,8 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1379,7 +1359,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1405,7 +1386,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1413,7 +1395,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -14,6 +14,7 @@ from microsoft.testsuites.dpdk.common import (
     force_dpdk_default_source,
 )
 from microsoft.testsuites.dpdk.dpdknffgo import DpdkNffGo
+from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdkutil import (
     UIO_HV_GENERIC_SYSFS_PATH,
     UnsupportedPackageVersionException,
@@ -24,7 +25,6 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     init_nodes_concurrent,
     initialize_node_resources,
     run_dpdk_symmetric_mp,
-    run_ovs_test,
     run_testpmd_hotplug,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
@@ -222,30 +222,6 @@ class Dpdk(TestSuite):
         verify_dpdk_build(
             node, log, variables, Pmd.FAILSAFE, HugePageSize.HUGE_1GB, result=result
         )
-
-    @TestCaseMetadata(
-        description="""
-           Install and run OVS+DPDK functional tests
-        """,
-        priority=4,
-        maturity="preview",
-        requirement=simple_requirement(
-            min_core_count=8,
-            min_nic_count=2,
-            network_interface=Sriov(),
-            unsupported_features=[Gpu, Infiniband],
-            disk=schema.DiskOptionSettings(
-                data_disk_count=search_space.IntRange(min=1),
-                data_disk_size=search_space.IntRange(min=64),
-            ),
-        ),
-    )
-    def verify_dpdk_ovs_mana(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
-    ) -> None:
-        # initialize DPDK first, OVS requires it built from source before configuring.
-        force_dpdk_default_source(variables)
-        run_ovs_test(node, log, variables, Pmd.MANA)
 
     @TestCaseMetadata(
         description="""
@@ -1350,8 +1326,7 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1359,8 +1334,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1386,8 +1360,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1395,8 +1368,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1537,3 +1509,50 @@ class Dpdk(TestSuite):
     def after_case(self, log: Logger, **kwargs: Any) -> None:
         environment: Environment = kwargs.pop("environment")
         do_parallel_cleanup(environment)
+
+
+def run_ovs_test(node: Node, log: Logger, variables: Dict[str, Any], pmd: Pmd) -> None:
+    if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
+        raise SkippedException("OVS test not supported on ARM64")
+    test_nics = [node.nics.get_secondary_nic()]
+    try:
+        test_kit = initialize_node_resources(
+            node,
+            log,
+            variables,
+            pmd,
+            HugePageSize.HUGE_2MB,
+            test_nics=test_nics,
+        )
+    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+        raise SkippedException(err)
+
+    # checkout OpenVirtualSwitch
+    ovs: DpdkOvs = node.tools.create(DpdkOvs)
+
+    # check for runbook variable to skip dpdk version check
+    use_latest_ovs = variables.get("use_latest_ovs", False)
+    # provide ovs build with DPDK tool info and build
+    ovs.build_with_dpdk(test_kit.testpmd, use_latest_ovs=use_latest_ovs)
+    # enable hugepages needed for dpdk EAL
+    hugepages = node.tools[Hugepages]
+    try:
+        hugepages.init_hugepages(HugePageSize.HUGE_2MB)
+    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+        raise SkippedException(err)
+
+    try:
+        # run OVS tests, providing OVS with the NIC info needed for DPDK init
+        ovs.setup_ovs(test_nics, test_kit.testpmd)
+
+        # validate if OVS was able to initialize DPDK
+        node.execute(
+            "ovs-vsctl get Open_vSwitch . dpdk_initialized",
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "OVS repoted that DPDK EAL failed to initialize."
+            ),
+        )
+    finally:
+        ovs.stop_ovs()

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -1518,7 +1518,8 @@ class Dpdk(TestSuite):
 def run_ovs_test(node: Node, log: Logger, variables: Dict[str, Any], pmd: Pmd) -> None:
     if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
         raise SkippedException("OVS test not supported on ARM64")
-    test_nics = [node.nics.get_secondary_nic()]
+
+    test_nics = [node.nics.get_nic_by_subnet("10.0.1.0/24")]
     try:
         test_kit = initialize_node_resources(
             node,

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -417,7 +417,32 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            test sriov failsafe with netvsc during vf revoke (receive side)
+            test sriov failsafe during vf revoke (receive side)
+        """,
+        priority=2,
+        maturity="preview",
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            min_count=2,
+            supported_features=[IsolatedResource],
+        ),
+    )
+    def verify_dpdk_testpmd_hotplug_receiver_failsafe_pmd(
+        self,
+        environment: Environment,
+        log: Logger,
+        variables: Dict[str, Any],
+    ) -> None:
+        self.run_testpmd_hotplug_recv_test(
+            environment, log, variables, pmd=Pmd.FAILSAFE
+        )
+
+    @TestCaseMetadata(
+        description="""
+            test sriov failsafe during vf revoke (receive side)
         """,
         priority=2,
         maturity="preview",
@@ -437,6 +462,25 @@ class Dpdk(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self.run_testpmd_hotplug_recv_test(environment, log, variables, pmd=Pmd.NETVSC)
+
+    @TestCaseMetadata(
+        description="""
+            testpmd with hotplug vf for failsafe pmd (send only version)
+        """,
+        priority=2,
+        maturity="preview",
+        requirement=simple_requirement(
+            min_core_count=8,
+            min_nic_count=2,
+            network_interface=Sriov(),
+            unsupported_features=[Gpu, Infiniband],
+            supported_features=[IsolatedResource],
+        ),
+    )
+    def verify_dpdk_testpmd_hotplug_sender_failsafe_pmd(
+        self, node: Node, log: Logger, variables: Dict[str, Any]
+    ) -> None:
+        self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.FAILSAFE)
 
     @TestCaseMetadata(
         description="""
@@ -1311,7 +1355,8 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1319,7 +1364,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1345,7 +1391,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1353,7 +1400,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -1326,7 +1326,8 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1334,7 +1335,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1360,7 +1362,8 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=("""
+        description=(
+            """
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1368,7 +1371,8 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """),
+        """
+        ),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -25,7 +25,7 @@ from microsoft.testsuites.dpdk.dpdkutil import (
     init_nodes_concurrent,
     initialize_node_resources,
     run_dpdk_symmetric_mp,
-    run_testpmd_concurrent,
+    run_testpmd_hotplug,
     verify_dpdk_build,
     verify_dpdk_l3fwd_ntttcp_tcp,
     verify_dpdk_mutliple_ports,
@@ -532,8 +532,10 @@ class Dpdk(TestSuite):
 
         kit_cmd_pairs = generate_send_receive_run_info(pmd, sender, receiver)
 
-        run_testpmd_concurrent(
-            kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
+        run_testpmd_hotplug(
+            kit_cmd_pairs=kit_cmd_pairs,
+            sender=sender,
+            receiver=receiver,
         )
 
         hotplug_pps_set = receiver.testpmd.get_mean_rx_pps_sriov_hotplug()
@@ -553,15 +555,13 @@ class Dpdk(TestSuite):
         except (NotEnoughMemoryException, UnsupportedOperationException) as err:
             raise SkippedException(err)
         testpmd = test_kit.testpmd
-        test_nic = node.nics.get_secondary_nic()
-        testpmd_cmd = testpmd.generate_testpmd_command([test_nic], 0, "txonly")
+        test_nic = node.nics.get_nic_by_subnet("10.0.1.0/24")
+        testpmd_cmd = testpmd.generate_testpmd_command([test_nic], 0, "txonly", pmd=pmd)
         kit_cmd_pairs = {
             test_kit: testpmd_cmd,
         }
 
-        run_testpmd_concurrent(
-            kit_cmd_pairs, DPDK_VF_REMOVAL_MAX_TEST_TIME, log, hotplug_sriov=True
-        )
+        run_testpmd_hotplug(kit_cmd_pairs=kit_cmd_pairs, sender=test_kit)
 
         hotplug_pps_set = testpmd.get_mean_tx_pps_sriov_hotplug()
         self._check_rx_or_tx_pps_sriov_hotplug("TX", hotplug_pps_set)
@@ -574,10 +574,12 @@ class Dpdk(TestSuite):
         self._check_rx_or_tx_pps(tx_or_rx, during_hotplug, sriov_enabled=False)
         self._check_rx_or_tx_pps(tx_or_rx, after_reenable, sriov_enabled=True)
         after_over_before = after_reenable / before_hotplug
-        assert_that(after_over_before).described_as(
-            "Error: pps of vf was very different before and after hotplug. "
-            f"before: {before_hotplug} after: {after_reenable}"
-        ).is_close_to(1, tolerance=0.125)
+        if after_reenable < before_hotplug:
+            assert_that(after_over_before).described_as(
+                "Error: pps of vf was very different before and "
+                "after hotplug. "
+                f"before: {before_hotplug} after: {after_reenable}"
+            ).is_close_to(1, tolerance=0.125)
 
     def _check_rx_or_tx_pps(
         self, tx_or_rx: str, pps: int, sriov_enabled: bool = True
@@ -1144,8 +1146,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1153,8 +1154,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1180,8 +1180,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1189,8 +1188,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -417,32 +417,7 @@ class Dpdk(TestSuite):
 
     @TestCaseMetadata(
         description="""
-            test sriov failsafe during vf revoke (receive side)
-        """,
-        priority=2,
-        maturity="preview",
-        requirement=simple_requirement(
-            min_core_count=8,
-            min_nic_count=2,
-            network_interface=Sriov(),
-            unsupported_features=[Gpu, Infiniband],
-            min_count=2,
-            supported_features=[IsolatedResource],
-        ),
-    )
-    def verify_dpdk_testpmd_hotplug_receiver_failsafe_pmd(
-        self,
-        environment: Environment,
-        log: Logger,
-        variables: Dict[str, Any],
-    ) -> None:
-        self.run_testpmd_hotplug_recv_test(
-            environment, log, variables, pmd=Pmd.FAILSAFE
-        )
-
-    @TestCaseMetadata(
-        description="""
-            test sriov failsafe during vf revoke (receive side)
+            test sriov failsafe with netvsc during vf revoke (receive side)
         """,
         priority=2,
         maturity="preview",
@@ -462,25 +437,6 @@ class Dpdk(TestSuite):
         variables: Dict[str, Any],
     ) -> None:
         self.run_testpmd_hotplug_recv_test(environment, log, variables, pmd=Pmd.NETVSC)
-
-    @TestCaseMetadata(
-        description="""
-            testpmd with hotplug vf for failsafe pmd (send only version)
-        """,
-        priority=2,
-        maturity="preview",
-        requirement=simple_requirement(
-            min_core_count=8,
-            min_nic_count=2,
-            network_interface=Sriov(),
-            unsupported_features=[Gpu, Infiniband],
-            supported_features=[IsolatedResource],
-        ),
-    )
-    def verify_dpdk_testpmd_hotplug_sender_failsafe_pmd(
-        self, node: Node, log: Logger, variables: Dict[str, Any]
-    ) -> None:
-        self.run_testpmd_hotplug_send_test(node, log, variables, pmd=Pmd.FAILSAFE)
 
     @TestCaseMetadata(
         description="""
@@ -1355,8 +1311,7 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1364,8 +1319,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1391,8 +1345,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1400,8 +1353,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -1146,8 +1146,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1155,8 +1154,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1182,8 +1180,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1191,8 +1188,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -1326,8 +1326,7 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1335,8 +1334,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1362,8 +1360,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1371,8 +1368,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1529,7 +1525,11 @@ def run_ovs_test(node: Node, log: Logger, variables: Dict[str, Any], pmd: Pmd) -
             HugePageSize.HUGE_2MB,
             test_nics=test_nics,
         )
-    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+    except (
+        NotEnoughMemoryException,
+        UnsupportedOperationException,
+        UnsupportedDistroException,
+    ) as err:
         raise SkippedException(err)
 
     # checkout OpenVirtualSwitch

--- a/lisa/microsoft/testsuites/dpdk/dpdksuite.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdksuite.py
@@ -579,6 +579,16 @@ class Dpdk(TestSuite):
                 "after hotplug. "
                 f"before: {before_hotplug} after: {after_reenable}"
             ).is_close_to(1, tolerance=0.125)
+        if after_reenable >= before_hotplug:
+            # better throughput after the hotplug is odd but fine.
+            # This check is more generous for the
+            # 'pps got better' case. The base PPS threshold is
+            # still asserted in checks elsewhere.
+            assert_that(after_over_before).described_as(
+                "Error: pps of vf was very different before and "
+                "after hotplug. "
+                f"before: {before_hotplug} after: {after_reenable}"
+            ).is_close_to(1, tolerance=0.15)
 
     def _check_rx_or_tx_pps(
         self, tx_or_rx: str, pps: int, sriov_enabled: bool = True
@@ -1355,8 +1365,7 @@ class Dpdk(TestSuite):
             raise SkippedException(err)
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1364,8 +1373,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(
@@ -1391,8 +1399,7 @@ class Dpdk(TestSuite):
         )
 
     @TestCaseMetadata(
-        description=(
-            """
+        description=("""
                 Run the L3 forwarding test for DPDK.
                 This test creates a DPDK port forwarding setup between
                 two NICs on the same VM. It forwards packets from a sender on
@@ -1400,8 +1407,7 @@ class Dpdk(TestSuite):
                 packets will not be able to jump the subnets.  This imitates
                 a network virtual appliance setup, firewall, or other data plane
                 tool for managing network traffic with DPDK.
-        """
-        ),
+        """),
         priority=3,
         maturity="preview",
         requirement=simple_requirement(

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -489,7 +489,8 @@ class DpdkTestpmd(Tool):
             for nic in nics:
                 bus_to_mac.setdefault(nic.pci_slot, []).append(nic.mac_addr)
             for bus, macs in bus_to_mac.items():
-                nic_include_infos += [f"--vdev={bus}," + ",".join(macs)]
+                mac_fmt = [f"mac={m}" for m in macs]
+                nic_include_infos += [f"--vdev={bus}," + ",".join(mac_fmt)]
         else:
             for node_nic in nics:
                 nic_include_infos.append(

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -3,7 +3,7 @@
 
 import re
 from pathlib import PurePath, PurePosixPath
-from typing import Any, List, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 
 from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.common import (
@@ -569,10 +569,11 @@ class DpdkTestpmd(Tool):
         mode: str,
         pmd: Pmd = Pmd.FAILSAFE,
         extra_args: str = "",
-        multiple_queues: bool = False,
+        queues: int = 1,
         service_cores: int = 1,
         mtu: int = 0,
         mbuf_size: int = 0,
+        stats_period: int = 2,
     ) -> str:
         #   testpmd \
         #   -l <core-list> \
@@ -585,15 +586,15 @@ class DpdkTestpmd(Tool):
         #   --eth-peer=<port id>,<receiver peer MAC address> \
         #   --stats-period <display interval in seconds>
 
-        # pick amount of queues for tx/rx (txq/rxq flag)
-        # our tests use equal amounts for rx and tx
-        if multiple_queues:
-            if self.is_mana and mode == "txonly":
-                queues = 8
-            else:
-                queues = 4
-        else:
-            queues = 1
+        # `queues` (txq/rxq) is an explicit value chosen by the caller: our
+        # tests use equal amounts for rx and tx. The forwarding core count is
+        # derived directly from it (one core per queue per port) instead of
+        # being silently shrunk to fit whatever the node happens to have,
+        # which used to make the actual queue/core count unpredictable.
+        assert_that(queues).described_as(
+            "queues must be a positive number. Callers must pick an explicit "
+            "queue count instead of relying on this tool to infer one."
+        ).is_greater_than_or_equal_to(1)
 
         # MANA needs a file descriptor argument, mlnx doesn't.
         txd = 256
@@ -603,31 +604,44 @@ class DpdkTestpmd(Tool):
             nic_to_include, vdev_id, pmd=pmd
         )
 
-        # infer core count to assign based on number of queues
-        threads_available = self.node.tools[Lscpu].get_thread_count()
-        assert_that(threads_available).described_as(
-            "DPDK tests need more than 4 threads, recommended more than 8 threads"
-        ).is_greater_than(4)
+        # one forwarding core per queue per port: this is the only place a
+        # caller with more than one nic (i.e. a multi-port test) differs from
+        # the rest, since its forwarding core count scales with port count.
+        forwarding_cores = queues * len(nic_to_include)
+        max_core_index = forwarding_cores + service_cores
 
-        queues_and_servicing_core = (queues * len(nic_to_include)) + service_cores
-
-        while queues_and_servicing_core > (threads_available - 2):
-            # if less, split the number of queues
-            queues = queues // 2
-            queues_and_servicing_core = queues + service_cores
-            txd = 64  # txd has to be >= 64 for MANA.
-            assert_that(queues).described_as(
-                "txq value must be greater than 1"
-            ).is_greater_than_or_equal_to(1)
-
-        # label core index for future use
-        max_core_index = queues_and_servicing_core
-
-        # service cores excluded from forwarding cores count
-        forwarding_cores = max_core_index - service_cores
+        # verify the requested queue/core count actually fits on this node's
+        # NUMA-0 core range instead of silently shrinking it: a test either
+        # runs with the exact queue count it asked for, or fails immediately
+        # with a clear explanation of what didn't fit.
+        first, last = self.node.tools[Lscpu].get_cpu_range_in_numa_node(0)
+        if last <= first:
+            raise AssertionError(
+                f"tool.Lscpu bug: cpu range for numa 0 found as {first}-{last}."
+            )
+        threads_available = last - first + 1
+        # 1 core is always reserved for the OS/management.
+        available_for_this_process = threads_available - 1
+        assert_that(available_for_this_process).described_as(
+            f"DPDK test requested {queues} queue(s) across "
+            f"{len(nic_to_include)} port(s) ({forwarding_cores} forwarding "
+            f"core(s)) plus {service_cores} service core(s) = "
+            f"{max_core_index} core(s) on NUMA node 0, but only "
+            f"{available_for_this_process} core(s) are available there "
+            f"(node has {threads_available} total). "
+            "Pick a smaller queue count for this SKU, or run this test on a "
+            "bigger one."
+        ).is_greater_than_or_equal_to(max_core_index)
 
         # core range argument
         core_list = f"-l 1-{max_core_index}"
+        self._log_core_queue_mapping(
+            nics=nic_to_include,
+            mode=mode,
+            queues=queues,
+            first_forwarding_core=1,
+            service_cores=service_cores,
+        )
         if extra_args:
             extra_args = extra_args.strip()
         else:
@@ -663,31 +677,71 @@ class DpdkTestpmd(Tool):
             and bool(self.get_dpdk_version() > "23.7.0")
         ):
             extra_args += " --txonly-multi-flow"
-        else:
+        elif mode == "txonly":
             self.node.log.debug(
                 "note: skipping use of testpmd txonly-multi-flow flag "
                 "before dpdk 24.11. perf on receive side may be suboptimal."
             )
 
-        assert_that(forwarding_cores).described_as(
-            ("DPDK tests need at least one forwading core. ")
-        ).is_greater_than(0)
-        assert_that(max_core_index).described_as(
-            "Test needs at least 1 core for servicing and one core for forwarding"
-        ).is_greater_than(0)
         assert_that(self._testpmd_install_path).described_as(
             "Testpmd install path was not set, this indicates a logic"
             " error in the DPDK installation process."
         ).is_not_empty()
-        # add debug logging args, EAL ones are very verbose
-        # but netvsc are useful for identifying hotplugs on azure
-        debug_logging = "--log-level netvsc,debug"
+        debug_log_args = self._eal_debug_log_args()
         nic_includes = " ".join(nic_include_infos)
         return (
             f"{self._testpmd_install_path} {core_list} "
-            f"{nic_includes} {debug_logging} -- --forward-mode={mode} "
-            f"-a --stats-period 2 --nb-cores={forwarding_cores} {extra_args} "
+            f"{nic_includes} {debug_log_args} -- --forward-mode={mode} "
+            f"-a --stats-period {stats_period} "
+            f"--nb-cores={forwarding_cores} {extra_args} "
         )
+
+    def _log_core_queue_mapping(
+        self,
+        nics: List[NicInfo],
+        mode: str,
+        queues: int,
+        first_forwarding_core: int,
+        service_cores: int,
+    ) -> None:
+        """Log a machine-parseable record of the core -> queue assignment a
+        generated command used, one line per port plus one for the service
+        cores, tagged with DPDK_CORE_QUEUE_MAP so it's easy to grep out of
+        the test log, e.g.:
+
+            DPDK_CORE_QUEUE_MAP mode=txonly port=0 pci=0002:00:02.0 queues=4 \
+cores=1-4
+            DPDK_CORE_QUEUE_MAP mode=txonly role=service cores=5-5
+
+        Each port gets its own contiguous block of ``queues`` cores (one
+        dedicated forwarding core per queue), assigned in port order
+        starting at ``first_forwarding_core``.
+        """
+        core = first_forwarding_core
+        for port_id, nic in enumerate(nics):
+            first_core = core
+            core += queues
+            self.node.log.info(
+                f"DPDK_CORE_QUEUE_MAP mode={mode} port={port_id} "
+                f"pci={nic.pci_slot} queues={queues} "
+                f"cores={first_core}-{core - 1}"
+            )
+        if service_cores:
+            self.node.log.info(
+                f"DPDK_CORE_QUEUE_MAP mode={mode} role=service "
+                f"cores={core}-{core + service_cores - 1}"
+            )
+
+    def _eal_debug_log_args(self) -> str:
+        """Return the EAL debug logging flags used by generated commands.
+
+        netvsc's debug log is the fallback used to locate a VF hotplug when
+        testpmd's own ethdev event message is not available, so it stays on.
+        """
+        debug_logging = []
+        for lib in ["netvsc"]:
+            debug_logging += [f"--log-level {lib},debug"]
+        return " ".join(debug_logging)
 
     def run_for_n_seconds(self, cmd: str, timeout: int) -> str:
         self._last_run_timeout = timeout

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -13,6 +13,7 @@ from microsoft.testsuites.dpdk.common import (
     Installer,
     OsPackageDependencies,
     PackageManagerInstall,
+    Pmd,
     TarDownloader,
     get_debian_backport_repo_args,
     is_url_for_git_repo,
@@ -471,10 +472,38 @@ class DpdkTestpmd(Tool):
             return False
 
     def generate_testpmd_include(
-        self, node_nic: NicInfo, vdev_id: int, force_netvsc: bool = False
-    ) -> str:
-        # handle generating different flags for pmds/device combos for testpmd
+        self,
+        nics: List[NicInfo],
+        vdev_id: int,
+        pmd: Pmd,
+    ) -> List[str]:
+        nic_include_infos = []
+        # handle them all at once for mana
+        # the format is --vdev=(bus_address),mac=...,mac=...
+        # as opposed to the multiple --vdev arguments
+        # for non-vport setups.
+        if pmd == Pmd.MANA:
+            # nics which share a bus address (i.e. MANA vports) have to be
+            # declared as one vdev with every mac listed on it.
+            bus_to_mac: Dict[str, List[str]] = {}
+            for nic in nics:
+                bus_to_mac.setdefault(nic.pci_slot, []).append(nic.mac_addr)
+            for bus, macs in bus_to_mac.items():
+                nic_include_infos += [f"--vdev={bus}," + ",".join(macs)]
+        else:
+            for node_nic in nics:
+                nic_include_infos.append(
+                    self._generate_testpmd_include(node_nic, vdev_id, pmd)
+                )
+                vdev_id += 1
+        return nic_include_infos
 
+    def _generate_testpmd_include(
+        self,
+        node_nic: NicInfo,
+        vdev_id: int,
+        pmd: Pmd,
+    ) -> str:
         # MANA and mlnx both don't require these arguments if all VFs are in use.
         # We have a primary nic to exclude in our tests, so we include the
         # test nic by either bus address and mac (MANA)
@@ -494,16 +523,24 @@ class DpdkTestpmd(Tool):
         else:
             include_flag = "-w"
 
-        include_flag = f' {include_flag} "{node_nic.pci_slot}"'
+        if self.is_mana:
+            # MANA vports share one bus address, so the vmbus device uuid
+            # is what actually distinguishes the devices from each other.
+            include_flag = f"{include_flag} {node_nic.dev_uuid}"
+        else:
+            include_flag = f' {include_flag} "{node_nic.pci_slot}"'
 
         # build pmd argument
         if self.has_dpdk_version() and self.get_dpdk_version() < "18.11.0":
             pmd_name = "net_failsafe"
             pmd_flags = f"dev({node_nic.pci_slot}),dev(iface={node_nic.name},force=1)"
         elif self.is_mana:
-            # mana selects by mac, just return the vdev info directly
-            if node_nic.module_name == "uio_hv_generic" or force_netvsc:
-                return f' --vdev="{node_nic.pci_slot},mac={node_nic.mac_addr}" '
+            # MANA netvsc mode selects by mac.
+            if pmd == Pmd.NETVSC:
+                return (
+                    f" {include_flag} "
+                    f'--vdev="{node_nic.pci_slot},mac={node_nic.mac_addr}" '
+                )
             # if mana_ib is present, use mana friendly args
             elif self.node.tools[Modprobe].module_exists("mana_ib"):
                 return (
@@ -518,34 +555,19 @@ class DpdkTestpmd(Tool):
                 # reset include flag for MANA since there is only one interface
                 include_flag = ""
         else:
+            if pmd == Pmd.NETVSC:
+                return include_flag
             # mlnx setup for failsafe
             pmd_name = "net_vdev_netvsc"
             pmd_flags = f"iface={node_nic.name},force=1"
-        if node_nic.module_name == "hv_netvsc":
-            # primary/upper/master nic is bound to hv_netvsc
-            # when using net_failsafe implicitly or explicitly.
-            # Set up net_failsafe/net_vdev_netvsc args here
-            return f'--vdev="{pmd_name}{vdev_id},{pmd_flags}" ' + include_flag
-        elif node_nic.module_name == "uio_hv_generic":
-            # if using netvsc pmd, just let -w or -a select
-            # which device to use. No other args are needed.
-            return include_flag
-        else:
-            # if we're all the way through and haven't picked a pmd, something
-            # has gone wrong. fail fast
-            raise LisaException(
-                (
-                    f"Unknown driver({node_nic.module_name}) bound to "
-                    f"{node_nic.name}/{node_nic.lower}."
-                    "Cannot generate testpmd include arguments."
-                )
-            )
+        return f'--vdev="{pmd_name}{vdev_id},{pmd_flags}" ' + include_flag
 
     def generate_testpmd_command(
         self,
         nic_to_include: List[NicInfo],
         vdev_id: int,
         mode: str,
+        pmd: Pmd = Pmd.FAILSAFE,
         extra_args: str = "",
         multiple_queues: bool = False,
         service_cores: int = 1,
@@ -577,10 +599,9 @@ class DpdkTestpmd(Tool):
         txd = 256
 
         # generate the flags for which devices to include in the tests
-        nic_include_infos = []
-        for nic in nic_to_include:
-            nic_include_infos += [self.generate_testpmd_include(nic, vdev_id)]
-            vdev_id += 1
+        nic_include_infos = self.generate_testpmd_include(
+            nic_to_include, vdev_id, pmd=pmd
+        )
 
         # infer core count to assign based on number of queues
         threads_available = self.node.tools[Lscpu].get_thread_count()

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -362,6 +362,7 @@ class DpdkGitDownloader(GitDownloader):  # type: ignore[misc]
 
 class DpdkTestpmd(Tool):
     # TestPMD tool to bundle the DPDK build and toolset together.
+    _instance_id = "testpmd"
 
     # regex to identify sriov re-enable event, example:
     # EAL: Probe PCI driver: net_mlx4 (15b3:1004) device: e8ef:00:02.0 (socket 0)
@@ -454,8 +455,10 @@ class DpdkTestpmd(Tool):
     def has_tx_ip_flag(self) -> bool:
         if not self.has_dpdk_version():
             fail(
-                "Test suite bug: dpdk version was not set prior "
-                "to querying the version information."
+                self._error_message(
+                    "Test suite bug: dpdk version was not set prior "
+                    "to querying the version information."
+                )
             )
 
         # black doesn't like to direct return VersionInfo comparison
@@ -463,8 +466,10 @@ class DpdkTestpmd(Tool):
 
     def use_package_manager_install(self) -> bool:
         assert_that(hasattr(self, "_dpdk_source")).described_as(
-            "_dpdk_source was not set in DpdkTestpmd instance. "
-            "set_dpdk_source must be called before instantiation."
+            self._error_message(
+                "_dpdk_source was not set in DpdkTestpmd instance. "
+                "set_dpdk_source must be called before instantiation."
+            )
         ).is_true()
         if self._dpdk_source == PACKAGE_MANAGER_SOURCE:
             return True
@@ -593,8 +598,10 @@ class DpdkTestpmd(Tool):
         # being silently shrunk to fit whatever the node happens to have,
         # which used to make the actual queue/core count unpredictable.
         assert_that(queues).described_as(
-            "queues must be a positive number. Callers must pick an explicit "
-            "queue count instead of relying on this tool to infer one."
+            self._error_message(
+                "queues must be a positive number. Callers must pick an explicit "
+                "queue count instead of relying on this tool to infer one."
+            )
         ).is_greater_than_or_equal_to(1)
 
         # MANA needs a file descriptor argument, mlnx doesn't.
@@ -618,20 +625,24 @@ class DpdkTestpmd(Tool):
         first, last = self.node.tools[Lscpu].get_cpu_range_in_numa_node(0)
         if last <= first:
             raise AssertionError(
-                f"tool.Lscpu bug: cpu range for numa 0 found as {first}-{last}."
+                self._error_message(
+                    f"tool.Lscpu bug: cpu range for numa 0 found as {first}-{last}."
+                )
             )
         threads_available = last - first + 1
         # 1 core is always reserved for the OS/management.
         available_for_this_process = threads_available - 1
         assert_that(available_for_this_process).described_as(
-            f"DPDK test requested {queues} queue(s) across "
-            f"{len(nic_to_include)} port(s) ({forwarding_cores} forwarding "
-            f"core(s)) plus {service_cores} service core(s) = "
-            f"{max_core_index} core(s) on NUMA node 0, but only "
-            f"{available_for_this_process} core(s) are available there "
-            f"(node has {threads_available} total). "
-            "Pick a smaller queue count for this SKU, or run this test on a "
-            "bigger one."
+            self._error_message(
+                f"DPDK test requested {queues} queue(s) across "
+                f"{len(nic_to_include)} port(s) ({forwarding_cores} forwarding "
+                f"core(s)) plus {service_cores} service core(s) = "
+                f"{max_core_index} core(s) on NUMA node 0, but only "
+                f"{available_for_this_process} core(s) are available there "
+                f"(node has {threads_available} total). "
+                "Pick a smaller queue count for this SKU, or run this test on a "
+                "bigger one."
+            )
         ).is_greater_than_or_equal_to(max_core_index)
 
         # core range argument
@@ -685,8 +696,10 @@ class DpdkTestpmd(Tool):
             )
 
         assert_that(self._testpmd_install_path).described_as(
-            "Testpmd install path was not set, this indicates a logic"
-            " error in the DPDK installation process."
+            self._error_message(
+                "Testpmd install path was not set, this indicates a logic"
+                " error in the DPDK installation process."
+            )
         ).is_not_empty()
         debug_log_args = self._eal_debug_log_args()
         nic_includes = " ".join(nic_include_infos)
@@ -828,7 +841,9 @@ cores=1-4
             # if this somehow didn't kill it, reset netvsc
             self.node.tools[Modprobe].reload("hv_netvsc")
             if self.check_testpmd_is_running():
-                raise LisaException("Testpmd has hung, killing the test.")
+                raise LisaException(
+                    self._error_message("Testpmd has hung, killing the test.")
+                )
             else:
                 self.node.log.debug(
                     "Testpmd killed with hv_netvsc reload. "
@@ -845,13 +860,13 @@ cores=1-4
         # Apply a list of filters to the data
         # return a single output from a final filter function
         assert_that(testpmd_output).described_as(
-            "Could not find output from last testpmd run."
+            self._error_message("Could not find output from last testpmd run.")
         ).is_not_equal_to("")
         matches = re.findall(
             self._testpmd_output_regex[search_key_constant], testpmd_output
         )
         assert_that(matches).described_as(
-            (
+            self._error_message(
                 "Could not locate any matches for search key "
                 f"{self._testpmd_output_regex[search_key_constant]} "
                 "in the test output."
@@ -859,15 +874,19 @@ cores=1-4
         )
         data_as_integers = list(map(int, matches))
         assert_that(data_as_integers).described_as(
-            f"Could not find any data in testpmd output"
-            f" for key {search_key_constant}"
+            self._error_message(
+                f"Could not find any data in testpmd output"
+                f" for key {search_key_constant}"
+            )
         ).is_not_empty()
         data_as_integers = _discard_first_zeroes(data_as_integers)
         if discard_first_and_last:
             data_as_integers = _discard_first_and_last_sample(data_as_integers)
         assert_that(data_as_integers).described_as(
-            f"Could not find any data in testpmd output"
-            f" for key {search_key_constant}."
+            self._error_message(
+                f"Could not find any data in testpmd output"
+                f" for key {search_key_constant}."
+            )
         ).is_not_empty()
         return data_as_integers
 
@@ -925,21 +944,25 @@ cores=1-4
     def check_tx_packet_drops(self) -> None:
         if self.tx_total_packets == 0:
             raise AssertionError(
-                "Test bug: tx packet data was 0, could not check dropped packets"
+                self._error_message(
+                    "Test bug: tx packet data was 0, could not check dropped packets"
+                )
             )
         self.packet_drop_rate = self.tx_packet_drops / self.tx_total_packets
         assert_that(self.packet_drop_rate).described_as(
-            "More than 33% of the tx packets were dropped!"
+            self._error_message("More than 33% of the tx packets were dropped!")
         ).is_close_to(0, 0.33)
 
     def check_rx_packet_drops(self) -> None:
         if self.rx_total_packets == 0:
             raise AssertionError(
-                "Test bug: rx packet data was 0 could not check dropped packets."
+                self._error_message(
+                    "Test bug: rx packet data was 0 could not check dropped packets."
+                )
             )
         self.packet_drop_rate = self.rx_packet_drops / self.rx_total_packets
         assert_that(self.packet_drop_rate).described_as(
-            "More than 1% of the received packets were dropped!"
+            self._error_message("More than 1% of the received packets were dropped!")
         ).is_close_to(0, 0.01)
 
     def get_mean_tx_pps_sriov_hotplug(self) -> Tuple[int, int, int]:
@@ -954,8 +977,10 @@ cores=1-4
         )
         shell = self.node.shell
         assert_that(shell.exists(source_path)).described_as(
-            "dpdk examples path does not exist, "
-            f"cannot use requested dpdk example: {app_name}"
+            self._error_message(
+                "dpdk examples path does not exist, "
+                f"cannot use requested dpdk example: {app_name}"
+            )
         ).is_true()
         # if the application has not been built;
         # check if there is a build directory and build the application
@@ -998,10 +1023,12 @@ cores=1-4
                 downloader = TarDownloader(node=self.node, tar_url=self._dpdk_source)
             else:
                 raise LisaException(
-                    "URL provided for dpdk source did not validate as "
-                    f"a tarball or git repo. Found {self._dpdk_source} "
-                    " Expected https://___/___.git or /path/to/tar.tar[.gz] or "
-                    "https://__/__.tar[.gz]"
+                    self._error_message(
+                        "URL provided for dpdk source did not validate as "
+                        f"a tarball or git repo. Found {self._dpdk_source} "
+                        " Expected https://___/___.git or /path/to/tar.tar[.gz] or "
+                        "https://__/__.tar[.gz]"
+                    )
                 )
             self.installer = DpdkSourceInstall(
                 node=self.node,
@@ -1016,6 +1043,12 @@ cores=1-4
                     self._dpdk_lib_name
                 )
 
+    def set_instance_id(self, instance_id: str) -> None:
+        self._instance_id = instance_id
+
+    def _error_message(self, message: str) -> str:
+        return f"[{self._instance_id}] {message}"
+
     def _determine_network_hardware(self) -> None:
         lspci = self.node.tools[Lspci]
         device_list = lspci.get_devices_by_type(DEVICE_TYPE_SRIOV)
@@ -1027,7 +1060,7 @@ cores=1-4
     def _check_data_exists(self, rx_or_tx: str, data_type: str = "pps") -> None:
         data_attr_name = f"{rx_or_tx.lower()}_{data_type}_data"
         assert_that(hasattr(self, data_attr_name)).described_as(
-            (
+            self._error_message(
                 f"{data_type} data ({rx_or_tx}) did not exist for testpmd object. "
                 "This indicates either testpmd did not run or the suite is "
                 "missing an assert. Contact the test maintainer."
@@ -1043,13 +1076,17 @@ cores=1-4
             data_set = self.tx_pps_data
         else:
             fail(
-                "Identifier passed to _check_pps_data was not recognized, "
-                f"must be RX or TX. Found {rx_or_tx}"
+                self._error_message(
+                    "Identifier passed to _check_pps_data was not recognized, "
+                    f"must be RX or TX. Found {rx_or_tx}"
+                )
             )
 
         assert_that(any(data_set)).described_as(
-            f"any({str(data_set)}) resolved to false. Test data was "
-            f"empty or all zeroes for dpdktestpmd.{rx_or_tx.lower()}_pps_data."
+            self._error_message(
+                f"any({str(data_set)}) resolved to false. Test data was "
+                f"empty or all zeroes for dpdktestpmd.{rx_or_tx.lower()}_pps_data."
+            )
         ).is_true()
 
     def check_bps_data(self, rx_or_tx: str) -> int:
@@ -1061,13 +1098,17 @@ cores=1-4
             data_set = self.tx_bps_data
         else:
             fail(
-                "Identifier passed to _check_pps_data was not recognized, "
-                f"must be RX or TX. Found {rx_or_tx}"
+                self._error_message(
+                    "Identifier passed to _check_pps_data was not recognized, "
+                    f"must be RX or TX. Found {rx_or_tx}"
+                )
             )
 
         assert_that(any(data_set)).described_as(
-            f"any({str(data_set)}) resolved to false. Test data was "
-            f"empty or all zeroes for dpdktestpmd.{rx_or_tx.lower()}_bps_data."
+            self._error_message(
+                f"any({str(data_set)}) resolved to false. Test data was "
+                f"empty or all zeroes for dpdktestpmd.{rx_or_tx.lower()}_bps_data."
+            )
         ).is_true()
 
         # bits -> gigabits N>>30
@@ -1187,7 +1228,11 @@ cores=1-4
         found_path = PurePosixPath(self._testpmd_install_path)
         path_check = bool(self._testpmd_install_path) and node.shell.exists(found_path)
         if assert_on_fail and not path_check:
-            fail("Could not locate testpmd binary after installation!")
+            fail(
+                self._error_message(
+                    "Could not locate testpmd binary after installation!"
+                )
+            )
         elif not path_check:
             self._testpmd_install_path = ""
         return path_check
@@ -1197,7 +1242,9 @@ cores=1-4
 
         device_removal_index = self._last_run_output.find(search_str)
         assert_that(device_removal_index).described_as(
-            "Could not locate SRIOV hotplug event in testpmd output"
+            self._error_message(
+                "Could not locate SRIOV hotplug event in testpmd output"
+            )
         ).is_not_equal_to(-1)
 
         self._testpmd_output_before_hotplug = self._last_run_output[
@@ -1211,7 +1258,9 @@ cores=1-4
             if not list(matches_list):
                 command_dumped = "timeout: the monitored command dumped core"
                 if command_dumped in self._last_run_output:
-                    raise LisaException("Testpmd crashed after device removal.")
+                    raise LisaException(
+                        self._error_message("Testpmd crashed after device removal.")
+                    )
 
         # pick the last match
 
@@ -1219,9 +1268,11 @@ cores=1-4
             last_match = matches_list[-1]
         else:
             raise LisaException(
-                "Found no vf hotplug events in testpmd output. "
-                "Check output to verify if PPS drop occurred and port removal "
-                "event message matches the expected forms."
+                self._error_message(
+                    "Found no vf hotplug events in testpmd output. "
+                    "Check output to verify if PPS drop occurred and port removal "
+                    "event message matches the expected forms."
+                )
             )
 
         self.node.log.info(f"Identified hotplug event: {last_match.group(0)}")

--- a/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdktestpmd.py
@@ -65,7 +65,8 @@ DPDK_PACKAGE_MANAGER_PACKAGES = DependencyInstaller(
         OsPackageDependencies(
             matcher=lambda x: isinstance(x, Debian)
             and bool(x.get_kernel_information().version >= "5.15.0")
-            and x.is_package_in_repo("linux-modules-extra-azure"),
+            and x.is_package_in_repo("linux-modules-extra-azure")
+            and not x.package_exists("linux-modules-extra-azure"),
             packages=["linux-modules-extra-azure"],
             requires_reboot=True,
         ),
@@ -121,7 +122,8 @@ DPDK_SOURCE_INSTALL_PACKAGES = DependencyInstaller(
         OsPackageDependencies(
             matcher=lambda x: isinstance(x, Debian)
             and bool(x.get_kernel_information().version >= "5.15.0")
-            and x.is_package_in_repo("linux-modules-extra-azure"),
+            and x.is_package_in_repo("linux-modules-extra-azure")
+            and not x.package_exists("linux-modules-extra-azure"),
             packages=["linux-modules-extra-azure"],
             requires_reboot=True,
         ),

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1974,9 +1974,13 @@ def run_dpdk_symmetric_mp(
         for nic in node.nics.nics.values()
         if nic != node.nics.get_primary_nic() and nic.lower
     ][:2]
-    ping = node.tools[Ping]
-    ping.install()
 
+    # handle the event where a tool isn't implemented for a platform
+    try:
+        ping = node.tools[Ping]
+        ping.install()
+    except UnsupportedDistroException as err:
+        raise SkippedException(err)
     # initialize for netvsc, we rely on the debug messages in this test
     # to identify the hotplug events.
     try:
@@ -1988,7 +1992,11 @@ def run_dpdk_symmetric_mp(
             HugePageSize.HUGE_2MB,
             test_nics=test_nics,
         )
-    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+    except (
+        NotEnoughMemoryException,
+        UnsupportedOperationException,
+        UnsupportedDistroException,
+    ) as err:
         raise SkippedException(err)
     testpmd = test_kit.testpmd
     testpmd.set_instance_id("symmetric_mp")

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -385,6 +385,7 @@ def generate_send_receive_run_info(
         [snd_nic],
         0,
         "txonly",
+        pmd=pmd,
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
         multiple_queues=multiple_queues,
         service_cores=use_service_cores,
@@ -395,7 +396,8 @@ def generate_send_receive_run_info(
         [rcv_nic],
         0,
         "rxonly",
-        multiple_queues=multiple_queues,
+        pmd=pmd,
+        queues=queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
@@ -468,6 +470,7 @@ def generate_testpmd_multiple_port_command(
             [sender_nic],
             0,
             "txonly",
+            pmd=pmd,
             extra_args=f"--tx-ip={sender_nic.ip_addr},{receiver_nic.ip_addr}",
             multiple_queues=multiple_queues,
             service_cores=use_service_cores,
@@ -477,18 +480,17 @@ def generate_testpmd_multiple_port_command(
         # store this senders command
         kit_cmd_pairs[sender] = snd_cmd
         # receiver needs multiple ports, so only generate the include.
-        receiver_include = receiver.testpmd.generate_testpmd_include(
-            receiver_nics[sender_subnet], i
+        receiver_includes += receiver.testpmd.generate_testpmd_include(
+            [receiver_nics[sender_subnet]], i, pmd=pmd
         )
-        # and save it
-        receiver_includes += [receiver_include]
 
     # and generate the command with multiple ports for the single receiver:
     rcv_cmd = receiver.testpmd.generate_testpmd_command(
         list([receiver_nics[key] for key in receiver_nics]),
         0,
         "rxonly",
-        multiple_queues=multiple_queues,
+        pmd=pmd,
+        queues=queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
@@ -543,7 +545,13 @@ def enable_uio_hv_generic(node: Node) -> None:
 def do_pmd_driver_setup(
     node: Node, test_nics: List[NicInfo], testpmd: DpdkTestpmd, pmd: Pmd = Pmd.FAILSAFE
 ) -> None:
-    if pmd == Pmd.NETVSC:
+    if pmd == Pmd.MANA:
+        # the MANA pmd drives the VF directly, so the only setup needed is
+        # to take the synthetic interfaces out of the kernel's hands.
+        for nic in test_nics:
+            node.tools[Ip].down(nic.name)
+        return
+    elif pmd == Pmd.NETVSC:
         # setup system for netvsc pmd
         # https://doc.dpdk.org/guides/nics/netvsc.html
         enable_uio_hv_generic(node)
@@ -757,7 +765,7 @@ def verify_dpdk_build(
     test_nic = node.nics.get_secondary_nic()
 
     testpmd_cmd = testpmd.generate_testpmd_command(
-        [test_nic], 0, "txonly", multiple_queues=multiple_queues
+        [test_nic], 0, "txonly", pmd=pmd, queues=queues
     )
     testpmd.run_for_n_seconds(testpmd_cmd, 10)
     tx_pps = testpmd.get_mean_tx_pps()
@@ -1369,14 +1377,11 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     )
 
     # generate the dpdk include arguments to add to our commandline
-    include_devices = [
-        fwd_kit.testpmd.generate_testpmd_include(
-            subnet_a_nics[forwarder], dpdk_port_a, force_netvsc=True
-        ),
-        fwd_kit.testpmd.generate_testpmd_include(
-            subnet_b_nics[forwarder], dpdk_port_b, force_netvsc=True
-        ),
-    ]
+    include_devices = fwd_kit.testpmd.generate_testpmd_include(
+        [subnet_a_nics[forwarder]], dpdk_port_a, pmd=Pmd.NETVSC
+    ) + fwd_kit.testpmd.generate_testpmd_include(
+        [subnet_b_nics[forwarder]], dpdk_port_b, pmd=Pmd.NETVSC
+    )
 
     # Generating port,queue,core mappings for forwarder
     # NOTE: For DPDK 'N queues' means N queues * N PORTS

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -127,19 +127,18 @@ class DpdkTestResources:
 
 
 def _set_forced_source_by_distro(node: Node, variables: Dict[str, Any]) -> None:
-    # if mana is present, force a source build of 24.11
-    # if no other source was provided.
-    if node.nics.is_mana_device_present():
-        variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
-        variables["dpdk_branch"] = variables.get("dpdk_branch", "v24.11")
     # DPDK packages 17.11 which is EOL and doesn't have the
     # net_vdev_netvsc pmd used for simple handling of hyper-v
     # guests. Force stable source build on this platform.
     # Default to 20.11 unless another version is provided by the
     # user. 20.11 is the latest dpdk version for 18.04.
-    elif isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
+    if isinstance(node.os, Ubuntu) and node.os.information.version < "20.4.0":
         variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
         variables["dpdk_branch"] = variables.get("dpdk_branch", "v20.11")
+    else:
+        # otherwise just use a new build of DPDK unless another is specified
+        variables["dpdk_source"] = variables.get("dpdk_source", DPDK_STABLE_GIT_REPO)
+        variables["dpdk_branch"] = variables.get("dpdk_branch", "v24.11")
 
 
 def get_rdma_core_installer(

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -48,7 +48,7 @@ from lisa import (
     notifier,
 )
 from lisa.base_tools.uname import Uname
-from lisa.executable import Process
+from lisa.executable import ExecutableResult, Process
 from lisa.features import NetworkInterface
 from lisa.nic import NicInfo
 from lisa.operating_system import OperatingSystem, Ubuntu
@@ -333,6 +333,9 @@ def run_testpmd_hotplug(
     hotplug: bool = True,
 ) -> None:
     processes: Dict[DpdkTestResources, Process] = {}
+    sender.testpmd.set_instance_id("sender")
+    if receiver:
+        receiver.testpmd.set_instance_id("receiver")
 
     collect_from = receiver if receiver else sender
     all_kits = [sender]
@@ -347,10 +350,7 @@ def run_testpmd_hotplug(
         # built from it. The slot is stable across a remove/rescan cycle.
         test_nic = node.nics.get_nic_by_subnet("10.0.1.0/24")
         switch_sriov_for_nic(node, test_nic)
-        if processes[collect_from].wait_output(
-            "Segmentation fault (core dumped)", timeout=5, error_on_missing=False
-        ):
-            raise LisaException("Test fail: testpmd crashed.")
+        check_process_for_segfault(processes[collect_from])
 
     # let it run for a bit
     sleep(30)
@@ -360,6 +360,20 @@ def run_testpmd_hotplug(
         sleep(1)
         # allow time for SIGINT/SIGKILL shutdown and stats flush
         kit.testpmd.process_testpmd_output(processes[kit].wait_result(timeout=120))
+
+
+def check_process_for_segfault(process: Process) -> None:
+    if process.wait_output(
+        "Segmentation fault (core dumped)", timeout=5, error_on_missing=False
+    ):
+        raise LisaException("Test fail: testpmd crashed.")
+
+
+def check_result_for_segfault(
+    result: Optional[ExecutableResult], label: str = "testpmd"
+) -> None:
+    if result and "Segmentation fault (core dumped)" in result.stdout + result.stderr:
+        raise LisaException(f"Test fail: {label} crashed.")
 
 
 def generate_send_receive_run_info(
@@ -830,6 +844,8 @@ def verify_dpdk_send_receive(
 
     check_send_receive_compatibility(test_kits)
     sender, receiver = test_kits
+    sender.testpmd.set_instance_id("sender")
+    receiver.testpmd.set_instance_id("receiver")
 
     # annotate test result before starting
     if result is not None:
@@ -844,14 +860,14 @@ def verify_dpdk_send_receive(
         set_mtu=set_mtu,
     )
     receive_timeout = kill_timeout + 10
-    receive_result = receiver.node.tools[Timeout].start_with_timeout(
+    receive_process = receiver.node.tools[Timeout].start_with_timeout(
         kit_cmd_pairs[receiver],
         receive_timeout,
         constants.SIGINT,
         kill_timeout=receive_timeout,
     )
-    receive_result.wait_output("start packet forwarding")
-    sender_result = sender.node.tools[Timeout].start_with_timeout(
+    receive_process.wait_output("start packet forwarding")
+    send_process = sender.node.tools[Timeout].start_with_timeout(
         kit_cmd_pairs[sender],
         test_duration,
         constants.SIGINT,
@@ -859,10 +875,21 @@ def verify_dpdk_send_receive(
     )
 
     results = dict()
-    results[sender] = sender.testpmd.process_testpmd_output(sender_result.wait_result())
-    results[receiver] = receiver.testpmd.process_testpmd_output(
-        receive_result.wait_result()
-    )
+    # NOTE: the sleeps here allow testpmd
+    #       to reliably generate output and give time
+    #       for the process (and buffer) to collect
+    #       the output.
+    sleep(10)
+    for kit in [sender, receiver]:
+        kit.testpmd.kill_previous_testpmd_command()
+    sleep(5)
+    # now collect the results and process them.
+    send_result = send_process.wait_result()
+    receive_result = receive_process.wait_result()
+    for res, label in [(send_result, "sender"), (receive_result, "receiver")]:
+        check_result_for_segfault(res, f"testpmd {label}")
+    results[sender] = sender.testpmd.process_testpmd_output(send_result)
+    results[receiver] = receiver.testpmd.process_testpmd_output(receive_result)
 
     # helpful to have the outputs labeled
     log.debug(f"\nSENDER:\n{results[sender]}")
@@ -1238,6 +1265,7 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
         )
     except (NotEnoughMemoryException, UnsupportedOperationException) as err:
         raise SkippedException(err)
+    fwd_kit.testpmd.set_instance_id("forwarder")
     if result is not None:
         annotate_dpdk_test_result(test_kit=fwd_kit, test_result=result, log=log)
     # NOTE: we're cheating here and not dynamically picking the port IDs
@@ -1963,6 +1991,7 @@ def run_dpdk_symmetric_mp(
     except (NotEnoughMemoryException, UnsupportedOperationException) as err:
         raise SkippedException(err)
     testpmd = test_kit.testpmd
+    testpmd.set_instance_id("symmetric_mp")
     if isinstance(testpmd.installer, PackageManagerInstall):
         # The Testpmd tool doesn't get re-initialized
         # even if you invoke it with new arguments.

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -362,7 +362,7 @@ def generate_send_receive_run_info(
     pmd: Pmd,
     sender: DpdkTestResources,
     receiver: DpdkTestResources,
-    multiple_queues: bool = False,
+    queues: int = 1,
     use_service_cores: int = 1,
     set_mtu: int = 0,
 ) -> Dict[DpdkTestResources, str]:
@@ -387,7 +387,7 @@ def generate_send_receive_run_info(
         "txonly",
         pmd=pmd,
         extra_args=f"--tx-ip={snd_nic.ip_addr},{rcv_nic.ip_addr}",
-        multiple_queues=multiple_queues,
+        queues=queues,
         service_cores=use_service_cores,
         mtu=set_mtu,
         mbuf_size=maxmtu_int,
@@ -415,7 +415,7 @@ def generate_testpmd_multiple_port_command(
     pmd: Pmd,
     senders: List[DpdkTestResources],
     receiver: DpdkTestResources,
-    multiple_queues: bool = False,
+    queues: int = 1,
     use_service_cores: int = 1,
     set_mtu: int = 0,
 ) -> Dict[DpdkTestResources, str]:
@@ -472,7 +472,7 @@ def generate_testpmd_multiple_port_command(
             "txonly",
             pmd=pmd,
             extra_args=f"--tx-ip={sender_nic.ip_addr},{receiver_nic.ip_addr}",
-            multiple_queues=multiple_queues,
+            queues=queues,
             service_cores=use_service_cores,
             mtu=set_mtu,
             mbuf_size=maxmtu_int,
@@ -724,13 +724,15 @@ def init_nodes_concurrent(
                     pmd,
                     hugepage_size=hugepage_size,
                     sample_apps=sample_apps,
-                    test_nics=specific_pairings[node]
-                    if specific_pairings
-                    else [
-                        nic
-                        for nic in node.nics.nics.values()
-                        if nic is not node.nics.get_primary_nic()
-                    ][:test_nic_count],
+                    test_nics=(
+                        specific_pairings[node]
+                        if specific_pairings
+                        else [
+                            nic
+                            for nic in node.nics.nics.values()
+                            if nic is not node.nics.get_primary_nic()
+                        ][:test_nic_count]
+                    ),
                 )
                 for node in environment.nodes.list()
             ],
@@ -747,7 +749,7 @@ def verify_dpdk_build(
     variables: Dict[str, Any],
     pmd: Pmd,
     hugepage_size: HugePageSize,
-    multiple_queues: bool = False,
+    queues: int = 1,
     result: Optional[TestResult] = None,
 ) -> DpdkTestResources:
     # setup and unwrap the resources for this test
@@ -787,7 +789,7 @@ def verify_dpdk_send_receive(
     pmd: Pmd,
     hugepage_size: HugePageSize,
     use_service_cores: int = 1,
-    multiple_queues: bool = False,
+    queues: int = 1,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
     check_sender_packet_drops: bool = False,
@@ -827,7 +829,7 @@ def verify_dpdk_send_receive(
         sender,
         receiver,
         use_service_cores=use_service_cores,
-        multiple_queues=multiple_queues,
+        queues=queues,
         set_mtu=set_mtu,
     )
     receive_timeout = kill_timeout + 10
@@ -920,6 +922,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     log: Logger,
     variables: Dict[str, Any],
     pmd: Pmd,
+    queues: int,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
     grading_metric: DpdkGradeMetric = DpdkGradeMetric.PPS,
@@ -933,7 +936,7 @@ def verify_dpdk_send_receive_multi_txrx_queue(
         pmd,
         HugePageSize.HUGE_2MB,
         use_service_cores=1,
-        multiple_queues=True,
+        queues=queues,
         result=result,
         set_mtu=set_mtu,
         grading_metric=grading_metric,
@@ -949,7 +952,7 @@ def verify_dpdk_mutliple_ports(
     pmd: Pmd,
     hugepage_size: HugePageSize,
     use_service_cores: int = 1,
-    multiple_queues: bool = False,
+    queues: int = 1,
     result: Optional[TestResult] = None,
     set_mtu: int = 0,
 ) -> Tuple[DpdkTestResources, DpdkTestResources, DpdkTestResources]:
@@ -1006,7 +1009,7 @@ def verify_dpdk_mutliple_ports(
         [sender_port_a, sender_port_b],
         receiver_kit,
         use_service_cores=use_service_cores,
-        multiple_queues=multiple_queues,
+        queues=queues,
         set_mtu=set_mtu,
     )
     receive_timeout = kill_timeout + 10

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -23,7 +23,6 @@ from microsoft.testsuites.dpdk.common import (
     is_url_for_tarball,
     update_kernel_from_repo,
 )
-from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdktestpmd import PACKAGE_MANAGER_SOURCE, DpdkTestpmd
 from microsoft.testsuites.dpdk.rdmacore import (
     RDMA_CORE_MANA_DEFAULT_SOURCE,
@@ -2171,51 +2170,3 @@ def run_dpdk_symmetric_mp(
     assert_that(process_data[2]["rx"]).described_as(
         "process 1 port_0_tx and port_1_rx should match"
     ).is_equal_to(process_data[3]["tx"])
-
-
-def run_ovs_test(node: Node, log: Logger, variables: Dict[str, Any], pmd: Pmd):
-    if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
-        raise SkippedException("OVS test not supported on ARM64")
-    test_nics = [node.nics.get_secondary_nic()]
-    try:
-        test_kit = initialize_node_resources(
-            node,
-            log,
-            variables,
-            pmd,
-            HugePageSize.HUGE_2MB,
-            test_nics=test_nics,
-        )
-    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
-        raise SkippedException(err)
-
-    # checkout OpenVirtualSwitch
-    ovs: DpdkOvs = node.tools[DpdkOvs]
-
-    # check for runbook variable to skip dpdk version check
-    use_latest_ovs = variables.get("use_latest_ovs", False)
-    # provide ovs build with DPDK tool info and build
-    ovs.build_with_dpdk(test_kit.testpmd, use_latest_ovs=use_latest_ovs)
-
-    # enable hugepages needed for dpdk EAL
-    hugepages = node.tools[Hugepages]
-    try:
-        hugepages.init_hugepages(HugePageSize.HUGE_2MB)
-    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
-        raise SkippedException(err)
-
-    try:
-        # run OVS tests, providing OVS with the NIC info needed for DPDK init
-        ovs.setup_ovs(test_nics, test_kit.testpmd)
-
-        # validate if OVS was able to initialize DPDK
-        node.execute(
-            "ovs-vsctl get Open_vSwitch . dpdk_initialized",
-            sudo=True,
-            expected_exit_code=0,
-            expected_exit_code_failure_message=(
-                "OVS repoted that DPDK EAL failed to initialize."
-            ),
-        )
-    finally:
-        ovs.stop_ovs()

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -1,12 +1,10 @@
 import itertools
 import re
-import time
-from collections import deque
 from decimal import Decimal
 from enum import Enum
 from functools import partial
 from pathlib import PurePath
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Pattern, Sequence, Tuple, Union
 
 from assertpy import assert_that, fail
 from microsoft.testsuites.dpdk.common import (
@@ -60,6 +58,7 @@ from lisa.tools import (
     Dmesg,
     Echo,
     Firewall,
+    Gcc,
     Hugepages,
     Ip,
     KernelConfig,
@@ -70,12 +69,14 @@ from lisa.tools import (
     Modprobe,
     Ntttcp,
     Ping,
+    Tee,
     Timeout,
 )
 from lisa.tools.hugepages import HugePageSize
 from lisa.tools.lscpu import CpuArchitecture
+from lisa.util import sleep
 from lisa.util.constants import DEVICE_TYPE_SRIOV, SIGINT
-from lisa.util.parallel import TaskManager, run_in_parallel, run_in_parallel_async
+from lisa.util.parallel import run_in_parallel
 
 
 # DPDK added new flags in 19.11 that some tests rely on for send/recv
@@ -198,6 +199,163 @@ def _ping_all_nodes_in_environment(environment: Environment) -> None:
                 f"{node_b.name} {ip_b} -> {node_a.name} {ip_a} : {ping_b}\n"
             )
         ).is_true()
+
+
+def testpmd_start_process(kit: DpdkTestResources, cmd: str) -> Process:
+    kit.node.log.debug(f"Starting process: sudo {cmd}")
+    proc = kit.node.execute_async(cmd, sudo=True, shell=True)
+    # Note: This is an extremely long timeout for this command...
+    # But some timeout here is better than none here.
+    # The hotplug tests have really long timeouts, but testpmd
+    # should be able to start within a few seconds.
+    proc.wait_output("start packet forwarding", timeout=60)
+    return proc
+
+
+# tags emitted by azure_uevent_listener for the pci device itself.
+# match the suffix so the plain PCI_ADD/PCI_REMOVE tags are caught too,
+# the device is identified by its pci slot, not by the azure_vf flag.
+_PCI_ADD_TAG = re.compile(r"PCI_ADD$")
+_PCI_REMOVE_TAG = re.compile(r"PCI_REMOVE$")
+
+_PCI_DEVICES_PATH = "/sys/bus/pci/devices"
+_PCI_RESCAN_PATH = "/sys/bus/pci/rescan"
+
+
+def get_vf_pci_slots(node: Node, nics: Optional[List[NicInfo]] = None) -> List[str]:
+    """Get the pci slots of the VF devices attached to the given nics.
+
+    Defaults to every nic on the node. Nics without a VF are skipped.
+    """
+    if nics is None:
+        nics = list(node.nics.nics.values())
+    slots = set([nic.pci_slot for nic in nics if nic.pci_slot])
+    assert_that(slots).described_as(
+        f"Node[{node.name}] has no VF pci devices to hotplug."
+    ).is_not_empty()
+    return list(slots)
+
+
+def remove_pci_devices(node: Node, pci_slots: List[str]) -> None:
+    """Detach pci devices from the guest, the equivalent of a surprise removal.
+
+    echo 1 | sudo tee /sys/bus/pci/devices/$slot/remove
+    """
+    tee = node.tools[Tee]
+    for slot in set(pci_slots):
+        node.log.debug(f"Removing pci device {slot}")
+        tee.write_to_file(
+            "1",
+            node.get_pure_path(f"{_PCI_DEVICES_PATH}/{slot}/remove"),
+            sudo=True,
+        )
+
+
+def rescan_pci_bus(node: Node) -> None:
+    """Re-discover any removed pci devices.
+
+    echo 1 | sudo tee /sys/bus/pci/rescan
+    """
+    node.log.debug("Rescanning the pci bus")
+    node.tools[Tee].write_to_file(
+        "1",
+        node.get_pure_path(_PCI_RESCAN_PATH),
+        sudo=True,
+    )
+
+
+def switch_sriov_for_nic(node: Node, test_nic: NicInfo) -> None:
+    switch_sriov_for_nics(node, [test_nic])
+
+
+def switch_sriov_for_nics(node: Node, test_nics: List[NicInfo]) -> None:
+    # all the VFs are removed and restored together, a single uevent
+    # listener covers the whole set. Running one listener per nic would
+    # have them competing for the same uevent socket.
+    pci_slots = get_vf_pci_slots(node, test_nics)
+
+    # start the uevent listener before triggering hotplug
+    listener = UeventListener(node)
+    listener.start()
+
+    # let testpmd run for a bit before triggering hotplug
+    sleep(10)
+
+    # remove the VF via sysfs instead of asking azure to disable
+    # accelerated networking, it's faster and doesn't touch the platform.
+    remove_pci_devices(node, pci_slots)
+    # wait for uevent listener to see each VF pci device go away
+    listener.wait_for_events(
+        [UeventListener.device_criteria(slot, _PCI_REMOVE_TAG) for slot in pci_slots],
+        timeout=60,
+    )
+
+    # let it run on synthetic path before restoring the VF
+    sleep(10)
+
+    rescan_pci_bus(node)
+    # wait for uevent listener to see each VF pci device come back.
+    # The VF may be paired with a different netdev after the rescan,
+    # seeing the same pci device added back is enough.
+    listener.wait_for_events(
+        [UeventListener.device_criteria(slot, _PCI_ADD_TAG) for slot in pci_slots],
+        timeout=60,
+    )
+
+    # stop the listener and validate that we saw the expected uevents
+    events = listener.stop()
+    node.log.debug(f"uevent listener captured {len(events)} events: {events}")
+    for slot in pci_slots:
+        removes = [
+            e
+            for e in events
+            if e.matches(UeventListener.device_criteria(slot, _PCI_REMOVE_TAG))
+        ]
+        adds = [
+            e
+            for e in events
+            if e.matches(UeventListener.device_criteria(slot, _PCI_ADD_TAG))
+        ]
+        assert_that(removes).described_as(
+            f"Expected a removal uevent for VF {slot} after sysfs remove"
+        ).is_not_empty()
+        assert_that(adds).described_as(
+            f"Expected an add uevent for VF {slot} after pci rescan"
+        ).is_not_empty()
+    # the nic/VF pairing may have changed, refresh the cached info
+    node.nics.reload()
+
+
+# run the send/receive hotplug test.
+def run_testpmd_hotplug(
+    kit_cmd_pairs: Dict[DpdkTestResources, str],
+    sender: DpdkTestResources,
+    receiver: Optional[DpdkTestResources] = None,
+    hotplug: bool = True,
+) -> None:
+    processes: Dict[DpdkTestResources, Process] = {}
+
+    collect_from = receiver if receiver else sender
+    all_kits = [sender]
+    if receiver:
+        all_kits += [receiver]
+        processes[receiver] = testpmd_start_process(receiver, kit_cmd_pairs[receiver])
+
+    processes[sender] = testpmd_start_process(sender, kit_cmd_pairs[sender])
+    if hotplug:
+        node = collect_from.node
+        # gather the VF pci slot up front, the uevent match criteria are
+        # built from it. The slot is stable across a remove/rescan cycle.
+        test_nic = node.nics.get_nic_by_subnet("10.0.1.0/24")
+        switch_sriov_for_nic(node, test_nic)
+
+    # let it run for a bit
+    sleep(30)
+    # kill testpmd and process the output
+    for kit in all_kits:
+        kit.testpmd.kill_previous_testpmd_command()
+        # allow time for SIGINT/SIGKILL shutdown and stats flush
+        kit.testpmd.process_testpmd_output(processes[kit].wait_result(timeout=120))
 
 
 def generate_send_receive_run_info(
@@ -528,72 +686,6 @@ def check_send_receive_compatibility(test_kits: List[DpdkTestResources]) -> None
                 kit.testpmd.get_dpdk_version(),
                 "-tx-ip flag for ip forwarding",
             )
-
-
-def run_testpmd_concurrent(
-    node_cmd_pairs: Dict[DpdkTestResources, str],
-    seconds: int,
-    log: Logger,
-    hotplug_sriov: bool = False,
-) -> Dict[DpdkTestResources, str]:
-    output: Dict[DpdkTestResources, str] = dict()
-
-    task_manager = start_testpmd_concurrent(node_cmd_pairs, seconds, log, output)
-    if hotplug_sriov:
-        time.sleep(10)  # run testpmd for a bit before disabling sriov
-
-        test_kits = node_cmd_pairs.keys()
-
-        # disable sriov (and wait for change to apply)
-        for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(
-                enable=False, wait=True, reset_connections=False
-            )
-
-        # let run for a bit with SRIOV disabled
-        time.sleep(10)
-
-        # re-enable sriov
-        for node_resources in [x for x in test_kits if x.switch_sriov]:
-            node_resources.nic_controller.switch_sriov(
-                enable=True, wait=True, reset_connections=False
-            )
-
-        # run for a bit with SRIOV re-enabled
-        time.sleep(10)
-
-        # kill the commands to collect the output early and terminate before timeout
-        for node_resources in test_kits:
-            node_resources.testpmd.kill_previous_testpmd_command()
-
-    task_manager.wait_for_all_workers()
-
-    return output
-
-
-def start_testpmd_concurrent(
-    node_cmd_pairs: Dict[DpdkTestResources, str],
-    seconds: int,
-    log: Logger,
-    output: Dict[DpdkTestResources, str],
-) -> TaskManager[Tuple[DpdkTestResources, str]]:
-    cmd_pairs_as_tuples = deque(node_cmd_pairs.items())
-
-    def _collect_dict_result(result: Tuple[DpdkTestResources, str]) -> None:
-        output[result[0]] = result[1]
-
-    def _run_command_with_testkit(
-        run_kit: Tuple[DpdkTestResources, str],
-    ) -> Tuple[DpdkTestResources, str]:
-        testkit, cmd = run_kit
-        return (testkit, testkit.testpmd.run_for_n_seconds(cmd, seconds))
-
-    task_manager = run_in_parallel_async(
-        [partial(_run_command_with_testkit, x) for x in cmd_pairs_as_tuples],
-        _collect_dict_result,
-    )
-
-    return task_manager
 
 
 def init_nodes_concurrent(
@@ -1663,6 +1755,243 @@ class DpdkDevnameInfo:
             )
         self.port_mask = hex(port_mask)[2:]
         return self.port_mask
+
+
+# Output line format from azure_uevent_listener:
+# [HH:MM:SS.mmm] TAG subsystem=X pci=... driver=... ifname=... name=... ...
+_uevent_line_regex = re.compile(
+    r"\[(?P<timestamp>[\d:.]+)\]\s+(?P<tag>\S+)\s+(?P<properties>.*)"
+)
+
+# a criteria value is either an exact string or a regex to search for
+UeventCriteria = Mapping[str, Union[str, Pattern[str]]]
+
+
+class UeventEntry:
+    """One parsed event from the uevent listener output."""
+
+    def __init__(self, timestamp: str, tag: str, properties: Dict[str, str]) -> None:
+        self.timestamp = timestamp
+        self.tag = tag
+        self.properties = properties
+
+    @property
+    def subsystem(self) -> str:
+        return self.properties.get("subsystem", "")
+
+    @property
+    def pci_slot(self) -> str:
+        return self.properties.get("pci", "")
+
+    @property
+    def interface(self) -> str:
+        return self.properties.get("ifname", "")
+
+    @property
+    def driver(self) -> str:
+        return self.properties.get("driver", "")
+
+    @property
+    def is_azure_vf(self) -> bool:
+        return self.properties.get("azure_vf") == "yes"
+
+    @property
+    def devpath(self) -> str:
+        return self.properties.get("devpath", "")
+
+    def matches(self, criteria: UeventCriteria) -> bool:
+        """Check the event against a dict of expected properties.
+
+        Every entry must match for the event to match. 'tag' is matched
+        against the event tag, any other key is matched against the parsed
+        event properties (subsystem, pci, driver, ifname, name, devnode,
+        azure_vf, devpath). String values must be equal, compiled regexes are
+        searched within the value.
+        """
+        for key, expected in criteria.items():
+            actual = self.tag if key == "tag" else self.properties.get(key, "")
+            if isinstance(expected, str):
+                if actual != expected:
+                    return False
+            elif not expected.search(actual):
+                return False
+        return True
+
+    def __repr__(self) -> str:
+        return f"UeventEntry({self.tag}, {self.properties})"
+
+
+class UeventListener:
+    """
+    Wrapper around the azure_uevent_listener C program.
+    Compiles and runs the uevent listener in the background, then
+    provides methods to stop it and parse captured hotplug events.
+    """
+
+    _SOURCE_FILE = "azure_uevent_listener.c"
+    _BINARY_NAME = "azure-uevent-listener"
+    _LOCAL_DIR = PurePath(__file__).parent / "uevent_listener"
+
+    def __init__(self, node: Node) -> None:
+        self._node = node
+        self._process: Optional[Process] = None
+        self._remote_binary = node.working_path.joinpath(self._BINARY_NAME)
+        self._compiled = False
+
+    def compile(self) -> None:
+        """Copy source to the node and compile it."""
+        if self._compiled:
+            return
+        remote_src = self._node.working_path.joinpath(self._SOURCE_FILE)
+        self._node.shell.copy(
+            self._LOCAL_DIR / self._SOURCE_FILE,
+            remote_src,
+        )
+        self._node.tools[Gcc].compile(
+            str(remote_src),
+            output_name=str(self._remote_binary),
+            arguments="-O2 -Wall",
+        )
+        self._compiled = True
+
+    def start(self, show_all: bool = False, verbose: bool = False) -> None:
+        """Start the listener in the background. Requires root."""
+        self.compile()
+        flags = ""
+        if show_all:
+            flags += " -a"
+        if verbose:
+            flags += " -v"
+        cmd = f"{str(self._remote_binary)}{flags}"
+        self._process = self._node.execute_async(cmd, sudo=True, shell=True)
+        # wait for the "watching kernel uevents" banner
+        self._process.wait_output("watching kernel uevents", timeout=10)
+
+    def wait_for_event(
+        self,
+        criteria: Optional[UeventCriteria] = None,
+        timeout: int = 60,
+        error_on_missing: bool = True,
+        **properties: Union[str, Pattern[str]],
+    ) -> Optional[UeventEntry]:
+        """Block until an event matching all the given properties is seen.
+
+        Properties can be passed as a dict and/or as keyword arguments, for
+        example:
+            listener.wait_for_event(tag="VF_PCI_REMOVE", devpath=vf_devpath)
+            listener.wait_for_event({"tag": re.compile("REMOVE"),
+                                     "azure_vf": "yes"})
+        Returns the matching event, or None if nothing matched and
+        error_on_missing is False.
+        """
+        if self._process is None:
+            raise LisaException("UeventListener is not running")
+        expected: Dict[str, Union[str, Pattern[str]]] = dict(criteria or {})
+        expected.update(properties)
+        if not expected:
+            raise LisaException("wait_for_event requires at least one property")
+
+        matched = self.wait_for_events(
+            [expected], timeout=timeout, error_on_missing=error_on_missing
+        )
+        return matched[0] if matched else None
+
+    def wait_for_events(
+        self,
+        criteria_list: Sequence[UeventCriteria],
+        timeout: int = 60,
+        error_on_missing: bool = True,
+    ) -> List[UeventEntry]:
+        """Block until every entry in criteria_list has matched an event.
+
+        The output is scanned once, so the events may arrive in any order.
+        Returns the matching events, or the partial list when nothing matched
+        and error_on_missing is False.
+        """
+        if self._process is None:
+            raise LisaException("UeventListener is not running")
+        if not criteria_list:
+            raise LisaException("wait_for_events requires at least one criteria")
+
+        pending = list(criteria_list)
+        matched: List[UeventEntry] = []
+
+        def _is_match(line: str) -> bool:
+            entry = self.parse_line(line)
+            if entry is None:
+                return False
+            for criteria in pending:
+                if entry.matches(criteria):
+                    pending.remove(criteria)
+                    matched.append(entry)
+                    break
+            # only stop once every criteria has been seen
+            return not pending
+
+        self._process.wait_line(
+            _is_match,
+            timeout=timeout,
+            error_on_missing=error_on_missing,
+            description=f"uevents matching {list(criteria_list)}",
+        )
+        return matched
+
+    def stop(self, timeout: int = 30) -> List[UeventEntry]:
+        """Send SIGINT, collect output, and return parsed events."""
+        if self._process is None:
+            return []
+        self._node.tools[Kill].by_name(
+            self._BINARY_NAME, signum=SIGINT, ignore_not_exist=True
+        )
+        result = self._process.wait_result(timeout=timeout)
+        self._process = None
+        return self.parse_output(result.stdout)
+
+    @staticmethod
+    def device_criteria(
+        pci_slot: str, tag: Union[str, Pattern[str]]
+    ) -> Dict[str, Union[str, Pattern[str]]]:
+        """Build match criteria for every event of one pci device.
+
+        The pci slot is the PCI_SLOT_NAME property on pci events only, but it
+        is always a path segment of DEVPATH, so matching the devpath catches
+        the net and infiniband events for the same device as well.
+        """
+        return {"tag": tag, "devpath": re.compile(re.escape(pci_slot))}
+
+    @staticmethod
+    def parse_line(line: str) -> Optional[UeventEntry]:
+        """Parse a single uevent listener output line, None if it's not one."""
+        match = _uevent_line_regex.match(line.strip())
+        if not match:
+            return None
+        props: Dict[str, str] = {}
+        for token in match.group("properties").split():
+            if "=" in token:
+                key, value = token.split("=", 1)
+                props[key] = value
+        if not props:
+            # banner and other non-event output
+            return None
+        return UeventEntry(
+            timestamp=match.group("timestamp"),
+            tag=match.group("tag"),
+            properties=props,
+        )
+
+    @staticmethod
+    def parse_output(output: str) -> List[UeventEntry]:
+        """Parse uevent listener stdout into a list of UeventEntry."""
+        entries: List[UeventEntry] = []
+        for line in output.splitlines():
+            entry = UeventListener.parse_line(line)
+            if entry is not None:
+                entries.append(entry)
+        return entries
+
+    def get_events_by_tag(self, output: str, tag: str) -> List[UeventEntry]:
+        """Filter parsed events by tag (e.g. VF_PCI_ADD, NETDEV_REMOVE)."""
+        return [e for e in self.parse_output(output) if e.tag == tag]
 
 
 # TODO: remove this method in 2028 when all updated versions are LTS

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -354,6 +354,7 @@ def run_testpmd_hotplug(
     # kill testpmd and process the output
     for kit in all_kits:
         kit.testpmd.kill_previous_testpmd_command()
+        sleep(1)
         # allow time for SIGINT/SIGKILL shutdown and stats flush
         kit.testpmd.process_testpmd_output(processes[kit].wait_result(timeout=120))
 
@@ -943,127 +944,6 @@ def verify_dpdk_send_receive_multi_txrx_queue(
     )
 
 
-# Multiple ports test
-#  to simplify this
-def verify_dpdk_mutliple_ports(
-    environment: Environment,
-    log: Logger,
-    variables: Dict[str, Any],
-    pmd: Pmd,
-    hugepage_size: HugePageSize,
-    use_service_cores: int = 1,
-    queues: int = 1,
-    result: Optional[TestResult] = None,
-    set_mtu: int = 0,
-) -> Tuple[DpdkTestResources, DpdkTestResources, DpdkTestResources]:
-    # helpful to have the public ips labeled for debugging
-    external_ips = []
-    for node in environment.nodes.list():
-        if isinstance(node, RemoteNode):
-            external_ips += node.connection_info[
-                constants.ENVIRONMENTS_NODES_REMOTE_ADDRESS
-            ]
-        else:
-            raise SkippedException()
-        # skip MTU test if not on MANA (for now).
-        if set_mtu and not node.nics.is_mana_device_present():
-            raise SkippedException("set mtu test is intended for MANA VMs only.")
-    log.debug(
-        (f"receiver:{external_ips[0]}\nsenders:{external_ips[1]},{external_ips[2]}\n")
-    )
-    receiver, sender_a, sender_b = environment.nodes.list()
-    nic_pairings = {
-        receiver: [
-            receiver.nics.get_nic_by_subnet("10.0.1.0/24"),
-            receiver.nics.get_nic_by_subnet("10.0.2.0/24"),
-        ],
-        sender_a: [sender_a.nics.get_nic_by_subnet("10.0.1.0/24")],
-        sender_b: [sender_b.nics.get_nic_by_subnet("10.0.2.0/24")],
-    }
-    # get test duration variable if set
-    # enables long-running tests to shakeQoS and SLB issue
-    test_duration: int = variables.get("dpdk_test_duration", 15)
-    kill_timeout = test_duration + 5
-
-    test_kits = init_nodes_concurrent(
-        environment,
-        log,
-        variables,
-        pmd,
-        hugepage_size=hugepage_size,
-        specific_pairings=nic_pairings,
-    )
-
-    check_send_receive_compatibility(test_kits)
-    receiver_kit = [kit for kit in test_kits if kit.node is receiver].pop()
-    sender_port_a = [kit for kit in test_kits if kit.node is sender_a].pop()
-    sender_port_b = [kit for kit in test_kits if kit.node is sender_b].pop()
-    sender_kits = [sender_port_a, sender_port_b]
-
-    # annotate test result before starting
-    if result is not None:
-        annotate_dpdk_test_result(test_kit=receiver_kit, test_result=result, log=log)
-
-    kit_cmd_pairs = generate_testpmd_multiple_port_command(
-        pmd,
-        [sender_port_a, sender_port_b],
-        receiver_kit,
-        use_service_cores=use_service_cores,
-        queues=queues,
-        set_mtu=set_mtu,
-    )
-    receive_timeout = kill_timeout + 10
-    receive_result = receiver.tools[Timeout].start_with_timeout(
-        kit_cmd_pairs[receiver_kit],
-        receive_timeout,
-        constants.SIGINT,
-        kill_timeout=receive_timeout,
-    )
-    receive_result.wait_output("start packet forwarding")
-    sender_results: Dict[DpdkTestResources, Process] = dict()
-    for sender in sender_kits:
-        sender_results[sender] = sender.node.tools[Timeout].start_with_timeout(
-            kit_cmd_pairs[sender],
-            test_duration,
-            constants.SIGINT,
-            kill_timeout=kill_timeout,
-        )
-
-    results = dict()
-    for sender in sender_results:
-        results[sender] = sender.testpmd.process_testpmd_output(
-            sender_results[sender].wait_result()
-        )
-    results[receiver_kit] = receiver_kit.testpmd.process_testpmd_output(
-        receive_result.wait_result()
-    )
-
-    # helpful to have the outputs labeled
-    for i in range(0, len(sender_kits)):
-        log.debug(f"\nSENDERS_{i}:\n{results[sender_kits[i]]}")
-    log.debug(f"\nRECEIVER:\n{results[receiver_kit]}")
-
-    rcv_rx_pps = receiver_kit.testpmd.get_mean_rx_pps()
-    log.info(f"receiver rx-pps: {rcv_rx_pps}")
-    sender_pps_measurements = []
-    for i in range(0, len(sender_kits)):
-        sender_pps_measurements += [sender_kits[i].testpmd.get_mean_tx_pps()]
-        log.info(f"sender_{i} tx-pps: {sender_pps_measurements[i]}")
-    for i in range(0, len(sender_kits)):
-        sender_kits[i].dmesg.check_kernel_errors(force_run=True)
-    receiver_kit.dmesg.check_kernel_errors(force_run=True)
-    # differences in NIC type throughput can lead to different snd/rcv counts
-    assert_that(rcv_rx_pps).described_as(
-        "Throughput for RECEIVE was below the correct order-of-magnitude"
-    ).is_greater_than(DPDK_PPS_THRESHOLD)
-    for sender_pps in sender_pps_measurements:
-        assert_that(sender_pps).described_as(
-            "Throughput for SEND was below the correct order of magnitude"
-        ).is_greater_than(DPDK_PPS_THRESHOLD)
-
-    return receiver_kit, sender_port_a, sender_port_b
-
-
 def do_parallel_cleanup(environment: Environment) -> None:
     def _parallel_cleanup(node: Node) -> None:
         interface = node.features[NetworkInterface]
@@ -1442,16 +1322,8 @@ def verify_dpdk_l3fwd_ntttcp_tcp(
     )
     # hotplug sriov and run again
     if hotplug_sriov:
-        forwarder.features[NetworkInterface].switch_sriov(
-            enable=False, wait=False, reset_connections=False
-        )
-        forwarder.features[NetworkInterface].switch_sriov(
-            enable=True, wait=False, reset_connections=False
-        )
-        fwd_proc.wait_output(
-            "HN_DRIVER: netvsc_hotplug_retry(): "
-            "Found matching MAC address, adding device",
-            delta_only=True,
+        switch_sriov_for_nics(
+            forwarder, [subnet_a_nics[forwarder], subnet_b_nics[forwarder]]
         )
         _receiver_after = ntttcp[receiver].run_as_server_async(
             subnet_b_nics[receiver].name,
@@ -2171,26 +2043,8 @@ def run_dpdk_symmetric_mp(
             hotplug_times -= 1
             # turn SRIOV off
 
-            node.features[NetworkInterface].switch_sriov(
-                enable=False, wait=False, reset_connections=False
-            )
+            switch_sriov_for_nics(node, test_nics)
 
-            # wait for the RTE_DEV_EVENT_REMOVE message
-            primary.wait_output(
-                "HN_DRIVER: netvsc_hotadd_callback(): "
-                "Device notification type=1",  # RTE_DEV_EVENT_REMOVE
-                delta_only=True,
-            )  # relying on compiler defaults here, not great.
-
-            # turn SRIOV on
-            node.features[NetworkInterface].switch_sriov(
-                enable=True, wait=False, reset_connections=False
-            )
-
-            primary.wait_output(
-                "HN_DRIVER: netvsc_hotadd_callback(): Device notification type=0",
-                delta_only=True,
-            )
             ping.ping_async(
                 target=test_nics[0].ip_addr,
                 nic_name=node.nics.get_primary_nic().name,

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -23,6 +23,7 @@ from microsoft.testsuites.dpdk.common import (
     is_url_for_tarball,
     update_kernel_from_repo,
 )
+from microsoft.testsuites.dpdk.dpdkovs import DpdkOvs
 from microsoft.testsuites.dpdk.dpdktestpmd import PACKAGE_MANAGER_SOURCE, DpdkTestpmd
 from microsoft.testsuites.dpdk.rdmacore import (
     RDMA_CORE_MANA_DEFAULT_SOURCE,

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -2170,3 +2170,51 @@ def run_dpdk_symmetric_mp(
     assert_that(process_data[2]["rx"]).described_as(
         "process 1 port_0_tx and port_1_rx should match"
     ).is_equal_to(process_data[3]["tx"])
+
+
+def run_ovs_test(node: Node, log: Logger, variables: Dict[str, Any], pmd: Pmd):
+    if node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64:
+        raise SkippedException("OVS test not supported on ARM64")
+    test_nics = [node.nics.get_secondary_nic()]
+    try:
+        test_kit = initialize_node_resources(
+            node,
+            log,
+            variables,
+            pmd,
+            HugePageSize.HUGE_2MB,
+            test_nics=test_nics,
+        )
+    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+        raise SkippedException(err)
+
+    # checkout OpenVirtualSwitch
+    ovs: DpdkOvs = node.tools[DpdkOvs]
+
+    # check for runbook variable to skip dpdk version check
+    use_latest_ovs = variables.get("use_latest_ovs", False)
+    # provide ovs build with DPDK tool info and build
+    ovs.build_with_dpdk(test_kit.testpmd, use_latest_ovs=use_latest_ovs)
+
+    # enable hugepages needed for dpdk EAL
+    hugepages = node.tools[Hugepages]
+    try:
+        hugepages.init_hugepages(HugePageSize.HUGE_2MB)
+    except (NotEnoughMemoryException, UnsupportedOperationException) as err:
+        raise SkippedException(err)
+
+    try:
+        # run OVS tests, providing OVS with the NIC info needed for DPDK init
+        ovs.setup_ovs(test_nics, test_kit.testpmd)
+
+        # validate if OVS was able to initialize DPDK
+        node.execute(
+            "ovs-vsctl get Open_vSwitch . dpdk_initialized",
+            sudo=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "OVS repoted that DPDK EAL failed to initialize."
+            ),
+        )
+    finally:
+        ovs.stop_ovs()

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -347,6 +347,10 @@ def run_testpmd_hotplug(
         # built from it. The slot is stable across a remove/rescan cycle.
         test_nic = node.nics.get_nic_by_subnet("10.0.1.0/24")
         switch_sriov_for_nic(node, test_nic)
+        if processes[collect_from].wait_output(
+            "Segmentation fault (core dumped)", timeout=5, error_on_missing=False
+        ):
+            raise LisaException("Test fail: testpmd crashed.")
 
     # let it run for a bit
     sleep(30)

--- a/lisa/microsoft/testsuites/dpdk/dpdkutil.py
+++ b/lisa/microsoft/testsuites/dpdk/dpdkutil.py
@@ -642,7 +642,14 @@ def initialize_node_resources(
     # *type* of installation is already installed,
     # taking it's creation arguments into account.
     testpmd.install()
-
+    version = testpmd.get_dpdk_version()
+    if version > "22.11.0" and pmd == Pmd.FAILSAFE:
+        raise SkippedException(
+            f"Skipping net_failsafe test on DPDK {str(version)}. "
+            "Please run the net_netvsc version for newer builds. "
+            "see https://learn.microsoft.com/en-us/azure/"
+            "virtual-network/setup-dpdk#run-testpmd for details."
+        )
     # init and enable hugepages (required by dpdk)
     hugepages = node.tools[Hugepages]
     numa_nodes = node.tools[Lscpu].get_numa_node_count()

--- a/lisa/microsoft/testsuites/dpdk/uevent_listener/azure_uevent_listener.c
+++ b/lisa/microsoft/testsuites/dpdk/uevent_listener/azure_uevent_listener.c
@@ -1,0 +1,452 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ *
+ * azure_hotplug_mon - watch kernel uevents for NIC hotplug/removal on Azure.
+ *
+ * Listens on the raw NETLINK_KOBJECT_UEVENT socket (kernel multicast group 1)
+ * and reports the events that matter to a DPDK application running with the
+ * mlx5, mana or netvsc PMDs:
+ *
+ *   VF_PCI_ADD/REMOVE   accelerated-networking VF appearing/disappearing
+ *   UVERBS_ADD/REMOVE   /dev/infiniband/uverbsN - earliest mlx5 removal signal
+ *   IBDEV_ADD/REMOVE    mlx5_N / mana_N RDMA device
+ *   NETDEV_ADD/REMOVE   VF or synthetic netdev (what netvsc MAC-matches on)
+ *   VMBUS_NETVSC_*      synthetic netvsc device on the vmbus
+ *   VMBUS_ADD/REMOVE    any other vmbus device
+ *
+ * This deliberately does not use EAL: rte_dev_event_monitor_start() only
+ * parses SUBSYSTEM=pci/uio/vfio *and* requires PCI_SLOT_NAME, so it silently
+ * drops every vmbus, net and infiniband event.
+ *
+ * Build:
+ *   gcc -O2 -Wall -Wextra -o azure-hotplug-mon azure_hotplug_mon.c
+ *
+ * Run (needs CAP_NET_ADMIN, i.e. root in practice):
+ *   sudo ./azure-hotplug-mon          # relevant events only
+ *   sudo ./azure-hotplug-mon -a       # every subsystem
+ *   sudo ./azure-hotplug-mon -v       # dump all properties per event
+ */
+
+#define _GNU_SOURCE	/* struct ucred, SCM_CREDENTIALS */
+
+#include <ctype.h>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <linux/netlink.h>
+
+/* Kernel caps a uevent payload at 2048 bytes; leave generous headroom. */
+#define UEV_BUF_SZ	16384
+#define RCVBUF_SZ	(2 * 1024 * 1024)
+
+/* netvsc vmbus class GUID, from drivers/net/netvsc/hn_ethdev.c hn_net_ids[]:
+ * f8615163-df3e-46c5-913f-f2d2f965ed0e, as it appears in MODALIAS.
+ */
+#define NETVSC_MODALIAS	"vmbus:f8615163df3e46c5913ff2d2f965ed0e"
+
+struct uevent {
+	const char *header;	/* "add@/devices/..." */
+	const char *action;
+	const char *subsystem;
+	const char *devpath;
+	const char *driver;
+	const char *pci_slot;	/* PCI_SLOT_NAME */
+	const char *interface;	/* INTERFACE (net) */
+	const char *name;	/* NAME (infiniband, infiniband_verbs) */
+	const char *devname;	/* DEVNAME */
+	const char *modalias;
+	const char *devtype;
+};
+
+static volatile sig_atomic_t stop_flag;
+
+static void
+sig_handler(int signum)
+{
+	(void)signum;
+	stop_flag = 1;
+}
+
+/* Return the value of "key=" in line, or NULL if line is a different key. */
+static const char *
+prop(const char *line, const char *key)
+{
+	size_t klen = strlen(key);
+
+	if (strncmp(line, key, klen) == 0 && line[klen] == '=')
+		return line + klen + 1;
+	return NULL;
+}
+
+/* True if s[0..35] is a 8-4-4-4-12 hex GUID, i.e. a vmbus device directory. */
+static bool
+is_guid(const char *s, size_t len)
+{
+	size_t i;
+
+	if (len != 36)
+		return false;
+
+	for (i = 0; i < 36; i++) {
+		if (i == 8 || i == 13 || i == 18 || i == 23) {
+			if (s[i] != '-')
+				return false;
+		} else if (!isxdigit((unsigned char)s[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/*
+ * On Azure an accelerated-networking VF is enumerated behind the pci-hyperv
+ * bridge, so its DEVPATH always contains a vmbus GUID path segment, e.g.
+ *   /devices/6f9b9d4c-.../pci0001:00/0001:00:02.0/net/eth1
+ * A plain (non-vmbus) PCI device never does.
+ */
+static bool
+is_azure_vf(const char *devpath)
+{
+	const char *seg = devpath;
+
+	if (devpath == NULL)
+		return false;
+
+	while (seg != NULL) {
+		const char *end = strchr(seg + 1, '/');
+		size_t len = (end != NULL) ? (size_t)(end - seg - 1)
+					   : strlen(seg + 1);
+
+		if (is_guid(seg + 1, len))
+			return true;
+		seg = end;
+	}
+	return false;
+}
+
+/*
+ * Map the event onto a short tag. Returns NULL when the event is not one of
+ * the Azure NIC cases (caller drops it unless -a was given).
+ */
+static const char *
+classify(const struct uevent *ev, bool vf)
+{
+	bool add;
+
+	if (ev->action == NULL || ev->subsystem == NULL)
+		return NULL;
+
+	if (strcmp(ev->action, "add") == 0)
+		add = true;
+	else if (strcmp(ev->action, "remove") == 0)
+		add = false;
+	else
+		return NULL;	/* change/bind/unbind/move - not hotplug */
+
+	if (strcmp(ev->subsystem, "pci") == 0) {
+		if (vf)
+			return add ? "VF_PCI_ADD" : "VF_PCI_REMOVE";
+		return add ? "PCI_ADD" : "PCI_REMOVE";
+	}
+	if (strcmp(ev->subsystem, "infiniband_verbs") == 0)
+		return add ? "UVERBS_ADD" : "UVERBS_REMOVE";
+	if (strcmp(ev->subsystem, "infiniband") == 0)
+		return add ? "IBDEV_ADD" : "IBDEV_REMOVE";
+	if (strcmp(ev->subsystem, "net") == 0)
+		return add ? "NETDEV_ADD" : "NETDEV_REMOVE";
+	if (strcmp(ev->subsystem, "vmbus") == 0) {
+		if (ev->modalias != NULL &&
+		    strcmp(ev->modalias, NETVSC_MODALIAS) == 0)
+			return add ? "VMBUS_NETVSC_ADD" : "VMBUS_NETVSC_REMOVE";
+		return add ? "VMBUS_ADD" : "VMBUS_REMOVE";
+	}
+	return NULL;
+}
+
+static void
+print_event(const struct uevent *ev, const char *tag, bool vf)
+{
+	struct timespec ts;
+	struct tm tm;
+	char when[16] = "??:??:??";
+
+	if (clock_gettime(CLOCK_REALTIME, &ts) == 0 &&
+	    localtime_r(&ts.tv_sec, &tm) != NULL)
+		strftime(when, sizeof(when), "%H:%M:%S", &tm);
+
+	printf("[%s.%03ld] %-18s subsystem=%s", when, ts.tv_nsec / 1000000,
+	       tag, ev->subsystem != NULL ? ev->subsystem : "?");
+
+	if (ev->pci_slot != NULL)
+		printf(" pci=%s", ev->pci_slot);
+	if (ev->driver != NULL)
+		printf(" driver=%s", ev->driver);
+	if (ev->interface != NULL)
+		printf(" ifname=%s", ev->interface);
+	if (ev->name != NULL)
+		printf(" name=%s", ev->name);
+	if (ev->devname != NULL)
+		printf(" devnode=/dev/%s", ev->devname);
+	if (vf)
+		printf(" azure_vf=yes");
+	if (ev->devpath != NULL)
+		printf(" devpath=%s", ev->devpath);
+	printf("\n");
+	fflush(stdout);
+}
+
+static int
+uev_socket_create(void)
+{
+	struct sockaddr_nl addr;
+	int fd, one = 1, bufsz = RCVBUF_SZ;
+
+	fd = socket(PF_NETLINK, SOCK_RAW | SOCK_CLOEXEC,
+		    NETLINK_KOBJECT_UEVENT);
+	if (fd < 0) {
+		fprintf(stderr, "socket(NETLINK_KOBJECT_UEVENT): %s\n",
+			strerror(errno));
+		return -1;
+	}
+
+	/* Big receive buffer: a VM-level hotplug can burst dozens of events. */
+	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUFFORCE, &bufsz,
+		       sizeof(bufsz)) < 0)
+		(void)setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bufsz,
+				 sizeof(bufsz));
+
+	/* Credentials let us drop anything not sent by the kernel. */
+	if (setsockopt(fd, SOL_SOCKET, SO_PASSCRED, &one, sizeof(one)) < 0)
+		fprintf(stderr, "warning: SO_PASSCRED failed: %s\n",
+			strerror(errno));
+
+	memset(&addr, 0, sizeof(addr));
+	addr.nl_family = AF_NETLINK;
+	addr.nl_pid = 0;	/* let the kernel assign */
+	addr.nl_groups = 1;	/* group 1 = kernel uevents, not udev's copy */
+
+	if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		fprintf(stderr, "bind: %s%s\n", strerror(errno),
+			errno == EPERM ? " (need root/CAP_NET_ADMIN)" : "");
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+/* Receive one message; returns length, 0 to skip, -1 on fatal error. */
+static ssize_t
+uev_recv(int fd, char *buf, size_t bufsz)
+{
+	struct sockaddr_nl snl;
+	struct iovec iov;
+	union {
+		struct cmsghdr hdr;
+		char buf[CMSG_SPACE(sizeof(struct ucred))];
+	} cmsg;
+	struct msghdr msg;
+	struct cmsghdr *cm;
+	struct ucred *cred;
+	ssize_t len;
+
+	iov.iov_base = buf;
+	iov.iov_len = bufsz - 1;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = &snl;
+	msg.msg_namelen = sizeof(snl);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsg;
+	msg.msg_controllen = sizeof(cmsg);
+
+	len = recvmsg(fd, &msg, 0);
+	if (len < 0) {
+		if (errno == EINTR || errno == EAGAIN)
+			return 0;
+		if (errno == ENOBUFS) {
+			fprintf(stderr,
+				"warning: uevent buffer overrun, events lost\n");
+			return 0;
+		}
+		fprintf(stderr, "recvmsg: %s\n", strerror(errno));
+		return -1;
+	}
+	if (len == 0)
+		return 0;
+
+	/* Only the kernel (port id 0, uid 0) is allowed to talk to us. */
+	if (snl.nl_pid != 0)
+		return 0;
+
+	cm = CMSG_FIRSTHDR(&msg);
+	if (cm == NULL || cm->cmsg_type != SCM_CREDENTIALS)
+		return 0;
+	cred = (struct ucred *)CMSG_DATA(cm);
+	if (cred->uid != 0)
+		return 0;
+
+	buf[len] = '\0';
+	return len;
+}
+
+static void
+uev_parse(char *buf, size_t len, struct uevent *ev)
+{
+	size_t off;
+
+	memset(ev, 0, sizeof(*ev));
+	ev->header = buf;
+
+	/* Payload is the header line, then NUL-separated KEY=VALUE pairs. */
+	off = strlen(buf) + 1;
+	while (off < len) {
+		char *line = buf + off;
+		size_t llen = strlen(line);
+		const char *val;
+
+		if (llen == 0) {
+			off++;
+			continue;
+		}
+
+		if ((val = prop(line, "ACTION")) != NULL)
+			ev->action = val;
+		else if ((val = prop(line, "SUBSYSTEM")) != NULL)
+			ev->subsystem = val;
+		else if ((val = prop(line, "DEVPATH")) != NULL)
+			ev->devpath = val;
+		else if ((val = prop(line, "DRIVER")) != NULL)
+			ev->driver = val;
+		else if ((val = prop(line, "PCI_SLOT_NAME")) != NULL)
+			ev->pci_slot = val;
+		else if ((val = prop(line, "INTERFACE")) != NULL)
+			ev->interface = val;
+		else if ((val = prop(line, "NAME")) != NULL)
+			ev->name = val;
+		else if ((val = prop(line, "DEVNAME")) != NULL)
+			ev->devname = val;
+		else if ((val = prop(line, "MODALIAS")) != NULL)
+			ev->modalias = val;
+		else if ((val = prop(line, "DEVTYPE")) != NULL)
+			ev->devtype = val;
+
+		off += llen + 1;
+	}
+}
+
+static void
+dump_raw(const char *buf, size_t len)
+{
+	size_t off = 0;
+
+	while (off < len) {
+		size_t llen = strlen(buf + off);
+
+		if (llen > 0)
+			printf("\t| %s\n", buf + off);
+		off += llen + 1;
+	}
+}
+
+static void
+usage(const char *argv0)
+{
+	fprintf(stderr,
+		"usage: %s [-a] [-v]\n"
+		"  -a  report every subsystem, not just Azure NIC events\n"
+		"  -v  dump all uevent properties for each reported event\n",
+		argv0);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct sigaction sa;
+	struct pollfd pfd;
+	char buf[UEV_BUF_SZ];
+	bool show_all = false, verbose = false;
+	int fd, opt, rc = EXIT_SUCCESS;
+
+	while ((opt = getopt(argc, argv, "avh")) != -1) {
+		switch (opt) {
+		case 'a':
+			show_all = true;
+			break;
+		case 'v':
+			verbose = true;
+			break;
+		case 'h':
+			usage(argv[0]);
+			return EXIT_SUCCESS;
+		default:
+			usage(argv[0]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = sig_handler;
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGTERM, &sa, NULL);
+
+	fd = uev_socket_create();
+	if (fd < 0)
+		return EXIT_FAILURE;
+
+	printf("watching kernel uevents (ctrl-c to stop)\n");
+	fflush(stdout);
+
+	pfd.fd = fd;
+	pfd.events = POLLIN;
+
+	while (!stop_flag) {
+		struct uevent ev;
+		const char *tag;
+		ssize_t len;
+		bool vf;
+
+		if (poll(&pfd, 1, -1) < 0) {
+			if (errno == EINTR)
+				continue;
+			fprintf(stderr, "poll: %s\n", strerror(errno));
+			rc = EXIT_FAILURE;
+			break;
+		}
+		if (!(pfd.revents & POLLIN))
+			continue;
+
+		len = uev_recv(fd, buf, sizeof(buf));
+		if (len < 0) {
+			rc = EXIT_FAILURE;
+			break;
+		}
+		if (len == 0)
+			continue;
+
+		uev_parse(buf, (size_t)len, &ev);
+		vf = is_azure_vf(ev.devpath);
+		tag = classify(&ev, vf);
+
+		if (tag == NULL) {
+			if (!show_all)
+				continue;
+			tag = "OTHER";
+		}
+
+		print_event(&ev, tag, vf);
+		if (verbose)
+			dump_raw(buf, (size_t)len);
+	}
+
+	close(fd);
+	return rc;
+}

--- a/lisa/microsoft/testsuites/dpdk/uevent_listener/azure_uevent_listener.c
+++ b/lisa/microsoft/testsuites/dpdk/uevent_listener/azure_uevent_listener.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause
  *
- * azure_hotplug_mon - watch kernel uevents for NIC hotplug/removal on Azure.
+ * azure_uevent_listener - watch kernel uevents for NIC hotplug/removal on Azure.
  *
  * Listens on the raw NETLINK_KOBJECT_UEVENT socket (kernel multicast group 1)
  * and reports the events that matter to a DPDK application running with the

--- a/lisa/sut_orchestrator/azure/arm_template.bicep
+++ b/lisa/sut_orchestrator/azure/arm_template.bicep
@@ -261,6 +261,7 @@ resource virtual_network_name_resource 'Microsoft.Network/virtualNetworks@2024-0
     subnets: [for j in range(0, subnet_count): {
       name: '${subnet_prefix}${j}'
       properties: {
+        // NOTE: changing this convention will break the DPDK suite.
         addressPrefixes: concat(
           ['10.0.${j}.0/24'],
           use_ipv6 ? ['2001:db8:${j}::/64'] : []


### PR DESCRIPTION
## Description

dpdk: hotplug VFs through sysfs and verify with a uevent listener
The VF removal tests previously toggled accelerated networking through
the Azure platform API, which is slow, racy against the SSH connection,
and only verifies that pps changed.

Replace that with a direct sysfs remove/rescan of the VF pci device and
watch the kernel uevent stream while it happens:

- testpmd_start_process waits for "start packet forwarding" so the
  hotplug is not triggered before the forwarder is actually running.
- get_vf_pci_slots/remove_pci_devices/rescan_pci_bus perform the
  surprise-removal and re-discovery through /sys/bus/pci.
- switch_sriov_for_nic(s) drives one uevent listener for the whole set
  of nics, waits for the PCI_REMOVE and PCI_ADD events of every slot,
  and asserts they were observed before reloading the nic info.
- UeventEntry/UeventListener wrap the azure_uevent_listener helper
  program, compiling it on the node and parsing its output into
  matchable events.
- run_testpmd_hotplug replaces run_testpmd_concurrent/
  start_testpmd_concurrent for the send and receive hotplug tests.

## Related Issue

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

verify_dpdk_testpmd_hotplug_.*

**Key Test Cases:**
verify_dpdk_testpmd_hotplug_receiver_failsafe_pmd|verify_dpdk_testpmd_hotplug_receiver_netvsc_pmd|verify_dpdk_testpmd_hotplug_sender_failsafe_pmd|verify_dpdk_testpmd_hotplug_sender_netvsc_pmd

**Impacted LISA Features:**

**Tested Azure Marketplace Images:**
canonical ubuntu-24_04-lts server latest
-

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|       |         | PASSED / FAILED / SKIPPED |
