### PR TITLE
Mark debug-kernel boot nodes dirty to prevent reuse

### DIFF
--- a/lisa/microsoft/testsuites/core/boot.py
+++ b/lisa/microsoft/testsuites/core/boot.py
@@ -48,6 +48,8 @@ class Boot(TestSuite):
     def verify_boot_with_debug_kernel(
         self, log: Logger, node: RemoteNode, log_path: Path
     ) -> None:
+        node.mark_dirty()
+
         # Defense-in-depth: catches custom VHD/SIG images whose OS detection
         # may misclassify the node and bypass the supported_os gate.
         if not isinstance(node.os, Redhat) and not isinstance(node.os, CentOs):

--- a/lisa/microsoft/testsuites/core/boot.py
+++ b/lisa/microsoft/testsuites/core/boot.py
@@ -48,7 +48,6 @@ class Boot(TestSuite):
     def verify_boot_with_debug_kernel(
         self, log: Logger, node: RemoteNode, log_path: Path
     ) -> None:
-        node.mark_dirty()
 
         # Defense-in-depth: catches custom VHD/SIG images whose OS detection
         # may misclassify the node and bypass the supported_os gate.
@@ -66,6 +65,11 @@ class Boot(TestSuite):
                 "This is expected for HPC and minimal images that intentionally "
                 "omit debug kernels."
             )
+
+        # Mark the node as dirty as it modifies the boot entry to use a debug kernel.
+        # This change may cause subsequent tests to run with the debug kernel,
+        # which is not the intended behavior for a kernel validation.
+        node.mark_dirty()
 
         # 3. Install kernel-debug package and set boot with this debug kernel.
         node.os.install_packages("kernel-debug")

--- a/lisa/microsoft/testsuites/core/boot.py
+++ b/lisa/microsoft/testsuites/core/boot.py
@@ -48,7 +48,6 @@ class Boot(TestSuite):
     def verify_boot_with_debug_kernel(
         self, log: Logger, node: RemoteNode, log_path: Path
     ) -> None:
-
         # Defense-in-depth: catches custom VHD/SIG images whose OS detection
         # may misclassify the node and bypass the supported_os gate.
         if not isinstance(node.os, Redhat) and not isinstance(node.os, CentOs):


### PR DESCRIPTION
## Description

Mark the node as dirty in the verify_boot_with_debug_kernel test case, as it modifies the boot entry to use a debug kernel. This change may cause subsequent tests to run with the debug kernel, which is not the intended behavior for kernel validation.

## Related Issue

<!-- Link to the related issue if applicable (e.g. Fixes #123). Leave blank if none. -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Description is filled in above
- [x] No credentials, secrets, or internal details are included
- [x] Peer review requested (if not, add required peer reviewers after raising PR)
- [x] Tests executed and results posted below

## Test Validation

<!-- Run the relevant tests and fill in the sections below before requesting review. -->

**Key Test Cases:**
<!-- Exact test method names separated by | (e.g. verify_reboot_in_platform|verify_stop_start_in_platform) -->
verify_boot_with_debug_kernel

**Impacted LISA Features:**
<!-- Feature class names affected (e.g. NetworkInterface, StartStop, Gpu) -->

**Tested Azure Marketplace Images:**
<!-- List exact image strings you tested against (e.g. canonical ubuntu-24_04-lts server latest) -->
- RedHat RHEL 810-gen2 8.10.2026061712

## Test Results

<!-- Post your test run results here. Reviewers will verify these before approving. -->

| Image | VM Size | Result |
|-------|---------|--------|
|RedHat RHEL 810-gen2 8.10.2026061712|Standard_D4ds_v6| PASSED|
