### PR TITLE
BugFix: support OpenVMM KVM guests

### DIFF
--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests.py
@@ -15,7 +15,7 @@ from lisa import (
     simple_requirement,
 )
 from lisa.environment import EnvironmentStatus
-from lisa.operating_system import CBLMariner
+from lisa.operating_system import CBLMariner, CpuArchitecture, Ubuntu
 from lisa.secret import add_secret
 from lisa.testsuite import TestResult
 from lisa.tools import Ls, Lscpu, Uname
@@ -36,7 +36,7 @@ def _get_openvmm_tests_type() -> Any:
     description="""
     This suite runs the upstream OpenVMM vmm_tests from the Linux OpenVMM host.
     """,
-    requirement=simple_requirement(supported_os=[CBLMariner]),
+    requirement=simple_requirement(supported_os=[CBLMariner, Ubuntu]),
     maturity="preview",
 )
 class OpenVmmUpstreamTestSuite(TestSuite):
@@ -44,7 +44,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         openvmm_tests_type = _get_openvmm_tests_type()
         node = cast(Node, kwargs["node"])
         host = self._get_initialized_host_node(node)
-        if not isinstance(host.os, CBLMariner):
+        if not isinstance(host.os, (CBLMariner, Ubuntu)):
             raise SkippedException(
                 f"OpenVMM upstream tests are not implemented for {host.os.name}"
             )
