### PR TITLE
[AI Generated] BugFix: skip vmsnapshot restore point cases on Confidential VM

### DIFF
--- a/lisa/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
+++ b/lisa/microsoft/testsuites/vm_extensions/vmsnapshot_extension.py
@@ -57,7 +57,9 @@ class VmSnapsotLinuxBVTExtension(TestSuite):
         Attempt it a few items to rule out cases when VM is under changes.
         """,
         priority=1,
-        requirement=simple_requirement(supported_features=[AzureExtension]),
+        requirement=simple_requirement(
+            supported_features=[AzureExtension, CvmDisabled()]
+        ),
     )
     def verify_vmsnapshot_extension(
         self, log: Logger, node: Node, environment: Environment
@@ -118,7 +120,7 @@ class VmSnapsotLinuxBVTExtension(TestSuite):
         """,
         priority=2,
         requirement=simple_requirement(
-            supported_features=[AzureExtension],
+            supported_features=[AzureExtension, CvmDisabled()],
             unsupported_os=[BSD, Windows],
         ),
     )


### PR DESCRIPTION
## Summary
The VMSnapshot restore-point cases declared `CvmDisabled()` only at the suite level, but each case supplied its own case-level `simple_requirement(...)`, which fully replaces (not merges with) the suite-level requirement. As a result, `verify_vmsnapshot_extension` and `verify_exclude_disk_support_restore_point` were scheduled onto Confidential VMs, where Azure Restore Point creation is unsupported, causing failures. Adding `CvmDisabled()` to both case-level requirements makes them skip correctly on CVM.

## Validation Results
| Image | VM Size | Result |
|-------|---------|--------|
| canonical 0001-com-ubuntu-confidential-vm-jammy 22_04-lts-cvm 22.04.202608070 | Standard_DC2eds_v6 | SKIPPED (expected) |
| canonical 0001-com-ubuntu-server-jammy 22_04-lts 22.04.202608060 | Standard_D2ds_v5 | PASSED |
