### PR TITLE
[AI Generated] Mark StressNg test suite as preview

### DIFF
--- a/lisa/microsoft/testsuites/stress/stress_ng_suite.py
+++ b/lisa/microsoft/testsuites/stress/stress_ng_suite.py
@@ -34,6 +34,7 @@ from lisa.util.process import Process
 @TestSuiteMetadata(
     area="stress-ng",
     category="stress",
+    maturity="preview",
     description="""
     A suite for running the various classes of stressors provided
     by stress-ng.


### PR DESCRIPTION
## Summary
- Mark `StressNgTestSuite` as `preview` maturity.

## Validation
- Imported the suite and verified all seven registered StressNg cases inherit `preview` maturity.

AI-generated change.