@@ -82,7 +82,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
 
     @TestCaseMetadata(
         description="""
-        Run the upstream OpenVMM vmm_tests flowey pipeline on the Linux x64 host.
+        Run the upstream OpenVMM vmm_tests flowey pipeline on the Linux host.
         Use openvmm_vmm_tests_guest_os=linux|windows|all to scope guest coverage,
         and openvmm_vmm_tests_filter for any additional nextest filter expression.
         Native Linux hosts automatically exclude PCAT coverage because upstream
@@ -95,7 +95,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         timeout=43200,
         requirement=simple_requirement(
             environment_status=EnvironmentStatus.Deployed,
-            supported_os=[CBLMariner],
+            supported_os=[CBLMariner, Ubuntu],
         ),
     )
     def verify_openvmm_upstream_vmm_tests(
@@ -107,6 +107,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
     ) -> None:
         host = self._get_initialized_host_node(node)
         command_group = self._ensure_vmm_tests_supported(host)
+        target = self._get_vmm_tests_target(host)
 
         openvmm_tests = host.tools[_get_openvmm_tests_type()]
         openvmm_tests.command_group = command_group or ""
@@ -115,6 +116,7 @@ class OpenVmmUpstreamTestSuite(TestSuite):
             ref=str(variables.get("openvmm_tests_ref", "")).strip(),
             release=self._is_truthy(variables.get("openvmm_tests_release", "")),
             test_filter=self._compose_vmm_tests_filter(variables, host),
+            target=target,
             install_missing_deps=self._is_truthy(
                 variables.get("openvmm_vmm_tests_install_missing_deps", "yes"),
                 default=True,
@@ -144,12 +146,6 @@ class OpenVmmUpstreamTestSuite(TestSuite):
         return host
 
     def _ensure_vmm_tests_supported(self, host: Node) -> Optional[str]:
-        hardware_platform = host.tools[Uname].get_linux_information().hardware_platform
-        if hardware_platform.lower() != "x86_64":
-            raise SkippedException(
-                "OpenVMM upstream vmm_tests currently require a Linux x64 host"
-            )
-
         virtualization_enabled = host.tools[Lscpu].is_virtualization_enabled()
         ls = host.tools[Ls]
         has_kvm = ls.path_exists(path="/dev/kvm", sudo=True)
@@ -201,6 +197,20 @@ class OpenVmmUpstreamTestSuite(TestSuite):
             )
 
         return command_group
+
+    def _get_vmm_tests_target(self, host: Node) -> str:
+        architecture = host.tools[Lscpu].get_architecture()
+        targets = {
+            CpuArchitecture.X64: "linux-x64",
+            CpuArchitecture.ARM64: "linux-aarch64-musl",
+        }
+        target = targets.get(architecture)
+        if not target:
+            raise SkippedException(
+                "OpenVMM upstream vmm_tests are not supported on host "
+                f"architecture '{architecture.value}'"
+            )
+        return target
 
     def _can_open_device(
         self,

--- a/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
+++ b/lisa/microsoft/testsuites/openvmm/openvmm_tests_tool.py
@@ -10,8 +10,8 @@ from pathlib import Path, PurePath
 from typing import Any, Dict, List, Optional, Type, cast
 
 from lisa.executable import Tool
-from lisa.operating_system import CBLMariner, Posix
-from lisa.tools import Cargo, Curl, Git, Ls
+from lisa.operating_system import CBLMariner, CpuArchitecture, Posix, Ubuntu
+from lisa.tools import Cargo, Curl, Git, Ls, Lscpu
 from lisa.util import LisaException, UnsupportedDistroException
 
 
@@ -41,6 +41,7 @@ class OpenVmmTests(Tool):
     VMM_TIMEOUT = 43200
     NEXTEST_VERSION = "0.9.101"
     NEXTEST_LINUX_X64_TARGET = "x86_64-unknown-linux-gnu"
+    NEXTEST_LINUX_ARM64_TARGET = "aarch64-unknown-linux-gnu"
     _ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
     _SUMMARY_PATTERN = re.compile(
         r"Summary \[\s*[\d.]+s\]\s+(?P<run>\d+)(?:/(?P<total>\d+))? tests run:\s+"
@@ -69,6 +70,14 @@ class OpenVmmTests(Tool):
             "pkg-config",
             "binutils",
             "glibc-devel",
+        ],
+        Ubuntu.__name__: [
+            "build-essential",
+            "libssl-dev",
+            "perl",
+            "pkg-config",
+            "binutils",
+            "linux-libc-dev",
         ],
     }
 
@@ -131,6 +140,7 @@ class OpenVmmTests(Tool):
         ref: str = "",
         release: bool = False,
         test_filter: str = "",
+        target: str = "linux-x64",
         install_missing_deps: bool = True,
         skip_vhd_prompt: bool = True,
     ) -> _JUnitSummary:
@@ -154,7 +164,7 @@ class OpenVmmTests(Tool):
             "xflowey",
             "vmm-tests-run",
             "--target",
-            "linux-x64",
+            target,
             "--dir",
             str(output_dir),
         ]
@@ -424,7 +434,18 @@ class OpenVmmTests(Tool):
         )
         install_dir = self._artifact_root / "cargo-nextest-install"
         release_name = f"cargo-nextest-{self.NEXTEST_VERSION}"
-        asset_name = f"{release_name}-{self.NEXTEST_LINUX_X64_TARGET}"
+        architecture = self.node.tools[Lscpu].get_architecture()
+        nextest_targets = {
+            CpuArchitecture.X64: self.NEXTEST_LINUX_X64_TARGET,
+            CpuArchitecture.ARM64: self.NEXTEST_LINUX_ARM64_TARGET,
+        }
+        nextest_target = nextest_targets.get(architecture)
+        if not nextest_target:
+            raise LisaException(
+                "cargo-nextest fallback is not supported on architecture "
+                f"'{architecture.value}'."
+            )
+        asset_name = f"{release_name}-{nextest_target}"
         archive_name = f"{asset_name}.tar.gz"
         sha256_name = f"{asset_name}.sha256"
         release_url = (

--- a/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
+++ b/lisa/sut_orchestrator/libvirt/libvirt_device_pool.py
@@ -1,11 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+from __future__ import annotations
+
 import re
 import xml.etree.ElementTree as ET  # noqa: N817
 from itertools import combinations
 from pathlib import PurePosixPath
-from typing import Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from lisa.node import Node, RemoteNode
 from lisa.sut_orchestrator.util.device_pool import BaseDevicePool
@@ -18,12 +20,14 @@ from lisa.util import (
     find_group_in_lines,
 )
 
-from .context import DevicePassthroughContext, NodeContext
 from .schema import (
     BaseLibvirtNodeSchema,
     BaseLibvirtPlatformSchema,
     DeviceAddressSchema,
 )
+
+if TYPE_CHECKING:
+    from .context import NodeContext
 
 
 class LibvirtDevicePool(BaseDevicePool):
@@ -634,6 +638,8 @@ class LibvirtDevicePool(BaseDevicePool):
         node_context: NodeContext,
         node_runbook: BaseLibvirtNodeSchema,
     ) -> None:
+        from .context import DevicePassthroughContext
+
         if not node_runbook.device_passthrough:
             return
         for config in node_runbook.device_passthrough:

--- a/lisa/sut_orchestrator/openvmm/context.py
+++ b/lisa/sut_orchestrator/openvmm/context.py
@@ -59,6 +59,7 @@ class NodeContext:
     working_path: str = ""
     uefi_firmware_path: str = ""
     disk_img_path: str = ""
+    vmgs_file_path: str = ""
     cloud_init_file_path: str = ""
     console_log_file_path: str = ""
     launcher_log_file_path: str = ""
@@ -82,6 +83,8 @@ class NodeContext:
     effective_network: Optional[OpenVmmNetworkSchema] = None
     process_id: str = ""
     command_line: str = ""
+    restart_on_guest_reset: bool = False
+    guest_reset_restart_count: int = 0
     passthrough_devices: List[DevicePassthroughContext] = field(default_factory=list)
 
 
@@ -97,6 +100,8 @@ class OpenVmmHostContext:
     ssh_forwarding_lock: RLock = field(default_factory=RLock)
     artifact_copy_lock: Lock = field(default_factory=Lock)
     artifact_cache: Dict[str, str] = field(default_factory=_new_str_dict)
+    hypervisor_prepare_lock: Lock = field(default_factory=Lock)
+    prepared_hypervisor: str = ""
     device_pool_lock: Lock = field(default_factory=Lock)
     device_pool: Optional[Any] = None
     device_pool_config_key: str = ""

--- a/lisa/sut_orchestrator/openvmm/installer.py
+++ b/lisa/sut_orchestrator/openvmm/installer.py
@@ -106,6 +106,19 @@ class OpenVmmSourceInstaller(OpenVmmInstaller):
         runbook = cast(OpenVmmSourceInstallerSchema, self.runbook)
         linux = cast(Linux, self._node.os)
         packages_list = self._distro_package_mapping[type(linux).__name__]
+        if isinstance(linux, Ubuntu):
+            needrestart_configuration = "$nrconf{restart} = 'l';"
+            self._node.execute(
+                "mkdir -p /etc/needrestart/conf.d && "
+                f"printf '%s\\n' {shlex.quote(needrestart_configuration)} > "
+                "/etc/needrestart/conf.d/99-lisa-openvmm.conf",
+                shell=True,
+                sudo=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    "failed to configure needrestart for OpenVMM installation"
+                ),
+            )
         self._log.info(f"installing packages: {packages_list}")
         linux.install_packages(packages_list)
 

--- a/lisa/sut_orchestrator/openvmm/node.py
+++ b/lisa/sut_orchestrator/openvmm/node.py
@@ -14,13 +14,31 @@ import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Type, cast
+from urllib.parse import urlparse
 
 import yaml
 
 from lisa import constants, schema, search_space
 from lisa.feature import Features
 from lisa.node import Node, RemoteNode
-from lisa.tools import Dnsmasq, Echo, Ip, Kill, Ls, Lspci, Mkdir, Modprobe, OpenVmm, Rm
+from lisa.operating_system import CpuArchitecture
+from lisa.tools import (
+    Dnsmasq,
+    Echo,
+    Ip,
+    Kill,
+    Ls,
+    Lscpu,
+    Lspci,
+    Mkdir,
+    Modprobe,
+    OpenVmm,
+    QemuImg,
+    Rm,
+    Tar,
+    Wget,
+)
+from lisa.tools.lscpu import CpuType
 from lisa.tools.openvmm import OpenVmmLaunchConfig
 from lisa.util import (
     LisaException,
@@ -48,6 +66,7 @@ from .context import (
 from .schema import (
     OPENVMM_ADDRESS_MODE_STATIC,
     OPENVMM_CONNECTION_MODE_HOST_PROXY,
+    OPENVMM_HYPERVISOR_KVM,
     OPENVMM_NETWORK_MODE_TAP,
     OPENVMM_NETWORK_MODE_USER,
     OpenVmmGuestNodeSchema,
@@ -65,6 +84,11 @@ OPENVMM_LOG_TAIL_LINES = 40
 OPENVMM_DHCP_SERVER_PORT = 67
 OPENVMM_DNS_SERVER_PORT = 53
 OPENVMM_GIBIBYTE = 1 << 30
+OPENVMM_GUEST_RESET_LOG_MARKERS = (
+    "guest halted reason=Reset",
+    "guest-initiated reset",
+)
+OPENVMM_MAX_EXTERNAL_RESET_RESTARTS = 1
 OPENVMM_BRIDGE_NETFILTER_KEYS = [
     "net.bridge.bridge-nf-call-iptables",
     "net.bridge.bridge-nf-call-arptables",
@@ -85,6 +109,11 @@ def _get_tap_host_interface_name(network: OpenVmmNetworkSchema) -> str:
 
 def _is_raw_disk_image(disk_img_path: str) -> bool:
     return Path(disk_img_path).suffix.lower() == ".raw"
+
+
+def _is_http_url(path: str) -> bool:
+    parsed_path = urlparse(path)
+    return parsed_path.scheme in ("http", "https")
 
 
 def _get_pci_address_str(device: PciAddressLike) -> str:
@@ -341,6 +370,95 @@ class OpenVmmController:
         )
         return str(destination)
 
+    def prepare_uefi_firmware_path(
+        self, source_path: str, is_remote_path: bool, working_path: PurePath
+    ) -> str:
+        if not _is_http_url(source_path):
+            return self.resolve_guest_artifact_path(
+                source_path, is_remote_path, working_path
+            )
+
+        archive_path = self.resolve_guest_url_artifact_path(
+            source_path,
+            working_path,
+            filename="uefi.tar.gz",
+        )
+        self.host_node.tools[Tar].extract(
+            archive_path,
+            str(working_path),
+            gzip=True,
+        )
+        return str(working_path / "FV" / "MSVM.fd")
+
+    def prepare_disk_image_path(
+        self, source_path: str, is_remote_path: bool, working_path: PurePath
+    ) -> str:
+        if not _is_http_url(source_path):
+            return self.resolve_guest_artifact_path(
+                source_path, is_remote_path, working_path
+            )
+
+        source_image_path = self.resolve_guest_url_artifact_path(
+            source_path,
+            working_path,
+            filename="guest.qcow2",
+        )
+        raw_image_path = str(working_path / "guest.raw")
+        self.host_node.tools[QemuImg].convert(
+            "qcow2",
+            source_image_path,
+            "raw",
+            raw_image_path,
+        )
+        return raw_image_path
+
+    def resolve_guest_url_artifact_path(
+        self, source_url: str, working_path: PurePath, filename: str
+    ) -> str:
+        host_context = get_host_context(self.host_node)
+        url_id = hashlib.sha256(source_url.encode("utf-8")).hexdigest()[:8]
+        cache_directory = working_path.parent / ".openvmm-artifacts"
+        cache_filename = f"{url_id}-{filename}"
+        cache_key = f"url|{source_url}"
+
+        with host_context.artifact_copy_lock:
+            cached_path = host_context.artifact_cache.get(cache_key)
+            if cached_path:
+                check = self.host_node.execute(
+                    f"test -f {shlex.quote(cached_path)}",
+                    shell=True,
+                    expected_exit_code=None,
+                )
+                if check.exit_code != 0:
+                    cached_path = None
+                    del host_context.artifact_cache[cache_key]
+
+            if not cached_path:
+                downloaded_path = self.host_node.tools[Wget].get(
+                    source_url,
+                    file_path=str(cache_directory),
+                    filename=cache_filename,
+                    force_run=True,
+                )
+                if not downloaded_path:
+                    raise LisaException(
+                        f"failed to download OpenVMM artifact from '{source_url}'"
+                    )
+                cached_path = cast(str, downloaded_path)
+                host_context.artifact_cache[cache_key] = cached_path
+
+        destination = working_path / filename
+        self.host_node.execute(
+            f"cp --reflink=auto {shlex.quote(cached_path)} "
+            f"{shlex.quote(str(destination))}",
+            shell=True,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                f"failed to copy cached OpenVMM URL artifact to '{destination}'"
+            ),
+        )
+        return str(destination)
+
     def get_openvmm_tool(self, binary_path: str) -> OpenVmm:
         openvmm = cast(OpenVmm, OpenVmm.create(self.host_node))
         openvmm.initialize()
@@ -391,6 +509,137 @@ class OpenVmmController:
                 "Verify the host has enough free space and supports sparse files."
             ),
         )
+
+    def prepare_raw_disk_kernel_command_line(
+        self,
+        disk_image_path: str,
+        working_path: PurePath,
+        kernel_command_line_args: List[str],
+    ) -> str:
+        if not kernel_command_line_args:
+            return disk_image_path
+        if not _is_raw_disk_image(disk_image_path):
+            raise LisaException(
+                "OpenVMM kernel_command_line_args require a raw guest disk image. "
+                f"Received '{disk_image_path}'."
+            )
+
+        source_path = PurePosixPath(disk_image_path)
+        destination = working_path / (
+            f"{source_path.stem}-kernel-args{source_path.suffix}"
+        )
+        quoted_source = shlex.quote(disk_image_path)
+        quoted_destination = shlex.quote(str(destination))
+        copy_result = self.host_node.execute(
+            (
+                "cp --reflink=auto --sparse=always -- "
+                f"{quoted_source} {quoted_destination}"
+            ),
+            shell=True,
+            sudo=True,
+            expected_exit_code=None,
+        )
+        if copy_result.exit_code != 0:
+            self.host_node.execute(
+                f"cp -f --sparse=always -- {quoted_source} {quoted_destination}",
+                shell=True,
+                sudo=True,
+                expected_exit_code=0,
+                expected_exit_code_failure_message=(
+                    "failed to create a private OpenVMM guest disk copy for "
+                    "kernel command-line updates"
+                ),
+            )
+
+        quoted_kernel_args = " ".join(
+            shlex.quote(kernel_arg) for kernel_arg in kernel_command_line_args
+        )
+        update_script = f"""
+set -eu
+loop_device=
+mount_dir=
+
+cleanup() {{
+    set +e
+    if [ -n "$mount_dir" ] && mountpoint -q "$mount_dir"; then
+        umount "$mount_dir"
+    fi
+    if [ -n "$loop_device" ]; then
+        losetup -d "$loop_device"
+    fi
+    if [ -n "$mount_dir" ]; then
+        rmdir "$mount_dir"
+    fi
+}}
+trap cleanup EXIT
+
+loop_device=$(losetup --find --show --partscan {quoted_destination})
+mount_dir=$(mktemp -d)
+modified=0
+
+for partition in "${{loop_device}}"p*; do
+    [ -b "$partition" ] || continue
+    fs_type=$(blkid -o value -s TYPE "$partition" 2>/dev/null || true)
+    case "$fs_type" in
+        ext2|ext3|ext4) ;;
+        *) continue ;;
+    esac
+
+    if ! mount "$partition" "$mount_dir"; then
+        continue
+    fi
+
+    for grub_cfg in \
+        "$mount_dir/grub/grub.cfg" \
+        "$mount_dir/boot/grub/grub.cfg"; do
+        [ -f "$grub_cfg" ] || continue
+        for kernel_arg in {quoted_kernel_args}; do
+            temp_cfg="$grub_cfg.lisa.tmp"
+            awk -v arg="$kernel_arg" '
+                /^[[:space:]]*linux[[:space:]]/ {{
+                    found = 0
+                    for (i = 1; i <= NF; i++) {{
+                        if ($i == arg) {{
+                            found = 1
+                            break
+                        }}
+                    }}
+                    if (!found) {{
+                        $0 = $0 " " arg
+                    }}
+                }}
+                {{ print }}
+            ' "$grub_cfg" > "$temp_cfg"
+            cat "$temp_cfg" > "$grub_cfg"
+            rm -f "$temp_cfg"
+        done
+        modified=1
+    done
+
+    umount "$mount_dir"
+done
+
+if [ "$modified" -eq 0 ]; then
+    echo "No GRUB configuration was found in {quoted_destination}." >&2
+    exit 1
+fi
+"""
+        self.host_node.execute(
+            f"bash -c {shlex.quote(update_script)}",
+            shell=True,
+            sudo=True,
+            timeout=300,
+            expected_exit_code=0,
+            expected_exit_code_failure_message=(
+                "failed to apply OpenVMM guest kernel command-line arguments "
+                f"{kernel_command_line_args} to '{destination}'"
+            ),
+        )
+        self._log.info(
+            "Applied OpenVMM guest kernel command-line arguments "
+            f"{kernel_command_line_args} to '{destination}'."
+        )
+        return str(destination)
 
     def create_effective_network(
         self, network: OpenVmmNetworkSchema, guest_index: int
@@ -737,14 +986,105 @@ class OpenVmmController:
                     f"{restore_error}"
                 )
 
+    def _host_has_kvm_device(self) -> bool:
+        return (
+            self.host_node.execute(
+                "test -c /dev/kvm",
+                shell=True,
+                sudo=True,
+                no_info_log=True,
+                no_error_log=True,
+                expected_exit_code=None,
+            ).exit_code
+            == 0
+        )
+
+    def _ensure_kvm_ready(self) -> None:
+        host_context = get_host_context(self.host_node)
+        with host_context.hypervisor_prepare_lock:
+            if host_context.prepared_hypervisor == OPENVMM_HYPERVISOR_KVM:
+                return
+            if not self._host_has_kvm_device():
+                self._load_kvm_modules()
+                if not self._host_has_kvm_device():
+                    raise LisaException(
+                        "OpenVMM KVM hypervisor requires /dev/kvm on the host, "
+                        "but it is not available after attempting to load the "
+                        "KVM kernel modules. Ensure hardware virtualization is "
+                        "enabled in firmware/BIOS, and that nested virtualization "
+                        "is enabled if this host is itself a VM."
+                    )
+            host_context.prepared_hypervisor = OPENVMM_HYPERVISOR_KVM
+
+    def _load_kvm_modules(self) -> None:
+        lscpu = self.host_node.tools[Lscpu]
+        modprobe = self.host_node.tools[Modprobe]
+        if lscpu.get_architecture() == CpuArchitecture.X64:
+            vendor_module = {
+                CpuType.Intel: "kvm_intel",
+                CpuType.AMD: "kvm_amd",
+            }.get(lscpu.get_cpu_type())
+            candidate_modules = [vendor_module] if vendor_module else ["kvm"]
+        else:
+            candidate_modules = ["kvm"]
+
+        for module in candidate_modules:
+            if not modprobe.module_exists(module):
+                continue
+            try:
+                modprobe.load(module)
+            except AssertionError:
+                self._log.debug(
+                    f"best-effort load of KVM kernel module '{module}' failed"
+                )
+
+    def _should_disable_vmbus(self, hypervisor: str) -> bool:
+        return (
+            hypervisor == OPENVMM_HYPERVISOR_KVM
+            and self.host_node.tools[Lscpu].get_architecture() == CpuArchitecture.ARM64
+        )
+
     def launch(self, node: "OpenVmmGuestNode", log: Logger) -> None:
         runbook = cast(OpenVmmGuestNodeSchema, node.runbook)
         node_context = get_node_context(node)
+        if runbook.hypervisor == OPENVMM_HYPERVISOR_KVM:
+            self._ensure_kvm_ready()
         network = self._get_node_network(node, node_context)
         self._prepare_tap_network(network, node_context)
+        self._launch_process(node, node_context, network, log)
+
+    def _launch_process(
+        self,
+        node: "OpenVmmGuestNode",
+        node_context: NodeContext,
+        network: OpenVmmNetworkSchema,
+        log: Logger,
+    ) -> None:
+        runbook = cast(OpenVmmGuestNodeSchema, node.runbook)
         processor_count = _countspace_to_int(node.capability.core_count)
+        restart_on_guest_reset = self._should_disable_vmbus(runbook.hypervisor)
+        node_context.restart_on_guest_reset = restart_on_guest_reset
+        create_vmgs = False
+        if restart_on_guest_reset:
+            create_vmgs = (
+                self.host_node.execute(
+                    f"test -f {shlex.quote(node_context.vmgs_file_path)}",
+                    shell=True,
+                    sudo=True,
+                    no_info_log=True,
+                    no_error_log=True,
+                    expected_exit_code=None,
+                ).exit_code
+                != 0
+            )
         launch_config = OpenVmmLaunchConfig(
             uefi_firmware_path=node_context.uefi_firmware_path,
+            with_hv=not restart_on_guest_reset,
+            hypervisor=runbook.hypervisor,
+            disable_vmbus=restart_on_guest_reset,
+            vmgs_path=(node_context.vmgs_file_path if restart_on_guest_reset else ""),
+            create_vmgs=create_vmgs,
+            exit_on_guest_reset=restart_on_guest_reset,
             disk_img_path=node_context.disk_img_path,
             disk_device=runbook.disk_device,
             iommu=runbook.iommu,
@@ -1284,7 +1624,14 @@ class OpenVmmController:
         node_context = get_node_context(node)
         network = self._get_node_network(cast(OpenVmmGuestNode, node), node_context)
 
-        guest_address = self._resolve_guest_address(node_context, network, log)
+        try:
+            guest_address = self._resolve_guest_address(node_context, network, log)
+        except LisaException:
+            if not self._restart_after_guest_reset(
+                cast(OpenVmmGuestNode, node), node_context, network, log
+            ):
+                raise
+            guest_address = self._resolve_guest_address(node_context, network, log)
         node_context.guest_address = guest_address
 
         address = guest_address
@@ -1294,6 +1641,7 @@ class OpenVmmController:
 
         proxy_jump_boxes = None
         if network.connection_mode == OPENVMM_CONNECTION_MODE_HOST_PROXY:
+            self._enable_ssh_forwarding(node_context, guest_address, network)
             self._wait_for_guest_ssh_from_host(
                 node_context, guest_address, network.ssh_port, log
             )
@@ -1856,9 +2204,12 @@ class OpenVmmController:
         node_context.working_path = ""
         node_context.uefi_firmware_path = ""
         node_context.disk_img_path = ""
+        node_context.vmgs_file_path = ""
         node_context.cloud_init_file_path = ""
         node_context.console_log_file_path = ""
         node_context.launcher_log_file_path = ""
+        node_context.restart_on_guest_reset = False
+        node_context.guest_reset_restart_count = 0
 
     def _get_host_public_address(self) -> str:
         if self.host_node.is_remote:
@@ -1948,17 +2299,24 @@ class OpenVmmController:
                     f"{shlex.quote(str(host_network))} -o "
                     f"{shlex.quote(forwarding_interface)} -j MASQUERADE",
                 ),
-                (
-                    "-t nat",
-                    f"PREROUTING -p tcp --dport {forwarded_port} "
-                    f"-j DNAT --to-destination {guest_address}:{guest_port}",
-                ),
-                (
-                    "-t nat",
-                    f"OUTPUT -p tcp --dport {forwarded_port} "
-                    f"-j DNAT --to-destination {guest_address}:{guest_port}",
-                ),
             ]
+            if network.forward_ssh_port:
+                rules.extend(
+                    [
+                        (
+                            "-t nat",
+                            f"PREROUTING -p tcp --dport {forwarded_port} "
+                            "-j DNAT --to-destination "
+                            f"{guest_address}:{guest_port}",
+                        ),
+                        (
+                            "-t nat",
+                            f"OUTPUT -p tcp --dport {forwarded_port} "
+                            "-j DNAT --to-destination "
+                            f"{guest_address}:{guest_port}",
+                        ),
+                    ]
+                )
 
             try:
                 self.host_node.execute(
@@ -2115,6 +2473,47 @@ class OpenVmmController:
             ),
             timeout=timeout,
         )
+
+    def _restart_after_guest_reset(
+        self,
+        node: "OpenVmmGuestNode",
+        node_context: NodeContext,
+        network: OpenVmmNetworkSchema,
+        log: Logger,
+    ) -> bool:
+        if (
+            not node_context.restart_on_guest_reset
+            or node_context.guest_reset_restart_count
+            >= OPENVMM_MAX_EXTERNAL_RESET_RESTARTS
+            or self._is_process_running(node_context.process_id)
+        ):
+            return False
+
+        reset_patterns = " ".join(
+            f"-e {shlex.quote(marker)}" for marker in OPENVMM_GUEST_RESET_LOG_MARKERS
+        )
+        reset_check = self.host_node.execute(
+            (
+                f"test -f {shlex.quote(node_context.launcher_log_file_path)} && "
+                f"grep -Fq {reset_patterns} -- "
+                f"{shlex.quote(node_context.launcher_log_file_path)}"
+            ),
+            shell=True,
+            sudo=True,
+            no_info_log=True,
+            no_error_log=True,
+            expected_exit_code=None,
+        )
+        if reset_check.exit_code != 0:
+            return False
+
+        node_context.guest_reset_restart_count += 1
+        log.info(
+            "Restarting OpenVMM after the guest-requested UEFI reset because "
+            "KVM/ARM64 does not support in-place partition reset."
+        )
+        self._launch_process(node, node_context, network, log)
+        return True
 
     def _is_process_running(self, process_id: str) -> bool:
         if not process_id:
@@ -2347,12 +2746,13 @@ class OpenVmmGuestNode(RemoteNode):
         base_working_path = host_node.get_pure_path(runbook.lisa_working_dir)
         working_path = base_working_path / vm_name
         node_context.working_path = str(working_path)
+        node_context.vmgs_file_path = str(working_path / "openvmm.vmgs")
         host_node.tools[Mkdir].create_directory(str(working_path))
 
         if runbook.uefi is None:
             raise LisaException("UEFI settings must be defined for OpenVMM guests")
         node_context.uefi_firmware_path = (
-            self._openvmm_controller.resolve_guest_artifact_path(
+            self._openvmm_controller.prepare_uefi_firmware_path(
                 runbook.uefi.firmware_path,
                 runbook.uefi.firmware_is_remote_path,
                 working_path,
@@ -2361,12 +2761,20 @@ class OpenVmmGuestNode(RemoteNode):
 
         if runbook.disk_img:
             node_context.disk_img_path = (
-                self._openvmm_controller.resolve_guest_artifact_path(
+                self._openvmm_controller.prepare_disk_image_path(
                     runbook.disk_img,
                     runbook.disk_img_is_remote_path,
                     working_path,
                 )
             )
+            if runbook.kernel_command_line_args:
+                node_context.disk_img_path = (
+                    self._openvmm_controller.prepare_raw_disk_kernel_command_line(
+                        node_context.disk_img_path,
+                        working_path,
+                        runbook.kernel_command_line_args,
+                    )
+                )
             if runbook.min_raw_disk_size_gb > 0 and _is_raw_disk_image(
                 node_context.disk_img_path
             ):

--- a/lisa/sut_orchestrator/openvmm/schema.py
+++ b/lisa/sut_orchestrator/openvmm/schema.py
@@ -17,6 +17,7 @@ from lisa.sut_orchestrator.util.schema import (
     HostDevicePoolSchema,
 )
 from lisa.tools.openvmm import (
+    OPENVMM_DISK_DEVICE_NVME,
     OPENVMM_DISK_DEVICE_SCSI,
     OPENVMM_DISK_DEVICE_VIRTIO_BLK,
     OPENVMM_IOMMU_AMD,
@@ -33,6 +34,8 @@ from lisa.util import LisaException
 from .. import OPENVMM
 
 OPENVMM_BOOT_MODE_UEFI = "uefi"
+OPENVMM_HYPERVISOR_KVM = "kvm"
+OPENVMM_HYPERVISOR_MSHV = "mshv"
 OPENVMM_ADDRESS_MODE_DISCOVER = "discover"
 OPENVMM_ADDRESS_MODE_STATIC = "static"
 OPENVMM_NETWORK_MODE_USER = "user"
@@ -295,6 +298,7 @@ class OpenVmmDevicePassthroughSchema(DevicePassthroughSchema):
 @dataclass
 class OpenVmmGuestNodeSchema(schema.GuestNode):
     type: str = OPENVMM
+    hypervisor: str = OPENVMM_HYPERVISOR_MSHV
     username: str = "root"
     password: str = field(
         default="", repr=False, metadata=config(exclude=lambda x: True)
@@ -306,6 +310,7 @@ class OpenVmmGuestNodeSchema(schema.GuestNode):
     uefi: Optional[OpenVmmUefiSchema] = None
     disk_img: str = ""
     disk_img_is_remote_path: bool = False
+    kernel_command_line_args: List[str] = field(default_factory=list)
     disk_device: str = OPENVMM_DISK_DEVICE_SCSI
     iommu: str = OPENVMM_IOMMU_NONE
     vps_per_socket: Optional[int] = field(
@@ -338,6 +343,15 @@ class OpenVmmGuestNodeSchema(schema.GuestNode):
         add_secret(self.username, PATTERN_HEADTAIL)
         add_secret(self.password)
         add_secret(self.private_key_file)
+        if self.hypervisor not in [
+            OPENVMM_HYPERVISOR_KVM,
+            OPENVMM_HYPERVISOR_MSHV,
+        ]:
+            raise LisaException(
+                f"hypervisor '{self.hypervisor}' is not supported for OpenVMM "
+                f"guests. Supported values: {OPENVMM_HYPERVISOR_KVM}, "
+                f"{OPENVMM_HYPERVISOR_MSHV}"
+            )
         if self.boot_mode != OPENVMM_BOOT_MODE_UEFI:
             raise LisaException(
                 f"boot mode '{self.boot_mode}' is not supported. "
@@ -349,13 +363,21 @@ class OpenVmmGuestNodeSchema(schema.GuestNode):
             )
         if not self.disk_img:
             raise LisaException("disk_img is required for UEFI OpenVMM guests")
+        for kernel_arg in self.kernel_command_line_args:
+            if not kernel_arg or any(character.isspace() for character in kernel_arg):
+                raise LisaException(
+                    "OpenVMM kernel_command_line_args entries must be non-empty "
+                    f"single tokens without whitespace: '{kernel_arg}'"
+                )
         if self.disk_device not in [
+            OPENVMM_DISK_DEVICE_NVME,
             OPENVMM_DISK_DEVICE_SCSI,
             OPENVMM_DISK_DEVICE_VIRTIO_BLK,
         ]:
             raise LisaException(
                 f"disk device '{self.disk_device}' is not supported for OpenVMM "
-                f"guests. Supported values: {OPENVMM_DISK_DEVICE_SCSI}, "
+                f"guests. Supported values: {OPENVMM_DISK_DEVICE_NVME}, "
+                f"{OPENVMM_DISK_DEVICE_SCSI}, "
                 f"{OPENVMM_DISK_DEVICE_VIRTIO_BLK}"
             )
         if self.iommu not in [

--- a/lisa/tools/openvmm.py
+++ b/lisa/tools/openvmm.py
@@ -13,7 +13,9 @@ from lisa.util import LisaException
 VERSION_PATTERN = re.compile(r"openvmm(?:\.exe)?\s+(?P<version>.+)")
 
 OPENVMM_NETWORK_BACKEND_CONSOMME = "consomme"
+OPENVMM_DEFAULT_NVME_CONTROLLER = "lisa_nvme0"
 OPENVMM_DEFAULT_SCSI_CONTROLLER = "lisa_scsi0"
+OPENVMM_DISK_DEVICE_NVME = "nvme"
 OPENVMM_DISK_DEVICE_SCSI = "scsi"
 OPENVMM_DISK_DEVICE_VIRTIO_BLK = "virtio-blk"
 OPENVMM_IOMMU_AMD = "amd-iommu"
@@ -26,6 +28,7 @@ OPENVMM_SMT_FORCE = "force"
 OPENVMM_SMT_OFF = "off"
 OPENVMM_VIRTIO_ROOT_COMPLEX = "lisa_virtio_rc0"
 OPENVMM_VIRTIO_DISK_PORT = "lisa_virtio_disk"
+OPENVMM_VIRTIO_DVD_PORT_PREFIX = "lisa_virtio_dvd"
 OPENVMM_VIRTIO_NETWORK_PORT = "lisa_virtio_net"
 
 _COMMAND_NOT_FOUND_MARKERS = (
@@ -49,6 +52,10 @@ class OpenVmmLaunchConfig:
     uefi_firmware_path: str
     with_hv: bool = True
     hypervisor: str = "mshv"
+    disable_vmbus: bool = False
+    vmgs_path: str = ""
+    create_vmgs: bool = False
+    exit_on_guest_reset: bool = False
     disk_img_path: str = ""
     disk_device: str = OPENVMM_DISK_DEVICE_SCSI
     iommu: str = OPENVMM_IOMMU_NONE
@@ -119,6 +126,8 @@ class OpenVmm(Tool):
             args.append("--hv")
         if config.hypervisor:
             args.extend(["--hypervisor", config.hypervisor])
+        if config.disable_vmbus:
+            args.append("--no-vmbus")
         self._validate_processor_topology(config)
         args.extend(["--processors", str(config.processors)])
         if config.vps_per_socket is not None:
@@ -131,6 +140,13 @@ class OpenVmm(Tool):
             raise LisaException("uefi_firmware_path must be provided for UEFI boot")
         args.append("--uefi")
         args.extend(["--uefi-firmware", config.uefi_firmware_path])
+        if config.vmgs_path:
+            vmgs_disk = f"file:{config.vmgs_path}"
+            if config.create_vmgs:
+                vmgs_disk = f"{vmgs_disk};create=VMGS_DEFAULT"
+            args.extend(["--vmgs", f"{vmgs_disk},fmt-on-fail"])
+        if config.exit_on_guest_reset:
+            args.extend(["--guest-reset-action", "exit"])
 
         self._validate_device_types(config)
         self._add_pcie_args(args, config)
@@ -169,6 +185,7 @@ class OpenVmm(Tool):
 
     def _validate_device_types(self, config: OpenVmmLaunchConfig) -> None:
         if config.disk_device not in [
+            OPENVMM_DISK_DEVICE_NVME,
             OPENVMM_DISK_DEVICE_SCSI,
             OPENVMM_DISK_DEVICE_VIRTIO_BLK,
         ]:
@@ -195,13 +212,23 @@ class OpenVmm(Tool):
             OPENVMM_IOMMU_AMD,
         ]:
             raise LisaException(f"Unsupported OpenVMM IOMMU: {config.iommu}")
+        if config.disable_vmbus and (
+            config.disk_device
+            not in [OPENVMM_DISK_DEVICE_NVME, OPENVMM_DISK_DEVICE_VIRTIO_BLK]
+            or config.network_device != OPENVMM_NETWORK_DEVICE_VIRTIO
+        ):
+            raise LisaException(
+                "OpenVMM no-VMBus mode requires an NVMe or virtio-blk disk and "
+                "virtio network devices"
+            )
 
     def _add_pcie_args(self, args: List[str], config: OpenVmmLaunchConfig) -> None:
-        use_virtio_disk = bool(config.disk_img_path) and (
-            config.disk_device == OPENVMM_DISK_DEVICE_VIRTIO_BLK
+        use_pcie_disk = bool(config.disk_img_path) and (
+            config.disk_device
+            in [OPENVMM_DISK_DEVICE_NVME, OPENVMM_DISK_DEVICE_VIRTIO_BLK]
         )
         use_virtio_network = config.network_device == OPENVMM_NETWORK_DEVICE_VIRTIO
-        if use_virtio_disk or use_virtio_network:
+        if use_pcie_disk or use_virtio_network or config.disable_vmbus:
             args.extend(["--pcie-root-complex", OPENVMM_VIRTIO_ROOT_COMPLEX])
             if config.iommu != OPENVMM_IOMMU_NONE:
                 args.extend([f"--{config.iommu}", OPENVMM_VIRTIO_ROOT_COMPLEX])
@@ -209,7 +236,7 @@ class OpenVmm(Tool):
             raise LisaException(
                 "OpenVMM IOMMU requires a virtio disk or network device on PCIe"
             )
-        if use_virtio_disk:
+        if use_pcie_disk:
             args.extend(
                 [
                     "--pcie-root-port",
@@ -226,9 +253,18 @@ class OpenVmm(Tool):
                     network_root_port,
                 ]
             )
+        if config.disable_vmbus:
+            for index, _ in enumerate(config.dvd_disk_paths):
+                args.extend(
+                    [
+                        "--pcie-root-port",
+                        f"{OPENVMM_VIRTIO_ROOT_COMPLEX}:"
+                        f"{OPENVMM_VIRTIO_DVD_PORT_PREFIX}{index}",
+                    ]
+                )
 
     def _add_disk_args(self, args: List[str], config: OpenVmmLaunchConfig) -> None:
-        if config.dvd_disk_paths or (
+        if (config.dvd_disk_paths and not config.disable_vmbus) or (
             config.disk_img_path and config.disk_device == OPENVMM_DISK_DEVICE_SCSI
         ):
             args.extend(["--vmbus-scsi", f"id={OPENVMM_DEFAULT_SCSI_CONTROLLER}"])
@@ -242,6 +278,17 @@ class OpenVmm(Tool):
                         f"on={OPENVMM_DEFAULT_SCSI_CONTROLLER},lun=0",
                     ]
                 )
+            elif config.disk_device == OPENVMM_DISK_DEVICE_NVME:
+                args.extend(
+                    [
+                        "--nvme-pci",
+                        f"id={OPENVMM_DEFAULT_NVME_CONTROLLER},"
+                        f"pcie_port={OPENVMM_VIRTIO_DISK_PORT}",
+                        "--disk",
+                        f"file:{config.disk_img_path},"
+                        f"on={OPENVMM_DEFAULT_NVME_CONTROLLER}",
+                    ]
+                )
             else:
                 args.extend(
                     [
@@ -251,14 +298,23 @@ class OpenVmm(Tool):
                     ]
                 )
 
-        for lun, dvd_disk_path in enumerate(config.dvd_disk_paths, start=1):
-            args.extend(
-                [
-                    "--disk",
-                    f"file:{dvd_disk_path},on={OPENVMM_DEFAULT_SCSI_CONTROLLER},"
-                    f"lun={lun},dvd",
-                ]
-            )
+        for index, dvd_disk_path in enumerate(config.dvd_disk_paths):
+            if config.disable_vmbus:
+                args.extend(
+                    [
+                        "--virtio-blk",
+                        f"file:{dvd_disk_path},ro,"
+                        f"pcie_port={OPENVMM_VIRTIO_DVD_PORT_PREFIX}{index}",
+                    ]
+                )
+            else:
+                args.extend(
+                    [
+                        "--disk",
+                        f"file:{dvd_disk_path},"
+                        f"on={OPENVMM_DEFAULT_SCSI_CONTROLLER},lun={index + 1},dvd",
+                    ]
+                )
 
     def _get_network_backend(self, config: OpenVmmLaunchConfig) -> str:
         if config.network_mode == "user":

--- a/selftests/test_openvmm_installer.py
+++ b/selftests/test_openvmm_installer.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 from types import SimpleNamespace
 from typing import Any, Dict, List, Type, cast
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from lisa.sut_orchestrator.openvmm.installer import OpenVmmSourceInstaller
 from lisa.sut_orchestrator.openvmm.schema import OpenVmmSourceInstallerSchema
@@ -82,10 +82,18 @@ class OpenVmmInstallerTestCase(TestCase):
             log=MagicMock(),
         )
 
-        version = installer.install()
+        with patch("lisa.sut_orchestrator.openvmm.installer.Ubuntu", Ubuntu):
+            version = installer.install()
 
         self.assertEqual("openvmm 1.0.0", version)
         self.assertTrue(package_installs)
+        needrestart_call = next(
+            command
+            for command in executed_commands
+            if "99-lisa-openvmm.conf" in command["command"]
+        )
+        self.assertIn("$nrconf{restart}", needrestart_call["command"])
+        self.assertTrue(needrestart_call["sudo"])
         restore_call = next(
             command
             for command in executed_commands

--- a/selftests/test_openvmm_node.py
+++ b/selftests/test_openvmm_node.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from importlib import import_module
 from pathlib import Path, PurePath, PurePosixPath
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from typing import Any, Tuple, cast
+from typing import Any, Dict, Tuple, cast
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +20,7 @@ from lisa.sut_orchestrator.openvmm.node import OpenVmmController, OpenVmmGuestNo
 from lisa.sut_orchestrator.openvmm.schema import (
     OPENVMM_ADDRESS_MODE_STATIC,
     OPENVMM_CONNECTION_MODE_HOST_PROXY,
+    OPENVMM_HYPERVISOR_KVM,
     OPENVMM_NETWORK_MODE_TAP,
     OpenVmmGuestNodeSchema,
     OpenVmmNetworkSchema,
@@ -26,7 +30,7 @@ from lisa.sut_orchestrator.openvmm.schema import (
 from lisa.sut_orchestrator.openvmm.serial_console import (
     SerialConsole as OpenVmmSerialConsole,
 )
-from lisa.tools import Cat, Ip, Kill, Mkdir
+from lisa.tools import Cat, Ip, Kill, Mkdir, QemuImg, Tar, Wget
 from lisa.tools.openvmm import (
     OPENVMM_DISK_DEVICE_SCSI,
     OPENVMM_IOMMU_NONE,
@@ -102,6 +106,123 @@ class OpenVmmNodeTestCase(TestCase):
         self.assertNotEqual(first_destination, second_destination)
         self.assertEqual(1, shell_copy.call_count)
 
+    def test_prepare_uefi_firmware_path_downloads_and_extracts_url(self) -> None:
+        controller, _, _, _ = self._create_controller()
+        wget = MagicMock()
+        wget.get.return_value = "/var/tmp/openvmm/uefi.tar.gz"
+        tar = MagicMock()
+        cast(Dict[Any, Any], controller.host_node.tools).update({Wget: wget, Tar: tar})
+
+        firmware_path = controller.prepare_uefi_firmware_path(
+            "https://example.test/uefi.tar.gz",
+            is_remote_path=False,
+            working_path=PurePosixPath("/var/tmp/openvmm"),
+        )
+
+        self.assertEqual("/var/tmp/openvmm/FV/MSVM.fd", firmware_path)
+        wget.get.assert_called_once_with(
+            "https://example.test/uefi.tar.gz",
+            file_path="/var/tmp/.openvmm-artifacts",
+            filename="9d88242b-uefi.tar.gz",
+            force_run=True,
+        )
+        tar.extract.assert_called_once_with(
+            "/var/tmp/openvmm/uefi.tar.gz",
+            "/var/tmp/openvmm",
+            gzip=True,
+        )
+
+    def test_prepare_disk_image_path_downloads_and_converts_url(self) -> None:
+        controller, _, _, _ = self._create_controller()
+        wget = MagicMock()
+        wget.get.return_value = "/var/tmp/openvmm/guest.qcow2"
+        qemu_img = MagicMock()
+        cast(Dict[Any, Any], controller.host_node.tools).update(
+            {Wget: wget, QemuImg: qemu_img}
+        )
+
+        disk_path = controller.prepare_disk_image_path(
+            "https://example.test/guest.img",
+            is_remote_path=False,
+            working_path=PurePosixPath("/var/tmp/openvmm"),
+        )
+
+        self.assertEqual("/var/tmp/openvmm/guest.raw", disk_path)
+        wget.get.assert_called_once_with(
+            "https://example.test/guest.img",
+            file_path="/var/tmp/.openvmm-artifacts",
+            filename="d0c6a634-guest.qcow2",
+            force_run=True,
+        )
+        qemu_img.convert.assert_called_once_with(
+            "qcow2",
+            "/var/tmp/openvmm/guest.qcow2",
+            "raw",
+            "/var/tmp/openvmm/guest.raw",
+        )
+
+    def test_resolve_guest_url_artifact_path_reuses_concurrent_download(self) -> None:
+        controller, _, _, _ = self._create_controller()
+        wget = MagicMock()
+        wget.get.return_value = "/var/tmp/.openvmm-artifacts/cached.qcow2"
+        cast(Dict[Any, Any], controller.host_node.tools).update({Wget: wget})
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            destinations = list(
+                executor.map(
+                    lambda guest: controller.resolve_guest_url_artifact_path(
+                        "https://example.test/guest.img",
+                        PurePosixPath(f"/var/tmp/openvmm/{guest}"),
+                        "guest.qcow2",
+                    ),
+                    ("g0", "g1"),
+                )
+            )
+
+        self.assertEqual(
+            [
+                "/var/tmp/openvmm/g0/guest.qcow2",
+                "/var/tmp/openvmm/g1/guest.qcow2",
+            ],
+            destinations,
+        )
+        wget.get.assert_called_once()
+
+    def test_device_pool_module_does_not_require_libvirt_python(self) -> None:
+        module_name = "lisa.sut_orchestrator.libvirt.libvirt_device_pool"
+        previous_module = sys.modules.pop(module_name, None)
+        try:
+            with patch.dict(sys.modules, {"libvirt": None}):
+                device_pool_module = import_module(module_name)
+
+            self.assertTrue(hasattr(device_pool_module, "LibvirtDevicePool"))
+        finally:
+            sys.modules.pop(module_name, None)
+            if previous_module:
+                sys.modules[module_name] = previous_module
+
+    def test_prepare_raw_disk_kernel_command_line_uses_private_copy(self) -> None:
+        controller, _, _, _ = self._create_controller()
+
+        destination = controller.prepare_raw_disk_kernel_command_line(
+            "/var/tmp/.openvmm-artifacts/guest.raw",
+            PurePosixPath("/var/tmp/openvmm/g0"),
+            ["initcall_blacklist=hyperv_init"],
+        )
+
+        self.assertEqual(
+            "/var/tmp/openvmm/g0/guest-kernel-args.raw",
+            destination,
+        )
+        commands = [
+            call.args[0]
+            for call in cast(MagicMock, controller.host_node.execute).call_args_list
+        ]
+        self.assertIn("cp --reflink=auto --sparse=always", commands[0])
+        self.assertIn("losetup --find --show --partscan", commands[1])
+        self.assertIn("initcall_blacklist=hyperv_init", commands[1])
+        self.assertIn("/grub/grub.cfg", commands[1])
+
     def test_stop_node_kills_process_after_wait_timeout(self) -> None:
         controller, _, kill_by_pid, guest_log = self._create_controller()
         node = SimpleNamespace(
@@ -137,6 +258,7 @@ class OpenVmmNodeTestCase(TestCase):
         node = SimpleNamespace(
             runbook=SimpleNamespace(
                 openvmm_binary="/usr/local/bin/openvmm",
+                hypervisor=OPENVMM_HYPERVISOR_KVM,
                 disk_device=OPENVMM_DISK_DEVICE_SCSI,
                 iommu=OPENVMM_IOMMU_NONE,
                 vps_per_socket=None,
@@ -165,7 +287,9 @@ class OpenVmmNodeTestCase(TestCase):
         with patch.object(controller, "get_openvmm_tool", return_value=openvmm), patch(
             "lisa.sut_orchestrator.openvmm.node.get_node_context",
             return_value=node_context,
-        ), patch.object(controller, "_ensure_process_running"):
+        ), patch.object(controller, "_ensure_process_running"), patch.object(
+            controller, "_should_disable_vmbus", return_value=False
+        ):
             controller.launch(cast(Any, node), cast(Any, node.log))
 
         openvmm.launch_vm.assert_called_once_with(
@@ -174,9 +298,52 @@ class OpenVmmNodeTestCase(TestCase):
             sudo=False,
         )
         launch_config = openvmm.launch_vm.call_args.args[0]
+        self.assertEqual(OPENVMM_HYPERVISOR_KVM, launch_config.hypervisor)
+        cast(MagicMock, controller.host_node.execute).assert_any_call(
+            "test -c /dev/kvm",
+            shell=True,
+            sudo=True,
+            no_info_log=True,
+            no_error_log=True,
+            expected_exit_code=None,
+        )
         self.assertEqual(OPENVMM_DISK_DEVICE_SCSI, launch_config.disk_device)
         self.assertEqual(OPENVMM_NETWORK_DEVICE_SYNTHETIC, launch_config.network_device)
         self.assertEqual(1, launch_config.network_queue_count)
+
+    def test_restart_after_guest_reset_relaunches_once(self) -> None:
+        controller, _, _, _ = self._create_controller()
+        node = SimpleNamespace(log=MagicMock())
+        node_context = NodeContext(
+            process_id="1234",
+            launcher_log_file_path="/var/tmp/openvmm-launcher.log",
+            restart_on_guest_reset=True,
+        )
+        network = OpenVmmNetworkSchema()
+
+        with patch.object(
+            controller, "_is_process_running", return_value=False
+        ), patch.object(controller, "_launch_process") as launch_process:
+            restarted = controller._restart_after_guest_reset(
+                cast(Any, node), node_context, network, cast(Any, node.log)
+            )
+
+        self.assertTrue(restarted)
+        self.assertEqual(1, node_context.guest_reset_restart_count)
+        reset_command = cast(MagicMock, controller.host_node.execute).call_args.args[0]
+        self.assertIn("guest halted reason=Reset", reset_command)
+        self.assertIn("guest-initiated reset", reset_command)
+        launch_process.assert_called_once_with(node, node_context, network, node.log)
+
+        with patch.object(
+            controller, "_is_process_running", return_value=False
+        ), patch.object(controller, "_launch_process") as launch_process:
+            restarted = controller._restart_after_guest_reset(
+                cast(Any, node), node_context, network, cast(Any, node.log)
+            )
+
+        self.assertFalse(restarted)
+        launch_process.assert_not_called()
 
     def test_create_effective_network_derives_unique_tap_settings(self) -> None:
         controller, _, _, _ = self._create_controller()
@@ -530,16 +697,51 @@ class OpenVmmNodeTestCase(TestCase):
         ), patch.object(
             controller, "_resolve_guest_address", return_value="10.0.0.2"
         ), patch.object(
+            controller, "_enable_ssh_forwarding"
+        ) as enable_forwarding, patch.object(
             controller, "_wait_for_guest_ssh_from_host"
         ) as wait_from_host:
             controller.configure_connection(cast(Any, node), MagicMock())
 
+        enable_forwarding.assert_called_once_with(
+            node_context,
+            "10.0.0.2",
+            network,
+        )
         wait_from_host.assert_called_once()
         node.set_connection_info.assert_called_once()
         kwargs = node.set_connection_info.call_args.kwargs
         self.assertEqual("10.0.0.2", kwargs["address"])
         self.assertFalse(kwargs["use_public_address"])
         self.assertEqual([host_connection], kwargs["proxy_jump_boxes"])
+
+    def test_host_proxy_forwarding_enables_egress_without_ssh_dnat(self) -> None:
+        def _execute(command: str, *args: Any, **kwargs: Any) -> Any:
+            if command.startswith("iptables") and " -C " in command:
+                return SimpleNamespace(exit_code=1, stderr="", stdout="")
+            return SimpleNamespace(exit_code=0, stderr="", stdout="0")
+
+        host_node = SimpleNamespace(
+            is_remote=True,
+            execute=MagicMock(side_effect=_execute),
+            tools={Ip: SimpleNamespace(get_default_route_info=lambda: ("eth0", ""))},
+        )
+        controller = OpenVmmController(cast(Any, host_node), MagicMock())
+        node_context = NodeContext(guest_address="10.0.0.2", ssh_port=22)
+        network = OpenVmmNetworkSchema(
+            mode=OPENVMM_NETWORK_MODE_TAP,
+            connection_mode=OPENVMM_CONNECTION_MODE_HOST_PROXY,
+            tap_name="tap0",
+            bridge_name="ovmbr0",
+            tap_host_cidr="10.0.0.1/24",
+        )
+
+        controller._enable_ssh_forwarding(node_context, "10.0.0.2", network)
+
+        commands = [call.args[0] for call in host_node.execute.call_args_list]
+        self.assertTrue(any("POSTROUTING" in command for command in commands))
+        self.assertTrue(any("MASQUERADE" in command for command in commands))
+        self.assertFalse(any("DNAT" in command for command in commands))
 
     def test_create_node_cloud_init_iso_skips_root_resize_for_non_raw_disk(
         self,
@@ -601,10 +803,8 @@ class OpenVmmNodeTestCase(TestCase):
         )
         controller = MagicMock()
         controller.get_openvmm_tool.return_value = SimpleNamespace(exists=True)
-        controller.resolve_guest_artifact_path.side_effect = [
-            "/var/tmp/host-g0/MSVM.fd",
-            "/var/tmp/host-g0/guest.img",
-        ]
+        controller.prepare_uefi_firmware_path.return_value = "/var/tmp/host-g0/MSVM.fd"
+        controller.prepare_disk_image_path.return_value = "/var/tmp/host-g0/guest.img"
         node = SimpleNamespace(
             parent=host_node,
             name="g0",

--- a/selftests/test_openvmm_schema.py
+++ b/selftests/test_openvmm_schema.py
@@ -8,18 +8,45 @@ from marshmallow import ValidationError
 
 from lisa.sut_orchestrator.openvmm.schema import (
     OPENVMM_CONNECTION_MODE_HOST_PROXY,
+    OPENVMM_HYPERVISOR_KVM,
+    OPENVMM_HYPERVISOR_MSHV,
     OPENVMM_NETWORK_MODE_TAP,
     OPENVMM_NETWORK_MODE_USER,
     OpenVmmGuestNodeSchema,
     OpenVmmNetworkSchema,
 )
 from lisa.tools.openvmm import (
+    OPENVMM_DISK_DEVICE_NVME,
     OPENVMM_DISK_DEVICE_VIRTIO_BLK,
     OPENVMM_NETWORK_DEVICE_VIRTIO,
 )
+from lisa.util import LisaException
 
 
 class OpenVmmSchemaTestCase(TestCase):
+    def test_guest_schema_accepts_kvm_hypervisor(self) -> None:
+        guest_schema = cast(Any, OpenVmmGuestNodeSchema).schema()
+        guest = guest_schema.load(
+            {
+                "hypervisor": OPENVMM_HYPERVISOR_KVM,
+                "uefi": {"firmware_path": "/firmware"},
+                "disk_img": "/disk.raw",
+            }
+        )
+
+        self.assertEqual(OPENVMM_HYPERVISOR_KVM, guest.hypervisor)
+
+    def test_guest_schema_defaults_to_mshv_hypervisor(self) -> None:
+        guest_schema = cast(Any, OpenVmmGuestNodeSchema).schema()
+        guest = guest_schema.load(
+            {
+                "uefi": {"firmware_path": "/firmware"},
+                "disk_img": "/disk.raw",
+            }
+        )
+
+        self.assertEqual(OPENVMM_HYPERVISOR_MSHV, guest.hypervisor)
+
     def test_network_schema_accepts_valid_ssh_port(self) -> None:
         network_schema = cast(Any, OpenVmmNetworkSchema).schema()
         network = network_schema.load(
@@ -79,6 +106,29 @@ class OpenVmmSchemaTestCase(TestCase):
 
         self.assertEqual(OPENVMM_DISK_DEVICE_VIRTIO_BLK, guest.disk_device)
         self.assertEqual(OPENVMM_NETWORK_DEVICE_VIRTIO, guest.network.device)
+
+    def test_guest_schema_accepts_nvme_disk(self) -> None:
+        guest_schema = cast(Any, OpenVmmGuestNodeSchema).schema()
+        guest = guest_schema.load(
+            {
+                "uefi": {"firmware_path": "/firmware"},
+                "disk_img": "/disk.raw",
+                "disk_device": OPENVMM_DISK_DEVICE_NVME,
+            }
+        )
+
+        self.assertEqual(OPENVMM_DISK_DEVICE_NVME, guest.disk_device)
+
+    def test_guest_schema_rejects_kernel_arg_with_whitespace(self) -> None:
+        guest_schema = cast(Any, OpenVmmGuestNodeSchema).schema()
+        with self.assertRaises(LisaException):
+            guest_schema.load(
+                {
+                    "uefi": {"firmware_path": "/firmware"},
+                    "disk_img": "/disk.raw",
+                    "kernel_command_line_args": ["console=ttyAMA0 earlycon"],
+                }
+            )
 
     def test_host_proxy_connection_mode_disables_forwarded_port(self) -> None:
         network_schema = cast(Any, OpenVmmNetworkSchema).schema()

--- a/selftests/test_openvmm_tests_suite.py
+++ b/selftests/test_openvmm_tests_suite.py
@@ -12,7 +12,7 @@ from lisa.microsoft.testsuites.openvmm.openvmm_tests import (
     _get_openvmm_tests_type,
 )
 from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import _JUnitSummary
-from lisa.operating_system import CBLMariner
+from lisa.operating_system import CBLMariner, CpuArchitecture
 from lisa.tools import Ls, Lscpu, Uname
 from lisa.tools.usermod import Usermod
 from lisa.util import SkippedException
@@ -179,6 +179,19 @@ class OpenVmmTestsSuiteTestCase(TestCase):
 
         self.assertEqual(result, "(test(linux_direct) | test(ubuntu) | test(alpine))")
 
+    def test_get_vmm_tests_target_selects_arm64_musl(self) -> None:
+        suite = self._suite_type.__new__(self._suite_type)
+        host = MagicMock()
+        host.tools = {
+            Lscpu: SimpleNamespace(
+                get_architecture=lambda: CpuArchitecture.ARM64,
+            )
+        }
+
+        target = suite._get_vmm_tests_target(host)
+
+        self.assertEqual("linux-aarch64-musl", target)
+
     def test_before_case_initializes_host_before_os_check(self) -> None:
         suite = self._suite_type.__new__(self._suite_type)
         host = MagicMock()
@@ -229,6 +242,7 @@ class OpenVmmTestsSuiteTestCase(TestCase):
 
         suite._get_host_node = MagicMock(return_value=host)
         suite._ensure_vmm_tests_supported = MagicMock(return_value="")
+        suite._get_vmm_tests_target = MagicMock(return_value="linux-aarch64-musl")
         suite._is_truthy = MagicMock(return_value=True)
         suite._compose_vmm_tests_filter = MagicMock(return_value="")
 
@@ -241,3 +255,7 @@ class OpenVmmTestsSuiteTestCase(TestCase):
 
         self.assertIn("upstream vmm_tests:", result.message)
         self.assertIn("3 tests run: 3 passed, 0 failed, 45 skipped", result.message)
+        self.assertEqual(
+            "linux-aarch64-musl",
+            tool.run_vmm_tests.call_args.kwargs["target"],
+        )

--- a/selftests/test_openvmm_tests_tool.py
+++ b/selftests/test_openvmm_tests_tool.py
@@ -8,7 +8,8 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from lisa.microsoft.testsuites.openvmm.openvmm_tests_tool import OpenVmmTests
-from lisa.tools import Curl
+from lisa.operating_system import CpuArchitecture
+from lisa.tools import Curl, Lscpu
 from lisa.util import LisaException
 
 
@@ -56,7 +57,12 @@ class OpenVmmTestsToolTestCase(TestCase):
         tool = OpenVmmTests.__new__(OpenVmmTests)
         tool._artifact_root = PurePosixPath("/repo/openvmm/target/lisa-openvmm-tests")
         tool.node = MagicMock()
-        tool.node.tools = {Curl: SimpleNamespace(command="curl")}
+        tool.node.tools = {
+            Curl: SimpleNamespace(command="curl"),
+            Lscpu: SimpleNamespace(
+                get_architecture=lambda: CpuArchitecture.X64,
+            ),
+        }
         tool._log = MagicMock()
         with TemporaryDirectory() as temp_dir, patch.object(
             tool, "_has_cargo_nextest", side_effect=[False, True]
@@ -71,6 +77,27 @@ class OpenVmmTestsToolTestCase(TestCase):
         asset_name = "cargo-nextest-0.9.101-x86_64-unknown-linux-gnu"
         self.assertIn(f"{release_url}/{asset_name}.tar.gz", install_command)
         self.assertIn(f"{release_url}/{asset_name}.sha256", install_command)
+
+    def test_ensure_cargo_nextest_uses_arm64_release_asset(self) -> None:
+        tool = OpenVmmTests.__new__(OpenVmmTests)
+        tool._artifact_root = PurePosixPath("/repo/openvmm/target/lisa-openvmm-tests")
+        tool.node = MagicMock()
+        tool.node.tools = {
+            Curl: SimpleNamespace(command="curl"),
+            Lscpu: SimpleNamespace(
+                get_architecture=lambda: CpuArchitecture.ARM64,
+            ),
+        }
+        tool._log = MagicMock()
+        with TemporaryDirectory() as temp_dir, patch.object(
+            tool, "_has_cargo_nextest", side_effect=[False, True]
+        ), patch.object(tool, "_run_logged_command") as run_logged_command:
+            tool._ensure_cargo_nextest(Path(temp_dir), {})
+
+        install_command = run_logged_command.call_args.kwargs["command"]
+        asset_name = "cargo-nextest-0.9.101-aarch64-unknown-linux-gnu"
+        self.assertIn(f"/{asset_name}.tar.gz", install_command)
+        self.assertIn(f"/{asset_name}.sha256", install_command)
 
     def test_check_vmm_tests_results_raises_on_junit_failures(self) -> None:
         tool = OpenVmmTests.__new__(OpenVmmTests)

--- a/selftests/test_openvmm_tool.py
+++ b/selftests/test_openvmm_tool.py
@@ -4,6 +4,7 @@
 from unittest import TestCase
 
 from lisa.tools.openvmm import (
+    OPENVMM_DISK_DEVICE_NVME,
     OPENVMM_DISK_DEVICE_VIRTIO_BLK,
     OPENVMM_IOMMU_INTEL,
     OPENVMM_NETWORK_DEVICE_VIRTIO,
@@ -70,3 +71,54 @@ class OpenVmmToolTestCase(TestCase):
         )
         self.assertNotIn("--disk file:/disks/guest.raw,on=lisa_scsi0,lun=0", command)
         self.assertNotIn("--net tap:tap0", command)
+
+    def test_build_command_disables_vmbus_with_pci_devices(self) -> None:
+        command = self._create_tool().build_command(
+            OpenVmmLaunchConfig(
+                uefi_firmware_path="/firmware/MSVM.fd",
+                hypervisor="kvm",
+                disable_vmbus=True,
+                with_hv=False,
+                vmgs_path="/disks/openvmm.vmgs",
+                create_vmgs=True,
+                exit_on_guest_reset=True,
+                disk_img_path="/disks/guest.raw",
+                disk_device=OPENVMM_DISK_DEVICE_NVME,
+                dvd_disk_paths=["/disks/cloud-init.iso"],
+                network_mode="tap",
+                network_device=OPENVMM_NETWORK_DEVICE_VIRTIO,
+                tap_name="tap0",
+                serial_path="/logs/console.log",
+            )
+        )
+
+        self.assertIn("--hypervisor kvm", command)
+        self.assertNotIn("--hv", command)
+        self.assertIn("--no-vmbus", command)
+        self.assertIn(
+            "--vmgs 'file:/disks/openvmm.vmgs;create=VMGS_DEFAULT,fmt-on-fail'",
+            command,
+        )
+        self.assertIn("--guest-reset-action exit", command)
+        self.assertIn("--nvme-pci id=lisa_nvme0,pcie_port=lisa_virtio_disk", command)
+        self.assertIn("--disk file:/disks/guest.raw,on=lisa_nvme0", command)
+        self.assertIn(
+            "--virtio-blk file:/disks/cloud-init.iso,ro,pcie_port=lisa_virtio_dvd0",
+            command,
+        )
+        self.assertNotIn("--vmbus-scsi", command)
+
+    def test_build_command_reuses_existing_vmgs(self) -> None:
+        command = self._create_tool().build_command(
+            OpenVmmLaunchConfig(
+                uefi_firmware_path="/firmware/MSVM.fd",
+                vmgs_path="/disks/openvmm.vmgs",
+                serial_path="/logs/console.log",
+            )
+        )
+
+        self.assertIn(
+            "--vmgs file:/disks/openvmm.vmgs,fmt-on-fail",
+            command,
+        )
+        self.assertNotIn("create=VMGS_DEFAULT", command)


### PR DESCRIPTION
## Description

Adds KVM guest support to the OpenVMM orchestrator while preserving the existing MSHV path.

This change:

- Prepares KVM hosts and loads the required kernel modules.
- Adds ARM64 and Ubuntu support for upstream OpenVMM VMM tests.
- Resolves and caches shared guest artifacts safely across multiple nodes.
- Configures TAP forwarding and outbound connectivity for guests.
- Preserves PCIe virtio-blk support and adds the required VMGS and reset handling.
- Keeps optional libvirt dependencies out of OpenVMM-only device-pool usage.

## Related Issue

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or private details are included
- [ ] Peer review requested
- [x] Tests executed and results posted below

## Test Validation

**Key Test Cases:**
verify_openvmm_guest_boot|verify_openvmm_restart_via_platform|verify_openvmm_upstream_vmm_tests

**Impacted LISA Features:**
StartStop, SerialConsole

**Tested Azure Marketplace Images:**
- canonical ubuntu-24_04-lts server-arm64 latest

## Test Results

Completed locally:

- 63 focused OpenVMM and installer tests passed.
- Black formatting check passed.
- Flake8 check passed.
- Pylint passed with 10.00/10.
- Mypy passed for all 14 changed files.
- Public content, DCO, import, and whitespace gates passed.

Staged end-to-end KVM validation is pending.

| Image | VM Size | Result |
|-------|---------|--------|
| Ubuntu 24.04 ARM64 | ARM64 KVM host | Guest boot passed; staged suite pending |